### PR TITLE
fix(cortex): preserve external task results

### DIFF
--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -27,6 +27,8 @@ export namespace Cortex {
   const acquiredTasks = new Set<string>()
 
   const CLEANUP_DELAY_MS = 20 * 60 * 1000
+  const EXTERNAL_TASK_RESULT_CHAR_LIMIT = 120_000
+  const EXTERNAL_TASK_RESULT_HEAD_CHARS = 20_000
   const DEFAULT_SUBAGENT_BLOCKED_TOOLS = [
     "task",
     "task_output",
@@ -38,6 +40,39 @@ export namespace Cortex {
   ]
 
   export const Event = CortexEvent
+
+  /** Extract final text from an external-agent subagent session.
+   *  Reads all assistant text parts (excluding synthetic, ignored, tool output, reasoning)
+   *  and returns the concatenated result, capped to avoid excessive context size. */
+  export async function extractExternalTaskResult(sessionID: string): Promise<string> {
+    const messages = await Session.messages({ sessionID })
+    const chunks: string[] = []
+
+    for (const message of messages) {
+      if (message.info.role !== "assistant") continue
+
+      for (const part of message.parts) {
+        if (part.type !== "text" || part.synthetic || part.ignored) continue
+        const text = part.text.trim()
+        if (text) chunks.push(text)
+      }
+    }
+
+    const result = chunks.join("\n\n").trim()
+    if (!result) return "No assistant text found in external subagent session."
+
+    if (result.length <= EXTERNAL_TASK_RESULT_CHAR_LIMIT) return result
+
+    const tailChars = EXTERNAL_TASK_RESULT_CHAR_LIMIT - EXTERNAL_TASK_RESULT_HEAD_CHARS
+    const omitted = result.length - EXTERNAL_TASK_RESULT_CHAR_LIMIT
+    return [
+      result.slice(0, EXTERNAL_TASK_RESULT_HEAD_CHARS).trimEnd(),
+      "",
+      `[External subagent result truncated: ${omitted.toLocaleString()} characters omitted.]`,
+      "",
+      result.slice(-tailChars).trimStart(),
+    ].join("\n")
+  }
 
   export const launch = fn(CortexTypes.LaunchInput, async (input) => {
     const taskID = Identifier.short("cortex")
@@ -250,8 +285,10 @@ export namespace Cortex {
 
       unsub()
 
-      const summary = await Trajectory.summarize(task.sessionID)
-      updateTaskStatus(task.id, "completed", undefined, summary || undefined)
+      const result = agent.external
+        ? await extractExternalTaskResult(task.sessionID)
+        : await Trajectory.summarize(task.sessionID)
+      updateTaskStatus(task.id, "completed", undefined, result || undefined)
     } catch (error) {
       unsub?.()
       log.error("task execution failed", { taskID: task.id, error })

--- a/packages/synergy/test/cortex/external-result.test.ts
+++ b/packages/synergy/test/cortex/external-result.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test, beforeAll } from "bun:test"
+import { Cortex } from "../../src/cortex"
+import { Instance } from "../../src/scope/instance"
+import { Session } from "../../src/session"
+import { Identifier } from "../../src/id/id"
+import { tmpdir } from "../fixture/fixture"
+import type { Scope } from "../../src/scope"
+
+async function createSessionWithAssistantText(
+  scope: Scope,
+  textParts: Array<{ text: string; synthetic?: boolean; ignored?: boolean }>,
+  sessionID?: string,
+) {
+  const session = await Session.create({ scope, id: sessionID })
+
+  // Create a dummy user message as parent
+  const userMsgID = Identifier.ascending("message")
+  await Session.updateMessage({
+    id: userMsgID,
+    sessionID: session.id,
+    role: "user" as const,
+    agent: "synergy-max",
+    model: { providerID: "openai", modelID: "gpt-5.5" },
+    time: { created: Date.now() },
+  })
+
+  const msgID = Identifier.ascending("message")
+  await Session.updateMessage({
+    id: msgID,
+    sessionID: session.id,
+    role: "assistant" as const,
+    parentID: userMsgID,
+    modelID: "gpt-5.5",
+    providerID: "openai",
+    mode: "codex",
+    agent: "codex",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: Date.now() },
+    finish: "stop",
+  })
+
+  for (const tp of textParts) {
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: msgID,
+      sessionID: session.id,
+      type: "text" as const,
+      text: tp.text,
+      synthetic: tp.synthetic ?? false,
+      ignored: tp.ignored ?? false,
+    })
+  }
+
+  return session
+}
+
+describe("extractExternalTaskResult", () => {
+  beforeAll(() => {
+    Cortex.reset()
+  })
+
+  test("extracts text from a single assistant message", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await createSessionWithAssistantText(await tmp.scope(), [{ text: "Hello from external agent" }])
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result).toBe("Hello from external agent")
+      },
+    })
+  })
+
+  test("filters out synthetic text", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await createSessionWithAssistantText(await tmp.scope(), [
+          { text: "Real output" },
+          { text: "System notification", synthetic: true },
+        ])
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result).toBe("Real output")
+        expect(result).not.toContain("System notification")
+      },
+    })
+  })
+
+  test("filters out ignored text", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await createSessionWithAssistantText(await tmp.scope(), [
+          { text: "Real output" },
+          { text: "Ignored content", ignored: true },
+        ])
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result).toBe("Real output")
+        expect(result).not.toContain("Ignored content")
+      },
+    })
+  })
+
+  test("joins multiple assistant messages in order", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const scope = await tmp.scope()
+        const session = await Session.create({ scope })
+
+        // Dummy user parent
+        const userMsgID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: userMsgID,
+          sessionID: session.id,
+          role: "user" as const,
+          agent: "synergy-max",
+          model: { providerID: "openai", modelID: "gpt-5.5" },
+          time: { created: Date.now() },
+        })
+
+        // Message 1
+        const msg1ID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: msg1ID,
+          sessionID: session.id,
+          role: "assistant" as const,
+          parentID: userMsgID,
+          modelID: "gpt-5.5",
+          providerID: "openai",
+          mode: "codex",
+          agent: "codex",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: Date.now() },
+          finish: "stop",
+        })
+        await Session.updatePart({
+          id: Identifier.ascending("part"),
+          messageID: msg1ID,
+          sessionID: session.id,
+          type: "text" as const,
+          text: "First message",
+        })
+
+        // Message 2
+        const msg2ID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: msg2ID,
+          sessionID: session.id,
+          role: "assistant" as const,
+          parentID: msg1ID,
+          modelID: "gpt-5.5",
+          providerID: "openai",
+          mode: "codex",
+          agent: "codex",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: Date.now() },
+          finish: "stop",
+        })
+        await Session.updatePart({
+          id: Identifier.ascending("part"),
+          messageID: msg2ID,
+          sessionID: session.id,
+          type: "text" as const,
+          text: "Second message",
+        })
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result).toContain("First message")
+        expect(result).toContain("Second message")
+      },
+    })
+  })
+
+  test("returns diagnostic for session with no assistant text", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({ scope: await tmp.scope() })
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result).toBe("No assistant text found in external subagent session.")
+      },
+    })
+  })
+
+  test("skips user messages", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const scope = await tmp.scope()
+        const session = await Session.create({ scope })
+
+        // User message
+        const userMsgID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: userMsgID,
+          sessionID: session.id,
+          role: "user" as const,
+          agent: "synergy-max",
+          model: { providerID: "openai", modelID: "gpt-5.5" },
+          time: { created: Date.now() },
+        })
+        await Session.updatePart({
+          id: Identifier.ascending("part"),
+          messageID: userMsgID,
+          sessionID: session.id,
+          type: "text" as const,
+          text: "User prompt text",
+        })
+
+        // Assistant message
+        const msgID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: msgID,
+          sessionID: session.id,
+          role: "assistant" as const,
+          parentID: userMsgID,
+          modelID: "gpt-5.5",
+          providerID: "openai",
+          mode: "codex",
+          agent: "codex",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: Date.now() },
+          finish: "stop",
+        })
+        await Session.updatePart({
+          id: Identifier.ascending("part"),
+          messageID: msgID,
+          sessionID: session.id,
+          type: "text" as const,
+          text: "Assistant output",
+        })
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result).toBe("Assistant output")
+        expect(result).not.toContain("User prompt")
+      },
+    })
+  })
+
+  test("truncates output exceeding char limit", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const longText = "A".repeat(150_000)
+        const session = await createSessionWithAssistantText(await tmp.scope(), [{ text: longText }])
+
+        const result = await Cortex.extractExternalTaskResult(session.id)
+        expect(result.length).toBeLessThan(150_000)
+        expect(result).toContain("truncated")
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Preserve external-agent task outputs by extracting assistant text directly for `task.result`.
- Keep native Synergy agent trajectory summarization unchanged.
- Add focused tests for external task result extraction, filtering, ordering, and truncation.

## Changes
| File | Change |
|------|--------|
| `packages/synergy/src/cortex/manager.ts` | Uses direct assistant text extraction for `agent.external` tasks while keeping `Trajectory.summarize` for native agents. |
| `packages/synergy/test/cortex/external-result.test.ts` | Adds coverage for external result extraction, synthetic/ignored filtering, user-message skipping, multi-message ordering, empty sessions, and truncation. |

## Verification
- `bun run typecheck` in `packages/synergy` passed.
- `bun test test/cortex/external-result.test.ts test/cortex/manager.test.ts` passed.
- `git push` pre-push hook passed full `bun turbo typecheck` and Prettier check.
- Runtime smoke test after restart confirmed `task_output(full)` returns external-agent final text (`EXTERNAL_TASK_RESULT_FIX_OK`) without requiring `session_read`.