### PR TITLE
fix(provider): add TTL to SDK and LanguageModel caches to prevent stale HTTP client state in long-running processes

### DIFF
--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -595,11 +595,11 @@ export namespace Provider {
     }
 
     const providers: { [providerID: string]: Info } = {}
-    const languages = new Map<string, LanguageModelV2>()
+    const models = new Map<string, { instance: LanguageModelV2; createdAt: number }>()
     const modelLoaders: {
       [providerID: string]: CustomModelLoader
     } = {}
-    const sdk = new Map<number, SDK>()
+    const sdk = new Map<number, { instance: SDK; createdAt: number }>()
 
     log.info("init")
 
@@ -856,7 +856,7 @@ export namespace Provider {
     }
 
     return {
-      models: languages,
+      models,
       providers,
       sdk,
       modelLoaders,
@@ -929,8 +929,13 @@ export namespace Provider {
         }
 
       const key = Bun.hash.xxHash32(JSON.stringify({ npm: model.api.npm, options }))
+      const SDK_CACHE_TTL_MS = 4 * 60 * 60 * 1000 // 4 hours — prevent stale HTTP client state in long-running processes
       const existing = s.sdk.get(key)
-      if (existing) return existing
+      if (existing) {
+        if (Date.now() - existing.createdAt < SDK_CACHE_TTL_MS) return existing.instance as SDK
+        s.sdk.delete(key) // Expired — force SDK recreation with fresh HTTP client
+        log.info("sdk cache entry expired, recreating", { providerID: model.providerID, key })
+      }
 
       const customFetch = options["fetch"]
 
@@ -953,7 +958,7 @@ export namespace Provider {
               idleController!.abort(
                 new DOMException("Idle timeout: no data received within " + timeoutMs + "ms", "TimeoutError"),
               )
-            }, timeoutMs as number)
+            }, timeoutMs as number).unref()
           }
           resetIdle()
 
@@ -993,7 +998,7 @@ export namespace Provider {
               idleController!.abort(
                 new DOMException("Idle timeout: no data received within " + timeoutMs + "ms", "TimeoutError"),
               )
-            }, timeoutMs as number)
+            }, timeoutMs as number).unref()
           }
 
           const wrappedStream = new ReadableStream({
@@ -1043,7 +1048,7 @@ export namespace Provider {
           name: model.providerID,
           ...options,
         })
-        s.sdk.set(key, loaded)
+        s.sdk.set(key, { instance: loaded, createdAt: Date.now() })
         return loaded as SDK
       }
 
@@ -1062,7 +1067,7 @@ export namespace Provider {
         name: model.providerID,
         ...options,
       })
-      s.sdk.set(key, loaded)
+      s.sdk.set(key, { instance: loaded, createdAt: Date.now() })
       return loaded as SDK
     } catch (e) {
       throw new InitError({ providerID: model.providerID }, { cause: e })
@@ -1096,7 +1101,13 @@ export namespace Provider {
   export async function getLanguage(model: Model): Promise<LanguageModelV2> {
     const s = await state()
     const key = `${model.providerID}/${model.id}`
-    if (s.models.has(key)) return s.models.get(key)!
+    const MODEL_CACHE_TTL_MS = 4 * 60 * 60 * 1000 // 4 hours — keep in sync with SDK_CACHE_TTL_MS
+    const cached = s.models.get(key)
+    if (cached) {
+      if (Date.now() - cached.createdAt < MODEL_CACHE_TTL_MS) return cached.instance
+      s.models.delete(key) // Expired — force recreation
+      log.info("model cache entry expired, recreating", { key })
+    }
 
     const provider = s.providers[model.providerID]
     const sdk = await getSDK(model)
@@ -1107,7 +1118,7 @@ export namespace Provider {
         : model.api.npm === "@ai-sdk/openai"
           ? (sdk as any).responses(model.api.id)
           : sdk.languageModel(model.api.id)
-      s.models.set(key, language)
+      s.models.set(key, { instance: language, createdAt: Date.now() })
       return language
     } catch (e) {
       if (e instanceof NoSuchModelError)


### PR DESCRIPTION
## Summary

After 40+ hours of continuous uptime, the Synergy server experiences intermittent `ConnectionRefused` errors (10-15%) on LLM API calls. Root cause: Provider SDK and LanguageModel instances are cached indefinitely in `Instance.state()`, and stale instances hold degraded Bun fetch HTTP client state (DNS cache, TLS session, connection pool).

## Changes

- **SDK cache TTL (4h)**: `s.sdk` Map entries now include `createdAt`. Expired entries are deleted and recreated with a fresh HTTP client, preventing reuse of degraded internal state.
- **LanguageModel cache TTL (4h)**: Same pattern for `s.models` Map, kept in sync with SDK TTL.
- **idleTimer `.unref()`**: Two `setTimeout` calls in the custom fetch wrapper (idle timeout logic) now call `.unref()` to prevent event loop pressure accumulation in long-running processes.

## Root Cause Chain

```
Provider SDK cached permanently (provider.ts:602)
  └─> SDK holds Bun fetch's internal HTTP client state
      └─> Bun runtime internal state degrades over 40h+
          (DNS cache, TLS session cache, connection pool)
          └─> Reusing degraded socket → ConnectionRefused
```

The existing `Connection: close` header only affects individual HTTP requests — it does not force the SDK's underlying HTTP client to reset its degraded internal state. The TTL-based cache eviction ensures SDK instances are periodically recreated with fresh HTTP clients.

## Verification

- ✅ TypeScript: `turbo typecheck` passes (9/9 packages)
- ✅ Prettier: formatting check passes
- ✅ Net diff: +21/-10 in a single file (`provider.ts`)

## Todos

Wait to be tested in long run.