### PR TITLE
fix(glob): add timeout and abort signal protection to glob/list tools

### DIFF
--- a/packages/synergy/src/file/index.ts
+++ b/packages/synergy/src/file/index.ts
@@ -175,8 +175,11 @@ export namespace File {
         return
       }
 
+      const INDEX_TIMEOUT_MS = 30_000
+      const timeoutSignal = AbortSignal.timeout(INDEX_TIMEOUT_MS)
       const set = new Set<string>()
-      for await (const file of Ripgrep.files({ cwd: Instance.directory })) {
+      for await (const file of Ripgrep.files({ cwd: Instance.directory, signal: timeoutSignal })) {
+        if (timeoutSignal.aborted) break
         result.files.push(file)
         let current = file
         while (true) {

--- a/packages/synergy/src/file/ripgrep.ts
+++ b/packages/synergy/src/file/ripgrep.ts
@@ -218,6 +218,7 @@ export namespace Ripgrep {
     hidden?: boolean
     follow?: boolean
     maxDepth?: number
+    signal?: AbortSignal
   }) {
     const args = [await filepath(), "--files", "--glob=!.git/*"]
     if (input.follow !== false) args.push("--follow")
@@ -246,6 +247,10 @@ export namespace Ripgrep {
       maxBuffer: 1024 * 1024 * 20,
     })
 
+    // Wire abort signal to kill the subprocess
+    const onAbort = () => proc.kill()
+    input.signal?.addEventListener("abort", onAbort, { once: true })
+
     const reader = proc.stdout.getReader()
     const decoder = new TextDecoder()
     let buffer = ""
@@ -254,6 +259,7 @@ export namespace Ripgrep {
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
+        if (input.signal?.aborted) break
 
         buffer += decoder.decode(value, { stream: true })
         // Handle both Unix (\n) and Windows (\r\n) line endings
@@ -265,8 +271,10 @@ export namespace Ripgrep {
         }
       }
 
-      if (buffer) yield buffer
+      // Don't yield partial buffer on abort — content may be incomplete
+      if (buffer && !input.signal?.aborted) yield buffer
     } finally {
+      input.signal?.removeEventListener("abort", onAbort)
       reader.releaseLock()
       await proc.exited
     }

--- a/packages/synergy/src/tool/glob.ts
+++ b/packages/synergy/src/tool/glob.ts
@@ -29,27 +29,50 @@ export const GlobTool = Tool.define("glob", {
     let search = params.path ?? Instance.directory
     search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
 
+    const TIMEOUT_MS = 15_000
     const limit = 100
     const files = []
     let truncated = false
-    for await (const file of Ripgrep.files({
-      cwd: search,
-      glob: [params.pattern],
-    })) {
-      if (files.length >= limit) {
-        truncated = true
-        break
+    let timedOut = false
+
+    // Combine local timeout with session abort signal
+    const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS)
+    const combinedSignal = ctx.abort ? AbortSignal.any([ctx.abort, timeoutSignal]) : timeoutSignal
+
+    try {
+      for await (const file of Ripgrep.files({
+        cwd: search,
+        glob: [params.pattern],
+        signal: combinedSignal,
+      })) {
+        if (files.length >= limit) {
+          truncated = true
+          break
+        }
+        const full = path.resolve(search, file)
+        const stats = await Bun.file(full)
+          .stat()
+          .then((x) => x.mtime.getTime())
+          .catch(() => 0)
+        files.push({
+          path: full,
+          mtime: stats,
+        })
       }
-      const full = path.resolve(search, file)
-      const stats = await Bun.file(full)
-        .stat()
-        .then((x) => x.mtime.getTime())
-        .catch(() => 0)
-      files.push({
-        path: full,
-        mtime: stats,
-      })
+    } catch {
+      // Subprocess was killed — check if it was our timeout
+      if (timeoutSignal.aborted && !ctx.abort?.aborted) {
+        timedOut = true
+      }
     }
+
+    if (timedOut) {
+      throw new Error(
+        `glob stopped after ${TIMEOUT_MS}ms before completing the search.\n` +
+          `Use a more specific glob pattern or specify a smaller directory path.`,
+      )
+    }
+
     files.sort((a, b) => b.mtime - a.mtime)
 
     const output = []

--- a/packages/synergy/src/tool/ls.ts
+++ b/packages/synergy/src/tool/ls.ts
@@ -51,12 +51,35 @@ export const ListTool = Tool.define("list", {
       },
     })
 
+    const TIMEOUT_MS = 15_000
     const ignoreGlobs = IGNORE_PATTERNS.map((p) => `!${p}*`).concat(params.ignore?.map((p) => `!${p}`) || [])
     const files = []
-    for await (const file of Ripgrep.files({ cwd: searchPath, glob: ignoreGlobs })) {
-      files.push(file)
-      if (files.length >= LIMIT) break
+    let timedOut = false
+
+    // Combine local timeout with session abort signal
+    const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS)
+    const combinedSignal = ctx.abort ? AbortSignal.any([ctx.abort, timeoutSignal]) : timeoutSignal
+
+    try {
+      for await (const file of Ripgrep.files({ cwd: searchPath, glob: ignoreGlobs, signal: combinedSignal })) {
+        files.push(file)
+        if (files.length >= LIMIT) break
+      }
+    } catch {
+      // Subprocess was killed — check if it was our timeout
+      if (timeoutSignal.aborted && !ctx.abort?.aborted) {
+        timedOut = true
+      }
     }
+
+    if (timedOut) {
+      throw new Error(
+        `list stopped after ${TIMEOUT_MS}ms before completing the listing.\n` +
+          `The directory may be too large. Specify a more specific path or add ignore patterns.`,
+      )
+    }
+
+    const truncated = files.length >= LIMIT
 
     // Build directory structure
     const dirs = new Set<string>()
@@ -96,8 +119,8 @@ export const ListTool = Tool.define("list", {
       }
 
       // Render files
-      const files = filesByDir.get(dirPath) || []
-      for (const file of files.sort()) {
+      const dirFiles = filesByDir.get(dirPath) || []
+      for (const file of dirFiles.sort()) {
         output += `${childIndent}${file}\n`
       }
 

--- a/packages/synergy/test/file/ripgrep.test.ts
+++ b/packages/synergy/test/file/ripgrep.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Ripgrep } from "../../src/file/ripgrep"
+import { tmpdir } from "../fixture/fixture"
+
+describe("Ripgrep.files", () => {
+  test("yields all files without signal parameter (backward compat)", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "alpha.ts"), "// alpha\n")
+        await Bun.write(path.join(dir, "beta.ts"), "// beta\n")
+        await Bun.write(path.join(dir, "gamma.ts"), "// gamma\n")
+      },
+    })
+
+    const results: string[] = []
+    for await (const file of Ripgrep.files({ cwd: tmp.path })) {
+      results.push(file)
+    }
+
+    const basenames = results.map((f) => path.basename(f)).sort()
+    expect(basenames).toEqual(["alpha.ts", "beta.ts", "gamma.ts"])
+  })
+
+  test("yields all files when signal is present but never aborted", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "one.ts"), "// one\n")
+        await Bun.write(path.join(dir, "two.ts"), "// two\n")
+      },
+    })
+
+    const controller = new AbortController()
+    const results: string[] = []
+    for await (const file of Ripgrep.files({ cwd: tmp.path, signal: controller.signal })) {
+      results.push(file)
+    }
+
+    const basenames = results.map((f) => path.basename(f)).sort()
+    expect(basenames).toEqual(["one.ts", "two.ts"])
+    // Signal was never aborted — controller still alive
+    expect(controller.signal.aborted).toBe(false)
+  })
+
+  test("aborted signal exits generator cleanly without throwing", async () => {
+    // Create enough files that ripgrep output spans multiple pipe reads,
+    // so aborting mid-iteration prevents yielding all files.
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        for (let i = 0; i < 300; i++) {
+          await Bun.write(path.join(dir, `file-${String(i).padStart(4, "0")}.ts`), `// file ${i}\n`)
+        }
+      },
+    })
+
+    const controller = new AbortController()
+    const results: string[] = []
+
+    for await (const file of Ripgrep.files({ cwd: tmp.path, signal: controller.signal })) {
+      results.push(file)
+      // Abort after yielding the first file
+      if (results.length === 1) {
+        controller.abort()
+      }
+    }
+
+    // Generator completed without throwing — this is the primary invariant.
+    // Signal should be in aborted state after the explicit abort.
+    expect(controller.signal.aborted).toBe(true)
+
+    // If ripgrep output was buffered into a single pipe read (fast system /
+    // small output), all files may still be yielded. That's acceptable — the
+    // abort path (proc.kill, finally cleanup) is still exercised. When output
+    // exceeds a single pipe buffer, fewer files will be yielded.
+  })
+
+  test("aborted signal prevents yielding partial buffer remnants", async () => {
+    // Create many files so the generator likely reads multiple pipe chunks.
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        for (let i = 0; i < 300; i++) {
+          await Bun.write(path.join(dir, `entry-${String(i).padStart(4, "0")}.txt`), `line ${i}\n`)
+        }
+      },
+    })
+
+    const controller = new AbortController()
+    const yielded: string[] = []
+
+    for await (const file of Ripgrep.files({ cwd: tmp.path, signal: controller.signal })) {
+      yielded.push(file)
+      if (yielded.length === 1) {
+        controller.abort()
+      }
+    }
+
+    // Every yielded result must be a complete path ending with .txt.
+    // A partial buffer remnant would be a truncated filename like "entry-00"
+    // without the extension.
+    for (const entry of yielded) {
+      expect(entry).toEndWith(".txt")
+    }
+
+    // Generator completed without throwing — abort path was exercised.
+    expect(controller.signal.aborted).toBe(true)
+  })
+})

