### PR TITLE
fix(agent): preserve explicit memory deny in primary-agent permission patch

### DIFF
--- a/packages/synergy/src/agent/agent.ts
+++ b/packages/synergy/src/agent/agent.ts
@@ -148,7 +148,16 @@ export namespace Agent {
       }
     }
 
-    for (const item of Object.values(result)) {
+    for (const [name, item] of Object.entries(result)) {
+      // Skip agents that explicitly deny memory_write/memory_edit (e.g. synergy-max).
+      // The blanket allow-patch uses PermissionNext.merge() which appends rules, and
+      // PermissionNext.evaluate() uses findLast() — so this patch would silently
+      // override any explicit "deny" configured in the agent's own permission builder.
+      const hasExplicitMemoryDeny = item.permission.some(
+        (r) => (r.permission === "memory_write" || r.permission === "memory_edit") && r.action === "deny",
+      )
+      if (hasExplicitMemoryDeny) continue
+
       if (item.mode === "primary" && item.hidden !== true) {
         item.permission = PermissionNext.merge(
           item.permission,


### PR DESCRIPTION
## Body

### 问题

`Agent.list()` 有一段构建时的通用补丁，它会无条件给所有 primary agent 追加 `memory_write: allow` 和 `memory_edit: allow`：

```ts
for (const item of Object.values(result)) {
  if (item.mode === "primary" && item.hidden !== true) {
    item.permission = PermissionNext.merge(
      item.permission,
      PermissionNext.fromConfig({
        memory_write: "allow",
        memory_edit: "allow",
      }),
    )
  }
}
```

`PermissionNext.merge()` 使用 `rulesets.flat()` 简单拼接规则数组。`PermissionNext.evaluate()` 用 `Array.findLast()` 解析规则——最后一条匹配的规则胜出。

这意味着这个通用补丁会静默覆盖某个 primary agent 在自己的 permission builder 中明确设置的 `deny`。具体来说，`synergy-max` 的 `maxPrimaryPermission()` 明确设置了：

```ts
memory_write: "deny",
memory_edit: "deny",
```

目的是强制将 memory 操作路由给 `memory-curator` 子 agent，而不是直接调用工具。但通用补丁执行后，实际的权限链变成了：

| 顺序 | 来源 | 结果 |
|------|------|------|
| [0]–[18] | ctx.defaults（19 条基线规则） | — |
| [19]–[34] | `maxPrimaryPermission()` | memory_write: deny, memory_edit: deny |
| [35]–[36] | agent.ts 通用补丁 | memory_write: allow, memory_edit: allow ✅ 胜出 |

`deny` 被静默忽略了。尽管 synergy-max 自身的权限配置明确 deny，它仍然可以直接调用 `memory_write`。

### 修复

在应用通用补丁之前，检查 agent 是否已经对 `memory_write` 或 `memory_edit` 有显式的 deny。如果有，则跳过该 agent 的补丁：

```ts
const hasExplicitMemoryDeny = item.permission.some(
  (r) => (r.permission === "memory_write" || r.permission === "memory_edit") && r.action === "deny",
)
if (hasExplicitMemoryDeny) continue
```

这是最小化的修复方案（方案 A）。更系统化的方案是修改 `PermissionNext.merge()` 的语义，让显式 deny 永远优先于通用补丁——但那涉及更大的行为变更，不在此次范围。

### 复现步骤

1. 通过 `GET /agent` 检查 `synergy-max` 的权限规则集
2. 观察到尽管 `maxPrimaryPermission()` 明确 deny，`memory_write` 和 `memory_edit` 实际解析为 `allow`
3. 应用本修复后，synergy-max 正确拒绝直接调用 memory 工具