### PR TITLE
fix(lsp): time out server spawn attempts

### DIFF
--- a/packages/synergy/src/lsp/index.ts
+++ b/packages/synergy/src/lsp/index.ts
@@ -62,6 +62,20 @@ export namespace LSP {
     })
   export type DocumentSymbol = z.infer<typeof DocumentSymbol>
 
+  const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+        }),
+      ])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
   const filterExperimentalServers = (servers: Record<string, LSPServer.Info>) => {
     if (Flag.SYNERGY_EXPERIMENTAL_LSP_TY) {
       // If experimental flag is enabled, disable pyright
@@ -196,8 +210,11 @@ export namespace LSP {
     const result: LSPClient.Info[] = []
 
     async function schedule(server: LSPServer.Info, root: string, key: string) {
-      const handle = await server
-        .spawn(root)
+      const handle = await withTimeout(
+        server.spawn(root),
+        30_000,
+        `Timed out spawning LSP server ${server.id}`,
+      )
         .then((value) => {
           if (!value) s.broken.add(key)
           return value


### PR DESCRIPTION
## Summary

Add a 30s timeout around LSP server spawn attempts so file writes do not hang indefinitely when an LSP server tries to download missing binaries over an unavailable network.

## Context

We hit this with `.tex` writes: `write` calls `LSP.touchFile()`, which matches `.tex` to `texlab`. If `texlab` is not installed, Synergy attempts to download it from GitHub releases. In restricted network environments, that fetch may hang indefinitely, which blocks the write tool.

## Temporary workaround

Locally we temporarily set:

```sh
SYNERGY_DISABLE_LSP_DOWNLOAD=1
```

This avoids the hang by disabling automatic LSP downloads, but it is only a workaround: missing LSP servers will not be auto-installed, so diagnostics for those languages may be unavailable unless the server is installed manually.

## Fix

This PR keeps existing auto-download behavior, but bounds the spawn path with a timeout. If an LSP server spawn/download stalls, it is marked broken and the write flow can continue instead of freezing.