### PR TITLE
refactor(app): subsession UI architecture — unified SessionMeta hook

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -236,6 +236,7 @@ interface PromptInputProps {
   ref?: (el: HTMLDivElement) => void
   newSessionWorktree?: string
   onNewSessionWorktreeReset?: () => void
+  hideAgentSelector?: boolean
 }
 
 const PLACEHOLDERS = [
@@ -2170,63 +2171,65 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   </Show>
                 </Match>
               </Switch>
-              {/* Agent selector */}
-              <ToolbarSelectorPopover
-                trigger={
-                  <button
-                    type="button"
-                    class="flex items-center gap-1.5 h-7 px-3 rounded-full border border-border-weak-base bg-surface-base hover:bg-surface-raised-base-hover transition-colors"
-                  >
-                    <span class="text-12-medium text-text-base whitespace-nowrap">
-                      {getAgentVisual(local.agent.current()).label}
-                    </span>
-                    <Icon name="chevron-down" size="small" class="text-icon-weak shrink-0" />
-                  </button>
-                }
-                title="Select agent"
-                contentClass="w-52 max-h-80"
-                placement="top-start"
-              >
-                {(close) => (
-                  <List
-                    class="p-1"
-                    items={local.agent.list().filter((a) => !a.hidden)}
-                    key={(x) => x.name}
-                    filterKeys={["name"]}
-                    onSelect={(x) => {
-                      if (!x) return
-                      if (sessionHasMessages() && x.external) return
-                      local.agent.set(x.name)
-                      close()
-                    }}
-                  >
-                    {(agent) => {
-                      const visual = getAgentVisual(agent)
-                      return (
-                        <Tooltip
-                          placement="right"
-                          value={
-                            sessionHasMessages() && agent.external
-                              ? "Create a new session to use this external agent"
-                              : undefined
-                          }
-                        >
-                          <div
-                            classList={{
-                              "flex items-center justify-between gap-3 px-2 py-1.5": true,
-                              "opacity-45": sessionHasMessages() && !!agent.external,
-                            }}
+              <Show when={!props.hideAgentSelector}>
+                {/* Agent selector */}
+                <ToolbarSelectorPopover
+                  trigger={
+                    <button
+                      type="button"
+                      class="flex items-center gap-1.5 h-7 px-3 rounded-full border border-border-weak-base bg-surface-base hover:bg-surface-raised-base-hover transition-colors"
+                    >
+                      <span class="text-12-medium text-text-base whitespace-nowrap">
+                        {getAgentVisual(local.agent.current()).label}
+                      </span>
+                      <Icon name="chevron-down" size="small" class="text-icon-weak shrink-0" />
+                    </button>
+                  }
+                  title="Select agent"
+                  contentClass="w-52 max-h-80"
+                  placement="top-start"
+                >
+                  {(close) => (
+                    <List
+                      class="p-1"
+                      items={local.agent.list().filter((a) => !a.hidden)}
+                      key={(x) => x.name}
+                      filterKeys={["name"]}
+                      onSelect={(x) => {
+                        if (!x) return
+                        if (sessionHasMessages() && x.external) return
+                        local.agent.set(x.name)
+                        close()
+                      }}
+                    >
+                      {(agent) => {
+                        const visual = getAgentVisual(agent)
+                        return (
+                          <Tooltip
+                            placement="right"
+                            value={
+                              sessionHasMessages() && agent.external
+                                ? "Create a new session to use this external agent"
+                                : undefined
+                            }
                           >
-                            <div class="min-w-0">
-                              <div class="text-13-medium text-text-base truncate">{visual.label}</div>
+                            <div
+                              classList={{
+                                "flex items-center justify-between gap-3 px-2 py-1.5": true,
+                                "opacity-45": sessionHasMessages() && !!agent.external,
+                              }}
+                            >
+                              <div class="min-w-0">
+                                <div class="text-13-medium text-text-base truncate">{visual.label}</div>
+                              </div>
                             </div>
-                          </div>
-                        </Tooltip>
-                      )
-                    }}
-                  </List>
-                )}
-              </ToolbarSelectorPopover>
+                          </Tooltip>
+                        )
+                      }}
+                    </List>
+                  )}
+                </ToolbarSelectorPopover>
+              </Show>
             </div>
             <div class="flex items-center gap-2">
               <input

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -28,6 +28,7 @@ export function PromptDock(props: {
   navigate: (path: string) => void
   handoffPrompt: string
   meta: Accessor<SessionMeta>
+  parentTitle?: string
   backPath?: Accessor<string | undefined>
   newSessionWorktree: Accessor<string>
   onNewSessionWorktreeReset: () => void
@@ -84,7 +85,7 @@ export function PromptDock(props: {
                 </Show>
                 <Show when={props.meta().showBackToParent}>
                   <div class="flex items-center justify-center pb-2">
-                    <Tooltip value="Parent session" placement="top">
+                    <Tooltip value={props.parentTitle || "Parent session"} placement="top">
                       <button
                         type="button"
                         class="flex items-center justify-center gap-1.5 h-8 px-3 rounded-full

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -10,10 +10,10 @@ import { QuestionPrompt } from "./question-prompt"
 import { PermissionDock } from "./permission-dock"
 import { SubagentDock } from "./subagent-dock"
 import { SubagentSessionFooter } from "./subagent-session-footer"
+import { type SessionMeta } from "@/composables/use-session-meta"
 import type { usePrompt } from "@/context/prompt"
 import type { useSync } from "@/context/sync"
 import type { useSDK } from "@/context/sdk"
-import type { SessionCortexDelegation } from "@ericsanchezok/synergy-sdk/client"
 
 export function PromptDock(props: {
   ref: (el: HTMLDivElement) => void
@@ -27,15 +27,13 @@ export function PromptDock(props: {
   sdk: ReturnType<typeof useSDK>
   navigate: (path: string) => void
   handoffPrompt: string
-  parentSession: Accessor<{ id: string; title?: string } | undefined>
+  meta: Accessor<SessionMeta>
   backPath?: Accessor<string | undefined>
   newSessionWorktree: Accessor<string>
   onNewSessionWorktreeReset: () => void
   scopeName: Accessor<string>
   branch: Accessor<string | undefined>
   lastModified: Accessor<string | null | undefined>
-  cortex?: Accessor<SessionCortexDelegation | undefined>
-  parentID?: Accessor<string | undefined>
 }) {
   const nav = useNavigate()
   return (
@@ -67,12 +65,9 @@ export function PromptDock(props: {
             </div>
           }
         >
-          {(() => {
-            const c = props.cortex?.()
-            if (c && !props.isNewSession()) {
-              return <SubagentSessionFooter cortex={c} parentSessionID={props.parentID?.()} />
-            }
-            return (
+          <Show
+            when={props.meta().isReadOnly}
+            fallback={
               <>
                 <Show when={props.sessionID}>
                   <PermissionDock sessionID={props.sessionID!} />
@@ -87,40 +82,38 @@ export function PromptDock(props: {
                 <Show when={props.sessionID}>
                   <SubagentDock sessionID={props.sessionID!} />
                 </Show>
-                <Show when={props.parentSession()}>
-                  {(parent) => (
-                    <div class="flex items-center justify-center pb-2">
-                      <Tooltip value={parent().title || "Parent session"} placement="top">
-                        <button
-                          type="button"
-                          class="flex items-center justify-center gap-1.5 h-8 px-3 rounded-full
-                            border border-border-base bg-surface-raised-stronger-non-alpha
-                            shadow-sm
-                            text-12-medium text-text-weak hover:text-text-base
-                            hover:bg-surface-raised-stronger-hover
-                            active:scale-95
-                            transition-all duration-150"
-                          onClick={() => props.navigate(parent().id)}
-                        >
-                          <Icon name="arrow-left" size="small" />
-                          <span>Back to parent</span>
-                        </button>
-                      </Tooltip>
-                    </div>
-                  )}
+                <Show when={props.meta().showBackToParent}>
+                  <div class="flex items-center justify-center pb-2">
+                    <Tooltip value="Parent session" placement="top">
+                      <button
+                        type="button"
+                        class="flex items-center justify-center gap-1.5 h-8 px-3 rounded-full
+                        border border-border-base bg-surface-raised-stronger-non-alpha
+                        shadow-sm
+                        text-12-medium text-text-weak hover:text-text-base
+                        hover:bg-surface-raised-stronger-hover
+                        active:scale-95
+                        transition-all duration-150"
+                        onClick={() => props.navigate(props.meta().parentID!)}
+                      >
+                        <Icon name="arrow-left" size="small" />
+                        <span>Back to parent</span>
+                      </button>
+                    </Tooltip>
+                  </div>
                 </Show>
-                <Show when={!props.parentSession() && props.backPath?.()}>
+                <Show when={!props.meta().isSubsession && props.backPath?.()}>
                   {(from) => (
                     <div class="flex items-center justify-center pb-2">
                       <button
                         type="button"
                         class="flex items-center justify-center gap-1.5 h-8 px-3 rounded-full
-                          border border-border-base bg-surface-raised-stronger-non-alpha
-                          shadow-sm
-                          text-12-medium text-text-weak hover:text-text-base
-                          hover:bg-surface-raised-stronger-hover
-                          active:scale-95
-                          transition-all duration-150"
+                        border border-border-base bg-surface-raised-stronger-non-alpha
+                        shadow-sm
+                        text-12-medium text-text-weak hover:text-text-base
+                        hover:bg-surface-raised-stronger-hover
+                        active:scale-95
+                        transition-all duration-150"
                         onClick={() => nav(from())}
                       >
                         <Icon name="arrow-left" size="small" />
@@ -134,11 +127,14 @@ export function PromptDock(props: {
                     ref={props.inputRef}
                     newSessionWorktree={props.newSessionWorktree()}
                     onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
+                    hideAgentSelector={!props.meta().showInputBar}
                   />
                 </div>
               </>
-            )
-          })()}
+            }
+          >
+            <SubagentSessionFooter cortex={props.meta().cortex!} parentSessionID={props.meta().parentID ?? undefined} />
+          </Show>
         </Show>
         <Show when={props.isNewSession() && !props.isGlobal}>
           <div class="flex items-center justify-center gap-1.5 pt-3 text-12-regular text-text-subtle pointer-events-none">

--- a/packages/app/src/components/status-bar.tsx
+++ b/packages/app/src/components/status-bar.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, Show } from "solid-js"
+import { createMemo, createSignal, Show, type JSX } from "solid-js"
 import { useParams } from "@solidjs/router"
 import { useHolos } from "@/context/holos"
 import { useServer } from "@/context/server"
@@ -107,7 +107,7 @@ function DetailRow(props: { label: string; value: string | undefined }) {
   )
 }
 
-function DetailGroup(props: { title: string; children: any }) {
+function DetailGroup(props: { title: string; children: JSX.Element }) {
   return (
     <div class="space-y-1.5 min-w-0">
       <div class="text-12-medium text-text-weak">{props.title}</div>
@@ -172,7 +172,7 @@ export function StatusBar() {
     return !!current.permission[id]?.length || !!current.question[id]?.length
   })
   const workspaceType = createMemo(() => session()?.workspace?.type ?? "main")
-  const isWorktree = createMemo(() => workspaceType() === "git_worktree")
+  const isWorktree = () => workspaceType() === "git_worktree"
   const workspaceName = createMemo(() => workspaceField(session(), "name") || (isWorktree() ? "worktree" : "main"))
   const branch = createMemo(() => workspaceField(session(), "branch") || store()?.vcs?.branch)
   const workspacePath = createMemo(() => session()?.workspace?.path || session()?.scope.directory || directory())

--- a/packages/app/src/components/top-bar/session-top-bar.tsx
+++ b/packages/app/src/components/top-bar/session-top-bar.tsx
@@ -10,6 +10,7 @@ import { useCommand } from "@/context/command"
 import { useSync } from "@/context/sync"
 import { base64Decode } from "@ericsanchezok/synergy-util/encode"
 import { isGlobalScope } from "@/utils/scope"
+import { useSessionMeta } from "@/composables/use-session-meta"
 import "./session-top-bar.css"
 
 export function SessionTopBar() {
@@ -21,10 +22,14 @@ export function SessionTopBar() {
 
   const isGlobal = () => (params.dir ? isGlobalScope(base64Decode(params.dir)) : false)
 
+  const sessionInfo = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
+
   const sessionHasMessages = createMemo(() => {
     if (!params.id) return false
     return (sync.data.message[params.id] ?? []).length > 0
   })
+
+  const sessionMeta = useSessionMeta(sessionInfo, sessionHasMessages)
 
   const isCurrentAgentExternal = createMemo(() => !!local.agent.current()?.external)
   const isCurrentExternalModelLocked = createMemo(() => {
@@ -42,24 +47,26 @@ export function SessionTopBar() {
           <span class="stb-slash">/</span>
         </Show>
         {/* Model selector */}
-        <Show
-          when={!isCurrentExternalModelLocked()}
-          fallback={
-            <Tooltip placement="bottom" value="Model is locked for this external agent after the session starts">
-              <button type="button" class="stb-selector-btn stb-locked">
-                <span class="stb-selector-label">{local.model.current()?.name ?? "Model locked"}</span>
-              </button>
-            </Tooltip>
-          }
-        >
-          <ModelSelectorPopover>
-            <TooltipKeybind placement="bottom" title="Choose model" keybind={command.keybind("model.choose")}>
-              <button type="button" class="stb-selector-btn">
-                <span class="stb-selector-label">{local.model.current()?.name ?? "Select model"}</span>
-                <Icon name="chevron-down" size="normal" class="stb-chevron" />
-              </button>
-            </TooltipKeybind>
-          </ModelSelectorPopover>
+        <Show when={sessionMeta().canSelectModel}>
+          <Show
+            when={!isCurrentExternalModelLocked()}
+            fallback={
+              <Tooltip placement="bottom" value="Model is locked for this external agent after the session starts">
+                <button type="button" class="stb-selector-btn stb-locked">
+                  <span class="stb-selector-label">{local.model.current()?.name ?? "Model locked"}</span>
+                </button>
+              </Tooltip>
+            }
+          >
+            <ModelSelectorPopover>
+              <TooltipKeybind placement="bottom" title="Choose model" keybind={command.keybind("model.choose")}>
+                <button type="button" class="stb-selector-btn">
+                  <span class="stb-selector-label">{local.model.current()?.name ?? "Select model"}</span>
+                  <Icon name="chevron-down" size="normal" class="stb-chevron" />
+                </button>
+              </TooltipKeybind>
+            </ModelSelectorPopover>
+          </Show>
         </Show>
 
         {/* Variant cycle */}

--- a/packages/app/src/composables/use-session-meta.ts
+++ b/packages/app/src/composables/use-session-meta.ts
@@ -1,0 +1,96 @@
+import type { Session, SessionCortexDelegation } from "@ericsanchezok/synergy-sdk/client"
+import { createMemo, type Accessor } from "solid-js"
+export interface SessionMeta {
+  // Source
+  source: "web" | "channel" | "holos"
+
+  // Hierarchy
+  isSubsession: boolean
+  isCortexSubagent: boolean
+  parentID: string | null
+
+  // Cortex delegation (full object for SubagentSessionFooter)
+  cortex: SessionCortexDelegation | undefined
+
+  // Interaction mode
+  isUnattended: boolean
+  isAgenda: boolean
+
+  // Read/write state
+  isReadOnly: boolean
+  canSelectModel: boolean
+  showInputBar: boolean
+  showBackToParent: boolean
+
+  // Workspace
+  workspaceType: string
+  isWorktree: boolean
+  workspaceName: string
+  branch: string | undefined
+}
+
+const DEFAULT_META: SessionMeta = {
+  source: "web",
+  isSubsession: false,
+  isCortexSubagent: false,
+  parentID: null,
+  cortex: undefined,
+  isUnattended: false,
+  isAgenda: false,
+  isReadOnly: false,
+  canSelectModel: true,
+  showInputBar: true,
+  showBackToParent: false,
+  workspaceType: "main",
+  isWorktree: false,
+  workspaceName: "main",
+  branch: undefined,
+}
+
+export function deriveSessionMeta(session: Session | undefined, hasMessages: boolean): SessionMeta {
+  if (!session) return DEFAULT_META
+
+  const endpointKind = session.endpoint?.kind
+  const source: SessionMeta["source"] =
+    endpointKind === "channel" ? "channel" : endpointKind === "holos" ? "holos" : "web"
+
+  const isSubsession = session.parentID != null
+  const isCortexSubagent = session.cortex != null
+  const parentID = session.parentID ?? null
+  const isUnattended = session.interaction?.mode === "unattended"
+  const isAgenda = session.agenda != null
+  const isReadOnly = isCortexSubagent && hasMessages
+  const canSelectModel = !isReadOnly
+  const showInputBar = !isReadOnly
+  const showBackToParent = isSubsession && parentID !== null
+
+  const workspaceType = session.workspace?.type ?? "main"
+  const isWorktree = workspaceType === "git_worktree"
+  const wsExtra = session.workspace as Record<string, unknown> | undefined
+  const workspaceName: string = (wsExtra?.name as string) ?? (isWorktree ? "worktree" : "main")
+  const branch: string | undefined = (wsExtra?.branch as string | undefined) ?? undefined
+
+  return {
+    source,
+    isSubsession,
+    isCortexSubagent,
+    parentID,
+    cortex: session.cortex ?? undefined,
+    isUnattended,
+    isAgenda,
+    isReadOnly,
+    canSelectModel,
+    showInputBar,
+    showBackToParent,
+    workspaceType,
+    isWorktree,
+    workspaceName,
+    branch,
+  }
+}
+export function useSessionMeta(
+  session: Accessor<Session | undefined>,
+  hasMessages: Accessor<boolean>,
+): Accessor<SessionMeta> {
+  return createMemo(() => deriveSessionMeta(session(), hasMessages()))
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -31,6 +31,7 @@ import { isGlobalScope } from "@/utils/scope"
 import { isHolosSession } from "@/utils/session"
 
 import { useSessionCommands } from "@/components/session/commands"
+import { useSessionMeta } from "@/composables/use-session-meta"
 import { SessionConversation } from "@/components/session/conversation"
 import { HolosConversation, HolosGreeting } from "@/components/session/holos-conversation"
 import { HolosPromptInput } from "@/components/session/holos-prompt-input"
@@ -395,8 +396,13 @@ export default function Page() {
 
   const status = createMemo(() => sync.data.session_status[params.id ?? ""] ?? idle)
 
+  const sessionHasMessages = createMemo(() => {
+    if (!params.id) return false
+    return (sync.data.message[params.id] ?? []).length > 0
+  })
+
   const currentSession = createMemo(() => sync.data.session.find((s) => s.id === params.id))
-  const currentSessionCortex = createMemo(() => currentSession()?.cortex)
+  const sessionMeta = useSessionMeta(currentSession, sessionHasMessages)
   const parentSession = createMemo(() => {
     const current = currentSession()
     if (!current?.parentID) return undefined
@@ -1018,15 +1024,13 @@ export default function Page() {
                 sdk={sdk}
                 navigate={(id) => navigate(`/${params.dir}/session/${id}`)}
                 handoffPrompt={handoff.prompt}
-                parentSession={parentSession}
+                meta={sessionMeta}
                 backPath={backPath}
                 newSessionWorktree={newSessionWorktree}
                 onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
                 scopeName={scopeName}
                 branch={branch}
                 lastModified={lastModified}
-                cortex={currentSessionCortex}
-                parentID={() => currentSession()?.parentID}
               />
             }
           >

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1025,6 +1025,7 @@ export default function Page() {
                 navigate={(id) => navigate(`/${params.dir}/session/${id}`)}
                 handoffPrompt={handoff.prompt}
                 meta={sessionMeta}
+                parentTitle={parentSession()?.title}
                 backPath={backPath}
                 newSessionWorktree={newSessionWorktree}
                 onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}


### PR DESCRIPTION
## Summary

Adds a `useSessionMeta` composable as the single source of truth for session-level UI decisions, replacing scattered ad-hoc checks across 5 components. Also fixes the ModelSelector showing on read-only subsession pages, restores the parent session title tooltip, and cleans up minor type issues in status-bar.

### Main change
- **New `useSessionMeta` hook** (`composables/use-session-meta.ts`) — 15 derived fields from raw Session object: source, hierarchy, interaction mode, read/write state, workspace
- **PromptDock** — 3 props (cortex/parentID/parentSession) → 1 meta prop; IIFE branching → declarative Show/fallback
- **SessionTopBar** — ModelSelector now hidden when `canSelectModel` is false (fixes the visible-ModelSelector-on-subsession bug)
- **PromptInput** — added `hideAgentSelector` prop for future-proofing
- **session.tsx** — removed dead `currentSessionCortex` signal, added `sessionMeta` memo

### Fixes
- Restored parent session title tooltip on back-to-parent button
- `DetailGroup` children type: `any` → `JSX.Element`
- `isWorktree`: removed redundant `createMemo` wrapper, inlined as plain function

## Files

| File | ± |
|------|---|
| `composables/use-session-meta.ts` (new) | +96 |
| `components/session/prompt-dock.tsx` | +31/-23 |
| `pages/session.tsx` | +7/-12 |
| `components/top-bar/session-top-bar.tsx` | +4/-2 |
| `components/prompt-input.tsx` | +5/-1 |
| `components/status-bar.tsx` | +3/-3 |

## Verification
- `tsc -b` zero errors
- `vite build` 5434 modules OK
- `turbo typecheck` 8/8 passed
- `formatting` passed