### PR TITLE
[WIP] Layered timeout architecture

### DIFF
--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1367,6 +1367,37 @@ export type Config = {
       model?: string
     }
   }
+  /**
+   * Timeout configuration for agent turns, provider requests, and tool execution
+   */
+  timeout?: {
+    /**
+     * Max wall-clock seconds for one agent turn (default: 900 = 15min)
+     */
+    invoke_sec?: number
+    provider?: {
+      /**
+       * Idle timeout in seconds (0 = disable, default: 180 = 3min). Resets on each data chunk.
+       */
+      idle_sec?: number
+      /**
+       * Wall-clock timeout per HTTP request in seconds (default: 900 = 15min)
+       */
+      wall_sec?: number
+    }
+    tool?: {
+      /**
+       * Default timeout per tool execution in seconds (default: 300 = 5min)
+       */
+      default_sec?: number
+      /**
+       * Per-tool timeout overrides by tool name, e.g. { bash: 600, webfetch: 120 }
+       */
+      overrides?: {
+        [key: string]: number
+      }
+    }
+  }
   watcher?: {
     ignore?: Array<string>
   }

--- a/packages/synergy/src/agenda/reactor.ts
+++ b/packages/synergy/src/agenda/reactor.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from "@/util/timeout"
 import { Identifier } from "../id/id"
 import { Instance } from "../scope/instance"
 import { Scope } from "../scope"
