### PR TITLE
fix(session): prevent title flicker from redundant summary saves

### DIFF
--- a/packages/synergy/src/session/summary.ts
+++ b/packages/synergy/src/session/summary.ts
@@ -183,7 +183,15 @@ export namespace SessionSummary {
 
     if (title) userMsg.summary.title = title
     if (body) userMsg.summary.body = body
-    await saveSummary(userMsg)
+
+    // Only persist when new content was produced. The processor path
+    // (finish-step) calls summarize() on every step; without this
+    // guard, saveSummary fires message.updated every time — even when
+    // title and body are unchanged — causing the frontend Typewriter to
+    // restart and producing a visible flicker.
+    if (title || body) {
+      await saveSummary(userMsg)
+    }
   }
 
   export const diff = fn(


### PR DESCRIPTION
## Summary

- 修复 session turn title 闪烁问题
- 只在真的有新 title 或 body 生成时才调用 `saveSummary()`

## Root Cause

`processor` 的 `finish-step` handler 在每个 LLM step 完成时都会调用 `SessionSummary.summarize()`。第一次调用时 LoopJob 已经生成了 title，后续调用 `generateTitle()` 因 `!userMsg.summary?.title` 不满足而返回 `undefined`，title 生成被跳过。但 `saveSummary()` 之前无条件执行，每次都触发 `message.updated` 事件：

1. 前端收到新事件 → Solid reconcile user message
2. `msg().summary` 引用变化 → `<Show when={msg().summary?.title}>` 重新求值
3. Typewriter `createEffect` 重新触发 → 清空文本重新打字
4. 视觉上消失又出现

## Fix

`packages/synergy/src/session/summary.ts:186` — 只在 `title || body` 时调用 `saveSummary()`。