### PR TITLE
fix(provider): guard reasoningEffort/textVerbosity behind native npm check, fix openrouter smallOptions shape

### DIFF
--- a/packages/synergy/src/provider/transform.ts
+++ b/packages/synergy/src/provider/transform.ts
@@ -599,24 +599,27 @@ export namespace ProviderTransform {
 
     if (model.api.id.includes("gpt-5") && !model.api.id.includes("gpt-5-chat")) {
       if (!model.api.id.includes("codex") && !model.api.id.includes("gpt-5-pro")) {
-        result["reasoningEffort"] = "medium"
-        // Only inject reasoningSummary for providers that support it natively.
-        // @ai-sdk/openai-compatible proxies (e.g. LiteLLM) do not understand this parameter.
+        // Only inject reasoningEffort for providers that support it natively.
+        // @ai-sdk/openai-compatible proxies (e.g. LiteLLM) do not support reasoningEffort + tools
+        // on /v1/chat/completions and will return a 400 error.
         if (
           model.api.npm === "@ai-sdk/openai" ||
           model.api.npm === "@ai-sdk/azure" ||
           model.api.npm === "@ai-sdk/github-copilot"
         ) {
+          result["reasoningEffort"] = "medium"
           result["reasoningSummary"] = "auto"
         }
       }
 
-      // Only set textVerbosity for non-chat gpt-5.x models (not codex, not chat variants)
+      // Only set textVerbosity for native openai/azure/copilot providers (Responses API feature).
+      // @ai-sdk/openai-compatible proxies do not support this parameter.
       if (
         model.api.id.includes("gpt-5.") &&
         !model.api.id.includes("codex") &&
         !model.api.id.includes("-chat") &&
-        model.providerID !== "azure"
+        model.providerID !== "azure" &&
+        (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/github-copilot")
       ) {
         result["textVerbosity"] = "low"
       }
@@ -649,7 +652,7 @@ export namespace ProviderTransform {
       if (model.api.id.includes("google")) {
         return { reasoning: { enabled: false } }
       }
-      return { reasoningEffort: "minimal" }
+      return { reasoning: { effort: "minimal" } }
     }
     return {}
   }


### PR DESCRIPTION
## Summary

- **`reasoningEffort` + `reasoningSummary` now gated behind native npm check** — previously injected unconditionally for any `gpt-5` model, causing `400` errors when using `@ai-sdk/openai-compatible` providers (e.g. LiteLLM proxies) because `/v1/chat/completions` rejects `reasoning_effort` when tools are present. Now only injected when npm is `@ai-sdk/openai`, `@ai-sdk/azure`, or `@ai-sdk/github-copilot`.

- **`textVerbosity` similarly gated** — this is a Responses API-specific field; added the same npm guard to prevent it being sent to incompatible proxy backends.

- **Fix openrouter `smallOptions` shape** — `reasoningEffort: "minimal"` → `reasoning: { effort: "minimal" }` to match the actual openrouter API contract.

## Root Cause

`reasoningSummary` at line ~605 already had the npm guard (added with a comment about openai-compatible proxies), but `reasoningEffort` directly above it did not — an inconsistency that caused silent 400s for any user who configured a `gpt-5.x` model through an openai-compatible proxy.

## Test

Typecheck and formatting pass (`bun turbo typecheck` + Prettier).