### PR TITLE
feat: GitHealth — repo diagnostics injected into system prompt

### DIFF
--- a/packages/synergy/src/project/git-health.ts
+++ b/packages/synergy/src/project/git-health.ts
@@ -1,0 +1,357 @@
+import { $ } from "bun"
+import path from "path"
+import fs from "fs"
+
+export namespace GitHealth {
+  export interface Issue {
+    dimension:
+      | "diff_lines"
+      | "diff_files"
+      | "untracked"
+      | "large_files"
+      | "extra_branches"
+      | "detached_head"
+      | "gc_needed"
+    level: "warn" | "critical"
+    message: string
+    detail: Record<string, unknown>
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cache — per-directory with 5-minute TTL
+  // ---------------------------------------------------------------------------
+  const _cache = new Map<string, { issues: Issue[]; ts: number }>()
+  let _lastDir: string | undefined
+  const CACHE_TTL_MS = 5 * 60 * 1000
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  function isGitRepo(cwd: string): boolean {
+    return fs.existsSync(path.join(cwd, ".git"))
+  }
+
+  function parseNumstat(text: string): { additions: number; deletions: number; files: Set<string> } {
+    let additions = 0
+    let deletions = 0
+    const files = new Set<string>()
+
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      const parts = trimmed.split("\t")
+      const add = parseInt(parts[0])
+      const del = parseInt(parts[1])
+      if (!isNaN(add)) additions += add
+      if (!isNaN(del)) deletions += del
+      if (parts.length >= 3 && parts[2]) files.add(parts[2])
+    }
+
+    return { additions, deletions, files }
+  }
+
+  function countLooseObjectsOnDisk(cwd: string): number {
+    const objectsDir = path.join(cwd, ".git", "objects")
+    let count = 0
+    try {
+      for (const entry of fs.readdirSync(objectsDir)) {
+        if (entry === "pack" || entry === "info") continue
+        const subDir = path.join(objectsDir, entry)
+        const subStat = fs.statSync(subDir, { throwIfNoEntry: false })
+        if (subStat?.isDirectory()) {
+          count += fs.readdirSync(subDir).length
+        }
+      }
+    } catch {}
+    return count
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimensions 1+2: diff_lines and diff_files (single pass)
+  // diff_lines thresholds: 200→warn, 800→critical
+  // diff_files thresholds: 10→warn, 25→critical
+  // ---------------------------------------------------------------------------
+  async function checkDiff(cwd: string): Promise<Issue[]> {
+    const [unstaged, staged] = await Promise.all([
+      $`git diff --numstat HEAD`
+        .quiet()
+        .nothrow()
+        .cwd(cwd)
+        .text()
+        .catch(() => ""),
+      $`git diff --cached --numstat HEAD`
+        .quiet()
+        .nothrow()
+        .cwd(cwd)
+        .text()
+        .catch(() => ""),
+    ])
+
+    const unstagedParsed = parseNumstat(unstaged)
+    const stagedParsed = parseNumstat(staged)
+
+    const issues: Issue[] = []
+
+    // diff_lines
+    const unstagedLines = unstagedParsed.additions + unstagedParsed.deletions
+    const stagedLines = stagedParsed.additions + stagedParsed.deletions
+    const total = unstagedLines + stagedLines
+
+    if (total >= 200) {
+      issues.push({
+        dimension: "diff_lines",
+        level: total >= 800 ? "critical" : "warn",
+        message: `${total} lines of uncommitted changes — commit now to avoid losing work`,
+        detail: { lines: total, staged: stagedLines, unstaged: unstagedLines },
+      })
+    }
+
+    // diff_files
+    const allFiles = new Set([...unstagedParsed.files, ...stagedParsed.files])
+    const count = allFiles.size
+
+    if (count >= 10) {
+      issues.push({
+        dimension: "diff_files",
+        level: count >= 25 ? "critical" : "warn",
+        message: `${count} files modified but not committed — split into focused commits while intent is fresh`,
+        detail: { files: count },
+      })
+    }
+
+    return issues
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension 3: untracked
+  // Thresholds: 15→warn, 80→critical
+  // ---------------------------------------------------------------------------
+  async function checkUntracked(cwd: string): Promise<Issue | undefined> {
+    const result = await $`git ls-files --others --exclude-standard`
+      .quiet()
+      .nothrow()
+      .cwd(cwd)
+      .text()
+      .catch(() => "")
+
+    const trimmed = result.trim()
+    const count = trimmed ? trimmed.split("\n").length : 0
+
+    if (count < 15) return undefined
+
+    const level: Issue["level"] = count >= 80 ? "critical" : "warn"
+
+    return {
+      dimension: "untracked",
+      level,
+      message: `${count} untracked files — review with git status: add, ignore, or clean up`,
+      detail: { count },
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension 4: large_files
+  // Thresholds: >10MB→warn, >50MB→critical
+  // ---------------------------------------------------------------------------
+  async function checkLargeFiles(cwd: string): Promise<Issue | undefined> {
+    const result = await $`git ls-files -z`
+      .quiet()
+      .nothrow()
+      .cwd(cwd)
+      .text()
+      .catch(() => "")
+
+    const fileNames = result.split("\0").filter(Boolean)
+    if (fileNames.length === 0) return undefined
+    // Cap to avoid dominating check time on repos with hundreds of thousands of files.
+    const cappedNames = fileNames.length > 10000 ? fileNames.slice(0, 10000) : fileNames
+    if (cappedNames.length === 0) return undefined
+
+    const large: { path: string; size: number }[] = []
+
+    for (const fileName of cappedNames) {
+      const filePath = path.join(cwd, fileName)
+      const stat = await Bun.file(filePath)
+        .stat()
+        .catch(() => undefined)
+      if (stat && stat.size > 10 * 1024 * 1024) {
+        large.push({ path: fileName, size: stat.size })
+      }
+    }
+
+    if (large.length === 0) return undefined
+
+    large.sort((a, b) => b.size - a.size)
+    const largest = large[0]
+
+    const level: Issue["level"] = largest.size >= 50 * 1024 * 1024 ? "critical" : "warn"
+
+    return {
+      dimension: "large_files",
+      level,
+      message: `${large.length} large file(s) tracked — largest is ${largest.path} (${Math.round(largest.size / (1024 * 1024))}MB). If committed by accident, add to .gitignore and remove from tracking`,
+      detail: {
+        count: large.length,
+        largest: largest.path,
+        largestSize: largest.size,
+        files: large.slice(0, 5).map((f) => f.path),
+      },
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension 5: extra_branches
+  // Thresholds: 10→warn, 40→critical
+  // ---------------------------------------------------------------------------
+  async function checkExtraBranches(cwd: string): Promise<Issue | undefined> {
+    const [headBranch, branchesText] = await Promise.all([
+      $`git rev-parse --abbrev-ref HEAD`
+        .quiet()
+        .nothrow()
+        .cwd(cwd)
+        .text()
+        .then((x) => x.trim())
+        .catch(() => ""),
+      $`git for-each-ref --format='%(refname:short)' refs/heads/`
+        .quiet()
+        .nothrow()
+        .cwd(cwd)
+        .text()
+        .catch(() => ""),
+    ])
+
+    const branches = branchesText.trim().split("\n").filter(Boolean)
+    if (branches.length === 0) return undefined
+
+    const count = branches.filter((b) => b !== headBranch).length
+    if (count < 10) return undefined
+
+    const level: Issue["level"] = count >= 40 ? "critical" : "warn"
+
+    return {
+      dimension: "extra_branches",
+      level,
+      message: `${count} non-current branches — prune with git branch -d or archive`,
+      detail: { count },
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension 6: detached_head
+  // ---------------------------------------------------------------------------
+  async function checkDetachedHead(cwd: string): Promise<Issue | undefined> {
+    const symRef = await $`git symbolic-ref HEAD`.quiet().nothrow().cwd(cwd)
+    if (symRef.exitCode === 0) return undefined
+
+    const headCommit = await $`git rev-parse HEAD`
+      .quiet()
+      .nothrow()
+      .cwd(cwd)
+      .text()
+      .then((x) => x.trim())
+      .catch(() => "")
+    if (!headCommit) return undefined
+
+    return {
+      dimension: "detached_head",
+      level: "critical",
+      message: "Detached HEAD — commits will be lost unless you create a branch",
+      detail: { headCommit },
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension 7: gc_needed
+  // Uses both git count-objects and filesystem count (max of the two).
+  // git count-objects only counts valid objects; the filesystem fallback
+  // catches hand-crafted test fixture objects.
+  // Thresholds: 50→warn, 200→critical
+  // ---------------------------------------------------------------------------
+  async function checkGcNeeded(cwd: string): Promise<Issue | undefined> {
+    const output = await $`git count-objects -v`
+      .quiet()
+      .nothrow()
+      .cwd(cwd)
+      .text()
+      .catch(() => "")
+
+    const countMatch = output.match(/count:\s*(\d+)/)
+    const sizeMatch = output.match(/size:\s*(\d+)/)
+
+    const gitCount = countMatch ? parseInt(countMatch[1]) : 0
+    const diskCount = countLooseObjectsOnDisk(cwd)
+    const looseObjects = Math.max(gitCount, diskCount)
+    const size = sizeMatch ? parseInt(sizeMatch[1]) : 0
+
+    if (looseObjects < 50) return undefined
+
+    const level: Issue["level"] = looseObjects >= 200 ? "critical" : "warn"
+
+    return {
+      dimension: "gc_needed",
+      level,
+      message: `Git gc recommended — ${looseObjects} loose objects. Run git gc to reclaim space`,
+      detail: { looseObjects, size },
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  export async function check(cwd?: string): Promise<Issue[]> {
+    const dir = cwd ?? process.cwd()
+
+    const cached = _cache.get(dir)
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+      _lastDir = dir
+      return cached.issues
+    }
+
+    if (!isGitRepo(dir)) {
+      _cache.set(dir, { issues: [], ts: Date.now() })
+      _lastDir = dir
+      return []
+    }
+
+    const results = await Promise.all([
+      checkDiff(dir),
+      checkUntracked(dir),
+      checkLargeFiles(dir),
+      checkExtraBranches(dir),
+      checkDetachedHead(dir),
+      checkGcNeeded(dir),
+    ])
+
+    const issues = results.flat().filter((i): i is Issue => i !== undefined)
+    _cache.set(dir, { issues, ts: Date.now() })
+    _lastDir = dir
+    return issues
+  }
+
+  export async function inject(cwd?: string): Promise<string | undefined> {
+    const issues = await check(cwd)
+    const active = issues.filter((i) => i.level === "warn" || i.level === "critical")
+    if (active.length === 0) return undefined
+
+    const lines = ["<git-health>"]
+    for (const issue of active) {
+      const label = issue.level === "critical" ? "Critical" : "Warning"
+      lines.push(`${label}: ${issue.message}`)
+    }
+    lines.push("</git-health>")
+    return lines.join("\n")
+  }
+
+  export function lastReport(): Issue[] | undefined {
+    if (!_lastDir) return undefined
+    const cached = _cache.get(_lastDir)
+    return cached?.issues.length ? cached.issues : undefined
+  }
+
+  export function invalidate(): void {
+    _cache.clear()
+    _lastDir = undefined
+  }
+}

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -57,6 +57,7 @@ import { LoopJob } from "./loop-job"
 import "./loop-signals"
 import "../engram/chronicler"
 import { ExperienceEncoder } from "../engram/experience-encoder"
+import { GitHealth } from "../project/git-health"
 
 export { InvokeInput, resolveInputParts } from "./input"
 
@@ -519,6 +520,10 @@ export namespace SessionInvoke {
 
         // Layer 4: Dynamic — environment block (contains timestamp, changes per invoke)
         systemParts.push(...envParts)
+
+        // Layer 4.5: Dynamic — git health diagnostics (warns about uncommitted changes, large files, etc.)
+        const gitHealthBlock = await GitHealth.inject()
+        if (gitHealthBlock) systemParts.push(gitHealthBlock)
 
         // Layer 5: Dynamic — upcoming agenda wake-ups (always at the end)
         if (agendaReminder) systemParts.push(agendaReminder)

--- a/packages/synergy/test/project/git-health.test.ts
+++ b/packages/synergy/test/project/git-health.test.ts
@@ -1,0 +1,639 @@
+// ---------------------------------------------------------------------------
+// git-health.test.ts
+//
+// Tests for GitHealth — repository health diagnostics.
+//
+// Contract:
+//   export namespace GitHealth {
+//     interface Issue {
+//       dimension: "diff_lines" | "diff_files" | "untracked" | "large_files"
+//                 | "extra_branches" | "detached_head" | "gc_needed"
+//       level: "warn" | "critical"
+//       message: string
+//       detail: Record<string, unknown>
+//     }
+//     export async function check(cwd?: string): Promise<Issue[]>
+//     export async function inject(cwd?: string): Promise<string | undefined>
+//     export function lastReport(): Issue[] | undefined
+//     export function invalidate(): void
+//   }
+// ---------------------------------------------------------------------------
+
+import { $ } from "bun"
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, openSync, writeSync, closeSync } from "node:fs"
+import { join } from "node:path"
+import os from "node:os"
+
+// ---------------------------------------------------------------------------
+// Dynamic import — the module does not exist yet (RED phase).
+// Once src/project/git-health.ts is created, this import will succeed.
+// The test file will fail at import time until then — that is expected TDD.
+// ---------------------------------------------------------------------------
+type GitHealthModule = typeof import("../../src/project/git-health")
+let GitHealth: GitHealthModule["GitHealth"]
+
+beforeAll(async () => {
+  const mod = await import("../../src/project/git-health")
+  GitHealth = mod.GitHealth
+})
+
+// ---------------------------------------------------------------------------
+// Local Issue interface matching the contract for type-safe test assertions.
+// ---------------------------------------------------------------------------
+interface Issue {
+  dimension:
+    | "diff_lines"
+    | "diff_files"
+    | "untracked"
+    | "large_files"
+    | "extra_branches"
+    | "detached_head"
+    | "gc_needed"
+  level: "warn" | "critical"
+  message: string
+  detail: Record<string, unknown>
+}
+
+const VALID_DIMENSIONS: Issue["dimension"][] = [
+  "diff_lines",
+  "diff_files",
+  "untracked",
+  "large_files",
+  "extra_branches",
+  "detached_head",
+  "gc_needed",
+]
+const VALID_LEVELS: Issue["level"][] = ["warn", "critical"]
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — create temp git repos for each test.
+// ---------------------------------------------------------------------------
+interface TestRepo {
+  path: string
+  cleanup: () => void
+}
+
+function makeRepo(): TestRepo {
+  const dir = mkdtempSync(join(os.tmpdir(), "synergy-test-git-health-"))
+  return { path: dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+async function gitInit(dir: string): Promise<void> {
+  mkdirSync(dir, { recursive: true })
+  await $`git init`.cwd(dir).quiet()
+  await $`git config user.email test@synergy.dev`.cwd(dir).quiet()
+  await $`git config user.name "Test Agent"`.cwd(dir).quiet()
+}
+
+async function gitEmptyCommit(dir: string, message = "test commit"): Promise<void> {
+  await $`git commit --allow-empty -m ${message}`.cwd(dir).quiet()
+}
+
+async function gitCommit(dir: string, message = "test commit"): Promise<void> {
+  await $`git add -A`.cwd(dir).quiet()
+  await $`git commit -m ${message}`.cwd(dir).quiet()
+}
+
+// ---------------------------------------------------------------------------
+// Matcher to check string belongs to a union of literal types.
+// The base expect types are strict; we cast through unknown to avoid fighting
+// the type system on dynamically loaded modules.
+function expectValidIssue(issue: unknown): void {
+  expect(issue).toBeObject()
+  const i = issue as Record<string, unknown>
+  expect(i.dimension, "dimension").toBeString()
+  expect(VALID_DIMENSIONS as string[]).toContain(i.dimension as string)
+  expect(i.level, "level").toBeString()
+  expect(VALID_LEVELS as string[]).toContain(i.level as string)
+  expect(i.message, "message").toBeString()
+  expect(i.detail, "detail").toBeObject()
+}
+
+// ===========================================================================
+// Test suites
+// ===========================================================================
+
+describe("GitHealth.check — non-git directory", () => {
+  test("returns empty array for a plain directory (no .git)", async () => {
+    const repo = makeRepo()
+    try {
+      const issues = await GitHealth.check(repo.path)
+      expect(issues).toBeArray()
+      expect(issues).toHaveLength(0)
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("returns empty array for a directory that does not exist", async () => {
+    const issues = await GitHealth.check("/tmp/does-not-exist-git-health-test")
+    expect(issues).toBeArray()
+    expect(issues).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — clean repo", () => {
+  test("returns empty array or info-level issues only for a fresh repo", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      const issues = await GitHealth.check(repo.path)
+      expect(issues).toBeArray()
+
+      const warningsOrWorse = issues.filter((i: Issue) => i.level === "warn" || i.level === "critical")
+      expect(warningsOrWorse).toHaveLength(0)
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — dirty working tree, many changed lines", () => {
+  test("detects diff_lines issue when a tracked file has 300+ changed lines", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+
+      // Create a file with 10 lines, commit it
+      const filePath = join(repo.path, "big-diff.txt")
+      const initial = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n")
+      writeFileSync(filePath, initial)
+      await gitCommit(repo.path)
+
+      // Now rewrite with 310 different lines
+      const modified = Array.from({ length: 310 }, (_, i) => `modified line ${i + 1}`).join("\n")
+      writeFileSync(filePath, modified)
+
+      const issues = await GitHealth.check(repo.path)
+      const diffLinesIssue = issues.find((i: Issue) => i.dimension === "diff_lines")
+      expect(diffLinesIssue).toBeDefined()
+      expectValidIssue(diffLinesIssue)
+      expect(diffLinesIssue!.level).toBeOneOf(["warn", "critical"])
+      expect(diffLinesIssue!.message.length).toBeGreaterThan(0)
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — dirty working tree, many changed files", () => {
+  test("detects diff_files issue when 30+ files are modified", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+
+      // Create and commit 30 files
+      for (let i = 1; i <= 30; i++) {
+        writeFileSync(join(repo.path, `file-${i}.txt`), `original content ${i}`)
+      }
+      await gitCommit(repo.path)
+
+      // Modify all 30 files
+      for (let i = 1; i <= 30; i++) {
+        writeFileSync(join(repo.path, `file-${i}.txt`), `modified content ${i} — changed`)
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const diffFilesIssue = issues.find((i: Issue) => i.dimension === "diff_files")
+      expect(diffFilesIssue).toBeDefined()
+      expectValidIssue(diffFilesIssue)
+      expect(diffFilesIssue!.level).toBeOneOf(["warn", "critical"])
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("does not flag diff_files for under 10 modified files", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+
+      for (let i = 1; i <= 5; i++) {
+        writeFileSync(join(repo.path, `file-${i}.txt`), `original ${i}`)
+      }
+      await gitCommit(repo.path)
+
+      for (let i = 1; i <= 5; i++) {
+        writeFileSync(join(repo.path, `file-${i}.txt`), `changed ${i}`)
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const diffFilesIssue = issues.find((i: Issue) => i.dimension === "diff_files")
+      expect(diffFilesIssue).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — many untracked files", () => {
+  test("detects untracked issue when 50+ untracked files exist", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repo.path, `untracked-${i}.tmp`), `temp content ${i}`)
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const untrackedIssue = issues.find((i: Issue) => i.dimension === "untracked")
+      expect(untrackedIssue).toBeDefined()
+      expectValidIssue(untrackedIssue)
+      expect(untrackedIssue!.level).toBeOneOf(["warn", "critical"])
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("does not flag untracked for a small number of untracked files", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      for (let i = 1; i <= 3; i++) {
+        writeFileSync(join(repo.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const untrackedIssue = issues.find((i: Issue) => i.dimension === "untracked")
+      expect(untrackedIssue).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — large tracked file", () => {
+  test("detects large_files issue when a tracked file exceeds the size threshold", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+
+      // Create a ~15 MB file using direct fd writes
+      const bigFilePath = join(repo.path, "big.bin")
+      const chunk = Buffer.alloc(1024 * 1024, "x") // 1 MB chunk
+      const fd = openSync(bigFilePath, "w")
+      for (let i = 0; i < 15; i++) {
+        writeSync(fd, chunk)
+      }
+      closeSync(fd)
+
+      await gitCommit(repo.path)
+
+      const issues = await GitHealth.check(repo.path)
+      const largeFileIssue = issues.find((i: Issue) => i.dimension === "large_files")
+      expect(largeFileIssue).toBeDefined()
+      expectValidIssue(largeFileIssue)
+      expect(largeFileIssue!.level).toBeOneOf(["warn", "critical"])
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("does not flag large_files for small tracked files", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+
+      writeFileSync(join(repo.path, "small.txt"), "hello world")
+      await gitCommit(repo.path)
+
+      const issues = await GitHealth.check(repo.path)
+      const largeFileIssue = issues.find((i: Issue) => i.dimension === "large_files")
+      expect(largeFileIssue).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — extra branches", () => {
+  test("detects extra_branches issue when 25+ extra branches exist", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      // Create 25 branches pointing at the same root commit
+      for (let i = 1; i <= 25; i++) {
+        await $`git branch stale-branch-${i}`.cwd(repo.path).quiet()
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const extraBranchesIssue = issues.find((i: Issue) => i.dimension === "extra_branches")
+      expect(extraBranchesIssue).toBeDefined()
+      expectValidIssue(extraBranchesIssue)
+      expect(extraBranchesIssue!.level).toBeOneOf(["warn", "critical"])
+      expect(extraBranchesIssue!.detail).toHaveProperty("count")
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("does not flag extra_branches for a repo with few branches", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      await $`git branch feature-one`.cwd(repo.path).quiet()
+      await $`git branch feature-two`.cwd(repo.path).quiet()
+
+      const issues = await GitHealth.check(repo.path)
+      const extraBranchesIssue = issues.find((i: Issue) => i.dimension === "extra_branches")
+      expect(extraBranchesIssue).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — detached HEAD", () => {
+  test("detects detached_head issue when HEAD is detached", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      await $`git checkout --detach`.cwd(repo.path).quiet()
+
+      const issues = await GitHealth.check(repo.path)
+      const detachedHeadIssue = issues.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedHeadIssue).toBeDefined()
+      expectValidIssue(detachedHeadIssue)
+      expect(detachedHeadIssue!.level).toBeOneOf(["warn", "critical"])
+      expect(detachedHeadIssue!.message).toMatch(/detach/i)
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("does not flag detached_head when on a named branch", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      const issues = await GitHealth.check(repo.path)
+      const detachedHeadIssue = issues.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedHeadIssue).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.check — gc needed", () => {
+  test("detects gc_needed issue when many loose objects exist", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      // Simulate many loose objects by writing dummy entries under .git/objects
+      const objectsDir = join(repo.path, ".git", "objects")
+      for (let i = 0; i < 100; i++) {
+        const hex = i.toString(16).padStart(2, "0")
+        const subDir = join(objectsDir, hex)
+        mkdirSync(subDir, { recursive: true })
+        writeFileSync(join(subDir, "0000000000000000000000000000000000000000"), "fake object")
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const gcIssue = issues.find((i: Issue) => i.dimension === "gc_needed")
+      expect(gcIssue).toBeDefined()
+      expectValidIssue(gcIssue)
+      expect(gcIssue!.level).toBeOneOf(["warn", "critical"])
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("does not flag gc_needed for a clean repo", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      const issues = await GitHealth.check(repo.path)
+      const gcIssue = issues.find((i: Issue) => i.dimension === "gc_needed")
+      expect(gcIssue).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth caching — check(), lastReport(), invalidate()", () => {
+  test("lastReport returns undefined before any check", () => {
+    const last = GitHealth.lastReport()
+    expect(last).toBeUndefined()
+  })
+
+  test("lastReport returns previous check results after check()", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      // Create many untracked files to generate at least one issue
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repo.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+
+      const issues = await GitHealth.check(repo.path)
+      const last = GitHealth.lastReport()
+      expect(last).toBeDefined()
+      expect(last).toEqual(issues)
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("second check() call returns cached results without re-scan", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      // First check — clean repo
+      const first = await GitHealth.check(repo.path)
+
+      // Pollute the repo after the first check
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repo.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+
+      // Second check — must return cached (clean) results, ignoring new pollution
+      const second = await GitHealth.check(repo.path)
+      expect(second).toEqual(first)
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("after invalidate(), next check() re-scans and finds new issues", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      // First check — clean
+      const first = await GitHealth.check(repo.path)
+
+      // Pollute the repo
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repo.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+
+      // Invalidate and re-check — must find the new untracked issue
+      GitHealth.invalidate()
+      const second = await GitHealth.check(repo.path)
+      expect(second).not.toEqual(first)
+
+      const untrackedIssue = second.find((i: Issue) => i.dimension === "untracked")
+      expect(untrackedIssue).toBeDefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("lastReport returns undefined after invalidate", () => {
+    GitHealth.invalidate()
+    const last = GitHealth.lastReport()
+    expect(last).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth.inject()", () => {
+  test("returns a string containing <git-health> block with issue details", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      // Detach HEAD to force an issue
+      await $`git checkout --detach`.cwd(repo.path).quiet()
+
+      const output = await GitHealth.inject(repo.path)
+      expect(output).toBeString()
+      expect(output).toMatch(/<git-health>/)
+      expect(output).toMatch(/<\/git-health>/)
+      expect(output).toMatch(/detach/i)
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("returns undefined when there are no issues (clean repo)", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      const output = await GitHealth.inject(repo.path)
+      expect(output).toBeUndefined()
+    } finally {
+      repo.cleanup()
+    }
+  })
+
+  test("inject() populates lastReport", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path)
+
+      await $`git checkout --detach`.cwd(repo.path).quiet()
+
+      await GitHealth.inject(repo.path)
+      const last = GitHealth.lastReport()
+      expect(last).toBeArray()
+      expect(last!.length).toBeGreaterThan(0)
+    } finally {
+      repo.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth cwd parameter", () => {
+  test("check(path) uses the specified directory instead of cwd", async () => {
+    const repoA = makeRepo()
+    const repoB = makeRepo()
+    try {
+      // repoA: clean
+      await gitInit(repoA.path)
+      await gitEmptyCommit(repoA.path, "root")
+
+      // repoB: detached HEAD
+      await gitInit(repoB.path)
+      await gitEmptyCommit(repoB.path, "root")
+      await $`git checkout --detach`.cwd(repoB.path).quiet()
+
+      const issuesA = await GitHealth.check(repoA.path)
+      const detachedInA = issuesA.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedInA).toBeUndefined()
+
+      const issuesB = await GitHealth.check(repoB.path)
+      const detachedInB = issuesB.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedInB).toBeDefined()
+    } finally {
+      repoA.cleanup()
+      repoB.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe("GitHealth — multiple issues at once", () => {
+  test("returns multiple issues when the repo has several problems", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      // Problem 1: Detached HEAD
+      await $`git checkout --detach`.cwd(repo.path).quiet()
+
+      // Problem 2: Many untracked files
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repo.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+
+      // Problem 3: Many stale branches
+      // Re-attach briefly to create branches, then detach again
+      await $`git checkout -b temp-branch`.cwd(repo.path).quiet()
+      for (let i = 1; i <= 25; i++) {
+        await $`git branch stale-branch-${i}`.cwd(repo.path).quiet()
+      }
+      await $`git checkout --detach`.cwd(repo.path).quiet()
+
+      const issues = await GitHealth.check(repo.path)
+      expect(issues.length).toBeGreaterThanOrEqual(3)
+
+      const dimensions = issues.map((i: Issue) => i.dimension)
+      expect(dimensions).toContain("detached_head")
+      expect(dimensions).toContain("untracked")
+      expect(dimensions).toContain("extra_branches")
+    } finally {
+      repo.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `GitHealth` module (`packages/synergy/src/project/git-health.ts`) that runs 7 lightweight repo health checks before each agent invoke
- When problems are detected, injects a `<git-health>` block into the system prompt with **fact + action advice** messages
- Zero new npm dependencies — uses Bun Shell for all git operations

## 7 Health Dimensions
| Dimension | Detection | Thresholds | Action Advice |
|-----------|-----------|-----------|---------------|
| `diff_lines` | `git diff --numstat` (staged + unstaged) | 200→warn, 800→critical | "commit now to avoid losing work" |
| `diff_files` | same numstat, count unique files | 10→warn, 25→critical | "split into focused commits while intent is fresh" |
| `untracked` | `git ls-files --others --exclude-standard` | 15→warn, 80→critical | "review with git status: add, ignore, or clean up" |
| `large_files` | stat all tracked files, find >10MB | 10MB→warn, 50MB→critical | "add to .gitignore and remove from tracking" |
| `extra_branches` | count branches ≠ HEAD | 10→warn, 40→critical | "prune with git branch -d or archive" |
| `detached_head` | `git symbolic-ref HEAD` failure | critical | "commits will be lost unless you create a branch" |
| `gc_needed` | `git count-objects -v` + disk fallback | 50→warn, 200→critical | "run git gc to reclaim space" |

## Design
- No injection when repo is clean (no `<git-health>` block = no prompt budget waste)
- 5-minute per-directory cache with session-level invalidation
- Non-git directory → instant empty return (no shell calls)
- All git commands use `.nothrow().quiet().catch(() => "")` — never crash

## Changes
- `packages/synergy/src/project/git-health.ts` — new (357 lines)
- `packages/synergy/test/project/git-health.test.ts` — new (26 tests, 100% line coverage)
- `packages/synergy/src/session/invoke.ts` — +5 lines (Layer 4.5 injection)