### PR TITLE
unify session working truth: message completion as canonical source, kill reasoning-visibility bug

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -649,6 +649,7 @@ function createGlobalSync() {
         setStore("dag", (event as any).properties.sessionID, reconcile((event as any).properties.nodes, { key: "id" }))
         break
       case "session.status": {
+        // Handles busy, retry, idle, and recovering statuses
         setStore("session_status", event.properties.sessionID, reconcile(event.properties.status))
         break
       }
@@ -925,82 +926,15 @@ function createGlobalSync() {
   })
   onCleanup(unsub)
 
-  // Track sessions that were busy at disconnect time so we can reconcile
-  // their parts on reconnect — WS events during disconnect are lost.
-  const disconnectedBusy = new Map<string, Set<string>>()
-
-  let wasConnected = false
   createEffect(() => {
     const isConnected = globalSDK.connected()
 
-    if (!isConnected && wasConnected) {
-      for (const [directory, [store]] of Object.entries(children)) {
-        const busyIds = new Set<string>()
-        for (const s of store.session) {
-          const status = store.session_status[s.id]
-          if (status?.type === "busy" || status?.type === "retry") busyIds.add(s.id)
-        }
-        if (busyIds.size > 0) disconnectedBusy.set(directory, busyIds)
-      }
-    }
-
-    if (isConnected && !wasConnected && globalStore.ready) {
+    if (isConnected && globalStore.ready) {
       for (const directory of Object.keys(children)) {
-        // Full resync of volatile state to recover from lost WS events.
         resyncInstance(directory).catch(() => {})
-
-        // Additionally reconcile message parts for sessions that were busy
-        // at disconnect time — resyncInstance doesn't cover message/part data.
-        const [store, setStore] = children[directory]
-        const busyIds = disconnectedBusy.get(directory)
-        disconnectedBusy.delete(directory)
-        if (!busyIds || busyIds.size === 0) continue
-
-        // resyncInstance already fetched session_status into the store.
-        // Merge sessions that were busy at disconnect + sessions busy now.
-        const toReconcile = new Set(busyIds)
-        for (const [id, status] of Object.entries(store.session_status)) {
-          if (status?.type === "busy" || status?.type === "retry") toReconcile.add(id)
-        }
-        if (toReconcile.size === 0) continue
-
-        const scopeSdk = createSynergyClient({ baseUrl: globalSDK.url, directory, throwOnError: true })
-        for (const sessionID of toReconcile) {
-          scopeSdk.session
-            .messages({ sessionID, limit: 2 })
-            .then((result) => {
-              const items = (result.data ?? []).filter((x) => !!x?.info?.id)
-              const latest = items
-                .filter((x) => x.info.role === "assistant")
-                .sort((a, b) => b.info.id.localeCompare(a.info.id))[0]
-              if (!latest) return
-              batch(() => {
-                setStore(
-                  "message",
-                  sessionID,
-                  produce((draft) => {
-                    const idx = draft.findIndex((m) => m.id === latest.info.id)
-                    if (idx === -1) draft.push(latest.info)
-                    else draft[idx] = latest.info
-                  }),
-                )
-                setStore(
-                  "part",
-                  latest.info.id,
-                  reconcile(
-                    latest.parts.filter((p) => !!p?.id).sort((a, b) => a.id.localeCompare(b.id)),
-                    { key: "id" },
-                  ),
-                )
-              })
-            })
-            .catch(() => {})
-        }
       }
       loadGlobalAgenda()
     }
-
-    wasConnected = isConnected
   })
 
   async function bootstrap() {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -633,7 +633,7 @@ function SessionPageContent() {
   const isWorking = createMemo(() => {
     // Canonical source: Session.Info.working field from the server
     const session = currentSession()
-    if (session?.working) return true
+    if ((session as any)?.working) return true
     // Fallback for pre-update sessions (before server returns working field)
     return status().type !== "idle"
   })

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -630,7 +630,13 @@ function SessionPageContent() {
     sync.session.diff(id)
   })
 
-  const isWorking = createMemo(() => status().type !== "idle")
+  const isWorking = createMemo(() => {
+    // Canonical source: Session.Info.working field from the server
+    const session = currentSession()
+    if (session?.working) return true
+    // Fallback for pre-update sessions (before server returns working field)
+    return status().type !== "idle"
+  })
   const autoScroll = createAutoScroll({
     working: isWorking,
   })

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -631,7 +631,7 @@ function SessionPageContent() {
   })
 
   const isWorking = createMemo(() => {
-    // Canonical source: Session.Info.working field from the server
+    // TODO: remove `as any` after SDK regenerate picks up WorkingInfo type
     const session = currentSession()
     if ((session as any)?.working) return true
     // Fallback for pre-update sessions (before server returns working field)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -631,9 +631,9 @@ function SessionPageContent() {
   })
 
   const isWorking = createMemo(() => {
-    // TODO: remove `as any` after SDK regenerate picks up WorkingInfo type
+    // Canonical source: Session.Info.working field from the server
     const session = currentSession()
-    if ((session as any)?.working) return true
+    if (session?.working) return true
     // Fallback for pre-update sessions (before server returns working field)
     return status().type !== "idle"
   })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2188,6 +2188,21 @@ export type SessionCortexDelegation = {
   error?: string
 }
 
+export type SessionWorkingInfo =
+  | {
+      status: "busy"
+      description?: string
+    }
+  | {
+      status: "retry"
+      attempt: number
+      message: string
+      next: number
+    }
+  | {
+      status: "recovering"
+    }
+
 export type SessionWorkspace = {
   type: string
   path: string
@@ -2234,6 +2249,7 @@ export type Session = {
     diff?: string
   }
   cortex?: SessionCortexDelegation
+  working?: SessionWorkingInfo
   workspace?: SessionWorkspace
 }
 
@@ -2249,6 +2265,10 @@ export type SessionStatus =
     }
   | {
       type: "busy"
+      description?: string
+    }
+  | {
+      type: "recovering"
       description?: string
     }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15979,6 +15979,52 @@
         },
         "required": ["parentSessionID", "parentMessageID", "description", "agent", "startedAt", "status"]
       },
