### PR TITLE
fix(ui): add execCommand fallback for clipboard in insecure contexts

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -11,6 +11,30 @@ const max = 200
 const cache = new Map<string, Entry>()
 const copyResetDelay = 2000
 
+/** Copy text to clipboard, falling back to execCommand for insecure contexts (http://IP, tailscale http) */
+async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text)
+    return true
+  }
+  // Fallback for HTTP / non-secure contexts (user-gesture-triggered only)
+  try {
+    const ta = document.createElement("textarea")
+    ta.value = text
+    ta.style.position = "fixed"
+    ta.style.opacity = "0"
+    ta.style.pointerEvents = "none"
+    document.body.appendChild(ta)
+    ta.focus()
+    ta.select()
+    const ok = document.execCommand("copy")
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}
+
 function touch(key: string, value: Entry) {
   cache.delete(key)
   cache.set(key, value)
@@ -58,28 +82,25 @@ function enhanceMarkdown(root: HTMLDivElement) {
 
     const handleKatexClick = async (e: MouseEvent) => {
       e.stopPropagation()
-      try {
-        await navigator.clipboard.writeText(source)
-        // Show "Copied" tooltip
-        const tooltip = document.createElement("span")
-        tooltip.dataset.slot = "katex-copy-tooltip"
-        tooltip.textContent = "Copied!"
-        // Ensure the element is positioned for the tooltip
-        const prevPosition = katexEl.style.position
-        if (!prevPosition || prevPosition === "static") {
-          katexEl.style.position = "relative"
-        }
-        katexEl.appendChild(tooltip)
-        window.clearTimeout(resetTimer)
-        resetTimer = window.setTimeout(() => {
-          tooltip.remove()
-          if (!prevPosition || prevPosition === "static") {
-            katexEl.style.position = prevPosition || ""
-          }
-        }, copyResetDelay)
-      } catch {
-        // clipboard failed silently
+      const ok = await copyToClipboard(source)
+      if (!ok) return
+      // Show "Copied" tooltip
+      const tooltip = document.createElement("span")
+      tooltip.dataset.slot = "katex-copy-tooltip"
+      tooltip.textContent = "Copied!"
+      // Ensure the element is positioned for the tooltip
+      const prevPosition = katexEl.style.position
+      if (!prevPosition || prevPosition === "static") {
+        katexEl.style.position = "relative"
       }
+      katexEl.appendChild(tooltip)
+      window.clearTimeout(resetTimer)
+      resetTimer = window.setTimeout(() => {
+        tooltip.remove()
+        if (!prevPosition || prevPosition === "static") {
+          katexEl.style.position = prevPosition || ""
+        }
+      }, copyResetDelay)
     }
 
     katexEl.addEventListener("click", handleKatexClick)
@@ -136,13 +157,11 @@ function enhanceMarkdown(root: HTMLDivElement) {
     setCopied(false)
 
     const handleClick = async () => {
-      try {
-        await navigator.clipboard.writeText(source)
-        window.clearTimeout(resetTimer)
-        setCopied(true)
+      const ok = await copyToClipboard(source)
+      window.clearTimeout(resetTimer)
+      setCopied(ok)
+      if (ok) {
         resetTimer = window.setTimeout(() => setCopied(false), copyResetDelay)
-      } catch {
-        setCopied(false)
       }
     }
 

--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -53,9 +53,30 @@ export function TextField(props: TextFieldProps) {
 
   async function handleCopy() {
     const value = local.value ?? local.defaultValue ?? ""
-    await navigator.clipboard.writeText(value)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    let ok = false
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(value)
+      ok = true
+    } else {
+      try {
+        const ta = document.createElement("textarea")
+        ta.value = value
+        ta.style.position = "fixed"
+        ta.style.opacity = "0"
+        ta.style.pointerEvents = "none"
+        document.body.appendChild(ta)
+        ta.focus()
+        ta.select()
+        ok = document.execCommand("copy")
+        document.body.removeChild(ta)
+      } catch {
+        /* execCommand failed */
+      }
+    }
+    if (ok) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
   }
 
   function handleClick() {


### PR DESCRIPTION
## Problem

`navigator.clipboard.writeText()` requires a [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`). When accessing Synergy over a plain HTTP address such as a Tailscale IP (`http://100.x.x.x:18080`), all three copy buttons silently fail:

- Code block **Copy** button
- KaTeX formula click-to-copy
- `TextField` copyable button

## Solution

Add a `copyToClipboard()` helper in `markdown.tsx` that:
1. Uses `navigator.clipboard.writeText()` when `window.isSecureContext` is true (HTTPS / localhost) — no behaviour change for secure contexts
2. Falls back to the `textarea` + `document.execCommand('copy')` pattern for non-secure contexts — works as long as the call is triggered by a user gesture (button click), which it always is here

Apply the same inline fallback to `TextField.handleCopy()`.

## Changes

- `packages/ui/src/components/markdown.tsx` — new `copyToClipboard()` helper; replace direct `navigator.clipboard` calls in `handleKatexClick` and `handleClick`
- `packages/ui/src/components/text-field.tsx` — inline fallback in `handleCopy`