### PR TITLE
fix(compaction): remove anchor injection that causes post-compact drift

### DIFF
--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -251,49 +251,6 @@ export namespace SessionCompaction {
     }
   }
 
-  const ANCHOR_OPEN = "<anchor>"
-  const ANCHOR_CLOSE = "</anchor>"
-
-  /**
-   * Build the anchor text that preserves the user's original request across
-   * compaction boundaries.  If a previous compaction already embedded an
-   * anchor in one of the continue messages, reuse it verbatim so the same
-   * text survives any number of compactions without degradation.
-   */
-  function buildAnchor(messages: MessageV2.WithParts[]): string | undefined {
-    // Check if a previous compaction already embedded an anchor.
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i]
-      if (msg.info.role !== "user") continue
-      for (const part of msg.parts) {
-        if (part.type === "text" && part.synthetic && part.text.startsWith(ANCHOR_OPEN)) {
-          return part.text
-        }
-      }
-    }
-
-    // First compaction — extract the original user request.
-    for (const msg of messages) {
-      if (msg.info.role !== "user") continue
-      const textParts = msg.parts.filter((p): p is MessageV2.TextPart => p.type === "text" && !p.synthetic)
-      if (textParts.length === 0) continue
-      const text = textParts
-        .map((p) => p.text)
-        .join("\n")
-        .trim()
-      if (!text) continue
-      return [
-        ANCHOR_OPEN,
-        "This is the user's original request that initiated this work session.",
-        "",
-        text,
-        ANCHOR_CLOSE,
-      ].join("\n")
-    }
-
-    return undefined
-  }
-
   export async function process(input: {
     parentID: string
     messages: MessageV2.WithParts[]
@@ -434,18 +391,6 @@ export namespace SessionCompaction {
         text: "Continue if you have next steps",
         time: { start: now, end: now },
       })
-      const anchor = buildAnchor(input.messages)
-      if (anchor) {
-        await Session.updatePart({
-          id: Identifier.ascending("part"),
-          messageID: continueMsg.id,
-          sessionID: input.sessionID,
-          type: "text",
-          synthetic: true,
-          text: anchor,
-          time: { start: now, end: now },
-        })
-      }
     }
     Bus.publish(Event.Compacted, { sessionID: input.sessionID })
     return input.auto ? "continue" : "stop"

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -464,7 +464,7 @@ export namespace MessageV2 {
         }
         result.push(userMessage)
         for (const part of msg.parts) {
-          if (part.type === "text" && !part.ignored)
+          if (part.type === "text" && !part.ignored && !part.synthetic)
             userMessage.parts.push({
               type: "text",
               text: part.text,

--- a/packages/synergy/test/session/message-v2.test.ts
+++ b/packages/synergy/test/session/message-v2.test.ts
@@ -94,7 +94,7 @@ describe("session.message-v2.toModelMessage", () => {
     expect(MessageV2.toModelMessage(input)).toStrictEqual([])
   })
 
-  test("includes synthetic text parts", () => {
+  test("excludes synthetic user text parts from model messages", () => {
     const messageID = "m-user"
 
     const input: MessageV2.WithParts[] = [
@@ -104,7 +104,13 @@ describe("session.message-v2.toModelMessage", () => {
           {
             ...basePart(messageID, "p1"),
             type: "text",
-            text: "hello",
+            text: "real user message",
+            synthetic: false,
+          },
+          {
+            ...basePart(messageID, "p2"),
+            type: "text",
+            text: "synthetic continuation",
             synthetic: true,
           },
         ] as MessageV2.Part[],
@@ -116,7 +122,6 @@ describe("session.message-v2.toModelMessage", () => {
             ...basePart("m-assistant", "a1"),
             type: "text",
             text: "assistant",
-            synthetic: true,
           },
         ] as MessageV2.Part[],
       },
@@ -125,7 +130,7 @@ describe("session.message-v2.toModelMessage", () => {
     expect(MessageV2.toModelMessage(input)).toStrictEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "hello" }],
+        content: [{ type: "text", text: "real user message" }],
       },
       {
         role: "assistant",


### PR DESCRIPTION
## Why

After automatic compaction, the agent frequently drifts away from its current task and instead resumes the session's very first user request. This is caused by the `buildAnchor()` function injecting the session-start request as a `<anchor>` synthetic text part into the post-compact continue message, which then occupies the highest-recency position in the LLM context.

Closes #32

## What

**Commit 1 — Remove anchor injection** (`compaction.ts`):
- Delete `buildAnchor()` function and its `ANCHOR_OPEN`/`ANCHOR_CLOSE` constants
- Remove the anchor injection block in the auto-compaction continue message creation
- The compaction summary (generated by the LLM summarization prompt) already preserves the current task state, making the anchor redundant

**Commit 2 — Defensive: exclude synthetic user text from model messages** (`message-v2.ts`):
- Add `!part.synthetic` check in `toModelMessage()` for user text parts
- Previously only `ignored` was filtered; synthetic text parts (like the "Continue if you have next steps" prompt) were passed through to the LLM as real user input
- This prevents any future synthetic content from leaking into model context

**Commit 3 — Update test** (`message-v2.test.ts`):
- Update the `toModelMessage` test to verify synthetic user text is now excluded
- Renamed from "includes synthetic text parts" to "excludes synthetic user text parts from model messages"

## Tests

- All 57 tests in `compaction.test.ts`, `message-v2.test.ts`, and `invoke-compaction.test.ts` pass
- The failing test was the one that asserted synthetic parts were included — updated to match the new correct behavior

## Out of scope

- No changes to compaction summary quality or the compaction LLM prompt
- No changes to how the invoke loop resolves `lastUser` (the continue message is still the last user, but now it only contains "Continue if you have next steps" without the anchor override)