### PR TITLE
refactor(app): unify session icon source of truth across all sidebar containers

### DIFF
--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -39,34 +39,44 @@ interface SessionStoreSlice {
   session: { id: string; parentID?: string; category?: string; workspace?: { type?: string } }[]
 }
 
-function resolveSessionVisualState(store: SessionStoreSlice, entry: NavEntry): SessionVisualState {
-  const status = store.session_status[entry.id]
-  const waiting = !!store.permission[entry.id]?.length || !!store.question[entry.id]?.length
-  const running = status?.type === "busy" || status?.type === "retry"
-  const childTasksRunning = store.cortex.some((task) => task.parentSessionID === entry.id && task.status === "running")
-  const fullSession = store.session.find((session) => session.id === entry.id)
+function resolveSessionVisualState(store: SessionStoreSlice | undefined, entry: NavEntry): SessionVisualState {
+  if (store) {
+    const status = store.session_status[entry.id]
+    const waiting = !!store.permission[entry.id]?.length || !!store.question[entry.id]?.length
+    const running = status?.type === "busy" || status?.type === "retry"
+    const childTasksRunning = store.cortex.some(
+      (task) => task.parentSessionID === entry.id && task.status === "running",
+    )
+    const fullSession = store.session.find((s) => s.id === entry.id)
 
-  if (running || childTasksRunning)
-    return { icon: getSemanticIcon("session.running"), label: "Running session", tone: "active", pulse: true }
-  if (waiting)
-    return { icon: getSemanticIcon("session.waiting"), label: "Waiting for you", tone: "waiting", pulse: true }
-  if (fullSession?.workspace?.type === "git_worktree")
-    return { icon: getSemanticIcon("workspace.worktree"), label: "Worktree session", tone: "worktree" }
-  if (entry.parentID) return { icon: getSemanticIcon("session.child"), label: "Child session", tone: "muted" }
-  if (entry.category === "background")
-    return { icon: getSemanticIcon("session.background"), label: "Background session", tone: "muted" }
-  if (entry.category === "channel")
-    return { icon: getSemanticIcon("session.channel"), label: "Channel session", tone: "muted" }
-  return { icon: getSemanticIcon("session.default"), label: "Session", tone: "default" }
-}
-
-function resolveGlobalSessionIcon(entry: NavEntry): SessionVisualState {
+    if (running || childTasksRunning)
+      return { icon: getSemanticIcon("session.running"), label: "Running session", tone: "active", pulse: true }
+    if (waiting)
+      return { icon: getSemanticIcon("session.waiting"), label: "Waiting for you", tone: "waiting", pulse: true }
+    if (fullSession?.workspace?.type === "git_worktree")
+      return { icon: getSemanticIcon("workspace.worktree"), label: "Worktree session", tone: "worktree" }
+    if (entry.parentID) return { icon: getSemanticIcon("session.child"), label: "Child session", tone: "muted" }
+    if (entry.category === "home") return { icon: "home", label: "Home session", tone: "default" }
+  }
+  // Fallback when store is unavailable (category-only)
   if (entry.category === "background")
     return { icon: getSemanticIcon("session.background"), label: "Background session", tone: "muted" }
   if (entry.category === "channel")
     return { icon: getSemanticIcon("session.channel"), label: "Channel session", tone: "muted" }
   if (entry.category === "home") return { icon: "home", label: "Home session", tone: "default" }
   return { icon: getSemanticIcon("session.default"), label: "Session", tone: "default" }
+}
+
+function getStoreForEntry(
+  globalSync: ReturnType<typeof useGlobalSync>,
+  entry: NavEntry,
+): SessionStoreSlice | undefined {
+  if (entry.scopeType === "global" || entry.scopeID === "global") {
+    return globalSync.child("global")[0]
+  }
+  const scope = globalSync.data.scope.find((s) => s.id === entry.scopeID)
+  if (!scope?.worktree) return undefined
+  return globalSync.child(scope.worktree)[0]
 }
 
 export function Sidebar(props: SidebarProps) {
@@ -371,7 +381,7 @@ export function Sidebar(props: SidebarProps) {
                         }}
                         onClick={() => handleNavEntryClick(entry)}
                       >
-                        <SessionRowIcon entry={entry} isGlobal={true} />
+                        <SessionRowIcon entry={entry} />
                         <span class="sb-session-title">{entry.title || "Untitled"}</span>
                       </button>
                     )}
@@ -423,7 +433,7 @@ export function Sidebar(props: SidebarProps) {
                           }}
                           onClick={() => handleNavEntryClick(entry)}
                         >
-                          <SessionRowIcon entry={entry} isGlobal={true} />
+                          <SessionRowIcon entry={entry} />
                           <span class="sb-session-title">{entry.title || "Untitled"}</span>
                         </button>
                       )}
@@ -443,7 +453,7 @@ export function Sidebar(props: SidebarProps) {
                           }}
                           onClick={() => handleNavEntryClick(entry)}
                         >
-                          <SessionRowIcon entry={entry} isGlobal={true} />
+                          <SessionRowIcon entry={entry} />
                           <span class="sb-session-title">{entry.title || "Untitled"}</span>
                         </button>
                       )}
@@ -722,7 +732,7 @@ function RootNavSection(props: {
                     }}
                     onClick={() => props.onSessionClick(entry)}
                   >
-                    <SessionRowIcon entry={entry} isGlobal={true} />
+                    <SessionRowIcon entry={entry} />
                     <span class="sb-session-title">{entry.title || "Untitled"}</span>
                   </button>
                 )}
