### PR TITLE
feat(app,ui): session progress panel for live DAG/Todo observation above composer

### DIFF
--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -9,6 +9,7 @@ import { NewSessionGreeting } from "./session-new-view"
 import { QuestionPrompt } from "./question-prompt"
 import { PermissionDock } from "./permission-dock"
 import { SubagentDock } from "./subagent-dock"
+import { SessionProgressPanel } from "./session-progress-panel"
 import { SubagentSessionFooter } from "./subagent-session-footer"
 import { type SessionMeta } from "@/composables/use-session-meta"
 import type { usePrompt } from "@/context/prompt"
@@ -122,6 +123,9 @@ export function PromptDock(props: {
                       </button>
                     </div>
                   )}
+                </Show>
+                <Show when={props.sessionID}>
+                  <SessionProgressPanel sessionID={props.sessionID!} />
                 </Show>
                 <div class="relative">
                   <PromptInput

--- a/packages/app/src/components/session/session-progress-dag.tsx
+++ b/packages/app/src/components/session/session-progress-dag.tsx
@@ -10,11 +10,11 @@ interface SessionProgressDagProps {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  completed: "bg-surface-success-base text-text-on-success",
-  running: "bg-surface-interactive-base text-text-on-interactive",
+  completed: "bg-surface-success-base text-on-success-base",
+  running: "bg-surface-interactive-base text-on-interactive-base",
   pending: "bg-surface-raised-stronger text-text-weak",
-  blocked: "bg-surface-danger-base text-text-on-danger",
-  failed: "bg-surface-danger-strong text-text-on-danger",
+  blocked: "bg-surface-critical-base text-on-critical-base",
+  failed: "bg-surface-critical-strong text-on-critical-base",
   cancelled: "bg-surface-raised-stronger text-text-subtle",
 }
 
@@ -24,6 +24,32 @@ export function SessionProgressDag(props: SessionProgressDagProps) {
   const nodes = createMemo<DagNode[]>(() => sync.data.dag[props.sessionID] ?? [])
 
   const summary = createMemo<DagSummary>(() => computeDagSummary(nodes()))
+  const [userInteracted, setUserInteracted] = createSignal(false)
+  let previousNodes = new Map<string, string>()
+
+  const changedNodeId = createMemo(() => {
+    const current = nodes()
+    if (previousNodes.size === 0 && current.length > 0) {
+      for (const n of current) previousNodes.set(n.id, n.status)
+      return undefined
+    }
+    const changed: Array<{ id: string; newStatus: string }> = []
+    for (const n of current) {
+      const prev = previousNodes.get(n.id)
+      if (prev && prev !== n.status) {
+        changed.push({ id: n.id, newStatus: n.status })
+      }
+      previousNodes.set(n.id, n.status)
+    }
+    if (changed.length === 0) return undefined
+    const first = (status: string) => changed.find((c) => c.newStatus === status)
+    return first("failed")?.id ?? first("blocked")?.id ?? first("running")?.id ?? changed[0].id
+  })
+
+  const focusNodeId = createMemo(() => {
+    if (userInteracted() || nodes().length === 0 || nodes().length > 200) return undefined
+    return changedNodeId()
+  })
 
   const [selectedNodeId, setSelectedNodeId] = createSignal<string | undefined>(undefined)
 
@@ -68,6 +94,8 @@ export function SessionProgressDag(props: SessionProgressDagProps) {
           variant="panel"
           selectedNodeId={selectedNodeId()}
           onSelectNode={handleSelectNode}
+          focusNodeId={focusNodeId()}
+          onViewportInteraction={() => setUserInteracted(true)}
         />
         <Show when={selectedNode()}>
           {(node) => (

--- a/packages/app/src/components/session/session-progress-dag.tsx
+++ b/packages/app/src/components/session/session-progress-dag.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createEffect, createSignal, Show, on } from "solid-js"
+import { createMemo, createEffect, createSignal, Show, on, onCleanup } from "solid-js"
 import { useSync } from "@/context/sync"
 import { DagGraph } from "@ericsanchezok/synergy-ui/dag-graph"
 import type { DagNode } from "@ericsanchezok/synergy-ui/dag-graph"
@@ -46,9 +46,23 @@ export function SessionProgressDag(props: SessionProgressDagProps) {
     return first("failed")?.id ?? first("blocked")?.id ?? first("running")?.id ?? changed[0].id
   })
 
+  const [debouncedNodeId, setDebouncedNodeId] = createSignal<string | undefined>(undefined)
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+  createEffect(() => {
+    const id = changedNodeId()
+    if (id === undefined) return
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      setDebouncedNodeId(id)
+    }, 120)
+  })
+
+  onCleanup(() => clearTimeout(debounceTimer))
+
   const focusNodeId = createMemo(() => {
     if (userInteracted() || nodes().length === 0 || nodes().length > 200) return undefined
-    return changedNodeId()
+    return debouncedNodeId()
   })
 
   const [selectedNodeId, setSelectedNodeId] = createSignal<string | undefined>(undefined)

--- a/packages/app/src/components/session/session-progress-dag.tsx
+++ b/packages/app/src/components/session/session-progress-dag.tsx
@@ -1,0 +1,123 @@
+import { createMemo, createEffect, createSignal, Show, on } from "solid-js"
+import { useSync } from "@/context/sync"
+import { DagGraph } from "@ericsanchezok/synergy-ui/dag-graph"
+import type { DagNode } from "@ericsanchezok/synergy-ui/dag-graph"
+import { computeDagSummary, type DagSummary } from "./session-progress-summary"
+
+interface SessionProgressDagProps {
+  sessionID: string
+  class?: string
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  completed: "bg-surface-success-base text-text-on-success",
+  running: "bg-surface-interactive-base text-text-on-interactive",
+  pending: "bg-surface-raised-stronger text-text-weak",
+  blocked: "bg-surface-danger-base text-text-on-danger",
+  failed: "bg-surface-danger-strong text-text-on-danger",
+  cancelled: "bg-surface-raised-stronger text-text-subtle",
+}
+
+export function SessionProgressDag(props: SessionProgressDagProps) {
+  const sync = useSync()
+
+  const nodes = createMemo<DagNode[]>(() => sync.data.dag[props.sessionID] ?? [])
+
+  const summary = createMemo<DagSummary>(() => computeDagSummary(nodes()))
+
+  const [selectedNodeId, setSelectedNodeId] = createSignal<string | undefined>(undefined)
+
+  const selectedNode = createMemo<DagNode | undefined>(() => {
+    const id = selectedNodeId()
+    if (!id) return undefined
+    return nodes().find((n) => n.id === id)
+  })
+
+  createEffect(
+    on(
+      () => nodes().map((n) => n.id),
+      () => {
+        const id = selectedNodeId()
+        if (id && !nodes().some((n) => n.id === id)) {
+          setSelectedNodeId(undefined)
+        }
+      },
+    ),
+  )
+
+  const handleSelectNode = (node: DagNode) => {
+    if (selectedNodeId() === node.id) {
+      setSelectedNodeId(undefined)
+    } else {
+      setSelectedNodeId(node.id)
+    }
+  }
+
+  const resultExpanded = createMemo(() => {
+    const result = selectedNode()?.result
+    if (!result) return false
+    return result.length <= 200
+  })
+
+  return (
+    <Show when={nodes().length > 0} fallback={<div class="text-text-weaker text-xs px-3 py-2">No active plan</div>}>
+      <div class={props.class}>
+        <DagGraph
+          nodes={nodes()}
+          ready={summary().ready}
+          variant="panel"
+          selectedNodeId={selectedNodeId()}
+          onSelectNode={handleSelectNode}
+        />
+        <Show when={selectedNode()}>
+          {(node) => (
+            <div class="bg-surface-raised-base rounded-lg p-3 mt-2 flex flex-col gap-1.5">
+              <div class="flex items-start justify-between gap-2">
+                <span class="text-text-strong font-medium text-sm leading-snug">{node().content}</span>
+                <span
+                  class={`text-11-medium px-1.5 py-0.5 rounded-full shrink-0 ${STATUS_COLORS[node().status] ?? "bg-surface-raised-stronger text-text-subtle"}`}
+                >
+                  {node().status}
+                </span>
+              </div>
+
+              <Show when={node().assign}>
+                <span class="text-xs text-text-weak">Assignee: {node().assign}</span>
+              </Show>
+
+              <Show when={node().deps.length > 0}>
+                <div class="flex flex-wrap items-center gap-1">
+                  <span class="text-xs text-text-subtle">Deps:</span>
+                  {node().deps.map((dep: string) => (
+                    <span class="text-11-regular text-text-weaker bg-surface-raised-stronger-non-alpha rounded px-1 py-px">
+                      {dep}
+                    </span>
+                  ))}
+                </div>
+              </Show>
+
+              <Show when={node().memo}>
+                <div class="bg-surface-raised-stronger-non-alpha rounded-md px-2.5 py-1.5 mt-0.5">
+                  <span class="text-xs text-text-base whitespace-pre-wrap">{node().memo}</span>
+                </div>
+              </Show>
+
+              <Show when={node().result}>
+                {(result) => (
+                  <details open={resultExpanded()} class="mt-0.5">
+                    <summary class="text-xs text-text-weak cursor-pointer select-none hover:text-text-base">
+                      Result{result().length > 200 ? ` (${result().length} chars)` : ""}
+                    </summary>
+                    <div class="bg-surface-raised-stronger-non-alpha rounded-md px-2.5 py-1.5 mt-1">
+                      <span class="text-xs text-text-base whitespace-pre-wrap break-words">{result()}</span>
+                    </div>
+                  </details>
+                )}
+              </Show>
+            </div>
+          )}
+        </Show>
+      </div>
+    </Show>
+  )
+}

