### PR TITLE
fix: add missing type and directory fields to Scope.Info schema

### DIFF
--- a/packages/synergy/src/scope/index.ts
+++ b/packages/synergy/src/scope/index.ts
@@ -210,6 +210,8 @@ export namespace Scope {
     if (!existing) {
       existing = {
         id,
+        type: "project",
+        directory: sandbox,
         worktree,
         vcs: vcs as Scope.Project["vcs"],
         sandboxes: [],
@@ -224,6 +226,8 @@ export namespace Scope {
 
     const persisted: z.infer<typeof Info> = {
       ...existing,
+      type: "project",
+      directory: sandbox,
       worktree,
       vcs: vcs as Scope.Project["vcs"],
       time: { ...existing.time },
@@ -278,7 +282,7 @@ export namespace Scope {
     return valid.map((data) => ({
       type: "project" as const,
       id: data.id,
-      directory: data.worktree,
+      directory: data.directory ?? data.worktree,
       worktree: data.worktree,
       vcs: data.vcs,
       name: data.name,

--- a/packages/synergy/src/scope/types.ts
+++ b/packages/synergy/src/scope/types.ts
@@ -24,6 +24,8 @@ export type Scope = Global | Project
 export const Info = z
   .object({
     id: z.string(),
+    type: z.enum(["global", "project"]),
+    directory: z.string(),
     worktree: z.string(),
     vcs: z.literal("git").optional(),
     name: z.string().optional(),

--- a/packages/synergy/test/scope/scope-info-schema.test.ts
+++ b/packages/synergy/test/scope/scope-info-schema.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test"
+import { Scope } from "../../src/scope"
+import { Info as InfoSchema } from "../../src/scope/types"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import { $ } from "bun"
+
+Log.init({ print: false })
+
+/**
+ * Scope.Info Zod schema must include `type` and `directory` fields
+ * to match what the server API routes actually return.
+ *
+ * The server returns Scope.Project / Scope.Global objects (which have
+ * `type` and `directory`), but the Info schema (which drives OpenAPI
+ * and SDK types) lacked these fields. This means the frontend SDK type
+ * `Scope` cannot type-safely access scope.type or scope.directory.
+ *
+ * These tests assert the CORRECT behavior — they will FAIL until the
+ * schema is fixed to include `type` and `directory`.
+ */
+
+describe("Scope.Info schema includes type and directory", () => {
+  test("Scope.Info schema has 'type' field", () => {
+    expect(InfoSchema.shape).toHaveProperty("type")
+  })
+
+  test("Scope.Info schema has 'directory' field", () => {
+    expect(InfoSchema.shape).toHaveProperty("directory")
+  })
+
+  test("Scope.Info preserves type and directory through parse", () => {
+    const data = {
+      id: "test-scope-id",
+      type: "project" as const,
+      directory: "/some/sandbox",
+      worktree: "/some/path",
+      sandboxes: [] as string[],
+      time: { created: Date.now(), updated: Date.now() },
+    }
+
+    const result = InfoSchema.parse(data) as any
+    expect(result.type).toBe("project")
+    expect(result.directory).toBe("/some/sandbox")
+  })
+
+  test("Scope.Info rejects data missing 'type'", () => {
+    const data = {
+      id: "test-scope-id",
+      directory: "/some/sandbox",
+      worktree: "/some/path",
+      sandboxes: [] as string[],
+      time: { created: Date.now(), updated: Date.now() },
+    }
+
+    const result = InfoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+
+  test("Scope.Info rejects data missing 'directory'", () => {
+    const data = {
+      id: "test-scope-id",
+      type: "project" as const,
+      worktree: "/some/path",
+      sandboxes: [] as string[],
+      time: { created: Date.now(), updated: Date.now() },
+    }
+
+    const result = InfoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("Scope.Info can represent Scope.Project from fromDirectory", () => {
+  test("Scope.Info validates Scope.Project returned by fromDirectory", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const { scope } = await Scope.fromDirectory(tmp.path)
+
+    const result = InfoSchema.safeParse(scope)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const parsed = result.data as any
+      expect(parsed.type).toBe("project")
+      expect(parsed.directory).toBe(tmp.path)
+    }
+  })
+
+  test("Scope.Info preserves directory as sandbox for linked worktrees", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const worktreePath = path.join(tmp.path, "..", `wt-info-${Math.random().toString(36).slice(2)}`)
+    await $`git worktree add ${worktreePath} -b wt-info-branch`.cwd(tmp.path).quiet()
+
+    const { scope } = await Scope.fromDirectory(worktreePath)
+
+    const result = InfoSchema.safeParse(scope)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const parsed = result.data as any
+      // directory should be the sandbox (actual checkout), not the worktree root
+      expect(parsed.directory).toBe(worktreePath)
+      expect(parsed.worktree).toBe(tmp.path)
+    }
+
+    await $`git worktree remove ${worktreePath}`.cwd(tmp.path).quiet()
+  })
+})
+
+describe("Scope.Info can represent Scope.list results", () => {
+  test("Scope.Info validates each scope returned by Scope.list with type and directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const { scope: resolved } = await Scope.fromDirectory(tmp.path)
+
+    const scopes = await Scope.list()
+    const found = scopes.find((s) => s.id === resolved.id)
+    expect(found).toBeDefined()
+    if (!found) return
+
+    const result = InfoSchema.safeParse(found)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const parsed = result.data as any
+      expect(parsed.type).toBe("project")
+      expect(parsed.directory).toBeDefined()
+    }
+  })
+})
+
+describe("Scope.Info type field distinguishes global from project", () => {
+  test("type field allows 'global' value", () => {
+    const data = {
+      id: "global",
+      type: "global" as const,
+      directory: "/home/user",
+      worktree: "/home/user",
+      sandboxes: [] as string[],
+      time: { created: Date.now(), updated: Date.now() },
+    }
+
+    const result = InfoSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).type).toBe("global")
+    }
+  })
+
+  test("type field allows 'project' value", () => {
+    const data = {
+      id: "some-hash",
+      type: "project" as const,
+      directory: "/some/repo",
+      worktree: "/some/repo",
+      sandboxes: [] as string[],
+      time: { created: Date.now(), updated: Date.now() },
+    }
+
+    const result = InfoSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as any).type).toBe("project")
+    }
+  })
+
+  test("type field rejects invalid values", () => {
+    const data = {
+      id: "test-id",
+      type: "invalid",
+      directory: "/some/path",
+      worktree: "/some/path",
+      sandboxes: [] as string[],
+      time: { created: Date.now(), updated: Date.now() },
+    }
+
+    const result = InfoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `type: z.enum(["global", "project"])` and `directory: z.string()` to `Scope.Info` Zod schema, matching the `Scope.Project` / `Scope.Global` interfaces that the server actually returns via API
- Persist `type` and `directory` in scope storage so `Scope.list()` can read them back correctly
- Fix `Scope.list()` returning `directory: data.worktree` instead of reading from persisted `directory` (which was wrong for linked git worktrees)

## Why

The `Scope.Info` Zod schema drives the OpenAPI spec and generated SDK types. It was missing `type` and `directory` fields that exist on `Scope.Project` / `Scope.Global` interfaces and are returned by the server routes (`/scope/list`, `/scope/current`). This caused:

1. **SDK type gap** — frontend `Scope` type lacked `type` and `directory`, forcing `as any` / `!` workarounds
2. **OpenAPI doc inaccuracy** — auto-generated docs didn't show these fields
3. **Wrong directory for worktrees** — `Scope.list()` hardcoded `directory = worktree`, losing the actual sandbox path for linked git worktrees

## Test

New test file `test/scope/scope-info-schema.test.ts` (11 tests) asserting:
- Schema has `type` and `directory` fields
- Parse preserves these fields through round-trip
- Schema rejects data missing required fields
- `Scope.fromDirectory` results validate correctly
- Linked worktree scenario preserves correct `directory` (sandbox ≠ worktree)
- `Scope.list` results validate with `type` and `directory`
- `type` enum accepts `"global"` and `"project"`, rejects invalid values