### PR TITLE
fix(session): clear pendingReply after loop completes

### DIFF
--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -656,6 +656,13 @@ export namespace SessionInvoke {
 
     evictRecallCache(sessionID)
 
+    // Clear pendingReply — the loop has fully completed and the assistant has
+    // replied. Without this, a crashed/restarted server would see pendingReply=true
+    // on already-finished sessions and incorrectly re-trigger loop() via resumePending().
+    await Session.update(sessionID, (draft) => {
+      draft.pendingReply = undefined
+    })
+
     let resultMessage = selectResultMessage(await Session.messages({ sessionID }))
     if (!resultMessage) {
       resultMessage = await writeAbortedAssistantMessage(sessionID, scopeID)


### PR DESCRIPTION
## Summary

- `pendingReply` is set to `true` before `loop()` is called (in both `invoke()` and `processMailbox()`), but was **never cleared** when `loop()` finished normally.
- Every completed session permanently retains `pendingReply=true` in its persisted metadata.
- `resumePending()` is already implemented in `invoke.ts` and designed to scan all `pendingReply=true` sessions on server startup, re-triggering `loop()` for any that genuinely still need a reply — but it is currently **unreachable dead code** (no call site exists).

## Impact

| Scenario | Impact |
|---|---|
| Normal running server | **None.** UI uses WebSocket `busy`/`idle` signal, not `pendingReply`. |
| Server crash + restart (if `resumePending()` were wired in) | **Severe.** Every already-finished session with `pendingReply=true` would have `loop()` re-triggered, causing ghost replies. |
| Current state | Latent bug — no active harm because `resumePending()` is never called, but the flag lifecycle is semantically incorrect and creates a trap for future crash-recovery work. |

## Fix

Clear `pendingReply = undefined` at the single exit point of `loop()` — after draining assistant mails and evicting the recall cache, before returning the result message. This is the one place where we know:
1. All tool calls and sub-turns are complete
2. The assistant has produced a terminal reply
3. The session is idle

```typescript
// After evictRecallCache(sessionID):
await Session.update(sessionID, (draft) => {
  draft.pendingReply = undefined
})
```

## Testing

- TypeScript typecheck passes (`bun turbo typecheck`)
- Change is additive — does not affect any running-server behavior, only corrects persisted state
- Enables safe future activation of `resumePending()` for crash recovery