--- a/packages/app/src/components/session/session-progress-drawer.tsx
+++ b/packages/app/src/components/session/session-progress-drawer.tsx
@@ -84,6 +84,7 @@ export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
       ref={(el) => {
         rootRef = el
       }}
+      id="session-progress-drawer"
       class={`session-progress-drawer flex flex-col rounded-2xl bg-surface-raised-stronger-non-alpha border border-border-base shadow-sm overflow-hidden ${props.class ?? ""}`}
       aria-label="Current session progress"
       data-closing={closing() ? "" : undefined}

--- a/packages/app/src/components/session/session-progress-drawer.tsx
+++ b/packages/app/src/components/session/session-progress-drawer.tsx
@@ -1,0 +1,104 @@
+import { Show, onMount, onCleanup, type JSX } from "solid-js"
+
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { formatRailText } from "./session-progress-summary"
+import type { DagSummary, TodoSummary } from "./session-progress-summary"
+
+interface SessionProgressDrawerProps {
+  mode: "dag" | "todo" | "both"
+  activeTab: "dag" | "todo"
+  onTabChange: (tab: "dag" | "todo") => void
+  onClose: () => void
+  dagSummary?: DagSummary
+  todoSummary?: TodoSummary
+  children: JSX.Element
+  class?: string
+}
+
+function footerText(dag: DagSummary): string {
+  const parts: string[] = []
+  if (dag.blocked > 0) parts.push(`${dag.blocked} blocked`)
+  if (dag.failed > 0) parts.push(`${dag.failed} failed`)
+  return parts.join(" · ")
+}
+
+export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
+  onMount(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        props.onClose()
+      }
+    }
+    document.addEventListener("keydown", handler)
+    onCleanup(() => document.removeEventListener("keydown", handler))
+  })
+
+  const showFooter = () =>
+    props.mode !== "todo" && props.dagSummary != null && (props.dagSummary.blocked > 0 || props.dagSummary.failed > 0)
+
+  const railText = () => formatRailText(props.mode, props.dagSummary, props.todoSummary)
+
+  const tab = (kind: "dag" | "todo") => {
+    const isActive = () => props.activeTab === kind
+    return (
+      <button
+        type="button"
+        class="rounded-full px-2 py-0.5 text-xs transition-colors"
+        classList={{
+          "bg-surface-interactive-solid text-text-on-interactive-base": isActive(),
+          "text-text-weak hover:text-text-base hover:bg-surface-raised-base-hover": !isActive(),
+        }}
+        onClick={() => props.onTabChange(kind)}
+      >
+        {kind === "dag" ? "DAG" : "To-do"}
+      </button>
+    )
+  }
+
+  return (
+    <div
+      class={`flex flex-col rounded-2xl bg-surface-raised-stronger-non-alpha border border-border-base shadow-sm overflow-hidden ${props.class ?? ""}`}
+      style={{
+        "max-height": "min(52vh, 560px)",
+        "min-height": "280px",
+      }}
+    >
+      {/* Header */}
+      <div class="shrink-0 flex items-center justify-between px-4 h-11 gap-2">
+        <div class="flex items-baseline gap-1.5 min-w-0">
+          <span class="text-xs text-text-weak shrink-0">Current work</span>
+          <Show when={railText()}>
+            <span class="text-xs text-text-subtle truncate">{railText()}</span>
+          </Show>
+        </div>
+
+        <div class="flex items-center gap-1.5 shrink-0">
+          <Show when={props.mode === "both"}>
+            <div class="flex items-center gap-1">
+              {tab("dag")}
+              {tab("todo")}
+            </div>
+          </Show>
+
+          <button
+            type="button"
+            class="flex items-center justify-center size-7 rounded-lg text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover transition-colors"
+            onClick={props.onClose}
+          >
+            <Icon name="x" size="small" />
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div class="flex-1 min-h-0">{props.children}</div>
+
+      {/* Footer */}
+      <Show when={showFooter()}>
+        <div class="shrink-0 px-4 py-2 text-xs text-text-weaker border-t border-border-weaker-base/60">
+          {footerText(props.dagSummary!)}
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/packages/app/src/components/session/session-progress-drawer.tsx
+++ b/packages/app/src/components/session/session-progress-drawer.tsx
@@ -24,6 +24,7 @@ function footerText(dag: DagSummary): string {
 
 export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
   const [closing, setClosing] = createSignal(false)
+  let rootRef: HTMLDivElement | undefined
 
   const handleClose = () => {
     setClosing(true)
@@ -36,13 +37,24 @@ export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
   }
 
   onMount(() => {
-    const handler = (e: KeyboardEvent) => {
+    const keyHandler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         handleClose()
       }
     }
-    document.addEventListener("keydown", handler)
-    onCleanup(() => document.removeEventListener("keydown", handler))
+    document.addEventListener("keydown", keyHandler)
+
+    const clickHandler = (e: MouseEvent) => {
+      if (rootRef && !rootRef.contains(e.target as Node)) {
+        handleClose()
+      }
+    }
+    document.addEventListener("click", clickHandler)
+
+    onCleanup(() => {
+      document.removeEventListener("keydown", keyHandler)
+      document.removeEventListener("click", clickHandler)
+    })
   })
 
   const showFooter = () =>
@@ -69,7 +81,11 @@ export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
 
   return (
     <div
+      ref={(el) => {
+        rootRef = el
+      }}
       class={`session-progress-drawer flex flex-col rounded-2xl bg-surface-raised-stronger-non-alpha border border-border-base shadow-sm overflow-hidden ${props.class ?? ""}`}
+      aria-label="Current session progress"
       data-closing={closing() ? "" : undefined}
       onAnimationEnd={handleAnimationEnd}
       style={{
@@ -80,7 +96,9 @@ export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
       {/* Header */}
       <div class="shrink-0 flex items-center justify-between px-4 h-11 gap-2">
         <div class="flex items-baseline gap-1.5 min-w-0">
-          <span class="text-xs text-text-weak shrink-0">Current work</span>
+          <span class="text-xs text-text-weak shrink-0">
+            {props.mode === "todo" ? "Current tasks" : "Current work"}
+          </span>
           <Show when={railText()}>
             <span class="text-xs text-text-subtle truncate">{railText()}</span>
           </Show>

--- a/packages/app/src/components/session/session-progress-drawer.tsx
+++ b/packages/app/src/components/session/session-progress-drawer.tsx
@@ -1,4 +1,4 @@
-import { Show, onMount, onCleanup, type JSX } from "solid-js"
+import { Show, onMount, onCleanup, createSignal, type JSX } from "solid-js"
 
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { formatRailText } from "./session-progress-summary"
@@ -23,10 +23,22 @@ function footerText(dag: DagSummary): string {
 }
 
 export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
+  const [closing, setClosing] = createSignal(false)
+
+  const handleClose = () => {
+    setClosing(true)
+  }
+
+  const handleAnimationEnd = (e: AnimationEvent) => {
+    if (e.animationName === "drawer-exit") {
+      props.onClose()
+    }
+  }
+
   onMount(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        props.onClose()
+        handleClose()
       }
     }
     document.addEventListener("keydown", handler)
@@ -57,7 +69,9 @@ export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
 
   return (
     <div
-      class={`flex flex-col rounded-2xl bg-surface-raised-stronger-non-alpha border border-border-base shadow-sm overflow-hidden ${props.class ?? ""}`}
+      class={`session-progress-drawer flex flex-col rounded-2xl bg-surface-raised-stronger-non-alpha border border-border-base shadow-sm overflow-hidden ${props.class ?? ""}`}
+      data-closing={closing() ? "" : undefined}
+      onAnimationEnd={handleAnimationEnd}
       style={{
         "max-height": "min(52vh, 560px)",
         "min-height": "280px",
@@ -83,7 +97,7 @@ export function SessionProgressDrawer(props: SessionProgressDrawerProps) {
           <button
             type="button"
             class="flex items-center justify-center size-7 rounded-lg text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover transition-colors"
-            onClick={props.onClose}
+            onClick={handleClose}
           >
             <Icon name="x" size="small" />
           </button>

--- a/packages/app/src/components/session/session-progress-panel.tsx
+++ b/packages/app/src/components/session/session-progress-panel.tsx
@@ -1,0 +1,115 @@
+import { createEffect, createMemo, createSignal, on, Show } from "solid-js"
+import { useSync } from "@/context/sync"
+import {
+  computeProgressMode,
+  computeDagSummary,
+  computeTodoSummary,
+  type ProgressMode,
+} from "./session-progress-summary"
+import { SessionProgressRail } from "./session-progress-rail"
+import { SessionProgressDrawer } from "./session-progress-drawer"
+import { SessionProgressDag } from "./session-progress-dag"
+import { SessionProgressTodo } from "./session-progress-todo"
+
+interface SessionProgressPanelProps {
+  sessionID: string
+  class?: string
+}
+
+export function SessionProgressPanel(props: SessionProgressPanelProps) {
+  const sync = useSync()
+
+  const hasDag = createMemo(() => (sync.data.dag[props.sessionID]?.length ?? 0) > 0)
+  const hasTodo = createMemo(() => (sync.data.todo[props.sessionID]?.length ?? 0) > 0)
+
+  const mode = createMemo<ProgressMode>(() => computeProgressMode(hasDag(), hasTodo()))
+
+  const dagSummary = createMemo(() => {
+    const nodes = sync.data.dag[props.sessionID]
+    if (!nodes) return undefined
+    return computeDagSummary(nodes)
+  })
+
+  const todoSummary = createMemo(() => {
+    const todos = sync.data.todo[props.sessionID]
+    if (!todos) return undefined
+    return computeTodoSummary(todos)
+  })
+
+  const [expanded, setExpanded] = createSignal(false)
+  const [activeTab, setActiveTab] = createSignal<"dag" | "todo">("dag")
+
+  // Auto-close and reset on sessionID change
+  createEffect(
+    on(
+      () => props.sessionID,
+      (_next: string, prev: string | undefined) => {
+        if (prev) {
+          setExpanded(false)
+          setActiveTab("dag")
+        }
+      },
+    ),
+  )
+
+  // Auto-close when all data disappears while expanded
+  createEffect(() => {
+    if (expanded() && mode() === "none") {
+      setExpanded(false)
+    }
+  })
+
+  // Default tab to the active mode when data appears
+  createEffect(() => {
+    const m = mode()
+    if (m === "dag") setActiveTab("dag")
+    else if (m === "todo") setActiveTab("todo")
+  })
+
+  // Lazy data fetch (idempotent)
+  createEffect(() => {
+    if (props.sessionID) {
+      sync.session.dag(props.sessionID)
+      sync.session.todo(props.sessionID)
+    }
+  })
+
+  const renderChild = () => {
+    const m = mode()
+    if (m === "dag") return <SessionProgressDag sessionID={props.sessionID} />
+    if (m === "todo") return <SessionProgressTodo sessionID={props.sessionID} />
+    return activeTab() === "dag" ? (
+      <SessionProgressDag sessionID={props.sessionID} />
+    ) : (
+      <SessionProgressTodo sessionID={props.sessionID} />
+    )
+  }
+
+  const railMode = createMemo(() => mode() as "dag" | "todo" | "both")
+
+  return (
+    <Show when={mode() !== "none"}>
+      <div class={`relative flex flex-col ${props.class ?? ""}`}>
+        <SessionProgressRail
+          mode={railMode()}
+          dagSummary={dagSummary()}
+          todoSummary={todoSummary()}
+          expanded={expanded()}
+          onClick={() => setExpanded((v) => !v)}
+        />
+        <Show when={expanded()}>
+          <SessionProgressDrawer
+            mode={railMode()}
+            activeTab={activeTab()}
+            onTabChange={setActiveTab}
+            onClose={() => setExpanded(false)}
+            dagSummary={dagSummary()}
+            todoSummary={todoSummary()}
+          >
+            {renderChild()}
+          </SessionProgressDrawer>
+        </Show>
+      </div>
+    </Show>
+  )
+}

--- a/packages/app/src/components/session/session-progress-rail.tsx
+++ b/packages/app/src/components/session/session-progress-rail.tsx
@@ -54,7 +54,7 @@ export function SessionProgressRail(props: SessionProgressRailProps) {
     <Show when={text()}>
       <button
         type="button"
-        class={`flex items-center gap-1.5 rounded-2xl border border-border-base bg-surface-raised-stronger-non-alpha px-3 py-1 text-12-regular text-text-weak shadow-sm transition-all duration-150 hover:bg-surface-raised-stronger-hover active:scale-[0.97] ${props.class ?? ""}`}
+        class={`flex items-center gap-1.5 rounded-full border border-border-base bg-surface-raised-stronger-non-alpha px-3 py-1 text-11-medium text-text-weak shadow-sm transition-all duration-150 hover:bg-surface-raised-stronger-hover active:scale-[0.98] ${props.class ?? ""}`}
         aria-label={ariaLabel()}
         aria-expanded={props.expanded}
         onClick={props.onClick}

--- a/packages/app/src/components/session/session-progress-rail.tsx
+++ b/packages/app/src/components/session/session-progress-rail.tsx
@@ -1,0 +1,75 @@
+import { Show, createMemo } from "solid-js"
+import type { DagSummary, TodoSummary } from "./session-progress-summary"
+import { formatRailText, formatProgressText } from "./session-progress-summary"
+
+export interface SessionProgressRailProps {
+  mode: "dag" | "todo" | "both"
+  dagSummary?: DagSummary
+  todoSummary?: TodoSummary
+  expanded: boolean
+  onClick: () => void
+  class?: string
+}
+
+export function SessionProgressRail(props: SessionProgressRailProps) {
+  const text = createMemo(() => formatRailText(props.mode, props.dagSummary, props.todoSummary))
+
+  const dotColor = createMemo(() => {
+    const dag = props.dagSummary
+    switch (dag?.attentionLevel) {
+      case "failed":
+        return "bg-surface-critical-base"
+      case "blocked":
+        return "bg-surface-warning-base"
+      case "running":
+        return "bg-surface-interactive-base"
+    }
+    const todo = props.todoSummary
+    if (todo && todo.inProgress > 0) return "bg-surface-interactive-base"
+    return "bg-surface-raised-strong-hover"
+  })
+
+  const shouldPulse = createMemo(() => {
+    const dag = props.dagSummary
+    const todo = props.todoSummary
+    if (dag && dag.attentionLevel !== "none") return true
+    if (todo && todo.inProgress > 0) return true
+    return false
+  })
+
+  const ariaLabel = createMemo(() => {
+    const parts: string[] = []
+    if (props.mode !== "todo") {
+      const d = props.dagSummary
+      if (d && d.total > 0) parts.push(`DAG ${formatProgressText(d.completed, d.total)}`)
+    }
+    if (props.mode !== "dag") {
+      const t = props.todoSummary
+      if (t && t.total > 0) parts.push(`Todo ${formatProgressText(t.completed, t.total)}`)
+    }
+    return parts.length > 0 ? `Session progress: ${parts.join(" · ")}` : "Session progress"
+  })
+
+  return (
+    <Show when={text()}>
+      <button
+        type="button"
+        class={`flex items-center gap-1.5 rounded-2xl border border-border-base bg-surface-raised-stronger-non-alpha px-3 py-1 text-12-regular text-text-weak shadow-sm transition-all duration-150 hover:bg-surface-raised-stronger-hover active:scale-[0.97] ${props.class ?? ""}`}
+        aria-label={ariaLabel()}
+        aria-expanded={props.expanded}
+        onClick={props.onClick}
+      >
+        <span
+          class={`size-2 shrink-0 rounded-full ${dotColor()} ${shouldPulse() ? "motion-safe:animate-pulse" : ""}`}
+        />
+        <span class="truncate">{text()}</span>
+        <span
+          class="shrink-0 text-[8px] leading-none transition-transform duration-150"
+          classList={{ "rotate-180": props.expanded }}
+        >
+          ▾
+        </span>
+      </button>
+    </Show>
+  )
+}

--- a/packages/app/src/components/session/session-progress-rail.tsx
+++ b/packages/app/src/components/session/session-progress-rail.tsx
@@ -57,6 +57,7 @@ export function SessionProgressRail(props: SessionProgressRailProps) {
         type="button"
         class={`absolute -top-4 left-4 flex items-center gap-1.5 rounded-full border border-border-base bg-surface-raised-stronger-non-alpha px-3 py-1 text-11-medium text-text-weak shadow-sm transition-all duration-150 hover:bg-surface-raised-stronger-hover active:scale-[0.98] ${props.class ?? ""}`}
         aria-label={ariaLabel()}
+        aria-controls="session-progress-drawer"
         aria-expanded={props.expanded}
         onClick={props.onClick}
       >

--- a/packages/app/src/components/session/session-progress-rail.tsx
+++ b/packages/app/src/components/session/session-progress-rail.tsx
@@ -1,6 +1,7 @@
 import { Show, createMemo } from "solid-js"
 import type { DagSummary, TodoSummary } from "./session-progress-summary"
 import { formatRailText, formatProgressText } from "./session-progress-summary"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
 
 export interface SessionProgressRailProps {
   mode: "dag" | "todo" | "both"
@@ -54,21 +55,22 @@ export function SessionProgressRail(props: SessionProgressRailProps) {
     <Show when={text()}>
       <button
         type="button"
-        class={`flex items-center gap-1.5 rounded-full border border-border-base bg-surface-raised-stronger-non-alpha px-3 py-1 text-11-medium text-text-weak shadow-sm transition-all duration-150 hover:bg-surface-raised-stronger-hover active:scale-[0.98] ${props.class ?? ""}`}
+        class={`absolute -top-4 left-4 flex items-center gap-1.5 rounded-full border border-border-base bg-surface-raised-stronger-non-alpha px-3 py-1 text-11-medium text-text-weak shadow-sm transition-all duration-150 hover:bg-surface-raised-stronger-hover active:scale-[0.98] ${props.class ?? ""}`}
         aria-label={ariaLabel()}
         aria-expanded={props.expanded}
         onClick={props.onClick}
       >
+        {/* Colored dot: no filled circle icon available in the project icon system */}
         <span
           class={`size-2 shrink-0 rounded-full ${dotColor()} ${shouldPulse() ? "motion-safe:animate-pulse" : ""}`}
         />
         <span class="truncate">{text()}</span>
-        <span
-          class="shrink-0 text-[8px] leading-none transition-transform duration-150"
+        <Icon
+          name="chevron-down"
+          size="small"
+          class="shrink-0 transition-transform duration-150"
           classList={{ "rotate-180": props.expanded }}
-        >
-          ▾
-        </span>
+        />
       </button>
     </Show>
   )

--- a/packages/app/src/components/session/session-progress-summary.test.ts
+++ b/packages/app/src/components/session/session-progress-summary.test.ts
@@ -1,0 +1,411 @@
+import { describe, test, expect } from "bun:test"
+import {
+  computeDagSummary,
+  computeTodoSummary,
+  computeProgressMode,
+  formatProgressText,
+  formatRailText,
+} from "./session-progress-summary"
+import type { DagNode } from "@ericsanchezok/synergy-ui/dag-graph"
+import type { TodoItem } from "./session-progress-summary"
+
+// --- Helpers ---
+
+function n(
+  id: string,
+  status: string,
+  deps: string[] = [],
+  extra?: Partial<Omit<DagNode, "id" | "status" | "deps">>,
+): DagNode {
+  return { id, content: `Task ${id}`, status, deps, ...extra }
+}
+
+function t(id: string, status: string, priority?: string): TodoItem {
+  return { id, content: `Task ${id}`, status, priority }
+}
+
+// --- computeDagSummary ---
+
+describe("computeDagSummary", () => {
+  test("empty array returns zeros and empty collections", () => {
+    const result = computeDagSummary([])
+    expect(result.total).toBe(0)
+    expect(result.completed).toBe(0)
+    expect(result.running).toBe(0)
+    expect(result.pending).toBe(0)
+    expect(result.blocked).toBe(0)
+    expect(result.failed).toBe(0)
+    expect(result.cancelled).toBe(0)
+    expect(result.ready).toEqual([])
+    expect(result.activeNodeIds).toEqual([])
+    expect(result.attentionLevel).toBe("none")
+    expect(result.progressRatio).toBe(0)
+  })
+
+  test("single pending node counts correctly", () => {
+    const result = computeDagSummary([n("a", "pending")])
+    expect(result.total).toBe(1)
+    expect(result.pending).toBe(1)
+    expect(result.completed).toBe(0)
+    expect(result.running).toBe(0)
+    expect(result.blocked).toBe(0)
+    expect(result.failed).toBe(0)
+    expect(result.cancelled).toBe(0)
+  })
+
+  test("pending node with no deps is vacuously ready", () => {
+    const result = computeDagSummary([n("a", "pending")])
+    // empty deps array → every() returns true (vacuous truth)
+    expect(result.ready).toEqual(["a"])
+  })
+
+  test("pending node with non-existent dep is not ready", () => {
+    const result = computeDagSummary([n("a", "pending", ["nonexistent"])])
+    expect(result.pending).toBe(1)
+    expect(result.ready).toEqual([])
+  })
+
+  test("single completed node", () => {
+    const result = computeDagSummary([n("a", "completed")])
+    expect(result.total).toBe(1)
+    expect(result.completed).toBe(1)
+    expect(result.progressRatio).toBe(1)
+  })
+
+  test("single running node sets attention and activeNodeIds", () => {
+    const result = computeDagSummary([n("a", "running")])
+    expect(result.running).toBe(1)
+    expect(result.attentionLevel).toBe("running")
+    expect(result.activeNodeIds).toEqual(["a"])
+  })
+
+  test("single blocked node sets attention and activeNodeIds", () => {
+    const result = computeDagSummary([n("a", "blocked")])
+    expect(result.blocked).toBe(1)
+    expect(result.attentionLevel).toBe("blocked")
+    expect(result.activeNodeIds).toEqual(["a"])
+  })
+
+  test("single failed node sets attention and activeNodeIds", () => {
+    const result = computeDagSummary([n("a", "failed")])
+    expect(result.failed).toBe(1)
+    expect(result.attentionLevel).toBe("failed")
+    expect(result.activeNodeIds).toEqual(["a"])
+  })
+
+  test("single cancelled node does not set attention", () => {
+    const result = computeDagSummary([n("a", "cancelled")])
+    expect(result.total).toBe(1)
+    expect(result.cancelled).toBe(1)
+    expect(result.attentionLevel).toBe("none")
+    expect(result.activeNodeIds).toEqual([])
+  })
+
+  test("attention priority: failed overrides blocked and running", () => {
+    const nodes = [n("r", "running"), n("b", "blocked"), n("f", "failed")]
+    const result = computeDagSummary(nodes)
+    expect(result.attentionLevel).toBe("failed")
+    expect(result.failed).toBe(1)
+    expect(result.blocked).toBe(1)
+    expect(result.running).toBe(1)
+  })
+
+  test("attention priority: blocked overrides running when no failed", () => {
+    const nodes = [n("r", "running"), n("b", "blocked")]
+    const result = computeDagSummary(nodes)
+    expect(result.attentionLevel).toBe("blocked")
+  })
+
+  test("attentionLevel is none when only pending and completed", () => {
+    const result = computeDagSummary([n("a", "pending"), n("b", "completed")])
+    expect(result.attentionLevel).toBe("none")
+  })
+
+  test("ready includes pending node whose single dep is completed", () => {
+    const result = computeDagSummary([n("a", "completed"), n("b", "pending", ["a"])])
+    expect(result.ready).toEqual(["b"])
+  })
+
+  test("ready excludes pending node whose dep is still pending", () => {
+    const result = computeDagSummary([n("a", "pending"), n("b", "pending", ["a"])])
+    // "a" is ready (no deps), "b" is not ready (dep "a" is only pending)
+    expect(result.ready).toEqual(["a"])
+  })
+
+  test("ready includes pending node whose multiple deps are all completed", () => {
+    const result = computeDagSummary([n("a", "completed"), n("b", "completed"), n("c", "pending", ["a", "b"])])
+    expect(result.ready).toEqual(["c"])
+  })
+
+  test("ready excludes pending node with one dep pending out of multiple", () => {
+    const result = computeDagSummary([n("a", "completed"), n("b", "pending"), n("c", "pending", ["a", "b"])])
+    // "b" is ready (no deps), "c" is not ready (dep "b" is pending)
+    expect(result.ready).toEqual(["b"])
+  })
+
+  test("progressRatio for 3 completed out of 7 total", () => {
+    const nodes = [
+      n("a", "completed"),
+      n("b", "completed"),
+      n("c", "completed"),
+      n("d", "pending"),
+      n("e", "pending"),
+      n("f", "pending"),
+      n("g", "pending"),
+    ]
+    const result = computeDagSummary(nodes)
+    expect(result.total).toBe(7)
+    expect(result.completed).toBe(3)
+    expect(result.progressRatio).toBe(0.43)
+  })
+
+  test("progressRatio includes cancelled nodes in total", () => {
+    const result = computeDagSummary([n("a", "completed"), n("b", "cancelled"), n("c", "cancelled"), n("d", "pending")])
+    expect(result.total).toBe(4)
+    expect(result.completed).toBe(1)
+    expect(result.cancelled).toBe(2)
+    expect(result.progressRatio).toBe(0.25)
+  })
+
+  test("progressRatio is 0 when no nodes completed", () => {
+    const result = computeDagSummary([n("a", "pending"), n("b", "pending")])
+    expect(result.progressRatio).toBe(0)
+  })
+
+  test("activeNodeIds includes running, blocked, and failed but not pending or cancelled", () => {
+    const nodes = [n("r", "running"), n("b", "blocked"), n("f", "failed"), n("p", "pending"), n("c", "cancelled")]
+    const result = computeDagSummary(nodes)
+    expect(result.activeNodeIds).toEqual(["r", "b", "f"])
+  })
+})
+
+// --- computeTodoSummary ---
+
+describe("computeTodoSummary", () => {
+  test("empty array returns zeros", () => {
+    const result = computeTodoSummary([])
+    expect(result.total).toBe(0)
+    expect(result.completed).toBe(0)
+    expect(result.inProgress).toBe(0)
+    expect(result.pending).toBe(0)
+    expect(result.cancelled).toBe(0)
+    expect(result.activeTodoIds).toEqual([])
+    expect(result.progressRatio).toBe(0)
+  })
+
+  test("mixed statuses produce correct counts", () => {
+    const todos = [
+      t("a", "completed"),
+      t("b", "in_progress"),
+      t("c", "pending"),
+      t("d", "cancelled"),
+      t("e", "completed"),
+    ]
+    const result = computeTodoSummary(todos)
+    expect(result.total).toBe(5)
+    expect(result.completed).toBe(2)
+    expect(result.inProgress).toBe(1)
+    expect(result.pending).toBe(1)
+    expect(result.cancelled).toBe(1)
+  })
+
+  test("all cancelled items produce progressRatio 0", () => {
+    const result = computeTodoSummary([t("a", "cancelled"), t("b", "cancelled")])
+    expect(result.total).toBe(2)
+    expect(result.cancelled).toBe(2)
+    expect(result.progressRatio).toBe(0)
+  })
+
+  test("in-progress items populate activeTodoIds", () => {
+    const result = computeTodoSummary([t("a", "in_progress"), t("b", "pending"), t("c", "in_progress")])
+    expect(result.inProgress).toBe(2)
+    expect(result.activeTodoIds).toEqual(["a", "c"])
+  })
+
+  test("progressRatio excludes cancelled from denominator", () => {
+    const result = computeTodoSummary([
+      t("a", "completed"),
+      t("b", "completed"),
+      t("c", "completed"),
+      t("d", "pending"),
+      t("e", "pending"),
+      t("f", "cancelled"),
+    ])
+    expect(result.total).toBe(6)
+    expect(result.cancelled).toBe(1)
+    // denominator = 6 - 1 = 5, ratio = 3/5 = 0.6
+    expect(result.progressRatio).toBe(0.6)
+  })
+
+  test("progressRatio is 1 when all non-cancelled are completed", () => {
+    const result = computeTodoSummary([t("a", "completed"), t("b", "completed"), t("c", "cancelled")])
+    expect(result.progressRatio).toBe(1)
+  })
+
+  test("progressRatio is 0 when only cancelled items exist", () => {
+    // all cancelled: denominator = 0, total = 3, fallback = clampRatio(0/3) = 0
+    const result = computeTodoSummary([t("a", "cancelled"), t("b", "cancelled"), t("c", "cancelled")])
+    expect(result.progressRatio).toBe(0)
+  })
+
+  test("progressRatio handles completed and cancelled only", () => {
+    // denominator = 3 - 2 = 1, ratio = 1/1 = 1
+    const result = computeTodoSummary([t("a", "completed"), t("b", "cancelled"), t("c", "cancelled")])
+    expect(result.progressRatio).toBe(1)
+  })
+})
+
+// --- computeProgressMode ---
+
+describe("computeProgressMode", () => {
+  test("both false returns none", () => {
+    expect(computeProgressMode(false, false)).toBe("none")
+  })
+
+  test("only DAG returns dag", () => {
+    expect(computeProgressMode(true, false)).toBe("dag")
+  })
+
+  test("only Todo returns todo", () => {
+    expect(computeProgressMode(false, true)).toBe("todo")
+  })
+
+  test("both true returns both", () => {
+    expect(computeProgressMode(true, true)).toBe("both")
+  })
+})
+
+// --- formatProgressText ---
+
+describe("formatProgressText", () => {
+  test("all done returns complete", () => {
+    expect(formatProgressText(5, 5)).toBe("complete")
+  })
+
+  test("over-completed returns complete", () => {
+    expect(formatProgressText(6, 5)).toBe("complete")
+  })
+
+  test("partial returns fraction string", () => {
+    expect(formatProgressText(3, 7)).toBe("3/7")
+  })
+
+  test("nothing done returns 0/5", () => {
+    expect(formatProgressText(0, 5)).toBe("0/5")
+  })
+
+  test("zero total returns 0/0", () => {
+    expect(formatProgressText(0, 0)).toBe("0/0")
+  })
+})
+
+// --- formatRailText ---
+
+describe("formatRailText", () => {
+  test("mode none returns empty string", () => {
+    const dag = computeDagSummary([n("a", "running")])
+    expect(formatRailText("none", dag)).toBe("")
+  })
+
+  test("mode dag with running attention", () => {
+    const dag = computeDagSummary([
+      n("a", "completed"),
+      n("b", "completed"),
+      n("c", "running"),
+      n("d", "pending"),
+      n("e", "pending"),
+    ])
+    expect(formatRailText("dag", dag)).toBe("DAG 2/5 · running")
+  })
+
+  test("mode dag with failed attention", () => {
+    const dag = computeDagSummary([
+      n("a", "completed"),
+      n("b", "completed"),
+      n("c", "failed"),
+      n("d", "pending"),
+      n("e", "pending"),
+    ])
+    expect(formatRailText("dag", dag)).toBe("DAG 2/5 · failed")
+  })
+
+  test("mode dag with blocked attention", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "blocked"), n("c", "pending")])
+    expect(formatRailText("dag", dag)).toBe("DAG 1/3 · blocked")
+  })
+
+  test("mode dag with no attention indicator when all normal", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "completed"), n("c", "pending")])
+    expect(formatRailText("dag", dag)).toBe("DAG 2/3")
+  })
+
+  test("mode dag with zero total returns empty string", () => {
+    const dag = computeDagSummary([])
+    expect(formatRailText("dag", dag)).toBe("")
+  })
+
+  test("mode dag with all completed returns complete indicator", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "completed"), n("c", "completed")])
+    expect(formatRailText("dag", dag)).toBe("DAG complete")
+  })
+
+  test("mode todo with mixed progress", () => {
+    const todo = computeTodoSummary([
+      t("a", "completed"),
+      t("b", "completed"),
+      t("c", "completed"),
+      t("d", "pending"),
+      t("e", "pending"),
+      t("f", "pending"),
+      t("g", "pending"),
+    ])
+    expect(formatRailText("todo", undefined, todo)).toBe("Todo 3/7")
+  })
+
+  test("mode todo with zero total returns empty string", () => {
+    const todo = computeTodoSummary([])
+    expect(formatRailText("todo", undefined, todo)).toBe("")
+  })
+
+  test("mode both with both present", () => {
+    const dag = computeDagSummary([
+      n("a", "completed"),
+      n("b", "completed"),
+      n("c", "pending"),
+      n("d", "pending"),
+      n("e", "pending"),
+    ])
+    const todo = computeTodoSummary([
+      t("x", "completed"),
+      t("y", "completed"),
+      t("z", "completed"),
+      t("w", "pending"),
+      t("v", "pending"),
+      t("u", "pending"),
+      t("r", "pending"),
+    ])
+    expect(formatRailText("both", dag, todo)).toBe("DAG 2/5 · Todo 3/7")
+  })
+
+  test("mode both when only dag has nodes", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "pending")])
+    const todo = computeTodoSummary([])
+    expect(formatRailText("both", dag, todo)).toBe("DAG 1/2")
+  })
+
+  test("mode both when only todo has nodes", () => {
+    const dag = computeDagSummary([])
+    const todo = computeTodoSummary([t("a", "completed"), t("b", "pending")])
+    expect(formatRailText("both", dag, todo)).toBe("Todo 1/2")
+  })
+
+  test("mode both when neither has nodes returns empty string", () => {
+    expect(formatRailText("both", computeDagSummary([]), computeTodoSummary([]))).toBe("")
+  })
+
+  test("mode both with dag all-complete and todo partial", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "completed")])
+    const todo = computeTodoSummary([t("x", "completed"), t("y", "pending")])
+    expect(formatRailText("both", dag, todo)).toBe("DAG complete · Todo 1/2")
+  })
+})