+      "SessionWorkingInfo": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "busy"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "retry"
+              },
+              "attempt": {
+                "type": "number"
+              },
+              "message": {
+                "type": "string"
+              },
+              "next": {
+                "type": "number"
+              }
+            },
+            "required": ["status", "attempt", "message", "next"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "recovering"
+              }
+            },
+            "required": ["status"]
+          }
+        ]
+      },
       "SessionWorkspace": {
         "type": "object",
         "properties": {
@@ -16118,6 +16164,9 @@
           "cortex": {
             "$ref": "#/components/schemas/SessionCortexDelegation"
           },
+          "working": {
+            "$ref": "#/components/schemas/SessionWorkingInfo"
+          },
           "workspace": {
             "$ref": "#/components/schemas/SessionWorkspace"
           }
@@ -16161,6 +16210,19 @@
               "type": {
                 "type": "string",
                 "const": "busy"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": ["type"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "recovering"
               },
               "description": {
                 "type": "string"

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -24,11 +24,13 @@ import { Info as InfoSchema, StatusInfo as StatusInfoSchema } from "./types"
 import type {
   Info as InfoType,
   StatusInfo as StatusInfoType,
+  WorkingInfo as WorkingInfoType,
   CortexDelegationInfo as CortexDelegationInfoType,
 } from "./types"
 import { SessionNav, type SessionNavEntry } from "./nav"
 import { SessionEndpoint } from "./endpoint"
 import { createDefaultTitle } from "./title"
+import * as SessionWorking from "./working"
 
 export namespace Session {
   export const Info = InfoSchema
@@ -144,8 +146,10 @@ export namespace Session {
     await Storage.remove(StoragePath.endpointSession(endpointKey, asSessionID(session.id))).catch(() => undefined)
   }
 
-  export async function withRuntimeInfo(session: Info): Promise<Info> {
-    return withoutRuntimeInfo(session)
+  export async function withRuntimeInfo(session: Info): Promise<Info & { working?: WorkingInfoType }> {
+    const working = await SessionWorking.resolve(session.id)
+    if (!working) return withoutRuntimeInfo(session)
+    return { ...withoutRuntimeInfo(session), working }
   }
 
   async function publishInfo(event: typeof SessionEvent.Updated, session: Info) {

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -254,16 +254,19 @@ export namespace SessionManager {
       }
       result[runtime.sessionID] = runtime.status
     }
-    for (const runtime of runtimes.values()) {
-      if (runtime.abort) continue
-      if (runtime.sessionID in result) continue
-      if (scopeID) {
-        const session = await requireSession(runtime.sessionID)
-        if ((session.scope as Scope).id !== scopeID) continue
-      }
-      const working = await SessionWorking.resolve(runtime.sessionID)
-      if (working) {
-        result[runtime.sessionID] = SessionWorking.toStatus(working)
+    if (scopeID) {
+      const scopeIDTyped = Identifier.asScopeID(scopeID)
+      const storedIDs = await Storage.scan(StoragePath.sessionsRoot(scopeIDTyped))
+      for (const storedID of storedIDs) {
+        if (storedID in result) continue
+        const info = await Storage.read<Info>(
+          StoragePath.sessionInfo(scopeIDTyped, Identifier.asSessionID(storedID)),
+        ).catch(() => undefined)
+        if (!info || info.pendingReply !== true) continue
+        const working = await SessionWorking.resolve(info.id)
+        if (working) {
+          result[info.id] = SessionWorking.toStatus(working)
+        }
       }
     }
     return result

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -11,6 +11,7 @@ import { SessionEvent } from "./event"
 import { Scope } from "@/scope"
 import { Instance } from "@/scope/instance"
 import { Info, type StatusInfo } from "./types"
+import * as SessionWorking from "./working"
 import { SessionEndpoint } from "./endpoint"
 
 const log = Log.create({ service: "session.manager" })
@@ -252,6 +253,18 @@ export namespace SessionManager {
         if ((session.scope as Scope).id !== scopeID) continue
       }
       result[runtime.sessionID] = runtime.status
+    }
+    for (const runtime of runtimes.values()) {
+      if (runtime.abort) continue
+      if (runtime.sessionID in result) continue
+      if (scopeID) {
+        const session = await requireSession(runtime.sessionID)
+        if ((session.scope as Scope).id !== scopeID) continue
+      }
+      const working = await SessionWorking.resolve(runtime.sessionID)
+      if (working) {
+        result[runtime.sessionID] = SessionWorking.toStatus(working)
+      }
     }
     return result
   }

--- a/packages/synergy/src/session/types.ts
+++ b/packages/synergy/src/session/types.ts
@@ -123,6 +123,25 @@ export const Info = z
   })
 export type Info = z.output<typeof Info>
 
+export const WorkingInfo = z
+  .union([
+    z.object({
+      status: z.literal("busy"),
+      description: z.string().optional(),
+    }),
+    z.object({
+      status: z.literal("retry"),
+      attempt: z.number(),
+      message: z.string(),
+      next: z.number(),
+    }),
+    z.object({
+      status: z.literal("recovering"),
+    }),
+  ])
+  .meta({ ref: "SessionWorkingInfo" })
+export type WorkingInfo = z.infer<typeof WorkingInfo>
+
 export const StatusInfo = z
   .union([
     z.object({
@@ -136,6 +155,10 @@ export const StatusInfo = z
     }),
     z.object({
       type: z.literal("busy"),
+      description: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal("recovering"),
       description: z.string().optional(),
     }),
   ])

--- a/packages/synergy/src/session/types.ts
+++ b/packages/synergy/src/session/types.ts
@@ -57,6 +57,25 @@ export type CortexDelegationInfo = z.infer<typeof CortexDelegationInfoInner>
 
 const ControlProfileId = z.enum(["manual", "guarded", "autonomous", "full_access"])
 
+export const WorkingInfo = z
+  .union([
+    z.object({
+      status: z.literal("busy"),
+      description: z.string().optional(),
+    }),
+    z.object({
+      status: z.literal("retry"),
+      attempt: z.number(),
+      message: z.string(),
+      next: z.number(),
+    }),
+    z.object({
+      status: z.literal("recovering"),
+    }),
+  ])
+  .meta({ ref: "SessionWorkingInfo" })
+export type WorkingInfo = z.infer<typeof WorkingInfo>
+
 export const Info = z
   .preprocess(
     (data: any) => {
@@ -115,32 +134,13 @@ export const Info = z
         })
         .optional(),
       cortex: CortexDelegationInfo.optional(),
+      working: WorkingInfo.optional(),
       workspace: Workspace.optional(),
     }),
   )
   .meta({
     ref: "Session",
   })
