### PR TITLE
refactor(app): replace WorkspacePanel with right-edge WorkspaceRail + WorkspaceDrawer

### DIFF
--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -522,14 +522,28 @@ function NoteEditor(props: { id: string; directory: string; onBack: () => void; 
   const globalSync = useGlobalSync()
   const directory = () => props.directory
 
-  const [note] = createResource(
-    () => ({ id: props.id, dir: directory(), ver: globalSync.noteVersion() }),
+  const [note, { refetch }] = createResource(
+    () => ({ id: props.id, dir: directory() }),
     async ({ id, dir }) => {
       if (!dir) return null
       const result = await sdk.client.note.get({ id, directory: dir })
       return result.data as NoteInfo
     },
   )
+
+  // Re-fetch this note only when it was updated by another session/tab
+  createEffect(() => {
+    const update = globalSync.noteUpdate()
+    if (!update) return
+    if (update.id !== props.id) return
+    if (update.type === "deleted") return
+    const base = baseNote()
+    // No base note yet = initial load handled by the resource itself
+    if (!base) return
+    // Our own save already set baseNote to the latest version — skip echo
+    if (update.version <= base.version) return
+    void refetch()
+  })
 
   const [baseNote, setBaseNote] = createSignal<NoteInfo | null>(null)
   const [title, setTitle] = createSignal("")

--- a/packages/app/src/components/session/commands.tsx
+++ b/packages/app/src/components/session/commands.tsx
@@ -92,8 +92,8 @@ export function useSessionCommands(params: {
     },
     {
       id: "workspace.close",
-      title: "Close workspace panel",
-      description: "Close the workspace panel",
+      title: "Close workspace drawer",
+      description: "Close the workspace drawer",
       category: "View",
       keybind: "mod+shift+w",
       disabled: !routeParams.id || !workspace.opened(),

--- a/packages/app/src/components/session/workspace-drawer.css
+++ b/packages/app/src/components/session/workspace-drawer.css
@@ -1,0 +1,13 @@
+.workspace-drawer {
+  transition: width var(--motion-duration-base) var(--motion-ease-emphasized);
+}
+
+.workspace-drawer--closing {
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-drawer {
+    transition: none;
+  }
+}

--- a/packages/app/src/components/session/workspace-drawer.tsx
+++ b/packages/app/src/components/session/workspace-drawer.tsx
@@ -1,4 +1,4 @@
-import { Show, onMount, onCleanup, createSignal, createMemo } from "solid-js"
+import { Show, onMount, onCleanup, createSignal, createMemo, createEffect } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { IconButton } from "@ericsanchezok/synergy-ui/icon-button"
@@ -37,6 +37,11 @@ export function WorkspaceDrawer() {
     }
 
     onCleanup(() => document.removeEventListener("keydown", keyHandler))
+  })
+
+  // Reset closing state when the drawer re-opens
+  createEffect(() => {
+    if (workspace.opened()) setClosing(false)
   })
 
   // Resize

--- a/packages/app/src/components/session/workspace-drawer.tsx
+++ b/packages/app/src/components/session/workspace-drawer.tsx
@@ -1,0 +1,104 @@
+import { Show, onMount, onCleanup, createSignal, createMemo } from "solid-js"
+import { Dynamic } from "solid-js/web"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { IconButton } from "@ericsanchezok/synergy-ui/icon-button"
+import { ResizeHandle } from "@ericsanchezok/synergy-ui/resize-handle"
+import { useWorkspace } from "@/context/workspace"
+import "./workspace-drawer.css"
+
+export function WorkspaceDrawer() {
+  const workspace = useWorkspace()
+  const tool = createMemo(() => workspace.activeTool())
+
+  // Track whether we are in closing animation to keep DOM alive
+  const [closing, setClosing] = createSignal(false)
+  let drawerEl: HTMLDivElement | undefined
+
+  onMount(() => {
+    // Escape key
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && workspace.opened()) {
+        setClosing(true)
+        workspace.closePanel()
+      }
+    }
+    document.addEventListener("keydown", keyHandler)
+
+    // Transition end cleanup
+    const el = drawerEl
+    if (el) {
+      const transitionHandler = () => {
+        if (!workspace.opened()) {
+          setClosing(false)
+        }
+      }
+      el.addEventListener("transitionend", transitionHandler)
+      onCleanup(() => el.removeEventListener("transitionend", transitionHandler))
+    }
+
+    onCleanup(() => document.removeEventListener("keydown", keyHandler))
+  })
+
+  // Resize
+  const maxWidth = () => Math.min(900, window.innerWidth * 0.45)
+  const handleResize = (w: number) => {
+    workspace.setWidth(Math.max(300, Math.min(w, maxWidth())))
+  }
+
+  return (
+    <>
+      <ResizeHandle
+        direction="horizontal"
+        size={workspace.width()}
+        min={300}
+        max={maxWidth()}
+        onResize={handleResize}
+        collapseThreshold={200}
+        onCollapse={() => {
+          setClosing(true)
+          workspace.closePanel()
+        }}
+      />
+      <aside
+        ref={drawerEl}
+        class="shrink-0 h-full flex flex-col overflow-hidden border-l border-border-weak-base bg-background-stronger"
+        classList={{
+          "workspace-drawer": true,
+          "workspace-drawer--closing": !workspace.opened() && closing(),
+        }}
+        role="complementary"
+        aria-label="Session workspace"
+        style={{
+          width: workspace.opened() ? `${workspace.width()}px` : "0px",
+        }}
+      >
+        <header class="shrink-0 flex items-center justify-between px-4 h-11 border-b border-border-weak-base">
+          <div class="flex items-center gap-2 min-w-0">
+            <Show when={tool()}>
+              <Icon name={tool()!.icon} size="normal" class="text-icon-weak shrink-0" />
+              <span class="text-14-medium text-text-strong truncate">{tool()?.label}</span>
+            </Show>
+          </div>
+          <IconButton
+            icon="x"
+            variant="ghost"
+            onClick={() => {
+              setClosing(true)
+              workspace.closePanel()
+            }}
+          />
+        </header>
+        <div class="flex-1 min-h-0 overflow-hidden">
+          <Show
+            when={tool()}
+            fallback={
+              <div class="flex items-center justify-center h-full text-text-weak text-14">No tool selected</div>
+            }
+          >
+            <Dynamic component={tool()!.component} />
+          </Show>
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/packages/app/src/components/session/workspace-panel.tsx
+++ b/packages/app/src/components/session/workspace-panel.tsx
@@ -2,74 +2,7 @@ import { Show, onMount, onCleanup } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { IconButton } from "@ericsanchezok/synergy-ui/icon-button"
-import { ResizeHandle } from "@ericsanchezok/synergy-ui/resize-handle"
 import { useWorkspace } from "@/context/workspace"
-import { useLayout } from "@/context/layout"
-
-export function WorkspacePanel() {
-  const workspace = useWorkspace()
-  const layout = useLayout()
-  const isDesktop = () => layout.isDesktop()
-
-  const tool = () => workspace.activeTool()
-
-  onMount(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && workspace.opened()) {
-        workspace.closePanel()
-      }
-    }
-    document.addEventListener("keydown", handler)
-    onCleanup(() => document.removeEventListener("keydown", handler))
-  })
-
-  const panelWidth = () => workspace.width()
-  const maxWidth = () => Math.min(900, window.innerWidth * 0.45)
-
-  const handleResize = (w: number) => {
-    workspace.setWidth(Math.max(300, Math.min(w, maxWidth())))
-  }
-
-  // Desktop: side panel with resize handle
-  return (
-    <Show when={isDesktop()}>
-      <ResizeHandle
-        direction="horizontal"
-        size={panelWidth()}
-        min={300}
-        max={maxWidth()}
-        onResize={handleResize}
-        collapseThreshold={200}
-        onCollapse={() => workspace.closePanel()}
-      />
-      <div
-        style={{ width: `${panelWidth()}px` }}
-        class="shrink-0 h-full flex flex-col border-l border-border-weak-base bg-background-stronger/60"
-      >
-        <div class="shrink-0 flex items-center justify-between px-4 h-11 border-b border-border-weak-base">
-          <div class="flex items-center gap-2">
-            <Show when={tool()}>
-              <Icon name={tool()!.icon} size="normal" class="text-icon-weak" />
-              <span class="text-14-medium text-text-strong">{tool()?.label}</span>
-            </Show>
-          </div>
-          <IconButton icon="x" variant="ghost" onClick={() => workspace.closePanel()} />
-        </div>
-        <div class="flex-1 min-h-0 overflow-hidden">
-          <Show
-            when={tool()}
-            fallback={
-              <div class="flex items-center justify-center h-full text-text-weak text-14">No tool selected</div>
-            }
-          >
-            <Dynamic component={tool()!.component} />
-          </Show>
-        </div>
-      </div>
-    </Show>
-  )
-}
-
 export function WorkspacePanelMobile() {
   const workspace = useWorkspace()
   const tool = () => workspace.activeTool()

--- a/packages/app/src/components/session/workspace-rail.css
+++ b/packages/app/src/components/session/workspace-rail.css
@@ -1,0 +1,50 @@
+.workspace-rail {
+  width: 48px;
+  flex-shrink: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  border-left: 1px solid var(--border-weaker-base);
+  background: var(--surface-raised-base);
+}
+
+.workspace-rail-btn {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+  color: var(--icon-weak);
+  transition:
+    color var(--motion-duration-fast) var(--motion-ease-standard),
+    background-color var(--motion-duration-fast) var(--motion-ease-standard);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.workspace-rail-btn:hover {
+  color: var(--icon-base);
+  background: var(--surface-raised-base-hover);
+}
+
+.workspace-rail-btn--active {
+  color: var(--icon-interactive-base);
+  background: var(--surface-raised-base-active);
+}
+
+.workspace-rail-btn:focus-visible {
+  outline: 2px solid var(--border-selected);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-rail-btn {
+    transition: none;
+  }
+}

--- a/packages/app/src/components/session/workspace-rail.tsx
+++ b/packages/app/src/components/session/workspace-rail.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from "solid-js"
+import { For, Show, createMemo } from "solid-js"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { Tooltip } from "@ericsanchezok/synergy-ui/tooltip"
 import { useWorkspace } from "@/context/workspace"
@@ -12,7 +12,7 @@ export function WorkspaceRail() {
       <div class="workspace-rail" role="toolbar" aria-label="Workspace tools">
         <For each={workspace.tools()}>
           {(tool) => {
-            const isActive = () => workspace.opened() && workspace.active() === tool.id
+            const isActive = createMemo(() => workspace.opened() && workspace.active() === tool.id)
             return (
               <Tooltip value={tool.label} placement="left">
                 <button

--- a/packages/app/src/components/session/workspace-rail.tsx
+++ b/packages/app/src/components/session/workspace-rail.tsx
@@ -1,0 +1,35 @@
+import { For, Show } from "solid-js"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { Tooltip } from "@ericsanchezok/synergy-ui/tooltip"
+import { useWorkspace } from "@/context/workspace"
+import "./workspace-rail.css"
+
+export function WorkspaceRail() {
+  const workspace = useWorkspace()
+
+  return (
+    <Show when={workspace.tools().length > 0}>
+      <div class="workspace-rail" role="toolbar" aria-label="Workspace tools">
+        <For each={workspace.tools()}>
+          {(tool) => {
+            const isActive = () => workspace.opened() && workspace.active() === tool.id
+            return (
+              <Tooltip value={tool.label} placement="left">
+                <button
+                  type="button"
+                  class="workspace-rail-btn"
+                  classList={{ "workspace-rail-btn--active": isActive() }}
+                  aria-label={tool.label}
+                  aria-pressed={isActive()}
+                  onClick={() => workspace.toggle(tool.id)}
+                >
+                  <Icon name={tool.icon} size="normal" />
+                </button>
+              </Tooltip>
+            )
+          }}
+        </For>
+      </div>
+    </Show>
+  )
+}

--- a/packages/app/src/components/top-bar/session-top-bar.tsx
+++ b/packages/app/src/components/top-bar/session-top-bar.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo } from "solid-js"
+import { Show, createMemo } from "solid-js"
 import { useParams } from "@solidjs/router"
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
@@ -8,7 +8,6 @@ import { ModelSelectorPopover } from "@/components/dialog"
 import { useLocal } from "@/context/local"
 import { useCommand } from "@/context/command"
 import { useSync } from "@/context/sync"
-import { useWorkspace } from "@/context/workspace"
 import { base64Decode } from "@ericsanchezok/synergy-util/encode"
 import { isGlobalScope } from "@/utils/scope"
 import { useSessionMeta } from "@/composables/use-session-meta"
@@ -20,7 +19,6 @@ export function SessionTopBar() {
   const local = useLocal()
   const command = useCommand()
   const sync = useSync()
-  const workspace = useWorkspace()
 
   const isGlobal = () => (params.dir ? isGlobalScope(base64Decode(params.dir)) : false)
 
@@ -91,35 +89,6 @@ export function SessionTopBar() {
               <Icon name="download" size="normal" />
             </button>
           </Tooltip>
-        </Show>
-        <Show when={!!params.id}>
-          <For each={workspace.tools()}>
-            {(tool) => {
-              const isActive = () => workspace.opened() && workspace.active() === tool.id
-              return (
-                <Tooltip value={tool.label} placement="bottom">
-                  <button
-                    type="button"
-                    class="stb-icon-btn"
-                    classList={{ "stb-icon-btn--active": isActive() }}
-                    onClick={() => {
-                      if (!workspace.opened()) {
-                        workspace.setActive(tool.id)
-                        workspace.openPanel()
-                      } else if (workspace.active() === tool.id) {
-                        workspace.setActive(null)
-                        workspace.closePanel()
-                      } else {
-                        workspace.setActive(tool.id)
-                      }
-                    }}
-                  >
-                    <Icon name={tool.icon} size="normal" />
-                  </button>
-                </Tooltip>
-              )
-            }}
-          </For>
         </Show>
       </div>
     </div>

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -88,7 +88,6 @@ type State = {
 
 export interface NoteUpdateSignal {
   id: string
-  scopeID: string
   version: number
   type: "created" | "updated" | "deleted"
 }
@@ -572,14 +571,12 @@ function createGlobalSync() {
       bumpNoteVersion()
       if (event.type === "note.deleted") {
         const props = event.properties as { id: string; scopeID: string }
-        setNoteUpdate({ id: props.id, scopeID: props.scopeID, version: -1, type: "deleted" })
+        setNoteUpdate({ id: props.id, version: -1, type: "deleted" })
       } else {
-        const props = event.properties as unknown as { note: { id: string; scopeID: string; version: number } }
-        const note = props.note
+        const props = event.properties as { note: { id: string; version: number } }
         setNoteUpdate({
-          id: note.id,
-          scopeID: note.scopeID,
-          version: note.version,
+          id: props.note.id,
+          version: props.note.version,
           type: event.type as "created" | "updated",
         })
       }

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -86,6 +86,13 @@ type State = {
   }
 }
 
+export interface NoteUpdateSignal {
+  id: string
+  scopeID: string
+  version: number
+  type: "created" | "updated" | "deleted"
+}
+
 function createGlobalSync() {
   const globalSDK = useGlobalSDK()
   const [globalStore, setGlobalStore] = createStore<{
@@ -109,6 +116,7 @@ function createGlobalSync() {
 
   const children: Record<string, ReturnType<typeof createStore<State>>> = {}
   const [noteVersion, setNoteVersion] = createSignal(0)
+  const [noteUpdate, setNoteUpdate] = createSignal<NoteUpdateSignal | null>(null, { equals: false })
   function bumpNoteVersion() {
     setNoteVersion((v) => v + 1)
   }
@@ -562,6 +570,19 @@ function createGlobalSync() {
     }
     if (event?.type === "note.created" || event?.type === "note.updated" || event?.type === "note.deleted") {
       bumpNoteVersion()
+      if (event.type === "note.deleted") {
+        const props = event.properties as { id: string; scopeID: string }
+        setNoteUpdate({ id: props.id, scopeID: props.scopeID, version: -1, type: "deleted" })
+      } else {
+        const props = event.properties as unknown as { note: { id: string; scopeID: string; version: number } }
+        const note = props.note
+        setNoteUpdate({
+          id: note.id,
+          scopeID: note.scopeID,
+          version: note.version,
+          type: event.type as "created" | "updated",
+        })
+      }
     }
 
     if (event?.type === "agenda.item.created" || event?.type === "agenda.item.updated") {
@@ -1077,6 +1098,7 @@ function createGlobalSync() {
     releaseChild,
     bootstrap,
     noteVersion,
+    noteUpdate,
     get agenda() {
       return globalStore.agenda
     },

--- a/packages/app/src/context/workspace.tsx
+++ b/packages/app/src/context/workspace.tsx
@@ -47,6 +47,17 @@ export const { use: useWorkspace, provider: WorkspaceProvider } = createSimpleCo
       closePanel: () => ws().close(),
       setActive: (id: string | null) => ws().setActive(id),
       setWidth: (w: number) => ws().setWidth(w),
+      toggle(toolId: string) {
+        if (!ws().opened()) {
+          ws().setActive(toolId)
+          ws().open()
+        } else if (ws().active() === toolId) {
+          ws().setActive(null)
+          ws().close()
+        } else {
+          ws().setActive(toolId)
+        }
+      },
     }
   },
 })

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -39,13 +39,13 @@ import { TabsPanel } from "@/components/session/tabs-panel"
 import { WorkspacePanelMobile } from "@/components/session/workspace-panel"
 import { WorkspaceRail } from "@/components/session/workspace-rail"
 import { WorkspaceDrawer } from "@/components/session/workspace-drawer"
+import { WorkspaceProvider, useWorkspace } from "@/context/workspace"
 import { WorkspaceNotesTool } from "@/components/workspace/tool-notes"
 import { TerminalPanel } from "@/components/session/terminal-panel"
 import { SessionTopBar } from "@/components/top-bar/session-top-bar"
 import { getScopeLabel } from "@/utils/scope"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
-
 const handoff = {
   prompt: "",
   terminals: [] as string[],
@@ -1115,7 +1115,7 @@ function SessionPageContent() {
               handoffFiles={handoff.files}
             />
           </Show>
-          <Show when={isDesktop() && workspace().opened()}>
+          <Show when={isDesktop() && !!params.id}>
             <WorkspaceDrawer />
           </Show>
           <Show when={isDesktop() && !!params.id}>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -36,8 +36,9 @@ import { HolosConversation, HolosGreeting } from "@/components/session/holos-con
 import { HolosPromptInput } from "@/components/session/holos-prompt-input"
 import { PromptDock } from "@/components/session/prompt-dock"
 import { TabsPanel } from "@/components/session/tabs-panel"
-import { WorkspacePanel, WorkspacePanelMobile } from "@/components/session/workspace-panel"
-import { WorkspaceProvider, useWorkspace } from "@/context/workspace"
+import { WorkspacePanelMobile } from "@/components/session/workspace-panel"
+import { WorkspaceRail } from "@/components/session/workspace-rail"
+import { WorkspaceDrawer } from "@/components/session/workspace-drawer"
 import { WorkspaceNotesTool } from "@/components/workspace/tool-notes"
 import { TerminalPanel } from "@/components/session/terminal-panel"
 import { SessionTopBar } from "@/components/top-bar/session-top-bar"
@@ -887,11 +888,11 @@ function SessionPageContent() {
           {/* Session panel */}
           <div
             classList={{
-              "@container relative shrink-0 flex flex-col min-h-0 min-w-0 h-full bg-background-stronger": true,
-              "flex-1 md:flex-none pt-3 pb-0 md:py-3": true,
+              "@container relative flex-1 min-w-0 flex flex-col min-h-0 h-full bg-background-stronger": true,
+              "pt-3 pb-0 md:py-3": true,
             }}
             style={{
-              width: isDesktop() && (showTabs() || workspace().opened()) ? `${layout.session.width()}px` : "100%",
+              width: isDesktop() && showTabs() ? `${layout.session.width()}px` : undefined,
               "--prompt-height": store.promptHeight ? `${store.promptHeight}px` : undefined,
             }}
           >
@@ -1115,7 +1116,10 @@ function SessionPageContent() {
             />
           </Show>
           <Show when={isDesktop() && workspace().opened()}>
-            <WorkspacePanel />
+            <WorkspaceDrawer />
+          </Show>
+          <Show when={isDesktop() && !!params.id}>
+            <WorkspaceRail />
           </Show>
         </div>
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -887,10 +887,7 @@ function SessionPageContent() {
 
           {/* Session panel */}
           <div
-            classList={{
-              "@container relative flex-1 min-w-0 flex flex-col min-h-0 h-full bg-background-stronger": true,
-              "pt-3 pb-0 md:py-3": true,
-            }}
+            class="@container relative flex-1 min-w-0 flex flex-col min-h-0 h-full bg-background-stronger pt-3 pb-0 md:py-3"
             style={{
               width: isDesktop() && showTabs() ? `${layout.session.width()}px` : undefined,
               "--prompt-height": store.promptHeight ? `${store.promptHeight}px` : undefined,


### PR DESCRIPTION
## Summary

- Replace the conditional **WorkspacePanel** with a persistent right-edge **WorkspaceRail** (icon toolbar) + animated **WorkspaceDrawer** (slide-out panel)
- Fix the black gap on the right when notes are open — session panel now uses flex-1 by default, only fixed-width when TabsPanel is present
- Eliminate the note save echo flash by decoupling the TipTap editor from the global `noteVersion` signal — editor now only re-fetches when its own note is updated elsewhere with a higher version
- Move workspace tool entry from top bar to the right-edge rail; add `workspace.toggle()` to unify open/switch/close behavior

### Changes

| Area | File | Change |
|---|---|---|
| New | `workspace-rail.tsx` / `.css` | Right-edge 48px icon toolbar, tooltip, active/hover/focus states |
| New | `workspace-drawer.tsx` / `.css` | Animated drawer (180ms width transition), resize handle, Escape key, closing state |
| Context | `workspace.tsx` | Add `toggle(toolId)` — unified open / switch / close |
| Context | `global-sync.tsx` | Add targeted `noteUpdate` signal: `{ id, version, type }` per note event |
| Layout | `session.tsx` | Session panel always `flex-1` (only fixed when `showTabs()`), wire Rail + Drawer |
| Notes | `note-panel.tsx` | Decouple `createResource` from `noteVersion`; watch `noteUpdate` for precise external-update detection |
| Cleanup | `session-top-bar.tsx` | Remove workspace tool button loop |
| Cleanup | `workspace-panel.tsx` | Delete `WorkspacePanel` desktop variant; keep `WorkspacePanelMobile` |
| Cleanup | `commands.tsx` | Update copy: "workspace panel" → "workspace drawer" |

### Verification

- `bun run typecheck` — 8/8 packages pass
- `bun run build` — passes
- `./script/format.ts` — all files match Prettier

### Design principles

- All colors use existing CSS token variables — no hardcoded hex
- Motion uses `--motion-duration-base` / `--motion-ease-emphasized` tokens
- Reduced motion respected via `@media (prefers-reduced-motion: reduce)`
- Rail is `role="toolbar"`, drawer is `role="complementary"`, all buttons have `aria-label` and `aria-pressed`
- Note echo fix follows the industry-standard "version guard + broadcast-to-others" pattern (Notion, SignalR, ProseMirror-collab)