--- a/packages/app/src/components/session/session-progress-summary.ts
+++ b/packages/app/src/components/session/session-progress-summary.ts
@@ -1,0 +1,199 @@
+import type { DagNode } from "@ericsanchezok/synergy-ui/dag-graph"
+
+export type { DagNode }
+
+export interface DagSummary {
+  total: number
+  completed: number
+  running: number
+  pending: number
+  blocked: number
+  failed: number
+  cancelled: number
+  ready: string[]
+  activeNodeIds: string[]
+  attentionLevel: "none" | "running" | "blocked" | "failed"
+  progressRatio: number
+}
+
+export interface TodoItem {
+  id: string
+  content: string
+  status: string
+  priority?: string
+}
+
+export interface TodoSummary {
+  total: number
+  completed: number
+  inProgress: number
+  pending: number
+  cancelled: number
+  activeTodoIds: string[]
+  progressRatio: number
+}
+
+export type ProgressMode = "none" | "dag" | "todo" | "both"
+
+function clampRatio(value: number): number {
+  return Math.min(1, Math.max(0, Math.round(value * 100) / 100))
+}
+
+export function computeDagSummary(nodes: DagNode[]): DagSummary {
+  let total = 0
+  let completed = 0
+  let running = 0
+  let pending = 0
+  let blocked = 0
+  let failed = 0
+  let cancelled = 0
+
+  const activeNodeIds: string[] = []
+  const pendingNodeIds: string[] = []
+  const completedNodeIds: string[] = []
+
+  for (const node of nodes) {
+    total++
+    switch (node.status) {
+      case "completed":
+        completed++
+        completedNodeIds.push(node.id)
+        break
+      case "running":
+        running++
+        activeNodeIds.push(node.id)
+        break
+      case "pending":
+        pending++
+        pendingNodeIds.push(node.id)
+        break
+      case "blocked":
+        blocked++
+        activeNodeIds.push(node.id)
+        break
+      case "failed":
+        failed++
+        activeNodeIds.push(node.id)
+        break
+      case "cancelled":
+        cancelled++
+        break
+    }
+  }
+
+  const readySatisfied = new Set(completedNodeIds)
+  const ready: string[] = []
+  for (const nodeId of pendingNodeIds) {
+    const node = nodes.find((n) => n.id === nodeId)!
+    if (node.deps.every((dep) => readySatisfied.has(dep))) {
+      ready.push(nodeId)
+    }
+  }
+
+  let attentionLevel: DagSummary["attentionLevel"] = "none"
+  if (failed > 0) attentionLevel = "failed"
+  else if (blocked > 0) attentionLevel = "blocked"
+  else if (running > 0) attentionLevel = "running"
+
+  const progressRatio = total === 0 ? 0 : clampRatio(completed / total)
+
+  return {
+    total,
+    completed,
+    running,
+    pending,
+    blocked,
+    failed,
+    cancelled,
+    ready,
+    activeNodeIds,
+    attentionLevel,
+    progressRatio,
+  }
+}
+
+export function computeTodoSummary(todos: TodoItem[]): TodoSummary {
+  let total = 0
+  let completed = 0
+  let inProgress = 0
+  let pending = 0
+  let cancelled = 0
+  const activeTodoIds: string[] = []
+
+  for (const todo of todos) {
+    total++
+    switch (todo.status) {
+      case "completed":
+        completed++
+        break
+      case "in_progress":
+        inProgress++
+        activeTodoIds.push(todo.id)
+        break
+      case "pending":
+        pending++
+        break
+      case "cancelled":
+        cancelled++
+        break
+    }
+  }
+
+  const denominator = total - cancelled
+  const progressRatio =
+    denominator === 0 ? (total === 0 ? 0 : clampRatio(completed / total)) : clampRatio(completed / denominator)
+
+  return {
+    total,
+    completed,
+    inProgress,
+    pending,
+    cancelled,
+    activeTodoIds,
+    progressRatio,
+  }
+}
+
+export function computeProgressMode(hasDag: boolean, hasTodo: boolean): ProgressMode {
+  if (hasDag && hasTodo) return "both"
+  if (hasDag) return "dag"
+  if (hasTodo) return "todo"
+  return "none"
+}
+
+export function formatProgressText(completed: number, total: number): string {
+  if (completed >= total && total > 0) return "complete"
+  return `${completed}/${total}`
+}
+
+export function formatRailText(mode: ProgressMode, dag?: DagSummary, todo?: TodoSummary): string {
+  function dagLine(d: DagSummary): string {
+    const progress = formatProgressText(d.completed, d.total)
+    const indicator = d.attentionLevel !== "none" ? ` · ${d.attentionLevel}` : ""
+    return `DAG ${progress}${indicator}`
+  }
+
+  function todoLine(t: TodoSummary): string {
+    return `Todo ${formatProgressText(t.completed, t.total)}`
+  }
+
+  const hasDag = dag && dag.total > 0
+  const hasTodo = todo && todo.total > 0
+
+  if (mode === "none") return ""
+
+  if (mode === "dag") {
+    return hasDag ? dagLine(dag!) : ""
+  }
+  if (mode === "todo") {
+    return hasTodo ? todoLine(todo!) : ""
+  }
+  if (mode === "both") {
+    if (hasDag && hasTodo) return `${dagLine(dag!)} · ${todoLine(todo!)}`
+    if (hasDag) return dagLine(dag!)
+    if (hasTodo) return todoLine(todo!)
+    return ""
+  }
+
+  return ""
+}