--- a/packages/synergy/test/tool/glob-ls.test.ts
+++ b/packages/synergy/test/tool/glob-ls.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { GlobTool } from "../../src/tool/glob"
+import { ListTool } from "../../src/tool/ls"
+import { Instance } from "../../src/scope/instance"
+import { tmpdir } from "../fixture/fixture"
+
+const ctx = {
+  sessionID: "test-glob-ls",
+  messageID: "",
+  callID: "",
+  agent: "test-strategist",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+}
+
+/**
+ * Build a ctx with a pre-aborted signal. The combined signal
+ * (AbortSignal.any([preAborted, timeoutSignal])) is immediately aborted,
+ * so Ripgrep is killed before producing any output.
+ */
+function abortedCtx() {
+  const controller = new AbortController()
+  controller.abort()
+  return { ...ctx, abort: controller.signal }
+}
+
+describe("tool.glob", () => {
+  test("finds files matching pattern in a small directory", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), "// a\n")
+        await Bun.write(path.join(dir, "b.ts"), "// b\n")
+        await Bun.write(path.join(dir, "c.txt"), "c\n")
+        await Bun.write(path.join(dir, "d.md"), "d\n")
+      },
+    })
+
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const tool = await GlobTool.init()
+        const result = await tool.execute({ pattern: "*.ts" }, ctx)
+
+        expect(result.metadata.truncated).toBe(false)
+        expect(result.metadata.count).toBe(2)
+        expect(result.output).toContain("a.ts")
+        expect(result.output).toContain("b.ts")
+        expect(result.output).not.toContain("c.txt")
+        expect(result.output).not.toContain("d.md")
+      },
+    })
+  })
+
+  test("returns empty result and not truncated when no files match", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (_dir) => {},
+    })
+
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const tool = await GlobTool.init()
+        const result = await tool.execute({ pattern: "*.zzz" }, ctx)
+
+        expect(result.metadata.truncated).toBe(false)
+        expect(result.metadata.count).toBe(0)
+        expect(result.output).toContain("No files found")
+      },
+    })
+  })
+
+  test("returns partial results without throwing when ctx.abort is already aborted", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), "// a\n")
+        await Bun.write(path.join(dir, "b.ts"), "// b\n")
+      },
+    })
+
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const tool = await GlobTool.init()
+        // ctx.abort is pre-aborted — the tool must not throw
+        const result = await tool.execute({ pattern: "*.ts" }, abortedCtx())
+
+        // User abort must NOT set truncated (only timeout does)
+        expect(result.metadata.truncated).toBe(false)
+        // Output should exist (may be empty or partial — don't crash)
+        expect(typeof result.output).toBe("string")
+        expect(result.metadata.count).toBeGreaterThanOrEqual(0)
+      },
+    })
+  })
+
+  test("outputs truncation message when truncated is true via limit", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        // Create 101 files so the 100-file limit triggers truncated
+        for (let i = 0; i < 101; i++) {
+          await Bun.write(path.join(dir, `file_${String(i).padStart(3, "0")}.ts`), `// ${i}\n`)
+        }
+      },
+    })
+
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const tool = await GlobTool.init()
+        const result = await tool.execute({ pattern: "*.ts" }, ctx)
+
+        expect(result.metadata.truncated).toBe(true)
+        expect(result.metadata.count).toBe(100)
+        expect(result.output).toContain("(Results are truncated.")
+      },
+    })
+  })
+})
+
+describe("tool.list", () => {
+  test("returns directory tree for a small directory", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), "a\n")
+        await Bun.write(path.join(dir, "b.ts"), "b\n")
+      },
+    })
+
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const tool = await ListTool.init()
+        const result = await tool.execute({}, ctx)
+
+        expect(result.metadata.truncated).toBe(false)
+        expect(result.metadata.count).toBeGreaterThanOrEqual(1)
+        expect(result.output).toContain("a.ts")
+        expect(result.output).toContain("b.ts")
+      },
+    })
+  })
+
+  test("returns partial results without throwing when ctx.abort is already aborted", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), "a\n")
+      },
+    })
+
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const tool = await ListTool.init()
+        // ctx.abort is pre-aborted — the tool must not throw
+        const result = await tool.execute({}, abortedCtx())
+
+        // User abort must NOT set truncated (only timeout does)
+        expect(result.metadata.truncated).toBe(false)
+        expect(typeof result.output).toBe("string")
+        expect(result.metadata.count).toBeGreaterThanOrEqual(0)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`Ripgrep.files()` 之前没有任何超时机制——`reader.read()` 和 `proc.exited` 在 NFS、超大仓库、或文件系统异常时可以无限挂起。

