### PR TITLE
feat(ui): add ErrorCard component with copy-to-clipboard button

### DIFF
--- a/packages/ui/src/components/error-card.css
+++ b/packages/ui/src/components/error-card.css
@@ -1,0 +1,63 @@
+[data-component="error-card"] {
+  display: flex;
+  align-items: start;
+  gap: 8px;
+  padding: 4px 0;
+
+  [data-slot="icon-svg"] {
+    color: var(--icon-critical-base);
+    margin-top: 4px;
+    flex-shrink: 0;
+  }
+
+  [data-slot="error-card-content"] {
+    flex: 1;
+    min-width: 0;
+  }
+
+  [data-slot="error-card-title"] {
+    font-weight: var(--font-weight-medium);
+    color: var(--text-on-critical-base);
+    white-space: nowrap;
+  }
+
+  [data-slot="error-card-message"] {
+    color: var(--text-on-critical-weak);
+    max-height: 240px;
+    overflow-y: auto;
+    word-break: break-word;
+    display: block;
+  }
+
+  [data-slot="error-card-copy"] {
+    flex-shrink: 0;
+    margin-top: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-sm);
+    color: var(--icon-weak);
+    cursor: pointer;
+    opacity: 0;
+    transition:
+      opacity 150ms ease,
+      background-color 150ms ease;
+
+    &:hover {
+      background: var(--surface-raised-base-hover);
+      color: var(--icon-base);
+    }
+  }
+
+  &:hover [data-slot="error-card-copy"] {
+    opacity: 1;
+  }
+
+  &[data-compact] {
+    [data-slot="error-card-message"] {
+      max-height: 120px;
+    }
+  }
+}

--- a/packages/ui/src/components/error-card.tsx
+++ b/packages/ui/src/components/error-card.tsx
@@ -1,0 +1,84 @@
+import { createSignal, Show, splitProps } from "solid-js"
+import { Card } from "./card"
+import { Icon } from "./icon"
+import { Tooltip } from "./tooltip"
+import "./error-card.css"
+
+export interface ErrorCardProps {
+  /** Full raw error text — copy button copies this exactly */
+  error: string
+  /** Compact single-line mode for session-level errors. Default false. */
+  compact?: boolean
+}
+
+const copyResetDelay = 2000
+
+/** Copy text to clipboard, falling back to execCommand for insecure contexts */
+async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text)
+    return true
+  }
+  try {
+    const ta = document.createElement("textarea")
+    ta.value = text
+    ta.style.position = "fixed"
+    ta.style.opacity = "0"
+    ta.style.pointerEvents = "none"
+    document.body.appendChild(ta)
+    ta.focus()
+    ta.select()
+    const ok = document.execCommand("copy")
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+function parseError(raw: string): { title: string | null; message: string } {
+  const stripped = raw.replace(/^error:\s*/i, "")
+  const colonSpace = stripped.indexOf(": ")
+  if (colonSpace > 0 && colonSpace < 30) {
+    return { title: stripped.slice(0, colonSpace), message: stripped.slice(colonSpace + 2) }
+  }
+  return { title: null, message: stripped }
+}
+
+export function ErrorCard(props: ErrorCardProps) {
+  const [local] = splitProps(props, ["error", "compact"])
+  const [copied, setCopied] = createSignal(false)
+  const parsed = () => parseError(local.error)
+
+  async function handleCopy() {
+    const ok = await copyToClipboard(local.error)
+    if (ok) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), copyResetDelay)
+    }
+  }
+
+  return (
+    <Card variant="error">
+      <div data-component="error-card" data-compact={local.compact ? "" : undefined}>
+        <Icon name="ban" size="small" />
+        <div data-slot="error-card-content">
+          <Show when={local.compact}>
+            <span data-slot="error-card-message">{local.error}</span>
+          </Show>
+          <Show when={!local.compact}>
+            <Show when={parsed().title}>
+              <span data-slot="error-card-title">{parsed().title}</span>
+            </Show>
+            <span data-slot="error-card-message">{parsed().message}</span>
+          </Show>
+        </div>
+        <Tooltip value={copied() ? "Copied" : "Copy error"} placement="top" gutter={4}>
+          <button type="button" data-slot="error-card-copy" onClick={handleCopy}>
+            <Icon name={copied() ? "check" : "copy"} size="small" />
+          </button>
+        </Tooltip>
+      </div>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -184,41 +184,6 @@
   }
 }
 