--- a/packages/app/src/components/session/session-progress-summary.ts
+++ b/packages/app/src/components/session/session-progress-summary.ts
@@ -1,7 +1,5 @@
 import type { DagNode } from "@ericsanchezok/synergy-ui/dag-graph"
 
-export type { DagNode }
-
 export interface DagSummary {
   total: number
   completed: number

--- a/packages/app/src/components/session/session-progress-todo.tsx
+++ b/packages/app/src/components/session/session-progress-todo.tsx
@@ -1,4 +1,4 @@
-import { createMemo, For, Show } from "solid-js"
+import { createMemo, createSignal, For, Show } from "solid-js"
 import { useSync } from "@/context/sync"
 import { computeTodoSummary, type TodoItem } from "./session-progress-summary"
 
@@ -86,6 +86,12 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
     return parts
   })
 
+  const [expandedTodoId, setExpandedTodoId] = createSignal<string | undefined>(undefined)
+
+  const toggleTodo = (id: string) => {
+    setExpandedTodoId((prev) => (prev === id ? undefined : id))
+  }
+
   return (
     <div class={`flex flex-col min-h-0 ${props.class ?? ""}`}>
       {/* Header */}
@@ -102,40 +108,62 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
           <For each={todos()}>
             {(todo) => {
               const isActive = () => todo.status === "in_progress"
+              const isExpanded = () => expandedTodoId() === todo.id && todo.content.length > 40
               return (
-                <div
-                  class="flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-surface-raised-base-hover"
-                  classList={{
-                    "bg-text-interactive-base/5 border-l-2 border-l-text-interactive-base": isActive(),
-                  }}
-                >
-                  {/* Status icon */}
-                  <span
-                    class={`shrink-0 text-sm leading-none ${statusClass(todo.status)}`}
-                    classList={{ "animate-pulse": isActive() }}
+                <>
+                  <div
+                    onClick={() => toggleTodo(todo.id)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e: KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        toggleTodo(todo.id)
+                      }
+                    }}
+                    class="flex items-center gap-2.5 px-3 py-2 transition-colors cursor-pointer select-none hover:bg-surface-raised-base-hover"
+                    classList={{
+                      "bg-text-interactive-base/5 border-l-2 border-l-text-interactive-base": isActive(),
+                    }}
                   >
-                    {statusIcon(todo.status)}
-                  </span>
+                    {/* Status icon */}
+                    <span
+                      class={`shrink-0 text-sm leading-none ${statusClass(todo.status)}`}
+                      classList={{ "animate-pulse": isActive() }}
+                    >
+                      {statusIcon(todo.status)}
+                    </span>
 
-                  {/* Content */}
-                  <span class={`text-xs leading-snug truncate flex-1 min-w-0 ${contentClass(todo.status)}`}>
-                    {todo.content}
-                  </span>
+                    {/* Content */}
+                    <span class={`text-xs leading-snug truncate flex-1 min-w-0 ${contentClass(todo.status)}`}>
+                      {todo.content}
+                    </span>
 
-                  {/* Priority */}
-                  <Show when={todo.priority === "high"}>
-                    <span class="shrink-0 size-1.5 rounded-full bg-border-warning-base/70" />
-                  </Show>
+                    {/* Priority */}
+                    <Show when={todo.priority === "high"}>
+                      <span class="shrink-0 size-1.5 rounded-full bg-border-warning-base/70" />
+                    </Show>
 
-                  {/* Status label */}
-                  <Show when={statusLabel(todo.status)}>
-                    {(label) => (
-                      <span class={`shrink-0 text-11-medium px-1.5 py-0.5 rounded-full ${labelClass(todo.status)}`}>
-                        {label()}
+                    {/* Status label */}
+                    <Show when={statusLabel(todo.status)}>
+                      {(label) => (
+                        <span class={`shrink-0 text-11-medium px-1.5 py-0.5 rounded-full ${labelClass(todo.status)}`}>
+                          {label()}
+                        </span>
+                      )}
+                    </Show>
+                  </div>
+
+                  {/* Expanded detail for long content */}
+                  <Show when={isExpanded()}>
+                    <div class="flex items-center gap-2.5 px-3 py-2 bg-surface-raised-base border-t border-border-weak-base/40">
+                      <span class="shrink-0 text-sm leading-none text-text-weaker"> </span>
+                      <span class="text-xs leading-snug text-text-base whitespace-pre-wrap break-words flex-1 min-w-0">
+                        {todo.content}
                       </span>
-                    )}
+                    </div>
                   </Show>
-                </div>
+                </>
               )
             }}
           </For>

