### PR TITLE
Fix edit fallback matching and cover doom-loop guard

### DIFF
--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -33,6 +33,20 @@ export namespace SessionProcessor {
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
 
+  export function shouldAskDoomLoop(parts: MessageV2.Part[], toolName: string, input: unknown) {
+    const lastThree = parts.slice(-DOOM_LOOP_THRESHOLD)
+    return (
+      lastThree.length === DOOM_LOOP_THRESHOLD &&
+      lastThree.every(
+        (part) =>
+          part.type === "tool" &&
+          part.tool === toolName &&
+          part.state.status !== "pending" &&
+          JSON.stringify(part.state.input) === JSON.stringify(input),
+      )
+    )
+  }
+
   export function create(input: {
     assistantMessage: MessageV2.Assistant
     sessionID: string
@@ -156,18 +170,7 @@ export namespace SessionProcessor {
                       sessionID: input.sessionID,
                       messageID: input.assistantMessage.id,
                     })
-                    const lastThree = parts.slice(-DOOM_LOOP_THRESHOLD)
-
-                    if (
-                      lastThree.length === DOOM_LOOP_THRESHOLD &&
-                      lastThree.every(
-                        (p) =>
-                          p.type === "tool" &&
-                          p.tool === value.toolName &&
-                          p.state.status !== "pending" &&
-                          JSON.stringify(p.state.input) === JSON.stringify(value.input),
-                      )
-                    ) {
+                    if (shouldAskDoomLoop(parts, value.toolName, value.input)) {
                       const agent = await Agent.get(input.assistantMessage.agent)
                       const session = await Session.get(input.assistantMessage.sessionID)
                       await PermissionNext.ask({

--- a/packages/synergy/src/tool/edit.ts
+++ b/packages/synergy/src/tool/edit.ts
@@ -179,7 +179,7 @@ export const EditTool = Tool.define("edit", {
 export type Replacer = (content: string, find: string) => Generator<string, void, unknown>
 
 // Similarity thresholds for block anchor fallback matching
-const SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.0
+const SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.3
 const MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD = 0.3
 
 /**
@@ -290,7 +290,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
     const actualBlockSize = endLine - startLine + 1
 
     let similarity = 0
-    let linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
+    const linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
 
     if (linesToCheck > 0) {
       for (let j = 1; j < searchBlockSize - 1 && j < actualBlockSize - 1; j++) {
@@ -302,11 +302,6 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
         }
         const distance = levenshtein(originalLine, searchLine)
         similarity += (1 - distance / maxLen) / linesToCheck
-
-        // Exit early when threshold is reached
-        if (similarity >= SINGLE_CANDIDATE_SIMILARITY_THRESHOLD) {
-          break
-        }
       }
     } else {
       // No middle lines to compare, just accept based on anchors

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+function toolPart(
+  callID: string,
+  input: Record<string, unknown>,
+  status: "pending" | "running" | "completed" | "error" = "completed",
+): MessageV2.ToolPart {
+  return {
+    id: `prt_${callID}`,
+    sessionID: "ses_test",
+    messageID: "msg_test",
+    type: "tool",
+    tool: "edit",
+    callID,
+    state:
+      status === "completed"
+        ? {
+            status,
+            input,
+            output: "",
+            metadata: {},
+            title: "",
+            time: { start: 0, end: 0 },
+          }
+        : status === "error"
+          ? {
+              status,
+              input,
+              error: "boom",
+              time: { start: 0, end: 0 },
+            }
+          : status === "running"
+            ? {
+                status,
+                input,
+                time: { start: 0 },
+              }
+            : {
+                status,
+                input,
+                raw: "",
+              },
+  } as MessageV2.ToolPart
+}
+
+describe("SessionProcessor.shouldAskDoomLoop", () => {
+  test("asks when the same edit input appears three times in a row", () => {
+    const input = {
+      filePath: "/tmp/example.ts",
+      oldString: "const value = foo()",
+      newString: "const value = bar()",
+    }
+
+    const parts: MessageV2.Part[] = [toolPart("1", input), toolPart("2", input), toolPart("3", input)]
+
+    expect(SessionProcessor.shouldAskDoomLoop(parts, "edit", input)).toBe(true)
+  })
+
+  test("does not ask when repeated edit calls vary the input slightly", () => {
+    const parts: MessageV2.Part[] = [
+      toolPart("1", {
+        filePath: "/tmp/example.ts",
+        oldString: "const value = foo()",
+        newString: "const value = bar()",
+      }),
+      toolPart("2", {
+        filePath: "/tmp/example.ts",
+        oldString: "  const value = foo()",
+        newString: "const value = bar()",
+      }),
+      toolPart("3", {
+        filePath: "/tmp/example.ts",
+        oldString: "const value = foo()\nreturn value",
+        newString: "const value = bar()\nreturn value",
+      }),
+    ]
+
+    expect(
+      SessionProcessor.shouldAskDoomLoop(parts, "edit", {
+        filePath: "/tmp/example.ts",
+        oldString: "const value = foo()\nreturn value",
+        newString: "const value = bar()\nreturn value",
+      }),
+    ).toBe(false)
+  })
+
+  test("ignores pending tool parts when checking for repeated calls", () => {
+    const input = {
+      filePath: "/tmp/example.ts",
+      oldString: "const value = foo()",
+      newString: "const value = bar()",
+    }
+
+    const parts: MessageV2.Part[] = [toolPart("1", input), toolPart("2", input), toolPart("3", input, "pending")]
+
+    expect(SessionProcessor.shouldAskDoomLoop(parts, "edit", input)).toBe(false)
+  })
+})

--- a/packages/synergy/test/tool/edit.test.ts
+++ b/packages/synergy/test/tool/edit.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { replace } from "../../src/tool/edit"
+
+describe("tool.edit replace", () => {
+  test("rejects a single anchored block when only the wrapper lines match", () => {
+    const content = [
+      "async function syncProfile() {",
+      "  const profile = await loadProfile()",
+      "  return profile",
+      "}",
+    ].join("\n")
+
+    const oldString = [
+      "async function syncProfile() {",
+      "  await deleteEverythingFromProduction()",
+      "  process.exit(1)",
+      "}",
+    ].join("\n")
+
+    expect(() =>
+      replace(
+        content,
+        oldString,
+        "async function syncProfile() {\n  await deleteEverythingFromProduction()\n  process.exit(0)\n}",
+      ),
+    ).toThrow("oldString not found in content")
+  })
+
+  test("does not accept a single block-anchor candidate with unrelated middle lines", () => {
+    const content = [
+      "function example() {",
+      "  const value = foo()",
+      "  return value",
+      "}",
+      "",
+      "const untouched = true",
+    ].join("\n")
+
+    const oldString = [
+      "function example() {",
+      "  await completelyDifferentWorkflow({ alpha: 1, beta: 2, gamma: 3 })",
+      "  throw new Error('stop')",
+      "}",
+    ].join("\n")
+
+    expect(() =>
+      replace(
+        content,
+        oldString,
+        "function example() {\n  await completelyDifferentWorkflow({ alpha: 1, beta: 2, gamma: 3 })\n  throw new Error('retry')\n}",
+      ),
+    ).toThrow("oldString not found in content")
+  })
+
+  test("accepts a single block-anchor candidate when the middle lines are still similar enough", () => {
+    const content = ["function example() {", "  const value = foo()", "  return value", "}"].join("\n")
+
+    const oldString = ["function example() {", "  const result = foo()", "  return value", "}"].join("\n")
+
+    expect(replace(content, oldString, "function example() {\n  const result = bar()\n  return value\n}")).toContain(
+      "const result = bar()",
+    )
+  })
+
+  test("still rejects ambiguous matches when the same block appears twice", () => {
+    const duplicated = [
+      "function example() {",
+      "  const value = foo()",
+      "  return value",
+      "}",
+      "",
+      "function example() {",
+      "  const value = foo()",
+      "  return value",
+      "}",
+    ].join("\n")
+
+    const oldString = ["function example() {", "  const value = foo()", "  return value", "}"].join("\n")
+
+    expect(() =>
+      replace(duplicated, oldString, "function example() {\n  const value = bar()\n  return value\n}"),
+    ).toThrow("Found multiple matches for oldString")
+  })
+})


### PR DESCRIPTION
## Summary
- tighten single-candidate block-anchor matching in the edit tool so unrelated anchored blocks fail instead of being rewritten
- add regression tests for edit fallback behavior and ambiguous matches
- extract and test the doom-loop guard predicate to show identical edit retries are caught while varied retries are not

## Testing
- bun test test/tool/edit.test.ts
- bun test test/session/processor.test.ts