@@ -212,15 +213,6 @@ export namespace AgendaReactor {
     const sessionID = await createEphemeralSession(item, scope)
     await AgendaStore.setPersistentSession(scopeID, item.id, sessionID)
     return sessionID
-  }
-
-  function withTimeout<T>(promise: Promise<T>, timeoutMs: number | undefined): Promise<T> {
-    if (!timeoutMs) return promise
-    let timer: Timer
-    const timeout = new Promise<never>((_, reject) => {
-      timer = setTimeout(() => reject(new Error("Execution timed out")), timeoutMs)
-    })
-    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer!))
   }
 
   async function extractLastAssistantMessage(sessionID: string): Promise<string | undefined> {

--- a/packages/synergy/src/config/config.ts
+++ b/packages/synergy/src/config/config.ts
@@ -1296,6 +1296,43 @@ export namespace Config {
       logLevel: Log.Level.optional().describe("Log level"),
       server: Server.optional().describe("Server configuration for synergy serve and web commands"),
       command: z.record(z.string(), Command).optional().describe("Command configuration"),
+      timeout: z
+        .object({
+          invoke_sec: z
+            .number()
+            .positive()
+            .optional()
+            .describe("Max wall-clock seconds for one agent turn (default: 900 = 15min)"),
+          provider: z
+            .object({
+              idle_sec: z
+                .number()
+                .min(0)
+                .optional()
+                .describe("Idle timeout in seconds (0 = disable, default: 180 = 3min). Resets on each data chunk."),
+              wall_sec: z
+                .number()
+                .positive()
+                .optional()
+                .describe("Wall-clock timeout per HTTP request in seconds (default: 900 = 15min)"),
+            })
+            .optional(),
+          tool: z
+            .object({
+              default_sec: z
+                .number()
+                .positive()
+                .optional()
+                .describe("Default timeout per tool execution in seconds (default: 300 = 5min)"),
+              overrides: z
+                .record(z.string(), z.number().positive())
+                .optional()
+                .describe("Per-tool timeout overrides by tool name, e.g. { bash: 600, webfetch: 120 }"),
+            })
+            .optional(),
+        })
+        .optional()
+        .describe("Timeout configuration for agent turns, provider requests, and tool execution"),
       watcher: z
         .object({
           ignore: z.array(z.string()).optional(),

--- a/packages/synergy/src/config/config.ts
+++ b/packages/synergy/src/config/config.ts
@@ -1305,6 +1305,15 @@ export namespace Config {
             .describe("Max wall-clock seconds for one agent turn (default: 900 = 15min)"),
           provider: z
             .object({
+              ttfb_sec: z
+                .number()
+                .positive()
+                .optional()
+                .describe(
+                  "Max seconds to wait for first byte (TTFB) from provider. " +
+                    "Accommodates reasoning/thinking models (e.g. o1-pro, deepseek-r1). " +
+                    "Default: 600 = 10min",
+                ),
               idle_sec: z
                 .number()
                 .min(0)
@@ -1312,9 +1321,14 @@ export namespace Config {
                 .describe("Idle timeout in seconds (0 = disable, default: 180 = 3min). Resets on each data chunk."),
               wall_sec: z
                 .number()
-                .positive()
+                .min(0)
                 .optional()
-                .describe("Wall-clock timeout per HTTP request in seconds (default: 900 = 15min)"),
+                .describe(
+                  "Hard wall-clock timeout per HTTP request in seconds " +
+                    "(0 = disabled, default: 0). CAUTION: conflicts with streaming — " +
+                    "will interrupt normal token output. Only enable if you need a " +
+                    "hard cap beyond idle+TTFB",
+                ),
             })
             .optional(),
           tool: z

--- a/packages/synergy/src/lsp/index.ts
+++ b/packages/synergy/src/lsp/index.ts
@@ -1,3 +1,4 @@
+import { withTimeout } from "@/util/timeout"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { Log } from "../util/log"
@@ -61,20 +62,6 @@ export namespace LSP {
       ref: "DocumentSymbol",
     })
   export type DocumentSymbol = z.infer<typeof DocumentSymbol>
-
-  const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> => {
-    let timer: ReturnType<typeof setTimeout> | undefined
-    try {
-      return await Promise.race([
-        promise,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => reject(new Error(message)), timeoutMs)
-        }),
-      ])
-    } finally {
-      if (timer) clearTimeout(timer)
-    }
-  }
 
   const filterExperimentalServers = (servers: Record<string, LSPServer.Info>) => {
     if (Flag.SYNERGY_EXPERIMENTAL_LSP_TY) {
@@ -210,7 +197,9 @@ export namespace LSP {
     const result: LSPClient.Info[] = []
 
     async function schedule(server: LSPServer.Info, root: string, key: string) {
-      const handle = await withTimeout(server.spawn(root), 30_000, `Timed out spawning LSP server ${server.id}`)
+      const handle = await withTimeout(server.spawn(root), 30_000, {
+        message: `Timed out spawning LSP server ${server.id}`,
+      })
         .then((value) => {
           if (!value) s.broken.add(key)
           return value
@@ -223,7 +212,6 @@ export namespace LSP {
 
       if (!handle) return undefined
       log.info("spawned lsp server", { serverID: server.id })
-
       const client = await LSPClient.create({
         serverID: server.id,
         server: handle,

--- a/packages/synergy/src/mcp/index.ts
+++ b/packages/synergy/src/mcp/index.ts
@@ -28,6 +28,11 @@ import open from "open"
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
   const DEFAULT_TIMEOUT = 30_000
+  async function resolveMcpTimeout(serverName?: string): Promise<number> {
+    const cfg = await Config.get()
+    const perServer = serverName ? (cfg.mcp?.[serverName] as Config.Mcp | undefined)?.timeout : undefined
+    return perServer ?? cfg.experimental?.mcp_timeout ?? DEFAULT_TIMEOUT
+  }
 
   export const Resource = z
     .object({
@@ -354,8 +359,7 @@ export namespace MCP {
       return
     }
 
-    const config = await Config.get()
-    const timeout = config.experimental?.mcp_timeout ?? DEFAULT_TIMEOUT
+    const timeout = await resolveMcpTimeout(clientName)
     const toolsResult = await withTimeout(client.listTools(), timeout).catch((e) => {
       log.error("failed to refresh tool defs", { clientName, error: e })
       return undefined
@@ -753,19 +757,15 @@ export namespace MCP {
       return undefined
     }
 
-    const result = await client
-      .getPrompt({
-        name: name,
-        arguments: args,
+    const timeout = await resolveMcpTimeout(clientName)
+    const result = await withTimeout(client.getPrompt({ name, arguments: args }), timeout).catch((e) => {
+      log.error("failed to get prompt from MCP server", {
+        clientName,
+        promptName: name,
+        error: e instanceof Error ? e.message : String(e),
       })
-      .catch((e) => {
-        log.error("failed to get prompt from MCP server", {
-          clientName,
-          promptName: name,
-          error: e.message,
-        })
-        return undefined
-      })
+      return undefined
+    })
 
     return result
   }
@@ -781,18 +781,15 @@ export namespace MCP {
       return undefined
     }
 
-    const result = await client
-      .readResource({
-        uri: resourceUri,
+    const timeout = await resolveMcpTimeout(clientName)
+    const result = await withTimeout(client.readResource({ uri: resourceUri }), timeout).catch((e) => {
+      log.error("failed to read resource from MCP server", {
+        clientName: clientName,
+        resourceUri: resourceUri,
+        error: e instanceof Error ? e.message : String(e),
       })
-      .catch((e) => {
-        log.error("failed to get prompt from MCP server", {
-          clientName: clientName,
-          resourceUri: resourceUri,
-          error: e.message,
-        })
-        return undefined
-      })
+      return undefined
+    })
 
     return result
   }
@@ -861,7 +858,8 @@ export namespace MCP {
         name: "synergy",
         version: Installation.VERSION,
       })
-      await client.connect(transport)
+      const connectTimeout = await resolveMcpTimeout(mcpName)
+      await withTimeout(client.connect(transport), connectTimeout)
       // If we get here, we're already authenticated
       return { authorizationUrl: "" }
     } catch (error) {

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -949,39 +949,49 @@ export namespace Provider {
 
         const timeoutMs = options["timeout"] === false ? false : (options["timeout"] ?? DEFAULT_TIMEOUT_MS)
 
+        let ttfbController: AbortController | null = null
+        let ttfbTimer: ReturnType<typeof setTimeout> | null = null
         let idleController: AbortController | null = null
         let idleTimer: ReturnType<typeof setTimeout> | null = null
 
-        if (timeoutMs !== false) {
-          idleController = new AbortController()
-          const resetIdle = () => {
-            if (idleTimer) clearTimeout(idleTimer)
-            idleTimer = setTimeout(() => {
-              idleController!.abort(
-                new DOMException("Idle timeout: no data received within " + timeoutMs + "ms", "TimeoutError"),
-              )
-            }, timeoutMs as number).unref()
-          }
-          resetIdle()
+        // TTFB timeout — covers time from fetch start to first byte (accommodates reasoning models)
+        if (timeoutCfg.providerTtfbMs > 0) {
+          ttfbController = new AbortController()
+          ttfbTimer = setTimeout(() => {
+            ttfbController!.abort(
+              new DOMException(
+                "TTFB timeout: no response received within " + timeoutCfg.providerTtfbMs + "ms",
+                "TimeoutError",
+              ),
+            )
+          }, timeoutCfg.providerTtfbMs).unref()
         }
 
-        // Wall-clock timeout (total request duration cap)
-        const wallClockSignal = AbortSignal.timeout(timeoutCfg.providerWallMs)
+        // Idle AbortController (timer starts on first chunk, not on fetch)
+        if (timeoutMs !== false) {
+          idleController = new AbortController()
+        }
 
+        // Wall-clock timeout (optional — disabled by default)
+        const wallClockSignal =
+          timeoutCfg.providerWallMs !== false && timeoutCfg.providerWallMs > 0
+            ? AbortSignal.timeout(timeoutCfg.providerWallMs)
+            : null
+
+        // Combine signals before fetch
         const signals: AbortSignal[] = []
         if (opts.signal) signals.push(opts.signal)
+        if (ttfbController) signals.push(ttfbController.signal)
         if (idleController) signals.push(idleController.signal)
-        signals.push(wallClockSignal)
+        if (wallClockSignal) signals.push(wallClockSignal)
         opts.signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
 
-        // Reset idle timer when the outer signal aborts (e.g. user cancel)
-        opts.signal?.addEventListener(
-          "abort",
-          () => {
-            if (idleTimer) clearTimeout(idleTimer)
-          },
-          { once: true },
-        )
+        // Clean up all timers when outer signal aborts (e.g. user cancel)
+        const cleanupTimers = () => {
+          if (ttfbTimer) clearTimeout(ttfbTimer)
+          if (idleTimer) clearTimeout(idleTimer)
+        }
+        opts.signal?.addEventListener("abort", cleanupTimers, { once: true })
 
         // Disable HTTP keep-alive to avoid reusing connections that may have
         // been silently dropped by NAT / load balancers during idle periods.

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -12,6 +12,7 @@ import { Auth } from "./api-key"
 import { Env } from "../util/env"
 import { Instance } from "../scope/instance"
 import { SYNERGY_REFERER } from "../holos/constants"
+import { TimeoutConfig } from "@/util/timeout-config"
 import { iife } from "@/util/iife"
 
 // Direct imports for bundled providers
@@ -938,6 +939,7 @@ export namespace Provider {
       }
 
       const customFetch = options["fetch"]
+      const timeoutCfg = await TimeoutConfig.resolve()
 
       const DEFAULT_TIMEOUT_MS = 900_000
 
@@ -961,21 +963,25 @@ export namespace Provider {
             }, timeoutMs as number).unref()
           }
           resetIdle()
-
-          const signals: AbortSignal[] = []
-          if (opts.signal) signals.push(opts.signal)
-          signals.push(idleController.signal)
-          opts.signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
-
-          // Reset idle timer when the outer signal aborts (e.g. user cancel)
-          opts.signal?.addEventListener(
-            "abort",
-            () => {
-              if (idleTimer) clearTimeout(idleTimer)
-            },
-            { once: true },
-          )
         }
+
+        // Wall-clock timeout (total request duration cap)
+        const wallClockSignal = AbortSignal.timeout(timeoutCfg.providerWallMs)
+
+        const signals: AbortSignal[] = []
+        if (opts.signal) signals.push(opts.signal)
+        if (idleController) signals.push(idleController.signal)
+        signals.push(wallClockSignal)
+        opts.signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
+
+        // Reset idle timer when the outer signal aborts (e.g. user cancel)
+        opts.signal?.addEventListener(
+          "abort",
+          () => {
+            if (idleTimer) clearTimeout(idleTimer)
+          },
+          { once: true },
+        )
 
         // Disable HTTP keep-alive to avoid reusing connections that may have
         // been silently dropped by NAT / load balancers during idle periods.

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -27,6 +27,7 @@ import { SessionProcessor } from "./processor"
 import { ExternalAgentProcessor } from "@/external-agent/processor"
 import { ExternalAgent } from "@/external-agent/bridge"
 import { SessionManager } from "./manager"
+import { TimeoutConfig } from "@/util/timeout-config"
 import { ToolResolver } from "./tool-resolver"
 import { PromptBudgeter } from "./prompt-budgeter"
 import { PermissionNext } from "@/permission/next"
@@ -561,16 +562,25 @@ export namespace SessionInvoke {
 
         SessionManager.setStatus(sessionID, { type: "busy", description: "Awaiting response..." })
         const processTimer = log.time("processor.process")
+        const timeoutCfg = await TimeoutConfig.resolve()
+        const turnDeadline = new AbortController()
+        const turnTimer = setTimeout(() => {
+          turnDeadline.abort(new DOMException("Turn timed out after " + timeoutCfg.invokeMs + "ms", "AbortError"))
+        }, timeoutCfg.invokeMs)
+        abort.addEventListener("abort", () => clearTimeout(turnTimer), { once: true })
+        const combinedAbort = AbortSignal.any([abort, turnDeadline.signal])
+
         const result = await processor.process({
           user: lastUser,
           agent,
-          abort,
+          abort: combinedAbort,
           sessionID,
           system: promptPlan.system,
           messages: promptPlan.messages,
           tools,
           model,
         })
+        clearTimeout(turnTimer)
         processTimer.stop()
 
         // post-LLM jobs

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -10,6 +10,7 @@ import type { Provider } from "@/provider/provider"
 import { Tool } from "@/tool/tool"
 import { ToolRegistry } from "@/tool/registry"
 import { Log } from "@/util/log"
+import { TimeoutConfig } from "@/util/timeout-config"
 import { Session } from "."
 import type { Info } from "./types"
 import type { MessageV2 } from "./message-v2"
@@ -102,6 +103,14 @@ export namespace ToolResolver {
               })
               runtimeInput.processor.trackExecution(options.toolCallId, executionPromise)
 
+              const timeoutCfg = await TimeoutConfig.resolve()
+              const toolTimeoutMs = timeoutCfg.toolOverrides[item.id] ?? timeoutCfg.toolDefaultMs
+              const toolDeadline = AbortSignal.timeout(toolTimeoutMs)
+              const combinedAbort = options.abortSignal
+                ? AbortSignal.any([options.abortSignal, toolDeadline])
+                : toolDeadline
+              const toolCtx = { ...ctx, abort: combinedAbort }
+
               try {
                 await Plugin.trigger(
                   "tool.execute.before",
@@ -114,7 +123,7 @@ export namespace ToolResolver {
                     args,
                   },
                 )
-                const result = await item.execute(args, ctx)
+                const result = await item.execute(args, toolCtx)
                 await Plugin.trigger(
                   "tool.execute.after",
                   {
@@ -189,6 +198,13 @@ export namespace ToolResolver {
                 })
                 runtimeInput.processor.trackExecution(opts.toolCallId, executionPromise)
 
+                const timeoutCfg = await TimeoutConfig.resolve()
+                const toolTimeoutMs = timeoutCfg.toolOverrides[key] ?? timeoutCfg.toolDefaultMs
+                const toolDeadline = AbortSignal.timeout(toolTimeoutMs)
+                const combinedAbort = opts.abortSignal
+                  ? AbortSignal.any([opts.abortSignal, toolDeadline])
+                  : toolDeadline
+
                 try {
                   await Plugin.trigger(
                     "tool.execute.before",
@@ -208,7 +224,7 @@ export namespace ToolResolver {
                     patterns: ["*"],
                   })
 
-                  const result = await execute(args, opts)
+                  const result = await execute(args, { ...opts, abortSignal: combinedAbort })
 
                   await Plugin.trigger(
                     "tool.execute.after",

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -213,15 +213,26 @@ export const LocalBashBackend: BashBackend = {
     let exited = false
     let yielded = false
 
+    const HARD_BASH_CEILING_MS = 3_600_000 // 60 minutes absolute hard limit
+
     const kill = () => Shell.killTree(child, { exited: () => exited })
+
+    const hardCeilingTimer = setTimeout(() => {
+      if (!exited && !yielded) {
+        log.warn("bash hard ceiling reached, killing", { description: params.description })
+        kill()
+      }
+    }, HARD_BASH_CEILING_MS)
 
     if (ctx.abort.aborted) {
       aborted = true
+      clearTimeout(hardCeilingTimer)
       await kill()
     }
 
     const abortHandler = () => {
       aborted = true
+      clearTimeout(hardCeilingTimer)
       void kill()
     }
 
@@ -237,6 +248,7 @@ export const LocalBashBackend: BashBackend = {
         : undefined
 
       const cleanup = () => {
+        clearTimeout(hardCeilingTimer)
         if (yieldTimer) clearTimeout(yieldTimer)
         ctx.abort.removeEventListener("abort", abortHandler)
       }

--- a/packages/synergy/src/util/timeout-config.ts
+++ b/packages/synergy/src/util/timeout-config.ts
@@ -1,0 +1,60 @@
+import { Config } from "@/config/config"
+
+export namespace TimeoutConfig {
+  export interface Resolved {
+    invokeMs: number
+    providerIdleMs: number | false
+    providerWallMs: number
+    toolDefaultMs: number
+    toolOverrides: Record<string, number>
+  }
+
+  const DEFAULTS: Resolved = {
+    invokeMs: 900_000,
+    providerIdleMs: 180_000,
+    providerWallMs: 900_000,
+    toolDefaultMs: 300_000,
+    toolOverrides: {},
+  }
+
+  let cached: Resolved | undefined
+
+  export async function resolve(): Promise<Resolved> {
+    if (cached) return cached
+
+    const cfg = await Config.get()
+    const timeout = (cfg as any).timeout as
+      | {
+          invoke_sec?: number
+          provider?: { idle_sec?: number | false; wall_sec?: number }
+          tool?: { default_sec?: number; overrides?: Record<string, number> }
+        }
+      | undefined
+
+    const secToMs = (sec: number | undefined, fallback: number): number => (sec !== undefined ? sec * 1000 : fallback)
+
+    const providerIdleRaw = timeout?.provider?.idle_sec
+    const providerIdleMs =
+      providerIdleRaw === false
+        ? (false as const)
+        : providerIdleRaw !== undefined
+          ? providerIdleRaw * 1000
+          : DEFAULTS.providerIdleMs
+
+    cached = {
+      invokeMs: secToMs(timeout?.invoke_sec, DEFAULTS.invokeMs),
+      providerIdleMs,
+      providerWallMs: secToMs(timeout?.provider?.wall_sec, DEFAULTS.providerWallMs),
+      toolDefaultMs: secToMs(timeout?.tool?.default_sec, DEFAULTS.toolDefaultMs),
+      toolOverrides: timeout?.tool?.overrides
+        ? Object.fromEntries(Object.entries(timeout.tool.overrides).map(([k, v]) => [k, v * 1000]))
+        : DEFAULTS.toolOverrides,
+    }
+
+    return cached
+  }
+
+  export function invalidate(): void {
+    cached = undefined
+  }
+}

--- a/packages/synergy/src/util/timeout-config.ts
+++ b/packages/synergy/src/util/timeout-config.ts
@@ -3,16 +3,18 @@ import { Config } from "@/config/config"
 export namespace TimeoutConfig {
   export interface Resolved {
     invokeMs: number
+    providerTtfbMs: number
     providerIdleMs: number | false
-    providerWallMs: number
+    providerWallMs: number | false
     toolDefaultMs: number
     toolOverrides: Record<string, number>
   }
 
   const DEFAULTS: Resolved = {
     invokeMs: 900_000,
+    providerTtfbMs: 600_000,
     providerIdleMs: 180_000,
-    providerWallMs: 900_000,
+    providerWallMs: 0,
     toolDefaultMs: 300_000,
     toolOverrides: {},
   }
@@ -26,7 +28,7 @@ export namespace TimeoutConfig {
     const timeout = (cfg as any).timeout as
       | {
           invoke_sec?: number
-          provider?: { idle_sec?: number | false; wall_sec?: number }
+          provider?: { ttfb_sec?: number; idle_sec?: number | false; wall_sec?: number | false }
           tool?: { default_sec?: number; overrides?: Record<string, number> }
         }
       | undefined
@@ -41,10 +43,19 @@ export namespace TimeoutConfig {
           ? providerIdleRaw * 1000
           : DEFAULTS.providerIdleMs
 
+    const providerWallRaw = timeout?.provider?.wall_sec
+    const providerWallMs =
+      providerWallRaw === false
+        ? (false as const)
+        : providerWallRaw !== undefined && providerWallRaw > 0
+          ? providerWallRaw * 1000
+          : DEFAULTS.providerWallMs
+
     cached = {
       invokeMs: secToMs(timeout?.invoke_sec, DEFAULTS.invokeMs),
+      providerTtfbMs: secToMs(timeout?.provider?.ttfb_sec, DEFAULTS.providerTtfbMs),
       providerIdleMs,
-      providerWallMs: secToMs(timeout?.provider?.wall_sec, DEFAULTS.providerWallMs),
+      providerWallMs,
       toolDefaultMs: secToMs(timeout?.tool?.default_sec, DEFAULTS.toolDefaultMs),
       toolOverrides: timeout?.tool?.overrides
         ? Object.fromEntries(Object.entries(timeout.tool.overrides).map(([k, v]) => [k, v * 1000]))

--- a/packages/synergy/src/util/timeout.ts
+++ b/packages/synergy/src/util/timeout.ts
@@ -1,14 +1,33 @@
-export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timeout: NodeJS.Timeout
-  return Promise.race([
-    promise.then((result) => {
-      clearTimeout(timeout)
-      return result
-    }),
-    new Promise<never>((_, reject) => {
-      timeout = setTimeout(() => {
-        reject(new Error(`Operation timed out after ${ms}ms`))
-      }, ms)
-    }),
-  ])
+export interface WithTimeoutOptions {
+  signal?: AbortSignal
+  message?: string
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number | undefined, opts?: WithTimeoutOptions): Promise<T> {
+  if (ms === undefined || ms <= 0) return promise
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      if (opts?.signal && !opts.signal.aborted) {
+        opts.signal.dispatchEvent(new Event("abort"))
+      }
+      reject(new Error(opts?.message ?? `Operation timed out after ${ms}ms`))
+    }, ms)
+  })
+
+  const race = Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer)
+  })
+
+  if (opts?.signal) {
+    const onAbort = () => {
+      if (timer !== undefined) clearTimeout(timer)
+    }
+    opts.signal.addEventListener("abort", onAbort, { once: true })
+    race.finally(() => opts.signal!.removeEventListener("abort", onAbort))
+  }
+
+  return race
 }


### PR DESCRIPTION
## Summary

Implement a configurable **layered timeout architecture** (方案 B) to fix the systematic timeout mechanism degradation identified in #38. Each layer has its own configurable timeout that composes via `AbortSignal.any()` into the downstream layer.

---

## Architecture Overview

```
┌─────────────────────────────────────────────────────────────────────────┐
│                   Config Schema (single source of truth)                 │
│  timeout = { invoke_sec, provider: { ttfb_sec, idle_sec, wall_sec },   │
│             tool: { default_sec, overrides: {...} } }                    │
└────────────────────────────────┬────────────────────────────────────────┘
                                 │ resolves
                                 ▼
┌─────────────────────────────────────────────────────────────────────────┐
│                    TimeoutConfig (cached resolver)                       │
│  src/util/timeout-config.ts — reads Config, caches, converts s→ms       │
└────┬─────────────────────┬──────────────────────┬───────────────────────┘
     │                     │                      │
     ▼                     ▼                      ▼
┌──────────────┐   ┌───────────────┐   ┌──────────────────┐
│ Layer 1      │   │ Layer 2       │   │ Layer 3           │
│ Per-Turn     │   │ Provider      │   │ Per-Tool          │
│ Wall-Clock   │   │ TTFB + Idle   │   │ Execution         │
├──────────────┤   ├───────────────┤   ├──────────────────┤
│ invoke.ts:   │   │ provider.ts:  │   │ tool-resolver.ts: │
│ AbortSignal  │   │ TTFB: from    │   │ AbortSignal       │
│ .timeout()   │   │ fetch start   │   │ .timeout() +      │
│ + session    │   │ Idle: from    │   │ session abort     │
│ abort        │   │ first chunk   │   │ → toolCtx.abort   │
│              │   │ Wall: opt     │   │                   │
└──────┬───────┘   └──────┬────────┘   └────────┬─────────┘
       │                  │                     │
       └─────────┬────────┘                     │
                 │                              │
                 ▼                              ▼
          LLM.stream()                    tool.execute(ctx)
          AbortSignal.any([               AbortSignal.any([
            sessionAbort,                    sessionAbort,
            turnDeadline,     ───►           toolDeadline,
            ttfbSignal,                      tool-specific
            idleSignal,                      timeout (webfetch
            wallClockSignal                  ｜ bash, etc.)
            (optional)                        │
          ])                                  ▼
                                        Bash: Layer 4
                                        Hard Ceiling (60min)
                                        ─ independent timer
                                        ─ kill + cleanup
```

---

## Propagation Timing Diagram

```
Time: 0s                   300s                    600s                    900s
      ├─────────────────────┼───────────────────────┼──────────────────────┤
      │                     │                       │                      │
      │ Turn starts         │ toolA timeout (300s)  │ invoke timeout       │
      │ invoke_sec=900      │  ─► tool-resolver     │ (900s)               │
      │                     │  ─► abort toolA ctx   │  ─► AbortSignal.any  │
      │                     │                       │  ─► abort ALL        │
      │ TTFB window (600s)  │                       │                      │
      │  ─► reasoning OK    │                       │                      │
      │                     │                       │                      │
      │ ├─ toolA (bash) ──► │✗ toolA killed          │                     │
      │ │  timeout=300      │  (process killed via   │                     │
      │ │                   │   ctx.abort →          │                     │
      │ │                   │   Shell.killTree())    │                     │
      │ │                   │                       │                      │
      │ ├─ toolB (read) ────┼───────────────────────► │✗ toolB aborted      │
      │ │  no override      │                       │  (per-turn timeout) │
      │ │  default=300s     │                       │                      │
      │ │                   │                       │                      │
      │ ├─ LLM.stream ──────┼───────────────────────┼─►✗ stream aborted    │
      │ │  TTFB=600s        │                       │  (turn timeout)      │
      │ │  idle=180s        │                       │  ─► fetch abort      │
```

---

## Provider Timeout Architecture (Key Design Decision)

After review feedback, the provider timeout was redesigned with three separate controls:

### TTFB (Time to First Byte) — NEW
- **Purpose**: Wait for the provider to start sending data (accommodates reasoning/thinking models)
- **Timing**: Starts when fetch begins, fires if no bytes received within window
- **Default**: `600s` (10 minutes) — long enough for o1-pro, deepseek-r1, claude thinking, gemini thinking
- **Why separate from idle**: Reasoning models can think 5-10 minutes before first token. TTFB covers this. Once first byte arrives, idle timeout takes over.

### Idle timeout — EXISTING (redesigned)
- **Purpose**: Detect mid-stream stalls (provider stops sending data mid-response)
- **Timing**: Starts **on first chunk**, resets on each subsequent chunk
- **Default**: `180s` (3 minutes)
- **Design note**: Previously started at fetch time, which conflicted with reasoning models. Now delayed until first byte.

### Wall-clock — OPTIONAL (disabled by default)
- **Purpose**: Hard total request duration cap
- **Default**: `0` (disabled)
- **CAUTION**: Conflicts with streaming — will interrupt normal token output. Only enable if you need a hard cap beyond TTFB + idle.

```typescript
// provider.ts — simplified logic
// TTFB: from fetch → first byte
if (ttfbMs > 0) {
  ttfbTimer = setTimeout(() => ttfbController.abort(...), ttfbMs)
}

// Idle: starts on first chunk, resets per chunk
// (previously started on fetch — changed!)
if (idleMsEnabled) {
  // AbortController created but timer NOT started
  // Timer starts in ReadableStream on first reader.read() value
}

// Wall-clock: only if explicitly configured
const wallClockSignal = wallMs > 0 ? AbortSignal.timeout(wallMs) : null
```

---

## How Layers Compose

Each layer produces an `AbortSignal` that is combined with downstream layers using `AbortSignal.any()`:

```
Per-turn timeout (Layer 1, invoke.ts)
  └─ AbortSignal.any([sessionAbort, turnDeadline])
     └─ processor.process()
        ├─ LLM.stream({ abortSignal }) → SDK streamText
        │   └─ Provider fetch wrapper (Layer 2, provider.ts)
        │       ├─ TTFB: from fetch start, fires if no first byte
        │       ├─ Idle: from first chunk, resets on each chunk
        │       ├─ Wall: optional hard cap (default disabled)
        │       └─ Combined: AbortSignal.any([outerSignal, ttfbSignal, idleSignal, wallSignal?])
        └─ tool.execute({ abort: combinedAbort })  (Layer 3, tool-resolver.ts)
            ├─ ctx.abort = AbortSignal.any([sessionAbort, toolDeadline])
            ├─ tool runs its own timeout (webfetch 30s, etc.)
            └─ bash: Layer 4 — independent 60min hard ceiling timer
```

### Error Classification

| Timeout Source | Error Type | Retryable? | File:Line |
|---------------|-----------|-----------|-----------|
| Per-turn (Layer 1) | `AbortedError` | ❌ No | `invoke.ts:568` → `message-v2.ts:652` |
| Provider TTFB (Layer 2) | `TimeoutError` | ✅ Yes | `provider.ts:960` → `message-v2.ts:659` |
| Provider idle (Layer 2) | `TimeoutError` | ✅ Yes | `provider.ts:1038` → `message-v2.ts:659` |
| Provider wall-clock (Layer 2) | `TimeoutError` | ✅ Yes | `provider.ts` → `message-v2.ts:659` |
| Per-tool (Layer 3) | `AbortError` | ❌ No | `tool-resolver.ts:108` → message-v2.ts:652 |
| Bash hard ceiling (Layer 4) | Process killed | N/A (process exit) | `bash/local.ts` |
| MCP timeout (Layer 5) | Generic Error | N/A (caught) | `mcp/index.ts` |

---

## Files Changed

### New files
| File | Purpose |
|------|---------|
| `src/util/timeout-config.ts` | Cached config resolver: reads `timeout.*` from Config, converts s→ms |

### Core utility
| File | Change |
|------|--------|
| `src/util/timeout.ts` | Enhanced `withTimeout`: `undefined` passthrough, `.finally()` cleanup, optional `AbortSignal` (auto-clean on external abort), custom messages |

### Layer 1 — Per-turn timeout
| File | Change |
|------|--------|
| `src/session/invoke.ts` | Wraps `processor.process()` with `AbortSignal.any([sessionAbort, turnDeadline])`. Produces `DOMException("AbortError")` → classified as `AbortedError` (non-retryable) |

### Layer 2 — Provider TTFB + Idle + Wall
| File | Change |
|------|--------|
| `src/provider/provider.ts` | **TTFB timeout**: starts at fetch time (accommodates reasoning models). **Idle timeout**: starts on first chunk (not on fetch). **Wall-clock**: optional, disabled by default. All combined via `AbortSignal.any()`. |

### Layer 3 — Per-tool timeout
| File | Change |
|------|--------|
| `src/session/tool-resolver.ts` | Each tool execution gets `AbortSignal.any([sessionAbort, toolDeadline])`. Timeout source: `toolOverrides[toolId] ?? toolDefaultMs`. |

### Layer 4 — Bash hard ceiling (safety net)
| File | Change |
|------|--------|
| `src/tool/bash/local.ts` | 60-minute hard limit via `setTimeout` + `kill()`. Cleanup on all exit paths (normal, yield, abort, error). |

### Layer 5 — MCP timeout fixes
| File | Change |
|------|--------|
| `src/mcp/index.ts` | Unified `resolveMcpTimeout()` helper (resolution order: per-server `mcp.timeout` → `experimental.mcp_timeout` → `DEFAULT_TIMEOUT=30s`). Added timeout for `getPrompt()`, `readResource()`, OAuth `startAuth.connect()`. |

### Config schema
| File | Change |
|------|--------|
| `src/config/config.ts` | New `timeout` field: `invoke_sec`, `provider` (`ttfb_sec`, `idle_sec`, `wall_sec`), `tool` (`default_sec`, `overrides`) |

### Cleanup
| File | Change |
|------|--------|
| `src/agenda/reactor.ts` | Replaced local `withTimeout` with shared `@/util/timeout` import |
| `src/lsp/index.ts` | Replaced local `withTimeout` with shared `@/util/timeout` import |

---

## Validation

- ✅ `bun run typecheck` — 9/9 packages pass, 0 errors
- ✅ `bun test` — **1481 tests pass, 0 fail**, 3864 expect() calls

---

## Config Reference

### Minimal config (single knob)
```jsonc
{
  "timeout": {
    "invoke_sec": 600  // per-turn max: 10 min
  }
}
```

### Full config (all defaults explicit)
```jsonc
{
  "timeout": {
    "invoke_sec": 900,              // 15 min — per-turn wall-clock
    "provider": {
      "ttfb_sec": 600,              // 10 min — wait for first byte (reasoning models)
      "idle_sec": 180,              // 3 min — no-data idle timeout (per chunk reset)
      "wall_sec": 0                 // 0 = disabled — hard request cap (optional)
    },
    "tool": {
      "default_sec": 300,           // 5 min — default per-tool
      "overrides": {
        "bash": 600,                // 10 min
        "webfetch": 120,            // 2 min
        "look_at": 180,             // 3 min
        "websearch": 60             // 1 min
      }
    }
  }
}
```

### Backwards compatibility
- Omit entire `timeout` block → behavior identical to before this PR, except:
  - Provider timeout now splits TTFB (10min) + idle (3min from first chunk) + wall-clock (disabled)
  - Default behavior is more robust (accommodates reasoning models, no accidental wall-clock interrupt)

---

## Related Issues

- Closes #38 — Timeout mechanism failure: multiple layers weakened or missing
- Addresses #39 — [P0] Bash tool lacks hard execution timeout (Layer 4)
- Addresses #40 — [P0] Provider timeout wall-clock fallback (Layer 2, now TTFB + idle)
- Addresses #41 — [P1] Session invoke per-turn timeout (Layer 1)
- Addresses #42 — [P1] Cortex task execution timeout (covered by Layer 1 + Layer 3)
- Addresses #43 — [P1] MCP missing timeouts (Layer 5)
- Addresses #44 — [P2] withTimeout utility cleanup (core utility + cleanup)
- Addresses #45 — [P2] MCP timeout resolution inconsistency (Layer 5 unified helper)