--- a/packages/app/src/components/session/session-progress-todo.tsx
+++ b/packages/app/src/components/session/session-progress-todo.tsx
@@ -23,7 +23,7 @@ function statusIcon(status: string): string {
 function statusClass(status: string): string {
   switch (status) {
     case "completed":
-      return "text-success"
+      return "text-on-success-base"
     case "in_progress":
       return "text-text-interactive-base"
     case "cancelled":
@@ -62,7 +62,7 @@ function labelClass(status: string): string {
     case "in_progress":
       return "bg-text-interactive-base/10 text-text-interactive-base ring-1 ring-inset ring-text-interactive-base/12"
     case "completed":
-      return "bg-surface-success-base/20 text-success ring-1 ring-inset ring-success/15"
+      return "bg-surface-success-base/20 text-on-success-base ring-1 ring-inset ring-border-success-base/15"
     case "cancelled":
       return "bg-surface-raised-stronger text-text-weaker ring-1 ring-inset ring-border-weak-base"
     default:
@@ -124,7 +124,7 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
 
                   {/* Priority */}
                   <Show when={todo.priority === "high"}>
-                    <span class="shrink-0 size-1.5 rounded-full bg-text-warning-base/70" />
+                    <span class="shrink-0 size-1.5 rounded-full bg-border-warning-base/70" />
                   </Show>
 
                   {/* Status label */}

--- a/packages/app/src/components/session/session-progress-todo.tsx
+++ b/packages/app/src/components/session/session-progress-todo.tsx
@@ -1,0 +1,146 @@
+import { createMemo, For, Show } from "solid-js"
+import { useSync } from "@/context/sync"
+import { computeTodoSummary, type TodoItem } from "./session-progress-summary"
+
+interface SessionProgressTodoProps {
+  sessionID: string
+  class?: string
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case "completed":
+      return "✓"
+    case "in_progress":
+      return "●"
+    case "cancelled":
+      return "✗"
+    default:
+      return "○"
+  }
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case "completed":
+      return "text-success"
+    case "in_progress":
+      return "text-text-interactive-base"
+    case "cancelled":
+      return "text-text-weaker"
+    default:
+      return "text-text-weak"
+  }
+}
+
+function contentClass(status: string): string {
+  switch (status) {
+    case "completed":
+      return "text-text-weaker"
+    case "cancelled":
+      return "text-text-weaker line-through"
+    default:
+      return "text-text-base"
+  }
+}
+
+function statusLabel(status: string): string | undefined {
+  switch (status) {
+    case "in_progress":
+      return "active"
+    case "completed":
+      return "done"
+    case "cancelled":
+      return "skipped"
+    default:
+      return undefined
+  }
+}
+
+function labelClass(status: string): string {
+  switch (status) {
+    case "in_progress":
+      return "bg-text-interactive-base/10 text-text-interactive-base ring-1 ring-inset ring-text-interactive-base/12"
+    case "completed":
+      return "bg-surface-success-base/20 text-success ring-1 ring-inset ring-success/15"
+    case "cancelled":
+      return "bg-surface-raised-stronger text-text-weaker ring-1 ring-inset ring-border-weak-base"
+    default:
+      return ""
+  }
+}
+
+export function SessionProgressTodo(props: SessionProgressTodoProps) {
+  const sync = useSync()
+
+  const todos = createMemo<TodoItem[]>(() => sync.data.todo[props.sessionID] ?? [])
+
+  const summary = createMemo(() => computeTodoSummary(todos()))
+
+  const summaryParts = createMemo(() => {
+    const s = summary()
+    const parts: string[] = []
+    if (s.completed > 0) parts.push(`${s.completed} completed`)
+    if (s.inProgress > 0) parts.push(`${s.inProgress} active`)
+    if (s.pending > 0) parts.push(`${s.pending} pending`)
+    return parts
+  })
+
+  return (
+    <div class={`flex flex-col min-h-0 ${props.class ?? ""}`}>
+      {/* Header */}
+      <Show
+        when={summaryParts().length > 0}
+        fallback={<div class="text-text-weaker text-xs px-3 py-1.5">No active tasks</div>}
+      >
+        <div class="text-xs text-text-weaker px-3 py-1.5 shrink-0">{summaryParts().join(" · ")}</div>
+      </Show>
+
+      {/* List */}
+      <Show when={todos().length > 0}>
+        <div class="flex flex-col divide-y divide-border-weak-base/60 overflow-y-auto min-h-0">
+          <For each={todos()}>
+            {(todo) => {
+              const isActive = () => todo.status === "in_progress"
+              return (
+                <div
+                  class="flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-surface-raised-base-hover"
+                  classList={{
+                    "bg-text-interactive-base/5 border-l-2 border-l-text-interactive-base": isActive(),
+                  }}
+                >
+                  {/* Status icon */}
+                  <span
+                    class={`shrink-0 text-sm leading-none ${statusClass(todo.status)}`}
+                    classList={{ "animate-pulse": isActive() }}
+                  >
+                    {statusIcon(todo.status)}
+                  </span>
+
+                  {/* Content */}
+                  <span class={`text-xs leading-snug truncate flex-1 min-w-0 ${contentClass(todo.status)}`}>
+                    {todo.content}
+                  </span>
+
+                  {/* Priority */}
+                  <Show when={todo.priority === "high"}>
+                    <span class="shrink-0 size-1.5 rounded-full bg-text-warning-base/70" />
+                  </Show>
+
+                  {/* Status label */}
+                  <Show when={statusLabel(todo.status)}>
+                    {(label) => (
+                      <span class={`shrink-0 text-11-medium px-1.5 py-0.5 rounded-full ${labelClass(todo.status)}`}>
+                        {label()}
+                      </span>
+                    )}
+                  </Show>
+                </div>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -160,6 +160,10 @@
     z-index: 1;
   }
 
+  .dag-graph[data-variant="panel"] [data-slot="dag-graph-stage"] {
+    transition: transform 500ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
   [data-slot="dag-graph-edges"] {
     position: absolute;
     top: 0;
@@ -423,4 +427,68 @@
 /* Selected node — subtle ring accent */
 .dag-node[data-selected="true"] {
   box-shadow: 0 0 0 2px var(--surface-interactive-selected);
+}
+
+/* ── Session Progress Drawer Animations ── */
+
+@keyframes drawer-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes drawer-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+.session-progress-drawer {
+  animation: drawer-enter 250ms cubic-bezier(0.2, 0, 0, 1) both;
+}
+
+.session-progress-drawer[data-closing] {
+  animation: drawer-exit 200ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes drawer-enter {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes drawer-exit {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  .session-progress-drawer {
+    animation-name: drawer-enter;
+    animation-duration: 150ms;
+    animation-timing-function: ease;
+  }
+
+  .session-progress-drawer[data-closing] {
+    animation-name: drawer-exit;
+    animation-duration: 150ms;
+    animation-timing-function: ease;
+  }
 }

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -385,3 +385,42 @@
     pointer-events: none;
   }
 }
+
+/* Panel variant — more compact for the progress drawer */
+.dag-graph[data-variant="panel"] {
+  [data-slot="dag-graph-viewport"] {
+    height: clamp(200px, 32vh, 380px);
+  }
+}
+
+/* Panel variant: node card slightly smaller */
+.dag-graph[data-variant="panel"] .dag-node {
+  padding: 8px 10px;
+  gap: 7px;
+
+  [data-slot="dag-graph-card-content"] {
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  [data-slot="dag-graph-status-label"] {
+    font-size: 10px;
+  }
+
+  [data-slot="dag-graph-assign"] {
+    font-size: 9px;
+  }
+
+  [data-slot="dag-graph-task"] {
+    font-size: 9px;
+  }
+
+  [data-slot="dag-graph-memo"] {
+    font-size: 10px;
+  }
+}
+
+/* Selected node — subtle ring accent */
+.dag-node[data-selected="true"] {
+  box-shadow: 0 0 0 2px var(--surface-interactive-selected);
+}

--- a/packages/ui/src/components/dag-graph.tsx
+++ b/packages/ui/src/components/dag-graph.tsx
@@ -196,6 +196,8 @@ export function DagGraph(props: {
   variant?: "default" | "panel"
   selectedNodeId?: string
   onSelectNode?: (node: DagNode) => void
+  focusNodeId?: string
+  onViewportInteraction?: () => void
 }) {
   const [containerWidth, setContainerWidth] = createSignal(0)
   const [scale, setScale] = createSignal(1)
@@ -227,6 +229,18 @@ export function DagGraph(props: {
     const l = layout()
     if (!viewport || hasUserMoved() || l.width === 0 || l.height === 0) return
     focusActiveNodes()
+  })
+
+  createEffect(() => {
+    const focusId = props.focusNodeId
+    if (!focusId || hasUserMoved() || nodes().length > 200) return
+    const laid = layout().laid
+    if (laid.length === 0) return
+    const target = laid.find((ln) => ln.node.id === focusId)
+    if (!target || target.h === 0) return
+    requestAnimationFrame(() => {
+      fitToNodes([target])
+    })
   })
 
   function fitView() {
@@ -277,6 +291,7 @@ export function DagGraph(props: {
     setScale(next)
     setPan({ x: originX - worldX * next, y: originY - worldY * next })
     setHasUserMoved(true)
+    props.onViewportInteraction?.()
   }
 
   function handleWheel(event: WheelEvent) {
@@ -292,6 +307,7 @@ export function DagGraph(props: {
     if (target?.closest("button")) return
     setDragging(true)
     setHasUserMoved(true)
+    props.onViewportInteraction?.()
     setPointerMoved(false)
     const card = target?.closest('[data-slot="dag-graph-card"]')
     clickNodeId = (card as HTMLElement | undefined)?.dataset.id ?? undefined

--- a/packages/ui/src/components/dag-graph.tsx
+++ b/packages/ui/src/components/dag-graph.tsx
@@ -445,6 +445,15 @@ export function DagGraph(props: {
                   data-status={ln.node.status}
                   data-ready={readySet().has(ln.node.id)}
                   data-selected={props.selectedNodeId && props.selectedNodeId === ln.node.id ? "true" : undefined}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`DAG node: ${ln.node.content}`}
+                  onKeyDown={(e: KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      props.onSelectNode?.(ln.node)
+                    }
+                  }}
                   style={{
                     left: `${ln.x}px`,
                     top: `${ln.y}px`,

--- a/packages/ui/src/components/dag-graph.tsx
+++ b/packages/ui/src/components/dag-graph.tsx
@@ -10,6 +10,7 @@ export interface DagNode {
   task_id?: string
   session_id?: string
   memo?: string
+  result?: string
 }
 
 interface LayoutNode {
@@ -189,18 +190,25 @@ function statusCounts(nodes: DagNode[]) {
     pending: nodes.filter((n) => n.status === "pending").length,
   }
 }
-
-export function DagGraph(props: { nodes?: DagNode[]; ready?: string[] }) {
+export function DagGraph(props: {
+  nodes?: DagNode[]
+  ready?: string[]
+  variant?: "default" | "panel"
+  selectedNodeId?: string
+  onSelectNode?: (node: DagNode) => void
+}) {
   const [containerWidth, setContainerWidth] = createSignal(0)
   const [scale, setScale] = createSignal(1)
   const [pan, setPan] = createSignal({ x: 0, y: 0 })
   const [dragging, setDragging] = createSignal(false)
   const [hasUserMoved, setHasUserMoved] = createSignal(false)
+  const [pointerMoved, setPointerMoved] = createSignal(false)
 
   const markerId = createUniqueId()
   let ref: HTMLDivElement | undefined
   let viewport: HTMLDivElement | undefined
   let dragStart: { pointer: { x: number; y: number }; pan: { x: number; y: number } } | undefined
+  let clickNodeId: string | undefined
 
   onMount(() => {
     if (!ref) return
@@ -284,26 +292,44 @@ export function DagGraph(props: { nodes?: DagNode[]; ready?: string[] }) {
     if (target?.closest("button")) return
     setDragging(true)
     setHasUserMoved(true)
+    setPointerMoved(false)
+    const card = target?.closest('[data-slot="dag-graph-card"]')
+    clickNodeId = (card as HTMLElement | undefined)?.dataset.id ?? undefined
     dragStart = { pointer: { x: event.clientX, y: event.clientY }, pan: pan() }
     viewport?.setPointerCapture(event.pointerId)
   }
 
   function handlePointerMove(event: PointerEvent) {
     if (!dragging() || !dragStart) return
+    const dx = event.clientX - dragStart.pointer.x
+    const dy = event.clientY - dragStart.pointer.y
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+      setPointerMoved(true)
+    }
     setPan({
-      x: dragStart.pan.x + event.clientX - dragStart.pointer.x,
-      y: dragStart.pan.y + event.clientY - dragStart.pointer.y,
+      x: dragStart.pan.x + dx,
+      y: dragStart.pan.y + dy,
     })
   }
 
   function handlePointerUp(event: PointerEvent) {
+    if (!pointerMoved() && clickNodeId && props.onSelectNode) {
+      const node = nodes().find((n) => n.id === clickNodeId)
+      if (node) props.onSelectNode(node)
+    }
     setDragging(false)
     dragStart = undefined
+    clickNodeId = undefined
     viewport?.releasePointerCapture(event.pointerId)
   }
 
   return (
-    <div data-component="dag-graph" ref={ref}>
+    <div
+      class="dag-graph"
+      data-component="dag-graph"
+      data-variant={props.variant === "panel" ? "panel" : undefined}
+      ref={ref}
+    >
       <Show when={layout()?.laid.length}>
         <div data-slot="dag-graph-toolbar">
           <div data-slot="dag-graph-stats">
@@ -397,9 +423,12 @@ export function DagGraph(props: { nodes?: DagNode[]; ready?: string[] }) {
             <For each={layout().laid}>
               {(ln) => (
                 <div
+                  class="dag-node"
                   data-slot="dag-graph-card"
+                  data-id={ln.node.id}
                   data-status={ln.node.status}
                   data-ready={readySet().has(ln.node.id)}
+                  data-selected={props.selectedNodeId && props.selectedNodeId === ln.node.id ? "true" : undefined}
                   style={{
                     left: `${ln.x}px`,
                     top: `${ln.y}px`,

--- a/packages/ui/src/components/tool-renders.tsx
+++ b/packages/ui/src/components/tool-renders.tsx
@@ -757,7 +757,6 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        defaultOpen
         icon="list-checks"
         trigger={() => ({
           title: "To-dos",
@@ -840,7 +839,6 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        defaultOpen
         icon={getSemanticIcon("orchestration.dag")}
         trigger={() => ({
           title: "DAG",
@@ -874,7 +872,6 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        defaultOpen
         icon={getSemanticIcon("orchestration.dag")}
         trigger={() => ({
           title: "DAG",
@@ -908,7 +905,6 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        defaultOpen
         icon={getSemanticIcon("orchestration.dag")}
         trigger={() => ({
           title: "Read DAG",


### PR DESCRIPTION
## Summary

- **New interactive panel** above the composer: live DAG/Todo progress for current session without scrolling conversation history
- **4 commits**, 7 new files + 7 modified, clean atomic history
- TypeScript passes on all 8 packages (`bun turbo typecheck`), formatting passes (`Prettier`)

## What this does

Current state: users must scroll through conversation history and open `dagwrite`/`todowrite` tool cards to understand agent progress.

After this PR: a permanent `SessionProgressPanel` sits above the composer input box, driven by the existing live event stream (`dag.updated` / `todo.updated` → `sync.data`):

```
PermissionDock / QuestionPrompt
SubagentDock
Back buttons
SessionProgressPanel    ← NEW
PromptInput
StatusBar
```

## Components added (packages/app/src/components/session/)

| File | Purpose |
|---|---|
| `session-progress-summary.ts` | Pure computation: DAG/Todo stats, ready detection, attention levels, rail text templates |
| `session-progress-rail.tsx` | Collapsed pill: protrudes from composer edge, status dot + pulse, full a11y |
| `session-progress-drawer.tsx` | Expandable drawer: header/tabs/close/outside-click, M3 easing animations, reduced-motion fallback |
| `session-progress-dag.tsx` | Live DAG graph via upgraded DagGraph, node selection + detail panel, 120ms debounced auto-focus |
| `session-progress-todo.tsx` | Read-only todo list, status/priority indicators, click-to-expand long content |
| `session-progress-panel.tsx` | Orchestrator: mode detection, expand/collapse, tab routing, session-switch reset |

## Components modified

| File | Change |
|---|---|
| `prompt-dock.tsx` | Insert `SessionProgressPanel` between back-buttons and PromptInput |
| `dag-graph.tsx` | Add `variant`, `selectedNodeId`, `onSelectNode`, `focusNodeId`, `onViewportInteraction` props + keyboard accessibility (tabIndex/Enter/Space on nodes) |
| `dag-graph.css` | Panel variant styles, selected-node ring, drawer keyframes, stage transition |
| `tool-renders.tsx` | Remove `defaultOpen` from `dagwrite`/`dagpatch`/`dagread`/`todowrite` – historical cards still expandable on click |

## Quality gates

- **TypeScript**: 8 packages clean (`bun turbo typecheck`)
- **Formatting**: Prettier clean
- **Unit tests**: 51 tests, 0 failures (`session-progress-summary.test.ts`)
- **Security review**: low risk, no blockers
- **Maintainability review**: PASS (all REVISE items resolved)
- **Visual token audit**: PASS (all `danger→critical`, `text-success→text-on-success-base`, legacy token replacements applied)

## Design spec coverage

Full implementation of the design note "Session DAG/Todo 进度面板完整设计稿" (`nte_edacc0996001mqUCKyG9sNgbdJ`). Sections 1-19, 21-23 fully implemented. Section 20 (responsive design) needs real-device iteration – not included in this pass.