### PR TITLE
refactor(toast): redesigned toast system with collapsible cards, semantic types, and countdown

### DIFF
--- a/packages/app/src/components/contacts/agent-card.tsx
+++ b/packages/app/src/components/contacts/agent-card.tsx
@@ -147,7 +147,7 @@ export function AgentCard(props: {
                             <DropdownMenu.Item
                               onSelect={() => {
                                 navigator.clipboard.writeText(props.agentId ?? "")
-                                showToast({ title: "Agent ID copied" })
+                                showToast({ type: "info", title: "Agent ID copied" })
                               }}
                             >
                               <Icon name="copy" size="small" class="mr-2" />

--- a/packages/app/src/components/contacts/contact-card.tsx
+++ b/packages/app/src/components/contacts/contact-card.tsx
@@ -182,7 +182,7 @@ function ContactCard(props: {
                     <DropdownMenu.Item
                       onSelect={() => {
                         navigator.clipboard.writeText(props.contact.holosId ?? "")
-                        showToast({ title: "ID copied" })
+                        showToast({ type: "info", title: "ID copied" })
                       }}
                     >
                       <Icon name="copy" size="small" class="mr-2" />

--- a/packages/app/src/components/contacts/contacts-view.tsx
+++ b/packages/app/src/components/contacts/contacts-view.tsx
@@ -86,6 +86,7 @@ function AddFriendForm(props: { onClose: () => void; onSent: () => void; existin
         ...(peerBio ? { peerBio } : {}),
       })
       showToast({
+        type: "info",
         title: result.data?.queued ? "Request queued" : "Friend request sent",
         description: result.data?.queued
           ? "The agent appears to be offline. Request will be delivered when they come online."
@@ -249,10 +250,10 @@ export function ContactsView(props: { onRefresh: () => void | Promise<void>; ref
     setRequestLoadingIds((prev) => new Set([...prev, id]))
     try {
       await globalSDK.client.holos.friendRequest.respond({ id, status })
-      showToast({ title: status === "accepted" ? "Friend request accepted" : "Friend request rejected" })
+      showToast({ type: "info", title: status === "accepted" ? "Friend request accepted" : "Friend request rejected" })
       await holos.refresh()
     } catch (e: any) {
-      showToast({ title: "Failed", description: e.message })
+      showToast({ type: "error", title: "Failed", description: e.message })
     } finally {
       setRequestLoadingIds((prev) => {
         const next = new Set(prev)
@@ -266,10 +267,10 @@ export function ContactsView(props: { onRefresh: () => void | Promise<void>; ref
     setRequestLoadingIds((prev) => new Set([...prev, id]))
     try {
       await globalSDK.client.holos.friendRequest.remove({ id })
-      showToast({ title: "Request cancelled" })
+      showToast({ type: "info", title: "Request cancelled" })
       await holos.refresh()
     } catch (e: any) {
-      showToast({ title: "Failed", description: e.message })
+      showToast({ type: "error", title: "Failed", description: e.message })
     } finally {
       setRequestLoadingIds((prev) => {
         const next = new Set(prev)
@@ -282,10 +283,10 @@ export function ContactsView(props: { onRefresh: () => void | Promise<void>; ref
   const handleRemoveContact = async (id: string) => {
     try {
       await globalSDK.client.holos.contact.remove({ id })
-      showToast({ title: "Contact removed" })
+      showToast({ type: "info", title: "Contact removed" })
       await holos.refresh()
     } catch (e: any) {
-      showToast({ title: "Failed", description: e.message })
+      showToast({ type: "error", title: "Failed", description: e.message })
     }
   }
 
@@ -294,7 +295,7 @@ export function ContactsView(props: { onRefresh: () => void | Promise<void>; ref
       await globalSDK.client.holos.contact.updateConfig({ id, ...config })
       await holos.refresh()
     } catch (e: any) {
-      showToast({ title: "Failed to update config", description: e.message })
+      showToast({ type: "error", title: "Failed to update config", description: e.message })
     }
   }
 
@@ -305,7 +306,7 @@ export function ContactsView(props: { onRefresh: () => void | Promise<void>; ref
       navigate(`/${base64Encode(directory)}/session/${sessionID}`)
       panel.close()
     } catch (e: any) {
-      showToast({ title: "Failed to open conversation", description: e?.message || String(e) })
+      showToast({ type: "error", title: "Failed to open conversation", description: e?.message || String(e) })
     }
   }
 

--- a/packages/app/src/components/contacts/edit-profile-dialog.tsx
+++ b/packages/app/src/components/contacts/edit-profile-dialog.tsx
@@ -16,7 +16,7 @@ export function EditProfileDialog(props: { profile: HolosProfile; onSaved: () =>
 
   async function handleSave() {
     if (!name().trim()) {
-      showToast({ title: "Name cannot be empty" })
+      showToast({ type: "warning", title: "Name cannot be empty" })
       return
     }
 
@@ -26,11 +26,11 @@ export function EditProfileDialog(props: { profile: HolosProfile; onSaved: () =>
         name: name().trim(),
         bio: bio().trim(),
       })
-      showToast({ title: "Profile updated" })
+      showToast({ type: "info", title: "Profile updated" })
       props.onSaved()
       dialog.close()
     } catch (e: any) {
-      showToast({ title: "Failed to save profile", description: e.message })
+      showToast({ type: "error", title: "Failed to save profile", description: e.message })
     } finally {
       setSaving(false)
     }
@@ -42,11 +42,11 @@ export function EditProfileDialog(props: { profile: HolosProfile; onSaved: () =>
     setResetting(true)
     try {
       await globalSDK.client.holos.profile.reset()
-      showToast({ title: "Setup will restart" })
+      showToast({ type: "info", title: "Setup will restart" })
       props.onRerunSetup()
       dialog.close()
     } catch (e: any) {
-      showToast({ title: "Failed to reset setup", description: e.message })
+      showToast({ type: "error", title: "Failed to reset setup", description: e.message })
     } finally {
       setResetting(false)
     }

--- a/packages/app/src/components/contacts/panel.tsx
+++ b/packages/app/src/components/contacts/panel.tsx
@@ -66,10 +66,10 @@ export function HolosPanel() {
   async function handleDisconnect() {
     try {
       await globalSDK.client.holos.logout()
-      showToast({ title: "Disconnected from Holos" })
+      showToast({ type: "info", title: "Disconnected from Holos" })
       void holos.refresh()
     } catch {
-      showToast({ title: "Failed to disconnect" })
+      showToast({ type: "error", title: "Failed to disconnect" })
     }
   }
 
@@ -78,7 +78,7 @@ export function HolosPanel() {
     setReconnecting(true)
     try {
       await globalSDK.client.holos.reconnect()
-      showToast({ title: "Reconnecting..." })
+      showToast({ type: "info", title: "Reconnecting..." })
     } catch (error: unknown) {
       const msg =
         error instanceof Error
@@ -90,7 +90,7 @@ export function HolosPanel() {
         void handleConnectHolos()
         return
       }
-      showToast({ title: "Reconnect failed", description: msg || "Failed to reconnect" })
+      showToast({ type: "error", title: "Reconnect failed", description: msg || "Failed to reconnect" })
     } finally {
       setReconnecting(false)
     }
@@ -101,7 +101,7 @@ export function HolosPanel() {
     globalSDK.client.holos.profile
       .reset()
       .then(() => auth.logout())
-      .catch(() => showToast({ title: "Failed to reset setup" }))
+      .catch(() => showToast({ type: "error", title: "Failed to reset setup" }))
   }
 
   const { trigger: handleConnectHolos, connecting } = useHolosLoginPopup({
@@ -111,9 +111,9 @@ export function HolosPanel() {
         auth.loginWithToken(agentId, { id: agentId })
       }
       void holos.refresh()
-      showToast({ title: "Connected to Holos" })
+      showToast({ type: "info", title: "Connected to Holos" })
     },
-    onError: (msg) => showToast({ title: msg }),
+    onError: (msg) => showToast({ type: "error", title: msg }),
   })
 
   return (

--- a/packages/app/src/components/dialog/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog/dialog-connect-provider.tsx
@@ -109,7 +109,7 @@ export function DialogConnectProvider(props: { provider: string }) {
     await globalSDK.client.global.dispose()
     dialog.close()
     showToast({
-      variant: "success",
+      type: "success",
       icon: "circle-check",
       title: `${provider().name} connected`,
       description: `${provider().name} models are now available to use.`,

--- a/packages/app/src/components/dialog/dialog-scope-edit.tsx
+++ b/packages/app/src/components/dialog/dialog-scope-edit.tsx
@@ -20,10 +20,10 @@ export function DialogScopeEdit(props: { scope: LocalScope }) {
     try {
       const scopeID = props.scope.id ?? props.scope.worktree
       await globalSDK.client.scope.update({ scopeID, name: name().trim() || undefined })
-      showToast({ title: "Project updated", description: name() || getScopeLabel(props.scope) })
+      showToast({ type: "info", title: "Project updated", description: name() || getScopeLabel(props.scope) })
       dialog.close()
     } catch (e: any) {
-      showToast({ title: "Failed to update project", description: e?.message ?? "Unknown error" })
+      showToast({ type: "error", title: "Failed to update project", description: e?.message ?? "Unknown error" })
     } finally {
       setSaving(false)
     }

--- a/packages/app/src/components/dialog/dialog-session-export.tsx
+++ b/packages/app/src/components/dialog/dialog-session-export.tsx
@@ -80,10 +80,10 @@ export function DialogSessionExport() {
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)
-      showToast({ title: "Session export downloading" })
+      showToast({ type: "info", title: "Session export downloading" })
       dialog.close()
     } catch (e: any) {
-      showToast({ title: "Export failed", description: e.message })
+      showToast({ type: "error", title: "Export failed", description: e.message })
     } finally {
       setExporting(false)
     }

--- a/packages/app/src/components/engram/skill-view.tsx
+++ b/packages/app/src/components/engram/skill-view.tsx
@@ -116,9 +116,9 @@ export function SkillView(props: {
     try {
       await scopedClient().skill.reload()
       await refetch()
-      showToast({ title: "Skills reloaded", description: "Skill directories rescanned" })
+      showToast({ type: "success", title: "Skills reloaded", description: "Skill directories rescanned" })
     } catch {
-      showToast({ title: "Failed to reload skills" })
+      showToast({ type: "error", title: "Failed to reload skills" })
     }
     setReloading(false)
   }
@@ -153,10 +153,10 @@ export function SkillView(props: {
     try {
       await scopedClient().skill.remove({ name })
       await refetch()
-      showToast({ title: "Skill deleted", description: `Removed "${name}" from disk` })
+      showToast({ type: "info", title: "Skill deleted", description: `Removed "${name}" from disk` })
       return true
     } catch {
-      showToast({ title: "Failed to delete skill" })
+      showToast({ type: "error", title: "Failed to delete skill" })
       return false
     }
   }
@@ -190,9 +190,9 @@ export function SkillView(props: {
       const result = await scopedClient().skill.import({ file, scope })
       await refetch()
       const data = result.data as any
-      showToast({ title: "Skill imported", description: `"${data?.name}" added to ${data?.scope ?? scope}` })
+      showToast({ type: "info", title: "Skill imported", description: `"${data?.name}" added to ${data?.scope ?? scope}` })
     } catch {
-      showToast({ title: "Import failed", description: "Check that the ZIP contains a valid SKILL.md" })
+      showToast({ type: "error", title: "Import failed", description: "Check that the ZIP contains a valid SKILL.md" })
     }
     setImporting(false)
     resetImport()
@@ -207,9 +207,9 @@ export function SkillView(props: {
       const result = await scopedClient().skill.importUrl({ url, scope: "global" })
       await refetch()
       const data = result.data as any
-      showToast({ title: "Skill imported", description: `"${data?.name}" added to ${data?.scope ?? "project"}` })
+      showToast({ type: "info", title: "Skill imported", description: `"${data?.name}" added to ${data?.scope ?? "project"}` })
     } catch {
-      showToast({ title: "Import failed", description: "Failed to download or extract. Check the URL." })
+      showToast({ type: "error", title: "Import failed", description: "Failed to download or extract. Check the URL." })
     }
     setImporting(false)
     resetImport()

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -446,6 +446,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   async function updateControlProfile(profile: ControlProfileId, close?: () => void) {
     if (working()) {
       showToast({
+        type: "warning",
         title: "Session is running",
         description: "Stop the session before changing its permission mode.",
       })
@@ -463,6 +464,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       close?.()
     } catch (err) {
       showToast({
+        type: "error",
         title: "Permission mode unchanged",
         description: err instanceof Error ? err.message : "Failed to update the session permission mode.",
       })
@@ -633,6 +635,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             : "This attachment couldn’t be prepared. Try another file."
 
       showToast({
+        type: "error",
         title: error instanceof PromptAttachmentError ? error.title : "Couldn’t attach file",
         description,
       })
@@ -1442,6 +1445,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const currentAgent = local.agent.current()
     if (!currentModel || !currentAgent) {
       showToast({
+        type: "warning",
         title: "Select an agent and model",
         description: "Choose an agent and model before sending a prompt.",
       })
@@ -1475,6 +1479,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           .then((x) => x.data)
           .catch((err) => {
             showToast({
+              type: "error",
               title: "Failed to create worktree",
               description: errorMessage(err),
             })
@@ -1483,6 +1488,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
         if (!createdWorktree?.path) {
           showToast({
+            type: "error",
             title: "Failed to create worktree",
             description: "Request failed",
           })
@@ -1577,6 +1583,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         })
         .catch((err) => {
           showToast({
+            type: "error",
             title: "Failed to send shell command",
             description: errorMessage(err),
           })
@@ -1645,6 +1652,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           })
           .catch((err) => {
             showToast({
+              type: "error",
               title: "Failed to send command",
               description: errorMessage(err),
             })
@@ -1885,6 +1893,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       .then(() => {
         if (!wsConnected) {
           showToast({
+            type: "warning",
             title: "Message sent",
             description: "Response will appear after reconnection",
           })
@@ -1892,6 +1901,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       })
       .catch((err) => {
         showToast({
+          type: "error",
           title: "Failed to send prompt",
           description: errorMessage(err),
         })
@@ -2291,6 +2301,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           event.preventDefault()
                           event.stopPropagation()
                           showToast({
+                            type: "warning",
                             title: "Session is running",
                             description: "Stop the session before changing its permission mode.",
                           })

--- a/packages/app/src/components/session/commands.tsx
+++ b/packages/app/src/components/session/commands.tsx
@@ -202,6 +202,7 @@ export function useSessionCommands(params: {
       onSelect: () => {
         local.model.variant.cycle()
         showToast({
+          type: "info",
           title: "Thinking effort changed",
           description: "The thinking effort has been changed to " + (local.model.variant.current() ?? "Default"),
         })
@@ -271,6 +272,7 @@ export function useSessionCommands(params: {
         const model = local.model.current()
         if (!model) {
           showToast({
+            type: "warning",
             title: "No model selected",
             description: "Connect a provider to summarize this session",
           })

--- a/packages/app/src/components/settings/SettingsDialog.tsx
+++ b/packages/app/src/components/settings/SettingsDialog.tsx
@@ -358,7 +358,11 @@ export function SettingsDialog(props: DialogSettingsProps) {
     setGeneral("sendShortcut", value)
     if (value !== input.sendShortcut()) {
       input.setSendShortcut(value)
-      showToast({ title: "Send shortcut updated", description: "This device preference is saved immediately." })
+      showToast({
+        type: "info",
+        title: "Send shortcut updated",
+        description: "This device preference is saved immediately.",
+      })
     }
   }
 
@@ -499,6 +503,7 @@ export function SettingsDialog(props: DialogSettingsProps) {
                       resetEditor()
                       const isActive = globalSync.configSets.find((s) => s.name === name)?.active
                       showToast({
+                        type: "info",
                         title: `Opened ${name}`,
                         description: isActive
                           ? "You are now editing the active Config Set. Save changes to update runtime config."
@@ -512,6 +517,7 @@ export function SettingsDialog(props: DialogSettingsProps) {
                   resetEditor()
                   const isActive = globalSync.configSets.find((s) => s.name === name)?.active
                   showToast({
+                    type: "info",
                     title: `Opened ${name}`,
                     description: isActive
                       ? "You are now editing the active Config Set. Save changes to update runtime config."

--- a/packages/app/src/components/settings/hooks/useSettingsSave.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsSave.ts
@@ -122,7 +122,7 @@ export function useSettingsSave(ctx: SaveContext) {
       setTimeout(() => setAutoStatus("idle"), 2000)
     } catch (error: any) {
       setAutoStatus("error")
-      showToast({ title: "Auto-save failed", description: error.message })
+      showToast({ type: "error", title: "Auto-save failed", description: error.message })
     }
   }
 
@@ -136,13 +136,14 @@ export function useSettingsSave(ctx: SaveContext) {
       setBgStatus("saved")
       await ctx.refreshAfterConfigChange()
       showToast({
+        type: "success",
         title: `Saved ${ctx.editingLabel()}`,
         description: `Updated: ${Object.keys(patch).join(", ")}`,
       })
       setTimeout(() => setBgStatus("idle"), 2000)
     } catch (error: any) {
       setBgStatus("error")
-      showToast({ title: "Background save failed", description: error.message })
+      showToast({ type: "error", title: "Background save failed", description: error.message })
     }
   }
 
@@ -217,6 +218,7 @@ export function useSettingsSave(ctx: SaveContext) {
 
       if (changed.length > 0) {
         showToast({
+          type: "success",
           title: shouldActivate ? `Saved and activated ${ctx.editingLabel()}` : `Saved ${ctx.editingLabel()}`,
           description: `Changed: ${changed.join(", ")}`,
         })
@@ -224,7 +226,7 @@ export function useSettingsSave(ctx: SaveContext) {
 
       if (options?.close) ctx.closeDialog()
     } catch (error: any) {
-      showToast({ title: "Failed to save", description: error.message })
+      showToast({ type: "error", title: "Failed to save", description: error.message })
     } finally {
       ctx.setSaving(false)
     }
@@ -236,7 +238,7 @@ export function useSettingsSave(ctx: SaveContext) {
 
     const valid = await ctx.validateRawConfig()
     if (!valid) {
-      showToast({ title: "Validation failed", description: "Fix the errors before saving." })
+      showToast({ type: "warning", title: "Validation failed", description: "Fix the errors before saving." })
       return
     }
 
@@ -258,13 +260,14 @@ export function useSettingsSave(ctx: SaveContext) {
 
       await ctx.refreshAfterConfigChange()
       showToast({
+        type: "success",
         title: shouldActivate ? `Saved and activated ${setName}` : `Saved ${setName}`,
         description: "Raw config saved and validated.",
       })
 
       if (options?.close) ctx.closeDialog()
     } catch (error: any) {
-      showToast({ title: "Failed to save", description: error.message })
+      showToast({ type: "error", title: "Failed to save", description: error.message })
     } finally {
       ctx.setSaving(false)
     }
@@ -326,9 +329,9 @@ export function useSettingsSave(ctx: SaveContext) {
           ctx.resetEditor()
           await globalSDK.client.config.set.activate({ name })
           await ctx.refreshAfterConfigChange()
-          showToast({ title: "Config Set activated", description: `Using ${name}` })
+          showToast({ type: "info", title: "Config Set activated", description: `Using ${name}` })
         } catch (error: any) {
-          showToast({ title: "Failed to switch Config Set", description: error.message })
+          showToast({ type: "error", title: "Failed to switch Config Set", description: error.message })
         } finally {
           ctx.setSaving(false)
         }
@@ -342,9 +345,9 @@ export function useSettingsSave(ctx: SaveContext) {
       ctx.resetEditor()
       await globalSDK.client.config.set.activate({ name })
       await ctx.refreshAfterConfigChange()
-      showToast({ title: "Config Set activated", description: `Using ${name}` })
+      showToast({ type: "info", title: "Config Set activated", description: `Using ${name}` })
     } catch (error: any) {
-      showToast({ title: "Failed to switch Config Set", description: error.message })
+      showToast({ type: "error", title: "Failed to switch Config Set", description: error.message })
     } finally {
       ctx.setSaving(false)
     }
@@ -353,7 +356,7 @@ export function useSettingsSave(ctx: SaveContext) {
   async function handleCreateSet(createSetName: string) {
     const name = createSetName.trim()
     if (!name) {
-      showToast({ title: "Config Set name required" })
+      showToast({ type: "warning", title: "Config Set name required" })
       return
     }
 
@@ -365,11 +368,12 @@ export function useSettingsSave(ctx: SaveContext) {
       ctx.setActiveTab("general")
       ctx.resetEditor()
       showToast({
+        type: "info",
         title: `Now editing ${name}`,
         description: `${name} starts as a copy of ${ctx.activeSet()?.name ?? "the active set"}. Review the tabs and save any changes you want to keep.`,
       })
     } catch (error: any) {
-      showToast({ title: "Failed to create Config Set", description: error.message })
+      showToast({ type: "error", title: "Failed to create Config Set", description: error.message })
     } finally {
       ctx.setSaving(false)
     }
@@ -377,7 +381,7 @@ export function useSettingsSave(ctx: SaveContext) {
 
   async function handleDeleteSet(name: string) {
     if (name === ctx.activeSet()?.name) {
-      showToast({ title: "Cannot delete active Config Set" })
+      showToast({ type: "warning", title: "Cannot delete active Config Set" })
       return
     }
 
@@ -386,9 +390,9 @@ export function useSettingsSave(ctx: SaveContext) {
       await globalSDK.client.config.set.delete({ name })
       await globalSync.loadConfigSets()
       if (ctx.selectedSet()?.name === name) ctx.setSelectedSetName(ctx.activeSet()?.name)
-      showToast({ title: "Config Set deleted", description: name })
+      showToast({ type: "info", title: "Config Set deleted", description: name })
     } catch (error: any) {
-      showToast({ title: "Failed to delete Config Set", description: error.message })
+      showToast({ type: "error", title: "Failed to delete Config Set", description: error.message })
     } finally {
       ctx.setSaving(false)
     }

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -96,7 +96,7 @@ export function Sidebar(props: SidebarProps) {
   const isGlobal = () => !dir() || dir() === "global" || !currentDirectory()
   const handleNewSession = async () => {
     if (isGlobal()) {
-      showToast({ title: "New Session", description: "Global sessions are coming soon." })
+      showToast({ type: "info", title: "New Session", description: "Global sessions are coming soon." })
       return
     }
     const scope = scopes().find((s) => s.worktree === currentDirectory())

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -322,7 +322,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
             }),
           )
           showToast({
-            variant: "error",
+            type: "error",
             title: "Failed to load file",
             description: e.message,
           })

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -372,7 +372,7 @@ function createGlobalSync() {
         console.error("Failed to load sessions", err)
         if (!sdk) {
           const project = getFilename(directory)
-          showToast({ title: `Failed to load sessions for ${project}`, description: err.message })
+          showToast({ type: "error", title: `Failed to load sessions for ${project}`, description: err.message })
         }
       })
   }

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -427,7 +427,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           })
           .catch((e) => {
             showToast({
-              variant: "error",
+              type: "error",
               title: "Failed to load file",
               description: e.message,
             })

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -7,7 +7,7 @@ import { base64Decode, base64Encode } from "@ericsanchezok/synergy-util/encode"
 import { getFilename } from "@ericsanchezok/synergy-util/path"
 import { usePlatform } from "@/context/platform"
 import { createStore } from "solid-js/store"
-import { showToast, Toast, toaster } from "@ericsanchezok/synergy-ui/toast"
+import { showToast, Toast, toaster, setToastConfig, type ToastConfig } from "@ericsanchezok/synergy-ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useNotification } from "@/context/notification"
 import { PanelProvider, usePanel, PANELS } from "@/context/panel"
@@ -47,6 +47,21 @@ export default function Layout(props: ParentProps) {
   const command = useCommand()
   const theme = useTheme()
   const [searchOpen, setSearchOpen] = createSignal(false)
+  // Wire toast config from serialized config, watching the current directory's config.
+  createEffect(() => {
+    const dir = params.dir ? base64Decode(params.dir) : undefined
+    if (!dir) return
+    const [store] = globalSync.child(dir)
+    const cfg = (store.config as any)?.toast
+    setToastConfig(
+      cfg
+        ? {
+            muted: cfg.muted,
+            durationOverrides: cfg.durationOverrides,
+          }
+        : undefined,
+    )
+  })
 
   const colorSchemeOrder: ColorScheme[] = ["system", "light", "dark"]
   const colorSchemeLabel: Record<ColorScheme, string> = {
@@ -63,6 +78,7 @@ export default function Layout(props: ParentProps) {
     const next = colorSchemeOrder[nextIndex]
     theme.setColorScheme(next)
     showToast({
+      type: "info",
       title: "Color scheme",
       description: colorSchemeLabel[next],
     })
@@ -105,6 +121,7 @@ export default function Layout(props: ParentProps) {
       }
 
       const toastId = showToast({
+        type: "warning",
         persistent: true,
         icon: "shield-alert",
         title: "Permission required",
@@ -510,7 +527,7 @@ function LayoutContent(
       <MobilePanelOverlay />
       <GlobalSearchModal open={props.searchOpen} onClose={props.onSearchClose} />
       <GlobalPanelOverlay panelContent={() => <GlobalPanelSwitch />} />
-      <Toast.Region />
+      <Toast.Region limit={5} swipeDirection="right" pauseOnInteraction={true} />
     </div>
   )
 }

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -1217,6 +1217,20 @@ export const Info = z
       .record(z.string(), CategoryConfig)
       .optional()
       .describe("Custom category configurations for background tasks. Categories define model and prompt presets."),
+    toast: z
+      .object({
+        muted: z
+          .array(z.enum(["info", "success", "warning", "error"]))
+          .optional()
+          .describe("Toast types to suppress. The underlying logic still runs but the visual card is not rendered."),
+        durationOverrides: z
+          .record(z.enum(["info", "success", "warning", "error"]), z.number().int().positive().max(30000))
+          .optional()
+          .describe("Override auto-dismiss duration in ms per toast type (max 30s)."),
+      })
+      .strict()
+      .optional()
+      .describe("Toast notification preferences"),
   })
   .strict()
   .meta({

--- a/packages/synergy/src/runtime/reload.ts
+++ b/packages/synergy/src/runtime/reload.ts
@@ -50,7 +50,7 @@ export namespace RuntimeReload {
     "external_agent",
     "email",
   ])
-  export const CONFIG_CLIENT_SIDE = new Set(["theme", "keybinds", "layout"])
+  export const CONFIG_CLIENT_SIDE = new Set(["theme", "keybinds", "layout", "toast"])
 
   export const Event = {
     Reloaded: BusEvent.define(

--- a/packages/ui/src/components/icon.tsx
+++ b/packages/ui/src/components/icon.tsx
@@ -147,6 +147,7 @@ import {
   Telescope,
   Terminal,
   TextSelect,
+  TriangleAlert,
   Trash2,
   Undo2,
   Redo2,
@@ -164,6 +165,7 @@ import {
 const icons = {
   activity: Activity,
   "align-right": AlignRight,
+  "alert-triangle": TriangleAlert,
   archive: Archive,
   "arrow-down-to-line": ArrowDownToLine,
   "arrow-left": ArrowLeft,

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -1,19 +1,18 @@
 [data-component="toast-region"] {
   position: fixed;
-  bottom: 48px;
-  right: 32px;
+  bottom: 40px;
+  right: 24px;
   z-index: 1000;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  max-width: 400px;
-  width: 100%;
+  gap: 6px;
+  max-width: 380px;
   pointer-events: none;
 
   [data-slot="toast-list"] {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -22,31 +21,39 @@
 
 [data-component="toast"] {
   display: flex;
-  align-items: flex-start;
-  gap: 20px;
-  padding: 16px 20px;
-  pointer-events: auto;
-  transition: all 150ms ease-out;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  height: 42px;
+  overflow: hidden;
+  transition:
+    height 200ms var(--motion-ease-emphasized),
+    padding 200ms var(--motion-ease-emphasized);
 
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-base);
+  border-left: 3px solid var(--toast-accent, var(--border-base));
   background: var(--surface-raised-stronger-non-alpha);
-  color: var(--text-base);
   box-shadow: var(--shadow-lg);
   backdrop-filter: blur(16px);
+  pointer-events: auto;
 
-  [data-slot="toast-inner"] {
-    display: flex;
+  max-width: 380px;
+
+  &:hover,
+  &:focus-within {
+    height: auto;
+    max-height: 220px;
     align-items: flex-start;
-    gap: 10px;
+    padding: 14px 18px;
   }
 
   &[data-opened] {
-    animation: toastPopIn 150ms ease-out;
+    animation: toastPopIn 200ms var(--motion-ease-emphasized);
   }
 
   &[data-closed] {
-    animation: toastPopOut 100ms ease-in forwards;
+    animation: toastPopOut 150ms ease-in forwards;
   }
 
   &[data-swipe="move"] {
@@ -61,18 +68,6 @@
   &[data-swipe="end"] {
     animation: toastSwipeOut 100ms ease-out forwards;
   }
-
-  /* &[data-variant="success"] { */
-  /*   border-color: var(--color-semantic-positive); */
-  /* } */
-  /**/
-  /* &[data-variant="error"] { */
-  /*   border-color: var(--color-semantic-danger); */
-  /* } */
-  /**/
-  /* &[data-variant="loading"] { */
-  /*   border-color: var(--color-semantic-info); */
-  /* } */
 
   [data-slot="toast-icon"] {
     flex-shrink: 0;
@@ -89,42 +84,27 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 2px;
     min-width: 0;
   }
 
   [data-slot="toast-title"] {
     color: var(--text-strong);
-
-    /* text-14-medium */
-    font-family: var(--font-family-sans);
-    font-size: 14px;
-    font-style: normal;
+    font-size: 13px;
     font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large); /* 142.857% */
-    letter-spacing: var(--letter-spacing-normal);
-
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     margin: 0;
   }
 
   [data-slot="toast-description"] {
     color: var(--text-base);
-    text-wrap-style: pretty;
-
-    /* text-14-regular */
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
-    font-style: normal;
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-x-large); /* 171.429% */
-    letter-spacing: var(--letter-spacing-normal);
-
-    margin: 0;
+    font-size: 13px;
   }
 
   [data-slot="toast-actions"] {
     display: flex;
-    gap: 16px;
+    gap: 12px;
     margin-top: 8px;
   }
 
@@ -133,13 +113,9 @@
     border: none;
     padding: 0;
     cursor: pointer;
-
     color: var(--text-weak);
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
+    font-size: 13px;
     font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large);
-    letter-spacing: var(--letter-spacing-normal);
 
     &:hover {
       text-decoration: underline;
@@ -152,6 +128,13 @@
 
   [data-slot="toast-close-button"] {
     flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 150ms;
+  }
+
+  &:hover [data-slot="toast-close-button"],
+  &:focus-within [data-slot="toast-close-button"] {
+    opacity: 1;
   }
 
   [data-slot="toast-progress-track"] {
@@ -159,39 +142,116 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: 3px;
-    background-color: var(--surface-base);
+    height: 2px;
+    background: var(--surface-base);
+    opacity: 0;
+    transition: opacity 150ms;
     border-radius: 0 0 var(--radius-lg) var(--radius-lg);
     overflow: hidden;
+  }
+
+  &:hover [data-slot="toast-progress-track"],
+  &:focus-within [data-slot="toast-progress-track"] {
+    opacity: 1;
   }
 
   [data-slot="toast-progress-fill"] {
     height: 100%;
     width: var(--kb-toast-progress-fill-width);
-    background-color: var(--color-primary);
+    background: var(--toast-accent, var(--border-base));
     transition: width 250ms linear;
   }
+}
+
+.toast-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.toast-body {
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition:
+    opacity 150ms ease,
+    max-height 200ms ease;
+}
+
+[data-component="toast"]:hover .toast-body,
+[data-component="toast"]:focus-within .toast-body {
+  opacity: 1;
+  max-height: 120px;
+}
+
+.toast-countdown {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-weaker);
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  min-width: 24px;
+  text-align: right;
+  margin-left: auto;
+}
+
+[data-type="success"] {
+  --toast-accent: var(--icon-success-base);
+}
+[data-type="error"] {
+  --toast-accent: var(--icon-critical-base);
+}
+[data-type="warning"] {
+  --toast-accent: var(--icon-warning-base);
+}
+[data-type="info"] {
+  --toast-accent: var(--border-base);
+}
+
+[data-type="success"] [data-slot="toast-icon"] [data-component="icon"] {
+  color: var(--icon-success-base);
+}
+[data-type="error"] [data-slot="toast-icon"] [data-component="icon"] {
+  color: var(--icon-critical-base);
+}
+[data-type="warning"] [data-slot="toast-icon"] [data-component="icon"] {
+  color: var(--icon-warning-base);
+}
+[data-type="info"] [data-slot="toast-icon"] [data-component="icon"] {
+  color: var(--icon-base);
+}
+
+[data-slot="toast-list"] [data-component="toast"]:nth-child(n + 2) {
+  opacity: 0.85;
+  transform: translateY(-4px);
+}
+
+[data-slot="toast-list"] [data-component="toast"]:nth-child(n + 3) {
+  opacity: 0.6;
+  transform: translateY(-8px);
 }
 
 @keyframes toastPopIn {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(12px) scale(0.97);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
 }
 
 @keyframes toastPopOut {
   from {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
   to {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(8px) scale(0.97);
   }
 }
 

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -1,9 +1,9 @@
 import { Toast as Kobalte, toaster } from "@kobalte/core/toast"
 import type { ToastRootProps, ToastCloseButtonProps, ToastTitleProps, ToastDescriptionProps } from "@kobalte/core/toast"
 import type { ComponentProps, JSX } from "solid-js"
-import { Show } from "solid-js"
+import { createSignal, onCleanup, Show } from "solid-js"
 import { Portal } from "solid-js/web"
-import { Icon, type IconProps, type IconName } from "./icon"
+import { Icon, type IconName } from "./icon"
 
 export interface ToastRegionProps extends ComponentProps<typeof Kobalte.Region> {}
 
@@ -90,88 +90,110 @@ export const Toast = Object.assign(ToastRoot, {
 
 export { toaster }
 
-export type ToastVariant = "default" | "success" | "error" | "loading"
+export type ToastType = "info" | "success" | "warning" | "error"
 
 export interface ToastAction {
   label: string
   onClick: "dismiss" | (() => void)
 }
+export interface ToastConfig {
+  muted?: ToastType[]
+  durationOverrides?: Partial<Record<ToastType, number>>
+}
+
+let toastConfig: ToastConfig | undefined
+
+export function setToastConfig(config: ToastConfig | undefined) {
+  toastConfig = config
+}
 
 export interface ToastOptions {
+  type?: ToastType
   title?: string
   description?: string
   icon?: IconName
-  variant?: ToastVariant
   duration?: number
   persistent?: boolean
   actions?: ToastAction[]
 }
 
-export function showToast(options: ToastOptions | string) {
-  const opts = typeof options === "string" ? { description: options } : options
-  return toaster.show((props) => (
-    <Toast
-      toastId={props.toastId}
-      duration={opts.duration}
-      persistent={opts.persistent}
-      data-variant={opts.variant ?? "default"}
-    >
-      <Show when={opts.icon}>
-        <Toast.Icon name={opts.icon!} />
-      </Show>
-      <Toast.Content>
-        <Show when={opts.title}>
-          <Toast.Title>{opts.title}</Toast.Title>
-        </Show>
-        <Show when={opts.description}>
-          <Toast.Description>{opts.description}</Toast.Description>
-        </Show>
-        <Show when={opts.actions?.length}>
-          <Toast.Actions>
-            {opts.actions!.map((action) => (
-              <button
-                data-slot="toast-action"
-                onClick={() => {
-                  if (typeof action.onClick === "function") {
-                    action.onClick()
-                  }
-                  toaster.dismiss(props.toastId)
-                }}
-              >
-                {action.label}
-              </button>
-            ))}
-          </Toast.Actions>
-        </Show>
-      </Toast.Content>
-      <Toast.CloseButton />
-    </Toast>
-  ))
+function defaultIconForType(type: ToastType): IconName | undefined {
+  switch (type) {
+    case "success":
+      return "circle-check"
+    case "warning":
+      return "alert-triangle"
+    case "error":
+      return "circle-x"
+    default:
+      return undefined
+  }
 }
 
-export interface ToastPromiseOptions<T, U = unknown> {
-  loading?: JSX.Element
-  success?: (data: T) => JSX.Element
-  error?: (error: U) => JSX.Element
-}
+export function showToast(options: ToastOptions): number {
+  const type = options.type ?? "info"
 
-export function showPromiseToast<T, U = unknown>(
-  promise: Promise<T> | (() => Promise<T>),
-  options: ToastPromiseOptions<T, U>,
-) {
-  return toaster.promise(promise, (props) => (
-    <Toast
-      toastId={props.toastId}
-      data-variant={props.state === "pending" ? "loading" : props.state === "fulfilled" ? "success" : "error"}
-    >
-      <Toast.Content>
-        <Toast.Description>
-          {props.state === "pending" && options.loading}
-          {props.state === "fulfilled" && options.success?.(props.data!)}
-          {props.state === "rejected" && options.error?.(props.error)}
-        </Toast.Description>
-      </Toast.Content>
-      <Toast.CloseButton />
-    </Toast>
-  ))
+  if (toastConfig?.muted?.includes(type)) return 0
+
+  const resolvedDuration = options.duration ?? toastConfig?.durationOverrides?.[type]
+  const iconName = options.icon ?? defaultIconForType(type)
+  return toaster.show((props) => {
+    const [countdown, setCountdown] = createSignal("")
+    const duration = resolvedDuration ?? 5000
+
+    if (!options.persistent && options.duration !== 0) {
+      const startTime = Date.now()
+      let rafId: number
+      const tick = () => {
+        const elapsed = Date.now() - startTime
+        const remaining = Math.max(0, duration - elapsed)
+        setCountdown(`${Math.ceil(remaining / 1000)}s`)
+        if (remaining > 0) rafId = requestAnimationFrame(tick)
+      }
+      rafId = requestAnimationFrame(tick)
+      onCleanup(() => cancelAnimationFrame(rafId))
+    }
+
+    return (
+      <Toast toastId={props.toastId} duration={duration} persistent={options.persistent} data-type={type}>
+        <Show when={iconName}>
+          <Toast.Icon name={iconName!} />
+        </Show>
+        <Toast.Content>
+          <div class="toast-header">
+            <Show when={options.title}>
+              <Toast.Title>{options.title}</Toast.Title>
+            </Show>
+            <span class="toast-countdown">{countdown()}</span>
+          </div>
+          <div class="toast-body">
+            <Show when={options.description}>
+              <Toast.Description>{options.description}</Toast.Description>
+            </Show>
+            <Show when={options.actions?.length}>
+              <Toast.Actions>
+                {options.actions!.map((action) => (
+                  <button
+                    data-slot="toast-action"
+                    onClick={() => {
+                      if (typeof action.onClick === "function") {
+                        action.onClick()
+                      }
+                      toaster.dismiss(props.toastId)
+                    }}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </Toast.Actions>
+            </Show>
+          </div>
+          <Toast.ProgressTrack>
+            <Toast.ProgressFill />
+          </Toast.ProgressTrack>
+        </Toast.Content>
+        <Toast.CloseButton />
+      </Toast>
+    )
+  })
 }


### PR DESCRIPTION
## Summary
- Replaced `ToastVariant` with semantic `ToastType` (`info`, `success`, `warning`, `error`)
- Collapsible card: 42px collapsed single-line → expand on hover
- Countdown display via rAF
- Auto-inferred icons, accent left-border, type-colored icons
- Removed dead code: `showPromiseToast`, `ToastVariant`, `ToastPromiseOptions`
- Added `toast` config field (muted types, duration overrides)
- All 47+ call sites annotated with semantic `type:`
- Added `TriangleAlert` icon

## Test plan
- 554 pass / 0 new failures (118 pre-existing env issues in worktree)