### PR TITLE
feat(app): mobile view adaptation

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en" style="background-color: var(--background-base); overflow: hidden">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Synergy</title>
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/packages/app/src/components/mobile-drawer.tsx
+++ b/packages/app/src/components/mobile-drawer.tsx
@@ -15,7 +15,9 @@ import { getScopeLabel, isGlobalScope } from "@/utils/scope"
 import { ActiveZone } from "@/components/scopes/active-zone"
 import { SessionRow } from "@/components/scopes/session-row"
 import { PaginationBar } from "@/components/scopes/pagination-bar"
+import { usePanel } from "@/context/panel"
 import type { Session } from "@ericsanchezok/synergy-sdk/client"
+import type { IconName } from "@ericsanchezok/synergy-ui/icon"
 
 export function MobileDrawer() {
   const layout = useLayout()
@@ -73,7 +75,7 @@ export function MobileDrawer() {
           </div>
 
           {/* Body */}
-          <div class="flex-1 min-h-0 overflow-y-auto">
+          <div class="flex-1 min-h-0 overflow-y-auto mobile-drawer-safe-bottom">
             <Show
               when={drilldown()}
               fallback={
@@ -81,6 +83,7 @@ export function MobileDrawer() {
                   currentDir={currentDir()}
                   onSelectScope={setDrilldown}
                   onNavigateHome={() => navigateAndClose(`/${base64Encode("global")}/session`)}
+                  onClose={close}
                 />
               }
             >
@@ -104,12 +107,22 @@ export function MobileDrawer() {
   )
 }
 
+const TOOLS: Array<{ id: string; icon: IconName; label: string }> = [
+  { id: "scopes", icon: "layout-grid", label: "Projects" },
+  { id: "note", icon: "notebook-pen", label: "Notes" },
+  { id: "engram", icon: "brain", label: "Engram" },
+  { id: "agenda", icon: "clipboard-list", label: "Agenda" },
+  { id: "holos", icon: "users", label: "Holos" },
+]
+
 function ScopeListView(props: {
   currentDir: string | undefined
   onSelectScope: (scope: LocalScope) => void
   onNavigateHome: () => void
+  onClose: () => void
 }) {
   const layout = useLayout()
+  const panel = usePanel()
   const globalSync = useGlobalSync()
 
   const scopes = createMemo(() => {
@@ -188,6 +201,35 @@ function ScopeListView(props: {
           )
         }}
       </For>
+
+      {/* Divider */}
+      <div class="mx-4 my-2 border-t border-border-weaker-base/60" />
+
+      {/* Tools */}
+      <div class="px-4 pb-1.5">
+        <span class="text-11-medium text-text-weak uppercase tracking-wider">Tools</span>
+      </div>
+      <div class="grid grid-cols-5 gap-1 px-3 pb-2">
+        <For each={TOOLS}>
+          {(tool) => (
+            <button
+              type="button"
+              classList={{
+                "flex flex-col items-center gap-1 py-2.5 rounded-xl transition-colors": true,
+                "bg-surface-interactive-base/8 text-text-interactive-base": panel.active() === tool.id,
+                "text-text-weak hover:text-text-base hover:bg-surface-raised-base-hover": panel.active() !== tool.id,
+              }}
+              onClick={() => {
+                props.onClose()
+                panel.toggle(tool.id)
+              }}
+            >
+              <Icon name={tool.icon} size="normal" />
+              <span class="text-[10px] font-medium leading-none">{tool.label}</span>
+            </button>
+          )}
+        </For>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/components/session/conversation.tsx
+++ b/packages/app/src/components/session/conversation.tsx
@@ -133,7 +133,7 @@ export function SessionConversation(props: {
               data-message-id={msg.id}
               classList={{
                 "min-w-0 w-full max-w-full": true,
-                "last:min-h-[calc(100vh-5.5rem-var(--prompt-height,8rem)-64px)] md:last:min-h-[calc(100vh-4.5rem-var(--prompt-height,10rem)-64px)]": true,
+                "last:min-h-[calc(100dvh-5.5rem-var(--prompt-height,8rem)-64px)] md:last:min-h-[calc(100dvh-4.5rem-var(--prompt-height,10rem)-64px)]": true,
               }}
               style={isLast() ? { animation: "fadeUp 0.3s ease-out both" } : undefined}
             >

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -39,8 +39,7 @@ export function PromptDock(props: {
       ref={props.ref}
       classList={{
         "absolute inset-x-0 bottom-0 flex flex-col justify-center items-center z-50 px-0 pointer-events-none prompt-dock-safe-bottom": true,
-        "pt-12 bg-gradient-to-t from-background-stronger via-background-stronger to-transparent":
-          !props.isNewSession(),
+        "pt-12 bg-gradient-to-t from-background-stronger via-background-stronger to-transparent": !props.isNewSession(),
       }}
       style={{
         transform: props.isNewSession() ? "translateY(-35vh)" : "translateY(0)",

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -38,10 +38,9 @@ export function PromptDock(props: {
     <div
       ref={props.ref}
       classList={{
-        "absolute inset-x-0 bottom-0 flex flex-col justify-center items-center z-50 px-0 pointer-events-none": true,
-        "pt-12 pb-0 md:pb-1.5 bg-gradient-to-t from-background-stronger via-background-stronger to-transparent":
+        "absolute inset-x-0 bottom-0 flex flex-col justify-center items-center z-50 px-0 pointer-events-none prompt-dock-safe-bottom": true,
+        "pt-12 bg-gradient-to-t from-background-stronger via-background-stronger to-transparent":
           !props.isNewSession(),
-        "pb-0 md:pb-1.5": props.isNewSession(),
       }}
       style={{
         transform: props.isNewSession() ? "translateY(-35vh)" : "translateY(0)",

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -145,3 +145,49 @@ a:active,
     transform: translateX(0);
   }
 }
+
+/* iOS safe area support (viewport-fit=cover) */
+:root {
+  --safe-inset-top: env(safe-area-inset-top, 0px);
+  --safe-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-inset-left: env(safe-area-inset-left, 0px);
+  --safe-inset-right: env(safe-area-inset-right, 0px);
+}
+
+/* Prompt dock safe bottom — ensures content clears iOS home indicator */
+.prompt-dock-safe-bottom {
+  padding-bottom: max(6px, env(safe-area-inset-bottom, 0px));
+}
+
+/* Mobile drawer safe bottom — pads scrollable area away from home indicator */
+.mobile-drawer-safe-bottom {
+  padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+}
+
+/* Generic safe bottom for absolutely positioned bottom bars */
+.safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Use dvh for dialog height calculations on mobile */
+@media (max-width: 767px) {
+  [data-slot="dialog-container"]:has(.dialog-settings-wide) {
+    height: min(calc(100dvh - 16px), 640px);
+  }
+
+  [data-slot="dialog-container"]:has(.dialog-skill-detail) {
+    height: min(calc(100dvh - 20px), 760px);
+  }
+
+  /* Settings dialog tabs bar — allow horizontal scroll on small screens */
+  .ds-tabs-bar {
+    padding: 4px 8px 0;
+    justify-content: flex-start;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .ds-tabs-bar::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -13,7 +13,7 @@ export default function Home() {
         <Mark class="size-12 text-icon-base" />
         <Button onClick={() => navigate(`/${base64Encode("global")}/session`)}>Start</Button>
       </div>
-      <div class="absolute bottom-0 left-0 right-0">
+      <div class="absolute bottom-0 left-0 right-0 safe-bottom">
         <StatusBar />
       </div>
     </div>

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -561,9 +561,7 @@ function LayoutContent(props: ParentProps) {
           style={{ animation: "mobileDrawerFadeIn 200ms ease-out both" }}
         >
           <div class="flex items-center justify-between px-4 h-11 shrink-0 border-b border-border-weaker-base/60">
-            <span class="text-14-medium text-text-strong">
-              {PANEL_LABELS[panel.active()!] ?? panel.active()}
-            </span>
+            <span class="text-14-medium text-text-strong">{PANEL_LABELS[panel.active()!] ?? panel.active()}</span>
             <button
               type="button"
               class="flex items-center justify-center size-8 rounded-lg text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover transition-colors"

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -15,6 +15,7 @@ import { PanelProvider, usePanel } from "@/context/panel"
 
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { useTheme, type ColorScheme } from "@ericsanchezok/synergy-ui/theme"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { DialogSelectProvider, DialogSelectServer, DialogSelectDirectory } from "@/components/dialog"
 import { useCommand, type CommandOption } from "@/context/command"
 import { navStart } from "@/utils/perf"
@@ -442,12 +443,26 @@ const PANEL_DEFAULT = 45
 const PANEL_MIN = 20
 const MAIN_MIN_PX = 480
 
+const PANEL_LABELS: Record<string, string> = {
+  engram: "Engram",
+  agenda: "Agenda",
+  note: "Notes",
+  scopes: "Projects",
+  holos: "Holos",
+  lucid: "Lucid",
+}
+
 function LayoutContent(props: ParentProps) {
   const panel = usePanel()
   const layout = useLayout()
   const [panelWidth, setPanelWidth] = createSignal(PANEL_DEFAULT)
   const [resizing, setResizing] = createSignal(false)
-  const isOpen = () => layout.isDesktop() && !!panel.active()
+
+  // Desktop: side panel; Mobile: full-screen overlay (handled separately)
+  const isDesktopOpen = () => layout.isDesktop() && !!panel.active()
+  const isMobileOpen = () => !layout.isDesktop() && !!panel.active()
+  // Keep the legacy name for the desktop panel container
+  const isOpen = isDesktopOpen
 
   const panelMax = () => Math.floor(((window.innerWidth - MAIN_MIN_PX) / window.innerWidth) * 100)
 
@@ -539,6 +554,49 @@ function LayoutContent(props: ParentProps) {
           </div>
         </div>
       </div>
+      {/* Mobile panel — full-screen overlay, shown instead of desktop side panel */}
+      <Show when={isMobileOpen()}>
+        <div
+          class="md:hidden fixed inset-0 z-[90] flex flex-col bg-background-stronger"
+          style={{ animation: "mobileDrawerFadeIn 200ms ease-out both" }}
+        >
+          <div class="flex items-center justify-between px-4 h-11 shrink-0 border-b border-border-weaker-base/60">
+            <span class="text-14-medium text-text-strong">
+              {PANEL_LABELS[panel.active()!] ?? panel.active()}
+            </span>
+            <button
+              type="button"
+              class="flex items-center justify-center size-8 rounded-lg text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover transition-colors"
+              onClick={() => panel.close()}
+            >
+              <Icon name="x" size="normal" />
+            </button>
+          </div>
+          <div class="flex-1 min-h-0 overflow-hidden">
+            <Switch>
+              <Match when={panel.active() === "engram"}>
+                <EngramPanel />
+              </Match>
+              <Match when={panel.active() === "agenda"}>
+                <AgendaPanel />
+              </Match>
+              <Match when={panel.active() === "note"}>
+                <NotePanel />
+              </Match>
+              <Match when={panel.active() === "scopes"}>
+                <ScopesPanel />
+              </Match>
+              <Match when={panel.active() === "holos"}>
+                <HolosPanel />
+              </Match>
+              <Match when={panel.active() === "lucid"}>
+                <LucidPanel />
+              </Match>
+              <Match when={panel.hasSlot(panel.active()!)}>{panel.slot(panel.active()!)}</Match>
+            </Switch>
+          </div>
+        </div>
+      </Show>
       <Toast.Region />
     </div>
   )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -843,7 +843,7 @@ export default function Page() {
         <div
           classList={{
             "@container relative shrink-0 flex flex-col min-h-0 h-full bg-background-stronger": true,
-            "flex-1 md:flex-none py-6 md:py-3": true,
+            "flex-1 md:flex-none pt-3 pb-0 md:py-3": true,
           }}
           style={{
             width: isDesktop() && showTabs() ? `${layout.session.width()}px` : "100%",


### PR DESCRIPTION
<h2>Summary</h2>
<ul>
<li><strong>Safe area / notch support</strong> — <code>viewport-fit=cover</code>, CSS custom properties for <code>env(safe-area-inset-*)</code>, and per-component padding classes (<code>prompt-dock-safe-bottom</code>, <code>mobile-drawer-safe-bottom</code>, <code>safe-bottom</code>) so nothing hides behind the iOS home indicator or notch</li>
<li><strong>Dynamic viewport height</strong> — last-turn <code>min-height</code> switched from <code>100vh</code> → <code>100dvh</code> so the chat area fills correctly when iOS Safari's collapsible browser bar is retracted</li>
<li><strong>Mobile panel overlay</strong> — panels (Engram, Agenda, Notes, Scopes, Holos, Lucid) were silently inaccessible on mobile because <code>isOpen</code> was gated on <code>layout.isDesktop()</code>. Added a <code>fixed inset-0 z-[90]</code> full-screen sheet that renders the active panel on mobile with a labelled header and × close button</li>
<li><strong>Tool discovery in MobileDrawer</strong> — added a 5-column tool grid (Projects / Notes / Engram / Agenda / Holos) to the hamburger drawer so users can open any panel from the mobile nav</li>
<li><strong>Settings dialog tabs overflow</strong> — made <code>.ds-tabs-bar</code> horizontally scrollable (<code>overflow-x: auto; justify-content: flex-start</code>) and switched dialog heights to <code>100dvh</code> so the 6-tab row no longer overflows</li>
<li><strong>Conversation vertical space</strong> — reduced mobile top padding from <code>py-6</code> → <code>pt-3 pb-0</code>, reclaiming 12 px for the message list</li>
</ul>
<h2>Files changed</h2>

File | Change
-- | --
packages/app/index.html | Add viewport-fit=cover
packages/app/src/index.css | Safe area CSS, mobile dialog/tabs overrides, dvh dialog heights
packages/app/src/components/session/conversation.tsx | 100vh → 100dvh for last-turn min-height
packages/app/src/components/session/prompt-dock.tsx | Use prompt-dock-safe-bottom for iOS safe area
packages/app/src/components/mobile-drawer.tsx | Add tool grid; onClose prop; mobile-drawer-safe-bottom
packages/app/src/pages/home.tsx | safe-bottom on status bar wrapper
packages/app/src/pages/layout.tsx | Split isOpen into desktop/mobile; add mobile panel overlay
packages/app/src/pages/session.tsx | Reduce mobile conversation padding


<h2>Known follow-up issues (TODO)</h2>
<h3>1. Panel inner layouts not adapted for narrow width</h3>
<p>Panels render as a full-screen overlay but their internals were designed for the ~320 px sidebar and break at full phone width:</p>
<ul>
<li><strong>Engram header tab row</strong> (<code>engram/shared.tsx</code>): four <code>flex-1</code> <code>ViewTab</code> buttons (Stats / Memory / Experience / Skill) plus an "X MB" badge sit in a single non-wrapping flex row. On 375 px screens the badge overflows or tabs compress to unreadable widths. Needs either <code>flex-wrap</code> or a <code>&lt;select&gt;</code> fallback below the <code>md:</code> breakpoint.</li>
<li><strong>Learning Reward Dimensions legend</strong> (<code>reward-radar.tsx</code>): five radar-chart legend items rendered horizontally overflow the panel width on narrow screens. Needs <code>flex-wrap</code> or vertical layout below <code>md:</code>.</li>
<li>Other panels (Notes, Agenda, Holos, Scopes) need audit for fixed-width containers, non-wrapping flex rows, and hard-coded pixel values.</li>
</ul>
<h3>2. Settings dialog body content still overflows</h3>
<p>The tab bar is now scrollable, but the <em>body</em> (<code>.ds-content</code>, 16/20/20 px padding) contains elements with implicit minimum widths:</p>
<ul>
<li><strong>Models tab</strong> — model-selector dropdowns (<code>ds-model-select</code>) exceed the ~359 px dialog body on 375 px phones.</li>
<li><strong>MCP tab</strong> — <code>ds-mcp-card</code> entries contain fixed-width provider badges and action button rows that cause body-level horizontal scroll.</li>
</ul>
<p>Each tab's content needs <code>max-w-full</code> / <code>min-w-0</code> / <code>overflow-hidden</code> guards plus a responsive-width audit.</p>
<h3>3. Header bar: long session title obscures the "+" new-session button</h3>
<p><code>SessionIdentitySwitcher</code> has <code>max-width: min(34rem, calc(100vw - 18rem))</code>. At 375 px that is ≈ 87 px. The new-session <code>&lt;A&gt;</code> button (44 px touch target on mobile) sits immediately to its right with only <code>ml-1</code> separation. On intermediate widths (390–430 px) the switcher can grow enough to push the "+" partially out of the left-side flex container. Fix: add <code>shrink-0</code> to the "+" button so it always maintains its reserved space regardless of switcher width.</p>
<h2>Test plan</h2>
<ul>
<li>[x] iOS Safari (375×812): home indicator / notch clear, chat fills viewport, drawer tool grid works, panels open as full-screen overlay</li>
<li>[x] Settings dialog: tab row scrolls, General / Models tabs don't overflow horizontally</li>
<li>[x] Desktop ≥ 768 px: side panel, prompt dock, header completely unaffected</li>
</ul>
<hr>