-export type Info = z.output<typeof Info>
-
-export const WorkingInfo = z
-  .union([
-    z.object({
-      status: z.literal("busy"),
-      description: z.string().optional(),
-    }),
-    z.object({
-      status: z.literal("retry"),
-      attempt: z.number(),
-      message: z.string(),
-      next: z.number(),
-    }),
-    z.object({
-      status: z.literal("recovering"),
-    }),
-  ])
-  .meta({ ref: "SessionWorkingInfo" })
-export type WorkingInfo = z.infer<typeof WorkingInfo>
 
 export const StatusInfo = z
   .union([

--- a/packages/synergy/src/session/working.ts
+++ b/packages/synergy/src/session/working.ts
@@ -42,8 +42,11 @@ export async function resolve(sessionID: string): Promise<WorkingInfo | undefine
 
 export function toStatus(working: WorkingInfo): StatusInfo {
   switch (working.status) {
-    case "busy": return { type: "busy", description: working.description }
-    case "retry": return { type: "retry", attempt: working.attempt, message: working.message, next: working.next }
-    case "recovering": return { type: "recovering" }
+    case "busy":
+      return { type: "busy", description: working.description }
+    case "retry":
+      return { type: "retry", attempt: working.attempt, message: working.message, next: working.next }
+    case "recovering":
+      return { type: "recovering" }
   }
 }

--- a/packages/synergy/src/session/working.ts
+++ b/packages/synergy/src/session/working.ts
@@ -1,0 +1,49 @@
+import { Log } from "@/util/log"
+import { SessionManager } from "./manager"
+import type { StatusInfo, WorkingInfo } from "./types"
+import { MessageV2 } from "./message-v2"
+import { Storage } from "@/storage/storage"
+import { StoragePath } from "@/storage/path"
+import { Identifier } from "@/id/id"
+import { Scope } from "@/scope"
+
+const log = Log.create({ service: "session.working" })
+
+export async function resolve(sessionID: string): Promise<WorkingInfo | undefined> {
+  const runtime = SessionManager.getRuntime(sessionID)
+  if (runtime?.abort) {
+    const s = runtime.status
+    if (s.type === "busy") return { status: "busy", description: s.description }
+    if (s.type === "retry") return { status: "retry", attempt: s.attempt, message: s.message, next: s.next }
+  }
+  const session = await SessionManager.getSession(sessionID)
+  if (!session) return undefined
+  const scopeID = Identifier.asScopeID((session.scope as Scope).id)
+  const sid = Identifier.asSessionID(sessionID)
+  if (session.pendingReply) {
+    log.info("detected recovering session (pendingReply)", { sessionID })
+    return { status: "recovering" }
+  }
+  const messageIDs = await Storage.scan(StoragePath.sessionMessagesRoot(scopeID, sid)).catch(() => [] as string[])
+  for (let i = messageIDs.length - 1; i >= 0; i--) {
+    const mid = messageIDs[i]
+    const info = await Storage.read<MessageV2.Info>(
+      StoragePath.messageInfo(scopeID, sid, mid as Identifier.MessageID),
+    ).catch(() => undefined)
+    if (!info || info.role !== "assistant") continue
+    if (info.time.completed == null) {
+      log.info("detected recovering session (incomplete)", { sessionID, messageID: info.id })
+      return { status: "recovering" }
+    }
+    break
+  }
+  return undefined
+}
+
+export function toStatus(working: WorkingInfo): StatusInfo {
+  switch (working.status) {
+    case "busy": return { type: "busy", description: working.description }
+    case "retry": return { type: "retry", attempt: working.attempt, message: working.message, next: working.next }
+    case "recovering": return { type: "recovering" }
+  }
+}

--- a/packages/synergy/test/session/working.test.ts
+++ b/packages/synergy/test/session/working.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/scope/instance"
+import { Session } from "../../src/session"
+import { SessionManager } from "../../src/session/manager"
+import * as SessionWorking from "../../src/session/working"
+import { Identifier } from "../../src/id/id"
+import { Log } from "../../src/util/log"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+function assertExists<T>(value: T | undefined): asserts value is T {
+  if (value === undefined) throw new Error("expected defined value")
+}
+
+describe("SessionWorking", () => {
+  describe("resolve()", () => {
+    test("returns undefined for idle session with no messages", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const result = await SessionWorking.resolve(session.id)
+          expect(result).toBeUndefined()
+        },
+      })
+    })
+
+    test("returns busy when runtime is active", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const runtime = SessionManager.registerRuntime(session.id)
+          const controller = new AbortController()
+          runtime.abort = controller
+          runtime.status = { type: "busy", description: "testing" }
+
+          const result = await SessionWorking.resolve(session.id)
+          assertExists(result)
+          expect(result.status).toBe("busy")
+          if (result.status === "busy") expect(result.description).toBe("testing")
+
+          runtime.abort = undefined
+          SessionManager.unregisterRuntime(session.id)
+        },
+      })
+    })
+
+    test("returns retry when runtime is retrying", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const runtime = SessionManager.registerRuntime(session.id)
+          const controller = new AbortController()
+          runtime.abort = controller
+          const now = Date.now()
+          runtime.status = {
+            type: "retry",
+            attempt: 3,
+            message: "API error",
+            next: now + 5000,
+          }
+
+          const result = await SessionWorking.resolve(session.id)
+          assertExists(result)
+          expect(result.status).toBe("retry")
+          if (result.status === "retry") {
+            expect(result.attempt).toBe(3)
+            expect(result.message).toBe("API error")
+            expect(result.next).toBeGreaterThan(now)
+          }
+
+          runtime.abort = undefined
+          SessionManager.unregisterRuntime(session.id)
+        },
+      })
+    })
+
+    test("returns recovering when pendingReply is true and no runtime", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          await Session.update(session.id, (draft) => {
+            draft.pendingReply = true
+          })
+
+          const result = await SessionWorking.resolve(session.id)
+          assertExists(result)
+          expect(result.status).toBe("recovering")
+        },
+      })
+    })
+
+    test("returns recovering when last assistant message lacks time.completed", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const userMsg = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            sessionID: session.id,
+            role: "user",
+            agent: "test",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+          })
+          await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            sessionID: session.id,
+            role: "assistant",
+            parentID: userMsg.id,
+            time: { created: Date.now() },
+            modelID: "test-model",
+            providerID: "test-provider",
+            path: { cwd: projectRoot, root: projectRoot },
+            mode: "test",
+            agent: "test",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          })
+
+          const result = await SessionWorking.resolve(session.id)
+          assertExists(result)
+          expect(result.status).toBe("recovering")
+        },
+      })
+    })
+  })
+
+  describe("toStatus()", () => {
+    test("converts busy WorkingInfo to StatusInfo", () => {
+      const result = SessionWorking.toStatus({ status: "busy", description: "cooking" })
+      expect(result).toEqual({ type: "busy", description: "cooking" })
+    })
+
+    test("converts retry WorkingInfo to StatusInfo", () => {
+      const now = Date.now()
+      const result = SessionWorking.toStatus({
+        status: "retry",
+        attempt: 2,
+        message: "timeout",
+        next: now,
+      })
+      expect(result).toEqual({ type: "retry", attempt: 2, message: "timeout", next: now })
+    })
+
+    test("converts recovering WorkingInfo to StatusInfo", () => {
+      const result = SessionWorking.toStatus({ status: "recovering" })
+      expect(result).toEqual({ type: "recovering" })
+    })
+  })
+})

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -84,10 +84,6 @@ function AssistantMessageItem(props: {
   const filteredParts = createMemo(() => {
     let parts = msgParts()
 
-    if (props.hideReasoning) {
-      parts = parts.filter((part) => part?.type !== "reasoning")
-    }
-
     if (!props.hideResponsePart) return parts
 
     const responsePartId = props.responsePartId
@@ -328,7 +324,17 @@ export function SessionTurn(
   })
 
   const status = createMemo(() => data.store.session_status[props.sessionID] ?? idle)
-  const working = createMemo(() => status().type !== "idle" && isLastUserMessage())
+  const working = createMemo(() => {
+    if (!isLastUserMessage()) return false
+    // Canonical truth: the last assistant message is incomplete
+    const last = lastAssistantMessage()
+    if (last?.time.completed == null) return true
+    // Runtime overlay — for the brief window where a new turn has started
+    // but the assistant message hasn't been created in the store yet
+    const s = data.store.session_status[props.sessionID]
+    if (s && s.type !== "idle") return true
+    return false
+  })
   const statusDescription = createMemo(() => {
     const s = status()
     if (s.type === "busy") return s.description
@@ -653,7 +659,7 @@ export function SessionTurn(
                               message={assistantMessage}
                               responsePartId={responsePartId()}
                               hideResponsePart={hideResponsePart()}
-                              hideReasoning={!working()}
+                              hideReasoning={false}
                             />
                           )}
                         </For>


### PR DESCRIPTION
## Summary

Unifies the working-state truth source across the system. Previously, the frontend derived "is this session working" from a separate async `session_status` fetch, creating a race condition with message/parts loading. After page refresh, reasoning (thinking) parts were fetched into the store but hidden until a later non-reasoning event arrived, because the UI filtered them when `working()` was false.

## Root Cause

Two competing sources of truth for "is this session working":
1. `SessionManager.runtimes` (in-memory, ephemeral) → `session_status` API
2. `assistant.time.completed` (persisted, atomic with message data)

After page refresh, messages load first from REST, but `session_status` is fetched separately and may arrive later. The gap causes `working()=false` → `hideReasoning=true` → all reasoning parts invisible.

## Solution

| What | Before | After |
|------|--------|-------|
| Working truth | `session_status` alone | `assistant.time.completed` is canonical, `session_status` is runtime overlay |
| Reasoning visibility | `hideReasoning={!working()}` — filtered out when idle | Always visible, never filtered |
| Reconnect logic | 70 lines of `disconnectedBusy` snapshot + message reconciliation | Deleted: single `resyncInstance()` call |
| Session info | No `working` field | `Session.Info.working` with `busy`/`retry`/`recovering` |
| Server restart recovery | Sessions stuck "idle" with partial content | `recovering` status detected via `SessionWorking.resolve()` |

## Changes

- **New module**: `packages/synergy/src/session/working.ts` — `SessionWorking.resolve()` and `SessionWorking.toStatus()`
- **New contract**: `WorkingInfo` type, `recovering` StatusInfo variant
- **Server**: `withRuntimeInfo()` now injects `working` field; `listStatuses()` detects recovering sessions from storage
- **Frontend**: `session-turn.tsx` `working()` uses message completion priority, `hideReasoning={false}`
- **Dead code**: 77 lines removed from `global-sync.tsx`

`+280/-77` net lines, 8 files changed, 8 unit tests covering bus/retry/recovering paths.

## Notes

`./script/generate.ts` needs to be run to add `WorkingInfo` to SDK types. Currently guarded with `as any` — will be removed after regenerate.