### PR TITLE
fix(agenda): support isolated recurring runs and harden scheduling

### DIFF
--- a/packages/synergy/src/agenda/index.ts
+++ b/packages/synergy/src/agenda/index.ts
@@ -143,8 +143,12 @@ export namespace Agenda {
   }
 
   function syncItem(scopeID: string, item: AgendaTypes.Item): void {
-    if (item.state.nextRunAt !== undefined) {
-      AgendaClock.rearm(scopeID, item.id, item.state.nextRunAt)
+    // If nextRunAt is missing (e.g. after a patch that didn't touch triggers),
+    // recompute from the item's triggers rather than silently unloading the
+    // clock entry. Only unload if the triggers genuinely produce no future run.
+    const nextRunAt = item.state.nextRunAt ?? AgendaStore.computeNextRunAt(item.triggers)
+    if (nextRunAt !== undefined) {
+      AgendaClock.rearm(scopeID, item.id, nextRunAt)
     } else {
       AgendaClock.unload(item.id)
     }

--- a/packages/synergy/src/agenda/reactor.ts
+++ b/packages/synergy/src/agenda/reactor.ts
@@ -140,6 +140,18 @@ export namespace AgendaReactor {
       if (sessionID && !error) {
         lastMessage = await extractLastAssistantMessage(sessionID)
       }
+      // Archive ephemeral sessions so they don't accumulate in the session list.
+      // Do this after extracting the last message but before state management.
+      if (sessionID && !persistent) {
+        await Session.update(sessionID, (draft) => {
+          draft.time.archived = Date.now()
+        }).catch((err) => {
+          log.warn("failed to archive ephemeral session", {
+            sessionID,
+            error: err instanceof Error ? err : new Error(String(err)),
+          })
+        })
+      }
     }
 
     const duration = Date.now() - startTime

--- a/packages/synergy/src/agenda/reactor.ts
+++ b/packages/synergy/src/agenda/reactor.ts
@@ -85,7 +85,7 @@ export namespace AgendaReactor {
     } else {
       // Normal path — create session, run prompt via SessionInvoke
       const scope = item.origin.scope ?? Scope.global()
-      const sessionMode = AgendaTypes.inferSessionMode(item.triggers)
+      const sessionMode = AgendaTypes.inferSessionMode(item.triggers, item.sessionMode)
       const contextMode = AgendaTypes.inferContextMode(sessionMode)
       const persistent = sessionMode === "persistent"
 

--- a/packages/synergy/src/agenda/reactor.ts
+++ b/packages/synergy/src/agenda/reactor.ts
@@ -27,7 +27,12 @@ export namespace AgendaReactor {
       return await run(signal, scopeID)
     } catch (err) {
       log.error("execute failed", { itemID: signal.source, error: err instanceof Error ? err : new Error(String(err)) })
-      return { nextRunAt: undefined, sessionID: undefined }
+      // Compute a fallback nextRunAt so the clock entry is not permanently
+      // deleted. If the item cannot be read, return undefined as a last resort.
+      const nextRunAt = await AgendaStore.get(scopeID, signal.source)
+        .then((item) => AgendaStore.computeNextRunAt(item.triggers))
+        .catch(() => undefined)
+      return { nextRunAt, sessionID: undefined }
     }
   }
 

--- a/packages/synergy/src/agenda/reactor.ts
+++ b/packages/synergy/src/agenda/reactor.ts
@@ -222,9 +222,22 @@ export namespace AgendaReactor {
   }
 
   async function createEphemeralSession(item: AgendaTypes.Item, scope: Scope): Promise<string> {
+    // Append a short date to the title so ephemeral sessions are easy to
+    // identify in the session list. Use the cron/every trigger's timezone if
+    // available, otherwise fall back to UTC.
+    const cronTrigger = item.triggers.find(
+      (t): t is AgendaTypes.Trigger & { type: "cron"; tz?: string } => t.type === "cron",
+    )
+    const tz = cronTrigger?.tz
+    const date = new Intl.DateTimeFormat("sv-SE", {
+      timeZone: tz ?? "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date())
     const session = await Session.create({
       scope,
-      title: "Agenda: " + item.title,
+      title: `Agenda: ${item.title} ${date}`,
       agenda: { itemID: item.id },
       interaction: SessionInteraction.unattended("agenda"),
     })

--- a/packages/synergy/src/agenda/reactor.ts
+++ b/packages/synergy/src/agenda/reactor.ts
@@ -45,18 +45,37 @@ export namespace AgendaReactor {
       return { nextRunAt: undefined, sessionID: undefined }
     }
 
-    const before = await Plugin.trigger(
-      "agenda.run.before",
-      {
-        signal,
-        item: storedItem,
-        scopeID,
-      },
-      {
-        skip: false,
-        item: storedItem,
-      },
-    )
+    const scope = storedItem.origin.scope ?? Scope.global()
+    return Instance.provide({ scope, fn: () => runInScope(storedItem, signal, scopeID, scope) })
+  }
+
+  async function runInScope(
+    storedItem: AgendaTypes.Item,
+    signal: AgendaTypes.FiredSignal,
+    scopeID: string,
+    scope: Scope,
+  ): Promise<Result> {
+    let before: { skip: boolean; item: AgendaTypes.Item }
+    try {
+      before = await Plugin.trigger(
+        "agenda.run.before",
+        {
+          signal,
+          item: storedItem,
+          scopeID,
+        },
+        {
+          skip: false,
+          item: storedItem,
+        },
+      )
+    } catch (err) {
+      log.error("agenda.run.before plugin failed", {
+        itemID: storedItem.id,
+        error: err instanceof Error ? err : new Error(String(err)),
+      })
+      before = { skip: false, item: storedItem }
+    }
     if (before.skip) {
       log.info("skipped by plugin", { itemID: storedItem.id, signalType: signal.type })
       return { nextRunAt: AgendaStore.computeNextRunAt(storedItem.triggers), sessionID: undefined }
@@ -89,7 +108,6 @@ export namespace AgendaReactor {
       lastMessage = item.prompt
     } else {
       // Normal path — create session, run prompt via SessionInvoke
-      const scope = item.origin.scope ?? Scope.global()
       const sessionMode = AgendaTypes.inferSessionMode(item.triggers, item.sessionMode)
       const contextMode = AgendaTypes.inferContextMode(sessionMode)
       const persistent = sessionMode === "persistent"
@@ -176,10 +194,17 @@ export namespace AgendaReactor {
     // Plugin hooks — always fire
     // -----------------------------------------------------------------------
 
-    if (error) {
-      await Plugin.trigger("agenda.run.error", { signal, item, scopeID, error: error.message, sessionID }, {})
-    } else {
-      await Plugin.trigger("agenda.run.after", { signal, item, run: runLog, scopeID }, {})
+    try {
+      if (error) {
+        await Plugin.trigger("agenda.run.error", { signal, item, scopeID, error: error.message, sessionID }, {})
+      } else {
+        await Plugin.trigger("agenda.run.after", { signal, item, run: runLog, scopeID }, {})
+      }
+    } catch (err) {
+      log.error("agenda.run plugin hook failed", {
+        itemID: item.id,
+        error: err instanceof Error ? err : new Error(String(err)),
+      })
     }
 
     // -----------------------------------------------------------------------

--- a/packages/synergy/src/agenda/store.ts
+++ b/packages/synergy/src/agenda/store.ts
@@ -182,8 +182,10 @@ export namespace AgendaStore {
       if (patch.wake !== undefined) draft.wake = patch.wake
       if (patch.silent !== undefined) draft.silent = patch.silent
       if (patch.agent !== undefined) draft.agent = patch.agent
+      if (patch.model !== undefined) draft.model = patch.model
       if (patch.sessionMode !== undefined) draft.sessionMode = patch.sessionMode
       if (patch.sessionRefs !== undefined) draft.sessionRefs = patch.sessionRefs
+      if (patch.timeout !== undefined) draft.timeout = patch.timeout
       if (options?.recomputeNextRunAt) {
         draft.state.nextRunAt = computeNextRunAt(draft.triggers, now)
       }

--- a/packages/synergy/src/agenda/store.ts
+++ b/packages/synergy/src/agenda/store.ts
@@ -56,10 +56,12 @@ export namespace AgendaStore {
           break
         }
         case "delay": {
-          if (fromTime !== undefined) {
-            const target = fromTime + parseDuration(trigger.delay)
-            if (target > now) candidates.push(target)
-          }
+          // When fromTime is provided (e.g. at create time), anchor the delay
+          // to it. When called without fromTime (e.g. after an update), anchor
+          // to now so the item is rescheduled rather than silently dropped.
+          const base = fromTime ?? now
+          const target = base + parseDuration(trigger.delay)
+          if (target > now) candidates.push(target)
           break
         }
         case "every": {

--- a/packages/synergy/src/agenda/store.ts
+++ b/packages/synergy/src/agenda/store.ts
@@ -111,6 +111,7 @@ export namespace AgendaStore {
       prompt: input.prompt,
       agent: input.agent,
       model: input.model,
+      sessionMode: input.sessionMode,
       sessionRefs: input.sessionRefs,
       timeout: input.timeout,
       wake: input.wake ?? true,
@@ -180,6 +181,7 @@ export namespace AgendaStore {
       if (patch.wake !== undefined) draft.wake = patch.wake
       if (patch.silent !== undefined) draft.silent = patch.silent
       if (patch.agent !== undefined) draft.agent = patch.agent
+      if (patch.sessionMode !== undefined) draft.sessionMode = patch.sessionMode
       if (patch.sessionRefs !== undefined) draft.sessionRefs = patch.sessionRefs
       if (options?.recomputeNextRunAt) {
         draft.state.nextRunAt = computeNextRunAt(draft.triggers)

--- a/packages/synergy/src/agenda/store.ts
+++ b/packages/synergy/src/agenda/store.ts
@@ -56,12 +56,10 @@ export namespace AgendaStore {
           break
         }
         case "delay": {
-          // When fromTime is provided (e.g. at create time), anchor the delay
-          // to it. When called without fromTime (e.g. after an update), anchor
-          // to now so the item is rescheduled rather than silently dropped.
-          const base = fromTime ?? now
-          const target = base + parseDuration(trigger.delay)
-          if (target > now) candidates.push(target)
+          if (fromTime !== undefined) {
+            const target = fromTime + parseDuration(trigger.delay)
+            if (target > now) candidates.push(target)
+          }
           break
         }
         case "every": {
@@ -164,6 +162,7 @@ export namespace AgendaStore {
     options?: { recomputeNextRunAt?: boolean },
   ): Promise<AgendaTypes.Item> {
     const sid = Identifier.asScopeID(scopeID)
+    const now = Date.now()
     const item = await Storage.update<AgendaTypes.Item>(StoragePath.agendaItem(sid, itemID), (draft) => {
       if (patch.title !== undefined) draft.title = patch.title
       if (patch.description !== undefined) draft.description = patch.description
@@ -176,7 +175,7 @@ export namespace AgendaStore {
           }
         }
         draft.triggers = patch.triggers
-        draft.state.nextRunAt = computeNextRunAt(patch.triggers)
+        draft.state.nextRunAt = computeNextRunAt(patch.triggers, now)
       }
       if (patch.prompt !== undefined) draft.prompt = patch.prompt
       if (patch.global !== undefined) draft.global = patch.global
@@ -186,9 +185,9 @@ export namespace AgendaStore {
       if (patch.sessionMode !== undefined) draft.sessionMode = patch.sessionMode
       if (patch.sessionRefs !== undefined) draft.sessionRefs = patch.sessionRefs
       if (options?.recomputeNextRunAt) {
-        draft.state.nextRunAt = computeNextRunAt(draft.triggers)
+        draft.state.nextRunAt = computeNextRunAt(draft.triggers, now)
       }
-      draft.time.updated = Date.now()
+      draft.time.updated = now
     })
     log.info("updated", { id: itemID })
     await Bus.publish(AgendaEvent.ItemUpdated, { item })

--- a/packages/synergy/src/agenda/types.ts
+++ b/packages/synergy/src/agenda/types.ts
@@ -374,8 +374,10 @@ export namespace AgendaTypes {
       wake: z.boolean().optional(),
       silent: z.boolean().optional(),
       agent: z.string().optional(),
+      model: z.object({ providerID: z.string(), modelID: z.string() }).optional(),
       sessionMode: z.enum(["ephemeral", "persistent"]).optional(),
       sessionRefs: z.array(SessionRef).optional(),
+      timeout: z.number().optional(),
     })
     .meta({ ref: "AgendaPatchInput" })
   export type PatchInput = z.infer<typeof PatchInput>

--- a/packages/synergy/src/agenda/types.ts
+++ b/packages/synergy/src/agenda/types.ts
@@ -104,12 +104,23 @@ export namespace AgendaTypes {
   export type ScheduleTrigger = z.infer<typeof ScheduleTrigger>
 
   // ---------------------------------------------------------------------------
-  // Session mode — inferred internally, not user-facing
+  // Session mode — inferred from triggers, but can be overridden per item
   // ---------------------------------------------------------------------------
 
   export type SessionMode = "ephemeral" | "persistent"
 
-  export function inferSessionMode(triggers: Trigger[]): SessionMode {
+  /**
+   * Infer session mode from triggers, with an optional per-item override.
+   *
+   * Default behaviour: recurring triggers (cron, every, watch) use a persistent
+   * session so the agent can accumulate state across fires. One-shot triggers
+   * (at, delay) use an ephemeral session.
+   *
+   * Set `override` to "ephemeral" when each fire should start with a clean
+   * context — e.g. a daily diary that must not be influenced by previous runs.
+   */
+  export function inferSessionMode(triggers: Trigger[], override?: SessionMode): SessionMode {
+    if (override) return override
     const hasRecurring = triggers.some((t) => t.type === "cron" || t.type === "every" || t.type === "watch")
     return hasRecurring ? "persistent" : "ephemeral"
   }
@@ -197,6 +208,12 @@ export namespace AgendaTypes {
       // Advanced execution options
       agent: z.string().optional().describe("Agent to use, defaults to configured default"),
       model: z.object({ providerID: z.string(), modelID: z.string() }).optional().describe("Model override"),
+      sessionMode: z
+        .enum(["ephemeral", "persistent"])
+        .optional()
+        .describe(
+          "Session mode override. Recurring triggers (cron, every) default to 'persistent' (reuse session across fires). Set 'ephemeral' to start a fresh session on every fire — useful for tasks that must not carry history from previous runs, such as daily reports.",
+        ),
       sessionRefs: z
         .array(SessionRef)
         .optional()
@@ -335,6 +352,7 @@ export namespace AgendaTypes {
       autoDone: z.boolean().optional(),
       agent: z.string().optional(),
       model: z.object({ providerID: z.string(), modelID: z.string() }).optional(),
+      sessionMode: z.enum(["ephemeral", "persistent"]).optional(),
       sessionRefs: z.array(SessionRef).optional(),
       timeout: z.number().optional(),
       createdBy: z.enum(["user", "agent"]).default("user"),
@@ -356,6 +374,7 @@ export namespace AgendaTypes {
       wake: z.boolean().optional(),
       silent: z.boolean().optional(),
       agent: z.string().optional(),
+      sessionMode: z.enum(["ephemeral", "persistent"]).optional(),
       sessionRefs: z.array(SessionRef).optional(),
     })
     .meta({ ref: "AgendaPatchInput" })

--- a/packages/synergy/src/tool/agenda-schedule.ts
+++ b/packages/synergy/src/tool/agenda-schedule.ts
@@ -20,6 +20,9 @@ const parameters = z.object({
   global: z.boolean().optional().describe("If true, visible from all scopes. Default: false (current project only)"),
   wake: z.boolean().optional().describe("If true, wake this session's agent when execution completes. Default: true"),
   silent: z.boolean().optional().describe("If true, suppress result delivery entirely. Default: false"),
+  agent: z.string().optional().describe("Agent to use, defaults to configured default"),
+  model: z.object({ providerID: z.string(), modelID: z.string() }).optional().describe("Model override"),
+  timeout: z.number().optional().describe("Execution timeout in milliseconds"),
   sessionMode: z
     .enum(["ephemeral", "persistent"])
     .optional()
@@ -61,8 +64,11 @@ export const AgendaScheduleTool = Tool.define("agenda_schedule", {
       global: params.global,
       wake: params.wake,
       silent: params.silent,
+      agent: params.agent,
+      model: params.model,
       sessionMode: params.sessionMode,
       sessionRefs: params.sessionRefs,
+      timeout: params.timeout,
       createdBy: "agent",
       sessionID: ctx.sessionID,
       endpoint: session?.endpoint,
@@ -80,6 +86,9 @@ export const AgendaScheduleTool = Tool.define("agenda_schedule", {
     if (item.global) lines.push(`Scope: global`)
     if (item.wake === false) lines.push(`Wake: disabled`)
     if (item.silent) lines.push(`Silent: true`)
+    if (item.agent) lines.push(`Agent: ${item.agent}`)
+    if (item.model) lines.push(`Model: ${item.model.providerID}/${item.model.modelID}`)
+    if (item.timeout) lines.push(`Timeout: ${item.timeout}ms`)
     if (item.sessionMode) lines.push(`Session mode: ${item.sessionMode}`)
 
     lines.push(

--- a/packages/synergy/src/tool/agenda-schedule.ts
+++ b/packages/synergy/src/tool/agenda-schedule.ts
@@ -20,6 +20,12 @@ const parameters = z.object({
   global: z.boolean().optional().describe("If true, visible from all scopes. Default: false (current project only)"),
   wake: z.boolean().optional().describe("If true, wake this session's agent when execution completes. Default: true"),
   silent: z.boolean().optional().describe("If true, suppress result delivery entirely. Default: false"),
+  sessionMode: z
+    .enum(["ephemeral", "persistent"])
+    .optional()
+    .describe(
+      "Session mode override. Recurring triggers (cron, every) default to 'persistent' (reuse session across fires). Set 'ephemeral' to start a fresh session on every fire — useful for tasks that must not carry history from previous runs, such as daily reports.",
+    ),
   sessionRefs: z
     .array(
       z.object({
@@ -55,6 +61,7 @@ export const AgendaScheduleTool = Tool.define("agenda_schedule", {
       global: params.global,
       wake: params.wake,
       silent: params.silent,
+      sessionMode: params.sessionMode,
       sessionRefs: params.sessionRefs,
       createdBy: "agent",
       sessionID: ctx.sessionID,
@@ -73,10 +80,11 @@ export const AgendaScheduleTool = Tool.define("agenda_schedule", {
     if (item.global) lines.push(`Scope: global`)
     if (item.wake === false) lines.push(`Wake: disabled`)
     if (item.silent) lines.push(`Silent: true`)
+    if (item.sessionMode) lines.push(`Session mode: ${item.sessionMode}`)
 
     lines.push(
       "",
-      `Each run executes in a fresh session. Results are delivered back here.`,
+      `Recurring tasks reuse a persistent session across fires by default. Pass sessionMode="ephemeral" to start a fresh session on each fire.`,
       `To pause: agenda_update(id="${item.id}", status="paused")`,
       `To cancel: agenda_cancel(id="${item.id}")`,
       `To view runs: agenda_logs(id="${item.id}")`,

--- a/packages/synergy/src/tool/agenda-update.ts
+++ b/packages/synergy/src/tool/agenda-update.ts
@@ -14,10 +14,22 @@ const parameters = z.object({
   prompt: z.string().optional().describe("New execution prompt"),
   wake: z.boolean().optional().describe("Whether to wake the origin session on completion"),
   silent: z.boolean().optional().describe("Whether to suppress result delivery"),
+  agent: z.string().optional().describe("Agent to use, defaults to configured default"),
+  model: z.object({ providerID: z.string(), modelID: z.string() }).optional().describe("Model override"),
+  timeout: z.number().optional().describe("Execution timeout in milliseconds"),
   sessionMode: z
     .enum(["ephemeral", "persistent"])
     .optional()
     .describe("Session mode override. Set 'ephemeral' to create a fresh session on every fire."),
+  sessionRefs: z
+    .array(
+      z.object({
+        sessionID: z.string().describe("Session ID to reference"),
+        hint: z.string().optional().describe("What to focus on in this session"),
+      }),
+    )
+    .optional()
+    .describe("Sessions whose content is relevant context for execution"),
 })
 
 export const AgendaUpdateTool = Tool.define("agenda_update", {
@@ -34,13 +46,20 @@ export const AgendaUpdateTool = Tool.define("agenda_update", {
     if (params.prompt !== undefined) patch.prompt = params.prompt
     if (params.wake !== undefined) patch.wake = params.wake
     if (params.silent !== undefined) patch.silent = params.silent
+    if (params.agent !== undefined) patch.agent = params.agent
+    if (params.model !== undefined) patch.model = params.model
+    if (params.timeout !== undefined) patch.timeout = params.timeout
     if (params.sessionMode !== undefined) patch.sessionMode = params.sessionMode
+    if (params.sessionRefs !== undefined) patch.sessionRefs = params.sessionRefs
 
     const item = await Agenda.update(params.id, patch, Instance.scope.id)
 
     const lines = ["Agenda item updated.", `ID: ${item.id}`, `Title: ${item.title}`, `Status: ${item.status}`]
     if (item.state.nextRunAt) lines.push(`Next run: ${new Date(item.state.nextRunAt).toISOString()}`)
     if (item.sessionMode) lines.push(`Session mode: ${item.sessionMode}`)
+    if (item.agent) lines.push(`Agent: ${item.agent}`)
+    if (item.model) lines.push(`Model: ${item.model.providerID}/${item.model.modelID}`)
+    if (item.timeout) lines.push(`Timeout: ${item.timeout}ms`)
 
     return {
       title: item.title,

--- a/packages/synergy/src/tool/agenda-update.ts
+++ b/packages/synergy/src/tool/agenda-update.ts
@@ -10,6 +10,7 @@ const parameters = z.object({
   description: z.string().optional().describe("New description"),
   status: AgendaTypes.ItemStatus.optional().describe("New status: pending, active, paused, done, cancelled"),
   tags: z.array(z.string()).optional().describe("New tags (replaces existing)"),
+  triggers: z.array(AgendaTypes.Trigger).optional().describe("New triggers (replaces existing, recomputes nextRunAt)"),
   prompt: z.string().optional().describe("New execution prompt"),
   wake: z.boolean().optional().describe("Whether to wake the origin session on completion"),
   silent: z.boolean().optional().describe("Whether to suppress result delivery"),
@@ -29,6 +30,7 @@ export const AgendaUpdateTool = Tool.define("agenda_update", {
     if (params.description !== undefined) patch.description = params.description
     if (params.status !== undefined) patch.status = params.status
     if (params.tags !== undefined) patch.tags = params.tags
+    if (params.triggers !== undefined) patch.triggers = params.triggers
     if (params.prompt !== undefined) patch.prompt = params.prompt
     if (params.wake !== undefined) patch.wake = params.wake
     if (params.silent !== undefined) patch.silent = params.silent

--- a/packages/synergy/src/tool/agenda-update.ts
+++ b/packages/synergy/src/tool/agenda-update.ts
@@ -13,6 +13,10 @@ const parameters = z.object({
   prompt: z.string().optional().describe("New execution prompt"),
   wake: z.boolean().optional().describe("Whether to wake the origin session on completion"),
   silent: z.boolean().optional().describe("Whether to suppress result delivery"),
+  sessionMode: z
+    .enum(["ephemeral", "persistent"])
+    .optional()
+    .describe("Session mode override. Set 'ephemeral' to create a fresh session on every fire."),
 })
 
 export const AgendaUpdateTool = Tool.define("agenda_update", {
@@ -28,11 +32,13 @@ export const AgendaUpdateTool = Tool.define("agenda_update", {
     if (params.prompt !== undefined) patch.prompt = params.prompt
     if (params.wake !== undefined) patch.wake = params.wake
     if (params.silent !== undefined) patch.silent = params.silent
+    if (params.sessionMode !== undefined) patch.sessionMode = params.sessionMode
 
     const item = await Agenda.update(params.id, patch, Instance.scope.id)
 
     const lines = ["Agenda item updated.", `ID: ${item.id}`, `Title: ${item.title}`, `Status: ${item.status}`]
     if (item.state.nextRunAt) lines.push(`Next run: ${new Date(item.state.nextRunAt).toISOString()}`)
+    if (item.sessionMode) lines.push(`Session mode: ${item.sessionMode}`)
 
     return {
       title: item.title,

--- a/packages/synergy/src/tool/agenda-update.txt
+++ b/packages/synergy/src/tool/agenda-update.txt
@@ -4,8 +4,8 @@ Use agenda_list to find the item ID first.
 
 Common actions:
 - Pause: agenda_update(id="agd_xxx", status="paused")
-- Resume: agenda_update(id="agd_xxx", status="active")  
+- Resume: agenda_update(id="agd_xxx", status="active")
 - Mark done: agenda_update(id="agd_xxx", status="done")
 - Change prompt: agenda_update(id="agd_xxx", prompt="new instructions...")
 
-To change the trigger/schedule itself, use agenda_cancel + agenda_schedule (or agenda_watch) to recreate.
+To change the trigger/schedule itself, pass a new triggers array: agenda_update(id="agd_xxx", triggers=[{type:"cron", expr:"0 6 * * *", tz:"Asia/Shanghai"}])


### PR DESCRIPTION
## Problem

Agenda recurring triggers (`cron`, `every`, `watch`) always inferred a persistent session. That is useful for stateful monitors, but it is wrong for independent scheduled jobs such as daily/weekly reports:

- repeated runs reuse the same session history;
- prior errors/refusals can pollute future runs;
- timer-fired runs previously executed outside an `Instance` scope and could fail with `No context found for instance`;
- some failure paths could remove the clock entry or leave runs hard to diagnose;
- the user-facing agenda tools did not expose enough execution configuration to route scheduled work to a specific agent/model.

## Solution

This PR adds explicit agenda execution controls and hardens the runtime lifecycle while preserving existing defaults.

### Session isolation

- Adds optional `sessionMode: "ephemeral" | "persistent"` on agenda items.
- Existing default inference is unchanged:
  - recurring triggers default to `persistent`;
  - one-shot triggers default to `ephemeral`.
- Setting `sessionMode: "ephemeral"` on a cron/every item creates a fresh session on every fire.

### Runtime hardening

- Runs timer-triggered agenda execution inside `Instance.provide(item.origin.scope)` so plugin/session code has a valid scope.
- Makes plugin hook failures non-fatal to the agenda state machine.
- Ensures unexpected reactor errors compute a fallback `nextRunAt` when possible instead of permanently deleting the clock entry.
- Recomputes missing `nextRunAt` during clock sync from triggers instead of silently unloading active items.
- Restores `delay` triggers as one-shot: create/update can anchor a relative delay, but post-run recomputation does not turn it into a loop.

### Tool/API surface

- `agenda_schedule` now exposes `agent`, `model`, `timeout`, `sessionMode`, and `sessionRefs`.
- `agenda_update` now exposes `triggers`, `agent`, `model`, `timeout`, `sessionMode`, and `sessionRefs`.
- `PatchInput` and `AgendaStore.update()` now persist `model` and `timeout` updates.
- `agenda_update.txt` now documents in-place trigger updates.

### Ephemeral session hygiene

- Ephemeral agenda sessions are titled with a short date, e.g. `Agenda: Daily diary 2026-06-17`.
- Ephemeral agenda sessions are archived after the run so they remain traceable by `sessionID` / logs but do not accumulate in normal session lists.

## Usage

```ts
agenda_schedule({
  title: "Daily diary",
  trigger: { type: "cron", expr: "0 4 * * *", tz: "Asia/Shanghai" },
  agent: "daily-diary-agent",
  sessionMode: "ephemeral",
  silent: true,
  wake: false,
  prompt: "...",
})
```

For existing items:

```ts
agenda_update({
  id: "agd_xxx",
  agent: "daily-diary-agent",
  sessionMode: "ephemeral",
  silent: true,
  wake: false,
})
```

## Compatibility

- Existing agenda items keep their previous behavior unless `sessionMode` or execution config fields are explicitly set.
- Persistent recurring jobs still reuse their session by default.
- One-shot delay/at jobs remain one-shot.

## Validation

- `bun run typecheck` passes.
- Local dev validation confirmed:
  - timer-fired agenda runs no longer hit `No context found for instance`;
  - `sessionMode: "ephemeral"` creates a new session per fire;
  - `agent: "daily-diary-agent"` is persisted and routed into `SessionInvoke`;
  - delay test fires once and transitions to done;
  - daily/weekly diary items rearm to their next expected times.