### PR TITLE
refactor: remove AppChannel singleton — home sessions are project-scoped

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1517,13 +1517,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     let session = info()
     if (!session && isNewSession) {
-      if (isGlobalScope(sessionDirectory)) {
-        session = await client.channel.app.session().then((x) => x.data ?? undefined)
-      } else {
-        session = await client.session
-          .create({ controlProfile: selectedControlProfile() })
-          .then((x) => x.data ?? undefined)
-      }
+      session = await client.session
+        .create({ controlProfile: selectedControlProfile() })
+        .then((x) => x.data ?? undefined)
       if (session) {
         createdSessionForSubmit = true
         navigate(`/${base64Encode(sessionDirectory)}/session/${session.id}`)

--- a/packages/app/src/components/session/commands.tsx
+++ b/packages/app/src/components/session/commands.tsx
@@ -67,8 +67,7 @@ export function useSessionCommands(params: {
       category: "Session",
       keybind: "mod+shift+s",
       slash: "new",
-      onSelect: async () => {
-        await sdk.client.channel.app.reset()
+      onSelect: () => {
         navigate(`/${routeParams.dir}/session`)
       },
     },

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -122,8 +122,7 @@ export function Sidebar(props: SidebarProps) {
     return undefined
   })
   const currentDirectory = createMemo(() => (dir() === "global" ? undefined : dir()))
-  const handleNewSession = async () => {
-    await globalSDK.client.channel.app.reset()
+  const handleNewSession = () => {
     navigate(`/${base64Encode("global")}/session`)
   }
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -75,7 +75,7 @@ export interface ScopeNavEntry {
   icon?: { url?: string; color?: string }
 }
 
-const ROOT_NAV_SECTION_LIMIT = 10
+const ROOT_NAV_SECTION_LIMIT = 100
 const ROOT_NAV_SECTION_KEYS = ["home", "channel", "background"] as const
 type RootNavSectionKey = (typeof ROOT_NAV_SECTION_KEYS)[number]
 type NavListState = { items: NavEntry[]; nextCursor: NavCursor | null; total: number }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -182,9 +182,7 @@ function SessionPageContent() {
   const hasReview = createMemo(() => reviewCount() > 0)
   const revertMessageID = createMemo(() => info()?.revert?.messageID)
   const messages = createMemo(() => (params.id ? (sync.data.message[params.id] ?? []) : []) ?? [])
-  const [resolvingHome, setResolvingHome] = createSignal(false)
   const isNewSession = createMemo(() => {
-    if (resolvingHome()) return false
     if (!params.id) return true
     if (isGlobalScope(sdk.directory) && (messages()?.length ?? 0) === 0) return true
     return false
@@ -360,19 +358,6 @@ function SessionPageContent() {
     if (!sdk.connected()) return
     const id = params.id
     if (id) sync.session.sync(id)
-  })
-
-  createEffect(() => {
-    if (params.id) return
-    if (!isGlobalScope(sdk.directory)) return
-    setResolvingHome(true)
-    sdk.client.channel.app.session().then((res) => {
-      const session = res.data
-      if (session) {
-        navigate(`/${params.dir}/session/${session.id}`, { replace: true })
-      }
-      setResolvingHome(false)
-    })
   })
 
   createEffect(() => {

--- a/packages/synergy/src/channel/app.ts
+++ b/packages/synergy/src/channel/app.ts
@@ -1,37 +1,23 @@
+import { Scope } from "../scope"
 import z from "zod"
 import { BusEvent } from "../bus/bus-event"
 import { Bus } from "../bus"
 import { Session } from "../session"
-import { SessionEndpoint } from "../session/endpoint"
 import { SessionInteraction } from "../session/interaction"
 import { Log } from "../util/log"
-import { Channel } from "."
 
 export namespace AppChannel {
   const log = Log.create({ service: "channel.app" })
 
-  const CHANNEL_TYPE = "app"
-  const ACCOUNT_ID = "local"
-  const CHAT_ID = "home"
-
-  export function channelInfo(): Channel.Info {
-    return {
-      type: CHANNEL_TYPE,
-      accountId: ACCOUNT_ID,
-      chatId: CHAT_ID,
-    }
-  }
-
-  export function endpoint(): SessionEndpoint.Info {
-    return SessionEndpoint.fromChannel(channelInfo())
-  }
-
   export async function session(): Promise<Session.Info> {
-    return Session.getOrCreateForEndpoint(endpoint(), undefined, SessionInteraction.interactive("channel:app"))
+    return Session.create({
+      scope: Scope.global(),
+      interaction: SessionInteraction.interactive("channel:app"),
+    })
   }
 
   export async function reset(): Promise<void> {
-    await Session.archiveEndpointSession(endpoint())
+    return
   }
 
   export const Event = {

--- a/packages/synergy/src/session/migration.ts
+++ b/packages/synergy/src/session/migration.ts
@@ -476,5 +476,34 @@ export const migrations: Migration[] = [
       log.info("snapshot per-session migration complete", { scopesHandled: scopeIDs.length })
     },
   },
+  {
+    id: "20260619-remove-home-endpoint",
+    description: "Strip endpoint from global-scope app-channel sessions and rebuild global nav index",
+    async up(progress) {
+      const scope = Identifier.asScopeID("global")
+      const sessionIDs = await Storage.scan(StoragePath.sessionsRoot(scope)).catch(() => [])
+      if (sessionIDs.length === 0) return
+
+      let done = 0
+      for (const sessionID of sessionIDs) {
+        const sID = Identifier.asSessionID(sessionID)
+        const info = await Storage.read<any>(StoragePath.sessionInfo(scope, sID)).catch(() => undefined)
+
+        // Strip endpoint from app-channel sessions
+        if (info?.endpoint?.channel?.type === "app") {
+          const { endpoint, ...rest } = info
+          await Storage.write(StoragePath.sessionInfo(scope, sID), rest)
+        }
+
+        done++
+        progress(done, sessionIDs.length)
+      }
+
+      // Rebuild global nav index so categories are correct
+      await SessionNav.buildNavIndex("global").catch((error) => {
+        // Log but don't fail — nav index rebuilds lazily
+      })
+    },
+  },
 ]
 MigrationRegistry.register("session", migrations)

--- a/packages/synergy/src/session/title.ts
+++ b/packages/synergy/src/session/title.ts
@@ -49,7 +49,6 @@ export async function ensureTitle(input: {
   modelID: string
 }) {
   if (input.session.parentID) return
-  if (input.session.endpoint) return
   if (!isDefaultTitle(input.session.title)) return
 
   const promptVisibleUsers = input.history.filter((m) => m.info.role === "user" && !Turn.isSyntheticUser(m))

--- a/packages/synergy/src/tool/session-control.ts
+++ b/packages/synergy/src/tool/session-control.ts
@@ -9,7 +9,6 @@ import { Identifier } from "../id/id"
 import { Agent } from "../agent/agent"
 import { MessageV2 } from "../session/message-v2"
 import { SessionInteraction } from "../session/interaction"
-import { AppChannel } from "../channel/app"
 import { Instance } from "../scope/instance"
 import { Scope } from "../scope"
 import DESCRIPTION from "./session-control.txt"
@@ -17,7 +16,7 @@ import DESCRIPTION from "./session-control.txt"
 const Action = z.enum(["status", "compact", "abort", "question_reply", "question_reject", "permission_reply"])
 
 const parameters = z.object({
-  target: z.string().describe("Target session. A session ID (ses_xxx) or 'home' for the app home session."),
+  target: z.string().describe("Target session ID (ses_xxx)."),
   action: Action.describe("The control action to perform on the target session."),
   requestID: z
     .string()
@@ -39,13 +38,10 @@ const parameters = z.object({
 })
 
 async function resolveSession(target: string): Promise<Session.Info> {
-  if (target === "home") {
-    return AppChannel.session()
-  }
   if (target.startsWith("ses_")) {
     return SessionManager.requireSession(target)
   }
-  throw new Error(`Invalid session target: "${target}". Use 'home' or a session ID (ses_xxx).`)
+  throw new Error(`Invalid session target: "${target}". Use a session ID (ses_xxx).`)
 }
 
 export const SessionControlTool = Tool.define("session_control", {

--- a/packages/synergy/src/tool/session-control.txt
+++ b/packages/synergy/src/tool/session-control.txt
@@ -2,7 +2,6 @@ Control a target session remotely — inspect its state and perform actions as i
 
 The `target` parameter identifies which session to control:
 - A session ID (e.g. "ses_xxx") to target a specific session
-- "home" to target the app home session
 - A Holos contact/agent ID
 
 ## Actions

--- a/packages/synergy/src/tool/session-list.ts
+++ b/packages/synergy/src/tool/session-list.ts
@@ -1,12 +1,11 @@
 import z from "zod"
 import { Tool } from "./tool"
 import { Session } from "../session"
-import { SessionEndpoint } from "../session/endpoint"
 import { Scope } from "@/scope"
 import { Identifier } from "../id/id"
 import { Storage } from "../storage/storage"
 import { StoragePath } from "../storage/path"
-import { AppChannel } from "../channel/app"
+import { SessionNav, type SessionNavEntry } from "../session/nav"
 import DESCRIPTION from "./session-list.txt"
 
 const parameters = z.object({
@@ -14,7 +13,7 @@ const parameters = z.object({
     .enum(["project", "home", "feishu"])
     .describe(
       "'project' = sessions across all projects (each entry includes its scope), " +
-        "'home' = the app home session, " +
+        "'home' = sessions in the home scope, " +
         "'feishu' = Feishu/Lark channel sessions.",
     ),
   limit: z.coerce.number().default(20).describe("Maximum number of items to return."),
@@ -32,6 +31,7 @@ interface TimeFilter {
   sinceMs?: number
   beforeMs?: number
 }
+const QueryLimit = 10000
 
 function formatScopeLabel(scope: Scope): string {
   if (scope.type === "global") return `Home [${scope.id}]`
@@ -50,70 +50,51 @@ function formatSessionEntry(session: Session.Info, extra?: string): string {
   if (session.lastExchange?.assistant) parts.push(`  Last assistant: ${session.lastExchange.assistant}`)
   return parts.join("\n")
 }
+async function loadSessions(entries: SessionNavEntry[]): Promise<Session.Info[]> {
+  if (entries.length === 0) return []
+  const keys = entries.map((e) =>
+    StoragePath.sessionInfo(Identifier.asScopeID(e.scopeID), Identifier.asSessionID(e.id)),
+  )
+  const sessions = await Storage.readMany<Session.Info>(keys)
+  return sessions.filter((s): s is Session.Info => s != null && !!s.scope && !s.parentID)
+}
+
+function applyTimeFilter(entries: SessionNavEntry[], filter: TimeFilter): SessionNavEntry[] {
+  const { sinceMs, beforeMs } = filter
+  let result = entries
+  if (sinceMs != null) result = result.filter((e) => e.lastActivityAt >= sinceMs)
+  if (beforeMs != null) result = result.filter((e) => e.lastActivityAt < beforeMs)
+  return result
+}
 
 async function listProject(limit: number, offset: number, filter: TimeFilter) {
-  const scopes = await Scope.list()
-  const allEntries: Array<Session.PageIndex["entries"][number] & { scopeID: Identifier.ScopeID }> = []
-
-  for (const scope of scopes) {
-    const scopeID = Identifier.asScopeID(scope.id)
-    const index = await Session.readPageIndex(scopeID)
-    for (const entry of index.entries) {
-      if (entry.archived) continue
-      if (filter.sinceMs && entry.updated < filter.sinceMs) continue
-      if (filter.beforeMs && entry.updated >= filter.beforeMs) continue
-      allEntries.push({ ...entry, scopeID })
-    }
-  }
-
-  allEntries.sort((a, b) => b.updated - a.updated)
-  const total = allEntries.length
-  const page = allEntries.slice(offset, offset + limit)
-
-  const keys = page.map((e) => StoragePath.sessionInfo(e.scopeID, Identifier.asSessionID(e.id)))
-  const sessions = await Storage.readMany<Session.Info>(keys)
-
-  const entries: string[] = []
-  for (const s of sessions) {
-    if (s && s.scope && !s.parentID) entries.push(formatSessionEntry(s))
-  }
+  const result = await SessionNav.queryGlobal({ limit: QueryLimit })
+  const filtered = applyTimeFilter(result.items, filter)
+  const total = filtered.length
+  const page = filtered.slice(offset, offset + limit)
+  const sessions = await loadSessions(page)
+  const entries = sessions.map((s) => formatSessionEntry(s))
   return { entries, total, shown: entries.length }
 }
 
-async function listHome() {
-  const session = await AppChannel.session()
-  const homeSession = { ...session, title: "Home" }
-  return {
-    entries: [formatSessionEntry(homeSession)],
-    total: 1,
-    shown: 1,
-  }
+async function listHome(limit: number, offset: number, filter: TimeFilter) {
+  const result = await SessionNav.queryScope("global", { category: "home", limit: QueryLimit })
+  const filtered = applyTimeFilter(result.items, filter)
+  const total = filtered.length
+  const page = filtered.slice(offset, offset + limit)
+  const sessions = await loadSessions(page)
+  const entries = sessions.map((s) => formatSessionEntry(s))
+  return { entries, total, shown: entries.length }
 }
 
 async function listFeishu(limit: number, offset: number, filter: TimeFilter) {
-  const scopeID = Identifier.asScopeID(Scope.global().id)
-  const index = await Session.readPageIndex(scopeID)
-  let entries = index.entries.filter((entry) => {
-    if (entry.archived) return false
-    if (filter.sinceMs && entry.updated < filter.sinceMs) return false
-    if (filter.beforeMs && entry.updated >= filter.beforeMs) return false
-    return true
-  })
-
-  // Need full session info to filter by endpoint type
-  const keys = entries.map((entry) => StoragePath.sessionInfo(scopeID, Identifier.asSessionID(entry.id)))
-  const all = await Storage.readMany<Session.Info>(keys)
-  const feishuSessions = all
-    .filter(
-      (s): s is Session.Info =>
-        s != null && !!s.scope && !s.parentID && !s.time.archived && SessionEndpoint.type(s.endpoint) === "feishu",
-    )
-    .toSorted((a, b) => b.time.updated - a.time.updated)
-
-  const total = feishuSessions.length
-  const page = feishuSessions.slice(offset, offset + limit)
-  const entries_formatted = page.map((s) => formatSessionEntry(s))
-  return { entries: entries_formatted, total, shown: page.length }
+  const result = await SessionNav.queryScope("global", { category: "channel", limit: QueryLimit })
+  const filtered = applyTimeFilter(result.items, filter)
+  const total = filtered.length
+  const page = filtered.slice(offset, offset + limit)
+  const sessions = await loadSessions(page)
+  const entries = sessions.map((s) => formatSessionEntry(s))
+  return { entries, total, shown: entries.length }
 }
 
 export const SessionListTool = Tool.define("session_list", {
@@ -134,7 +115,7 @@ export const SessionListTool = Tool.define("session_list", {
         result = await listProject(clampedLimit, offset, filter)
         break
       case "home":
-        result = await listHome()
+        result = await listHome(clampedLimit, offset, filter)
         break
       case "feishu":
         result = await listFeishu(clampedLimit, offset, filter)

--- a/packages/synergy/src/tool/session-list.txt
+++ b/packages/synergy/src/tool/session-list.txt
@@ -2,7 +2,7 @@ List sessions by scope. Returns session metadata, scope info, and the latest mes
 
 The `scope` parameter selects which sessions to list:
 - "project": Sessions across all projects. Each entry includes which scope (project) it belongs to.
-- "home": The app home session
+- "home": Sessions in the home scope
 - "contacts": Holos friend/contact sessions, includes contact metadata and online status
 - "feishu": Feishu/Lark channel sessions
 

--- a/packages/synergy/src/tool/session-read.ts
+++ b/packages/synergy/src/tool/session-read.ts
@@ -7,11 +7,10 @@ import { Scope } from "@/scope"
 import { Identifier } from "../id/id"
 import { Storage } from "../storage/storage"
 import { StoragePath } from "../storage/path"
-import { AppChannel } from "../channel/app"
 import DESCRIPTION from "./session-read.txt"
 
 const parameters = z.object({
-  target: z.string().describe("Session to read. A session ID (ses_xxx), 'home' for the app home session."),
+  target: z.string().describe("Session to read. A session ID (ses_xxx)."),
   limit: z.coerce.number().default(20).describe("Number of messages to return."),
   offset: z.coerce.number().default(0).describe("Number of messages to skip (0 = most recent)."),
   around: z
@@ -23,13 +22,10 @@ const parameters = z.object({
 })
 
 async function resolveSession(target: string): Promise<Session.Info> {
-  if (target === "home") {
-    return AppChannel.session()
-  }
   if (target.startsWith("ses_")) {
     return SessionManager.requireSession(target)
   }
-  throw new Error(`Unknown target "${target}". Use a session ID (ses_xxx) or 'home'.`)
+  throw new Error(`Unknown target "${target}". Use a session ID (ses_xxx).`)
 }
 
 function extractMessageText(parts: MessageV2.Part[]): string {

--- a/packages/synergy/src/tool/session-read.txt
+++ b/packages/synergy/src/tool/session-read.txt
@@ -2,7 +2,6 @@ Read messages from a session. Returns session metadata and a paginated list of m
 
 The `target` parameter identifies which session to read:
 - A session ID (e.g. "ses_xxx") to read a specific session
-- "home" to read the app home session
 - A contact ID to read the conversation with a holos friend
 
 Each message includes its role, text content, timestamp, and tool call summaries (for assistant messages).

--- a/packages/synergy/src/tool/session-send.ts
+++ b/packages/synergy/src/tool/session-send.ts
@@ -4,11 +4,10 @@ import { Session } from "../session"
 import { SessionManager } from "../session/manager"
 import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
-import { AppChannel } from "../channel/app"
 import DESCRIPTION from "./session-send.txt"
 
 const parameters = z.object({
-  target: z.string().describe("Target session. A session ID (ses_xxx) or 'home' for the app home session."),
+  target: z.string().describe("Target session. A session ID (ses_xxx)."),
   content: z.string().describe("The text content to send."),
   role: z
     .enum(["user", "assistant"])
@@ -24,13 +23,10 @@ const parameters = z.object({
 })
 
 async function resolveSession(target: string): Promise<Session.Info> {
-  if (target === "home") {
-    return AppChannel.session()
-  }
   if (target.startsWith("ses_")) {
     return SessionManager.requireSession(target)
   }
-  throw new Error(`Unknown session target "${target}". Expected a session ID (ses_xxx) or 'home'.`)
+  throw new Error(`Unknown session target "${target}". Expected a session ID (ses_xxx).`)
 }
 
 export const SessionSendTool = Tool.define("session_send", {

--- a/packages/synergy/src/tool/session-send.txt
+++ b/packages/synergy/src/tool/session-send.txt
@@ -2,7 +2,6 @@ Send a message to a session. Use this to deliver results, notifications, or inst
 
 The `target` parameter identifies which session to send to:
 - A session ID (e.g. "ses_xxx") to send to a specific session
-- "home" to send to the app home session
 - A contact ID to send to a holos friend's session
 
 By default, messages are sent as the assistant (role: "assistant") — useful for delivering task results or notifications without triggering a response. Set role to "user" to trigger the target session's agent to process and respond to the message.


### PR DESCRIPTION
## Summary
- Remove the endpoint-based singleton model that forced all home sessions to share one key
- Home sessions now behave identically to project sessions: multiple can exist, no implicit archiving
- 16 files, +89 / -130 lines

## Changes
### Server
- **channel/app.ts**: `session()` → `Session.create({ scope: global })`, no endpoint. `reset()` is a no-op. Removed `channelInfo()`, `endpoint()`, constants.
- **session/title.ts**: Removed endpoint guard — all sessions now get auto-generated titles
- **session/migration.ts**: New migration strips endpoint from existing app-channel sessions + rebuilds nav index

### Frontend
- **session.tsx**: Removed resolvingHome auto-redirect. `/global/session` shows new-session greeting.
- **prompt-input.tsx**: Unified `session.create()` path for all scopes
- **commands.tsx + sidebar.tsx**: Removed `channel.app.reset()` from New Session flows
- **layout.tsx**: `ROOT_NAV_SECTION_LIMIT` 10→100

### Tools
- **session-read/send/control**: Removed `'home'` target shortcut — agents use explicit session IDs
- **session-list.ts**: Unified all three scope queries to `SessionNav` as single data source. Removed `SessionEndpoint`, `PageIndex`, `Scope.list()` usage.

## Quality
- Typecheck: zero new errors
- Format: passes
- No dead code, no redundant imports remain