### PR TITLE
Add --restart policy to synergy server with watchdog

### DIFF
--- a/packages/synergy/src/cli/cmd/server.ts
+++ b/packages/synergy/src/cli/cmd/server.ts
@@ -20,17 +20,17 @@ export const ServerCommand = cmd({
         default: false,
         hidden: true,
       })
-  .option("banner", {
-    type: "boolean",
-    default: true,
-    hidden: true,
-  })
-  .option("restart", {
-    type: "string",
-    choices: ["none", "always"],
-    default: "none",
-    describe: "Server restart policy. 'none': run once and exit; 'always': respawn the server on unexpected exits.",
-  }),
+      .option("banner", {
+        type: "boolean",
+        default: true,
+        hidden: true,
+      })
+      .option("restart", {
+        type: "string",
+        choices: ["none", "always"],
+        default: "none",
+        describe: "Server restart policy. 'none': run once and exit; 'always': respawn the server on unexpected exits.",
+      }),
   describe: "start synergy server",
   handler: async (args) => {
     try {

--- a/packages/synergy/src/cli/cmd/server.ts
+++ b/packages/synergy/src/cli/cmd/server.ts
@@ -20,11 +20,17 @@ export const ServerCommand = cmd({
         default: false,
         hidden: true,
       })
-      .option("banner", {
-        type: "boolean",
-        default: true,
-        hidden: true,
-      }),
+  .option("banner", {
+    type: "boolean",
+    default: true,
+    hidden: true,
+  })
+  .option("restart", {
+    type: "string",
+    choices: ["none", "always"],
+    default: "none",
+    describe: "Server restart policy. 'none': run once and exit; 'always': respawn the server on unexpected exits.",
+  }),
   describe: "start synergy server",
   handler: async (args) => {
     try {
@@ -33,6 +39,7 @@ export const ServerCommand = cmd({
       const managedService = args.managedService
 
       await runServerRuntime({
+        restartPolicy: (args.restart as "none" | "always" | undefined) ?? "none",
         interactive: !(managedService || args.nonInteractive),
         printBanner: args.banner,
         printChannelStatus: !managedService,

--- a/packages/synergy/src/cli/cmd/upgrade.ts
+++ b/packages/synergy/src/cli/cmd/upgrade.ts
@@ -66,8 +66,10 @@ export const UpgradeCommand = {
     // If this CLI is running under an --restart=always watchdog, we need to
     // stop this server child so the wrapper can respawn with the new binary.
     if (process.env.SYNERGY_RESTART_POLICY === "always") {
+      prompts.outro("Done — restarting server with new binary")
       // Short delay to let any output finish flushing
       setTimeout(() => process.exit(0), 300)
+      return
     }
 
     prompts.outro("Done")

--- a/packages/synergy/src/cli/cmd/upgrade.ts
+++ b/packages/synergy/src/cli/cmd/upgrade.ts
@@ -62,6 +62,14 @@ export const UpgradeCommand = {
       return
     }
     spinner.stop("Upgrade complete")
+
+    // If this CLI is running under an --restart=always watchdog, we need to
+    // stop this server child so the wrapper can respawn with the new binary.
+    if (process.env.SYNERGY_RESTART_POLICY === "always") {
+      // Short delay to let any output finish flushing
+      setTimeout(() => process.exit(0), 300)
+    }
+
     prompts.outro("Done")
   },
 }

--- a/packages/synergy/src/server/runtime.ts
+++ b/packages/synergy/src/server/runtime.ts
@@ -43,8 +43,12 @@ async function runWithRestartPolicyAlways(options: RuntimeOptions): Promise<neve
   const onWrapperSignal = async (child: ReturnType<typeof Bun.spawn>) => {
     if (shuttingDown) return
     shuttingDown = true
-    try { child.kill() } catch {}
-    try { await child.exited } catch {}
+    try {
+      child.kill()
+    } catch {}
+    try {
+      await child.exited
+    } catch {}
   }
 
   for (;;) {

--- a/packages/synergy/src/server/runtime.ts
+++ b/packages/synergy/src/server/runtime.ts
@@ -14,6 +14,73 @@ import { EOL } from "os"
 
 const log = Log.create({ service: "server-runtime" })
 
+/**
+ * Minimal watchdog child spawner for --restart=always.
+ * Responsibilities:
+ *  - Construct child argv without restart-related options
+ *  - Spawn child process
+ *  - Forward SIGINT/SIGTERM to child
+ *  - When child exits:
+ *    - If shutdown was requested via signal -> exit wrapper
+ *    - Otherwise -> automatically respawn a new child
+ */
+async function runWithRestartPolicyAlways(options: RuntimeOptions): Promise<never> {
+  const originalArgv = process.argv.slice(1)
+
+  // Drop restart argument so child runs with restart=none
+  const childArgv = originalArgv.reduce<string[]>((acc, v, i, arr) => {
+    if (v === "--restart" && arr[i + 1] === "always") return acc
+    if (v === "--restart=always") return acc
+    if (i > 0 && arr[i - 1] === "--restart") return acc
+    return acc.concat(v)
+  }, [])
+
+  // Remove --non-interactive so Ctrl+C in child works
+  const idx = childArgv.indexOf("--non-interactive")
+  if (idx >= 0) childArgv.splice(idx, 1)
+
+  let shuttingDown = false
+  const onWrapperSignal = async (child: ReturnType<typeof Bun.spawn>) => {
+    if (shuttingDown) return
+    shuttingDown = true
+    try { child.kill() } catch {}
+    try { await child.exited } catch {}
+  }
+
+  for (;;) {
+    const child = Bun.spawn({
+      cmd: [process.argv0, ...childArgv],
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+      env: {
+        ...process.env,
+        SYNERGY_RESTART_POLICY: "always",
+      },
+    })
+
+    const sigint = () => onWrapperSignal(child)
+    const sigterm = () => onWrapperSignal(child)
+    process.on("SIGINT", sigint)
+    process.on("SIGTERM", sigterm)
+
+    // Wait for child
+    const exitStatus = await child.exited
+
+    // Clean up signal handlers
+    process.off("SIGINT", sigint)
+    process.off("SIGTERM", sigterm)
+
+    // Decide whether to respawn
+    if (shuttingDown) {
+      // A signal handler was invoked, so stop the watchdog
+      process.exit(0)
+    }
+
+    // Otherwise always respawn; no other business logic
+  }
+}
+
 const DIM = UI.Style.TEXT_DIM
 const RESET = UI.Style.TEXT_NORMAL
 const CYAN = UI.Style.TEXT_HIGHLIGHT
@@ -26,6 +93,7 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 const SPINNER_INTERVAL = 80
 
 export interface RuntimeOptions {
+  restartPolicy?: "none" | "always"
   interactive: boolean
   printBanner: boolean
   printChannelStatus: boolean
@@ -38,6 +106,12 @@ export interface RuntimeOptions {
 }
 
 export async function run(options: RuntimeOptions) {
+  // If user asked for always-restart, spawn a child and act as a dumb watcher
+  if (options.restartPolicy === "always") {
+    return runWithRestartPolicyAlways(options)
+  }
+
+  // Normal path (unchanged)
   await ensureMigrations()
 
   // TODO: redesign CLI Holos login so it does not conflict with Web UI onboarding.

--- a/packages/synergy/src/server/runtime.ts
+++ b/packages/synergy/src/server/runtime.ts
@@ -17,32 +17,29 @@ const log = Log.create({ service: "server-runtime" })
 /**
  * Minimal watchdog child spawner for --restart=always.
  * Responsibilities:
- *  - Construct child argv without restart-related options
+ *  - Add --restart=none to child argv (overrides any previous --restart)
  *  - Spawn child process
  *  - Forward SIGINT/SIGTERM to child
  *  - When child exits:
  *    - If shutdown was requested via signal -> exit wrapper
- *    - Otherwise -> automatically respawn a new child
+ *    - Otherwise -> automatically respawn with crash backoff
  */
 async function runWithRestartPolicyAlways(options: RuntimeOptions): Promise<never> {
   const originalArgv = process.argv.slice(1)
 
-  // Drop restart argument so child runs with restart=none
-  const childArgv = originalArgv.reduce<string[]>((acc, v, i, arr) => {
-    if (v === "--restart" && arr[i + 1] === "always") return acc
-    if (v === "--restart=always") return acc
-    if (i > 0 && arr[i - 1] === "--restart") return acc
-    return acc.concat(v)
-  }, [])
-
-  // Remove --non-interactive so Ctrl+C in child works
-  const idx = childArgv.indexOf("--non-interactive")
-  if (idx >= 0) childArgv.splice(idx, 1)
+  // Add --restart=none to override any --restart in original argv (yargs honors last value)
+  const childArgv = [...originalArgv, "--restart=none"]
 
   let shuttingDown = false
+  let crashCount = 0
+  const crashStartTime: number[] = []
+
+  const log = Log.create({ service: "server-watchdog" })
+
   const onWrapperSignal = async (child: ReturnType<typeof Bun.spawn>) => {
     if (shuttingDown) return
     shuttingDown = true
+    log.info("received shutdown signal, forwarding to child and exiting watchdog")
     try {
       child.kill()
     } catch {}
@@ -63,6 +60,7 @@ async function runWithRestartPolicyAlways(options: RuntimeOptions): Promise<neve
       },
     })
 
+    const childStartTime = Date.now()
     const sigint = () => onWrapperSignal(child)
     const sigterm = () => onWrapperSignal(child)
     process.on("SIGINT", sigint)
@@ -75,13 +73,49 @@ async function runWithRestartPolicyAlways(options: RuntimeOptions): Promise<neve
     process.off("SIGINT", sigint)
     process.off("SIGTERM", sigterm)
 
+    // Track crash time for backoff calculation
+    crashStartTime.push(childStartTime)
+
+    // Keep only crashes from last 30 seconds for rapid crash counting
+    const thirtySecondsAgo = Date.now() - 30000
+    while (crashStartTime.length > 0 && crashStartTime[0] < thirtySecondsAgo) {
+      crashStartTime.shift()
+    }
+
+    // Count rapid crashes (those that didn't run for at least 30s)
+    crashCount = 0
+    for (let i = 0; i < crashStartTime.length; i++) {
+      crashCount++
+    }
+
     // Decide whether to respawn
     if (shuttingDown) {
-      // A signal handler was invoked, so stop the watchdog
+      log.info("child exited after shutdown signal, watchdog stopping")
       process.exit(0)
     }
 
-    // Otherwise always respawn; no other business logic
+    // Apply crash backoff logic
+    if (crashCount >= 5) {
+      log.error(`child crashed ${crashCount} times in 30s, stopping watchdog to prevent crash loop`, {
+        exitCode: exitStatus,
+        crashCount,
+      })
+      process.exit(1)
+    }
+
+    // Calculate backoff delay: min(1000 * 2^(n-1), 30000)
+    const backoffDelay = Math.min(1000 * Math.pow(2, crashCount - 1), 30000)
+
+    log.info("child exited unexpectedly, scheduling respawn", {
+      exitCode: exitStatus,
+      crashCount,
+      delayMs: backoffDelay,
+    })
+
+    // Always delay at least 1s, and apply exponential backoff for rapid crashes
+    await Bun.sleep(backoffDelay)
+
+    log.info("respawning child", { crashCount, nextDelayMinMs: Math.min(1000 * Math.pow(2, crashCount), 30000) })
   }
 }
 


### PR DESCRIPTION
Adds --restart=none|always to synergy server.

Policy none (default): run once and exit (no change).

Policy always: watchdog running a lightweight spawn loop:
- Wrapper sets SYNERGY_RESTART_POLICY=always on the child.
- On child exit, respawns the server child.
- On SIGINT/SIGTERM to wrapper, forwards to the child, waits, then stops restart.

Upgrade integration:
- After synergy upgrade completes, if SYNERGY_RESTART_POLICY=always, the current server child exits so the watchdog respawns with the new binary.