## Changes

### Core: `Ripgrep.files()` — `src/file/ripgrep.ts`
- 新增 `signal?: AbortSignal` 参数
- Abort 触发时 kill rg 子进程并干净退出生成器
- `reader.read()` 循环中检查 `signal.aborted`，不在 abort 后 yield 部分缓冲数据
- finally 块中清理 event listener、释放 reader

### 工具层 — `src/tool/glob.ts` + `src/tool/ls.ts`
- 15 秒 `AbortSignal.timeout()`，与 `ctx.abort` 组合
- 超时时抛出语义化 Error，告诉 Agent 发生了超时以及如何缩小搜索范围
- 用户取消（非超时）时不抛错误，静默返回部分结果

### 保护扩展 — `src/file/index.ts`
- 后台文件索引器加 30 秒 `AbortSignal.timeout()` 保护

### 测试
- `test/file/ripgrep.test.ts` — 4 个测试：向后兼容、信号正常时全量 yield、abort 后干净退出、buffer 完整性
- `test/tool/glob-ls.test.ts` — 6 个测试：正常 glob/list、空结果、用户取消不抛、limit truncation
- 全量 1491 测试通过，无回归

## 与 PR #46 的关系
此 PR 依赖 PR #46 的 `ctx.abort` 信号框架（tool-resolver 层生成 `AbortSignal.any`），但在此之上完成了信号的实际消费链路。

## Testing
- `bun run typecheck` ✅
- `bun test` — 1491 pass, 0 fail ✅
- 新增测试不使用任何真实时间延迟（同步 abort 和假信号模式）