@@ -749,7 +759,6 @@ const CATEGORY_LABELS_PROJECT: Record<string, string> = {
 
 function GroupedSessionList(props: {
   entries: NavEntry[]
-  isGlobal?: boolean
   scope?: LocalScope
   activeID?: string
   onSessionClick: (entry: NavEntry) => void
@@ -789,7 +798,7 @@ function GroupedSessionList(props: {
               props.onSessionClick(entry)
             }}
           >
-            <SessionRowIcon entry={entry} isGlobal={props.isGlobal} scope={props.scope} />
+            <SessionRowIcon entry={entry} scope={props.scope} />
             <span class="sb-session-title">{entry.title || "Untitled"}</span>
           </button>
         )}
@@ -811,7 +820,7 @@ function GroupedSessionList(props: {
                     props.onSessionClick(entry)
                   }}
                 >
-                  <SessionRowIcon entry={entry} isGlobal={props.isGlobal} scope={props.scope} />
+                  <SessionRowIcon entry={entry} scope={props.scope} />
                   <span class="sb-session-title">{entry.title || "Untitled"}</span>
                 </button>
               )}
@@ -823,12 +832,12 @@ function GroupedSessionList(props: {
   )
 }
 
-function SessionRowIcon(props: { entry: NavEntry; isGlobal?: boolean; scope?: LocalScope }) {
+function SessionRowIcon(props: { entry: NavEntry; scope?: LocalScope }) {
   const globalSync = useGlobalSync()
 
   const visual = createMemo(() => {
-    if (props.isGlobal || !props.scope) return resolveGlobalSessionIcon(props.entry)
-    return resolveSessionVisualState(globalSync.child(props.scope.worktree)[0], props.entry)
+    if (props.scope) return resolveSessionVisualState(globalSync.child(props.scope.worktree)[0], props.entry)
+    return resolveSessionVisualState(getStoreForEntry(globalSync, props.entry), props.entry)
   })
 
   return (

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -319,6 +319,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             total: data.total,
           })
         }
+        // Pre-warm the global child store for live sidebar icons
+        globalSync.child("global")
       } finally {
         navPending.delete(key)
       }
@@ -342,6 +344,15 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           setRecentEntries({ items: merged, nextCursor: data.nextCursor, total: data.total })
         } else {
           setRecentEntries({ items: data.items as NavEntry[], nextCursor: data.nextCursor, total: data.total })
+        }
+        // Pre-warm child stores so sidebar icons resolve to live runtime status
+        for (const item of data.items) {
+          if (item.scopeType === "global") {
+            globalSync.child("global")
+          } else {
+            const scope = globalSync.data.scope.find((s) => s.id === item.scopeID)
+            if (scope?.worktree) globalSync.child(scope.worktree)
+          }
         }
       } finally {
         navPending.delete(key)

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -363,8 +363,14 @@ export namespace SessionManager {
             })
           }
         })
-        .catch(() => {
-          // Session was cleaned up before the async fallback ran — safe to ignore.
+        .catch((err) => {
+          // Session was cleaned up before the async fallback ran — idle event dropped.
+          if (status.type === "idle") {
+            log.warn("emitStatus fallback: session already cleaned up, idle event dropped", {
+              sessionID: runtime.sessionID,
+              error: (err as Error)?.message ?? String(err),
+            })
+          }
         })
     }
   }


### PR DESCRIPTION
## Summary

- Unifies sidebar session icon rendering: **Recent/Home/Channel/Background** containers now show live runtime status (running pulse, waiting pulse, worktree, child session) instead of static category-only icons — same source of truth as Projects.
- Merges two previously separate icon resolution paths (`resolveGlobalSessionIcon` + `resolveSessionVisualState`) into one unified decision tree.
- Fixes a bug where `emitStatus` silently dropped idle transition events during session cleanup races.

## Root cause

Sidebar had two independent icon resolution paths:
- **Path A** (`resolveGlobalSessionIcon`): Recent/Home/Channel/Background — static, only checked `entry.category`, zero reactive dependencies. 4 output states.  
- **Path B** (`resolveSessionVisualState`): Projects/Flyout — reactive, read `session_status`/`permission`/`question`/`cortex`/`session` from `globalSync.child(scope.worktree)`. 7 states + pulse animation.

Same session showed different icons in different containers. A running session would pulse in Projects but show a static message-square in Recent.

## Changes

| File | Change |
|---|---|
| `packages/app/src/components/sidebar/sidebar.tsx` | Delete `resolveGlobalSessionIcon`. Rewrite `resolveSessionVisualState` to accept `SessionStoreSlice | undefined`. Add `getStoreForEntry` to route `NavEntry.scopeID` → child store. Rewrite `SessionRowIcon` to use unified path for all containers. Remove unused `isGlobal` prop cascade. |
| `packages/app/src/context/layout.tsx` | Pre-warm child stores in `loadRootNavSection` and `loadGlobalRecent` so icons resolve to live status immediately. |
| `packages/synergy/src/session/manager.ts` | Replace silent `.catch(() => {})` in `emitStatus` async fallback with conditional warning when idle event is dropped. |

## Result

### Sidebar containers — before vs after

| Container | Before | After |
|---|---|---|
| Recent | Static category icon | Running pulse / waiting pulse / worktree / child / ... |
| Home | Static home icon | Running pulse / waiting pulse / home / ... |
| Channel | Static message-circle | Running pulse / waiting pulse / channel / ... |
| Background | Static calendar-days | Running pulse / waiting pulse / background / ... |
| Projects | Already reactive | Unchanged |

## Test

- Format check: PASS
- Session tests (pre-existing env failures, unrelated to this change)
- Typecheck (sidebar.tsx, manager.ts): zero new errors
- Grep: zero remaining references to `resolveGlobalSessionIcon` or `isGlobal` in sidebar