-[data-component="tool-error"] {
-  display: flex;
-  align-items: start;
-  gap: 8px;
-
-  [data-slot="icon-svg"] {
-    color: var(--icon-critical-base);
-    margin-top: 4px;
-  }
-
-  [data-slot="message-part-tool-error-content"] {
-    display: flex;
-    align-items: start;
-    gap: 8px;
-  }
-
-  [data-slot="message-part-tool-error-title"] {
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
-    font-style: normal;
-    font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large);
-    letter-spacing: var(--letter-spacing-normal);
-    color: var(--text-on-critical-base);
-    white-space: nowrap;
-  }
-
-  [data-slot="message-part-tool-error-message"] {
-    color: var(--text-on-critical-weak);
-    max-height: 240px;
-    overflow-y: auto;
-    word-break: break-word;
-  }
-}
-
 [data-component="tool-output"] {
   width: 100%;
   min-width: 0;
@@ -597,7 +562,6 @@
 [data-component="user-message"] [data-slot="user-message-text"],
 [data-component="text-part"],
 [data-component="reasoning-part"],
-[data-component="tool-error"],
 [data-component="tool-output"],
 [data-component="anchored-summary"],
 [data-component="anchored-warning"],

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -42,6 +42,7 @@ import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { FileIcon } from "./file-icon"
 import { AttachmentList } from "./attachment-card"
+import { ErrorCard } from "./error-card"
 import { getDirectory as _getDirectory, getFilename } from "@ericsanchezok/synergy-util/path"
 import { checksum } from "@ericsanchezok/synergy-util/encode"
 import { parsePartialJson } from "@ericsanchezok/synergy-util/json"
@@ -1641,28 +1642,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
       <div data-component="tool-card-area">
         <Switch>
           <Match when={part().state.status === "error" && (part().state as ToolStateError).error}>
-            {(error) => {
-              const cleaned = error().replace("Error: ", "")
-              const [title, ...rest] = cleaned.split(": ")
-              return (
-                <Card variant="error">
-                  <div data-component="tool-error">
-                    <Icon name="ban" size="small" />
-                    <Switch>
-                      <Match when={title && title.length < 30}>
-                        <div data-slot="message-part-tool-error-content">
-                          <div data-slot="message-part-tool-error-title">{title}</div>
-                          <span data-slot="message-part-tool-error-message">{rest.join(": ")}</span>
-                        </div>
-                      </Match>
-                      <Match when={true}>
-                        <span data-slot="message-part-tool-error-message">{cleaned}</span>
-                      </Match>
-                    </Switch>
-                  </div>
-                </Card>
-              )
-            }}
+            {(error) => <ErrorCard error={error()} />}
           </Match>
           <Match when={true}>
             <Dynamic

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -347,10 +347,4 @@
       display: none;
     }
   }
-
-  .error-card {
-    color: var(--text-on-critical-base);
-    max-height: 240px;
-    overflow-y: auto;
-  }
 }

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -25,7 +25,7 @@ import { Accordion } from "./accordion"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 import { FileIcon } from "./file-icon"
 import { Icon } from "./icon"
-import { Card } from "./card"
+import { ErrorCard } from "./error-card"
 import { Dynamic } from "solid-js/web"
 import { Button } from "./button"
 import { Spinner } from "./spinner"
@@ -681,9 +681,7 @@ export function SessionTurn(
                           )}
                         </For>
                         <Show when={error()}>
-                          <Card variant="error" class="error-card">
-                            {error()?.data?.message as string}
-                          </Card>
+                          <ErrorCard error={(error()?.data?.message as string) ?? ""} compact />
                         </Show>
                       </div>
                     </Show>
@@ -773,9 +771,7 @@ export function SessionTurn(
                     </Show>
                     {/* Error (when expanded steps section is not showing it) */}
                     <Show when={error() && !(working() || (props.stepsExpanded && hasSteps()))}>
-                      <Card variant="error" class="error-card">
-                        {error()?.data?.message as string}
-                      </Card>
+                      <ErrorCard error={(error()?.data?.message as string) ?? ""} compact />
                     </Show>
                   </Match>
                 </Switch>


### PR DESCRIPTION
## Summary
- 新增 `ErrorCard` 统一组件，替换 tool error 和 session error 两处重复的 inline 错误渲染
- 添加 hover-reveal copy 按钮，用户可一键复制完整错误信息

## What changed
- **新建** `error-card.tsx` + `error-card.css`：parseError 解析、compact 模式、copy 按钮
- **替换** `message-part.tsx` 中 24 行 inline Switch/Match 错误块 → 1 行 `<ErrorCard>`
- **替换** `session-turn.tsx` 两处 `<Card variant="error">` → `<ErrorCard compact>`
- **清理** 移除旧 `tool-error` 和 `.error-card` CSS 死代码

## Verification
- `bun turbo typecheck` 9/9 包通过
- prettier 格式化通过
- 所有旧 CSS 引用已清零