### PR TITLE
fix(worktree): refresh runtime workspace context

### DIFF
--- a/packages/synergy/src/project/worktree.ts
+++ b/packages/synergy/src/project/worktree.ts
@@ -553,7 +553,7 @@ export namespace Worktree {
 
   async function bindSession(sessionID: string, info: Info) {
     const { repoRoot } = ensureGitScope()
-    await Session.updateWorkspace(sessionID, {
+    const workspace = {
       type: "git_worktree",
       path: info.path,
       scopeID: info.scopeID,
@@ -562,7 +562,9 @@ export namespace Worktree {
       branch: info.branch,
       baseRef: info.baseRef,
       originalCheckout: path.resolve(repoRoot),
-    })
+    }
+    await Session.updateWorkspace(sessionID, workspace)
+    Instance.refreshWorkspace(workspace as import("../session/types").Workspace)
     await updateBinding(info, sessionID, "add")
   }
 
@@ -589,7 +591,10 @@ export namespace Worktree {
       )
     }
     const scope = session.scope as Scope
-    return Session.updateWorkspace(sessionID, { type: "main", path: scope.directory, scopeID: scope.id })
+    const mainWorkspace = { type: "main" as const, path: scope.directory, scopeID: scope.id }
+    const result = await Session.updateWorkspace(sessionID, mainWorkspace)
+    Instance.refreshWorkspace(mainWorkspace as import("../session/types").Workspace)
+    return result
   }
 
   export async function status(sessionID: string) {

--- a/packages/synergy/src/scope/instance.ts
+++ b/packages/synergy/src/scope/instance.ts
@@ -52,6 +52,10 @@ export const Instance = {
   get workspace(): import("../session/types").Workspace | undefined {
     return workspaceContext.tryUse()
   },
+  refreshWorkspace(workspace: import("../session/types").Workspace): void {
+    if (workspaceContext.tryUse() === undefined) return
+    workspaceContext.update(workspace)
+  },
   get worktree() {
     return scopeContext.use().worktree
   },

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -161,9 +161,14 @@ export namespace SessionManager {
     registerRuntime(session.id)
     try {
       const scope = session.scope as Scope
+      const workspace = (session as Info).workspace ?? {
+        type: "main" as const,
+        path: scope.directory,
+        scopeID: scope.id,
+      }
       return await Instance.provide({
         scope,
-        workspace: (session as Info).workspace,
+        workspace,
         fn: async () => {
           const workspace = (session as Info).workspace
           if (workspace?.type !== "git_worktree") return fn()

--- a/packages/synergy/src/util/context.ts
+++ b/packages/synergy/src/util/context.ts
@@ -7,21 +7,35 @@ export namespace Context {
     }
   }
 
+  interface Store<T> {
+    value: T
+    overlay?: T
+  }
+
   export function create<T>(name: string) {
-    const storage = new AsyncLocalStorage<T>()
+    const storage = new AsyncLocalStorage<Store<T>>()
     return {
       use() {
-        const result = storage.getStore()
-        if (!result) {
+        const store = storage.getStore()
+        if (!store) {
           throw new NotFound(name)
         }
-        return result
+        return store.overlay ?? store.value
       },
       tryUse() {
-        return storage.getStore()
+        const store = storage.getStore()
+        if (!store) return undefined
+        return store.overlay ?? store.value
       },
       provide<R>(value: T, fn: () => R) {
-        return storage.run(value, fn)
+        return storage.run({ value }, fn)
+      },
+      update(overlay: T) {
+        const store = storage.getStore()
+        if (!store) {
+          throw new NotFound(name)
+        }
+        store.overlay = overlay
       },
     }
   }

--- a/packages/synergy/test/session/workspace.test.ts
+++ b/packages/synergy/test/session/workspace.test.ts
@@ -3,9 +3,10 @@ import { tmpdir } from "../fixture/fixture"
 import { Session } from "../../src/session"
 import { SessionManager } from "../../src/session/manager"
 import { Instance } from "../../src/scope/instance"
+import { EnforcementGate } from "../../src/enforcement/gate"
 import { Scope } from "../../src/scope"
 import { Log } from "../../src/util/log"
-import { Info as InfoSchema } from "../../src/session/types"
+import { Info as InfoSchema, type Workspace } from "../../src/session/types"
 import path from "path"
 
 Log.init({ print: false })
@@ -325,6 +326,121 @@ describe("session workspace binding", () => {
             expect(childWs).toEqual(parentWsFromSession)
 
             await Session.remove(parent.id)
+          })(),
+      })
+    })
+  })
+
+  describe("mid-turn workspace refresh", () => {
+    test("refreshes Instance.directory after a worktree-style workspace switch", async () => {
+      await using tmp = await tmpdir({ git: true })
+      const scope = await tmp.scope()
+
+      await Instance.provide({
+        scope,
+        fn: () =>
+          using(async () => {
+            const session = await Session.create({})
+            const worktreeWs: SessionWorkspace = {
+              type: "git_worktree",
+              path: path.join(scope.directory, ".synergy-test-worktree"),
+              scopeID: scope.id,
+              worktreeID: "wt_test",
+              name: "test-worktree",
+            }
+
+            await SessionManager.run(session.id, async () => {
+              expect(Instance.directory).toBe(scope.directory)
+
+              await Session.updateWorkspace(session.id, worktreeWs)
+              Instance.refreshWorkspace(worktreeWs as Workspace)
+
+              expect(Instance.directory).toBe(worktreeWs.path)
+              expect((Instance.workspace as SessionWorkspace | undefined)?.type).toBe("git_worktree")
+            })
+
+            await Session.remove(session.id)
+          })(),
+      })
+    })
+
+    test("refreshes Instance.directory after leaving a worktree-style workspace", async () => {
+      await using tmp = await tmpdir({ git: true })
+      const scope = await tmp.scope()
+
+      await Instance.provide({
+        scope,
+        fn: () =>
+          using(async () => {
+            const worktreeWs: SessionWorkspace = {
+              type: "git_worktree",
+              path: path.join(scope.directory, ".synergy-test-worktree"),
+              scopeID: scope.id,
+              worktreeID: "wt_test",
+              name: "test-worktree",
+            }
+            const session = await Session.create({})
+            const mainWs: SessionWorkspace = {
+              type: "main",
+              path: scope.directory,
+              scopeID: scope.id,
+            }
+
+            await Instance.provide({
+              scope,
+              workspace: worktreeWs as Workspace,
+              fn: async () => {
+                expect(Instance.directory).toBe(worktreeWs.path)
+
+                await Session.updateWorkspace(session.id, mainWs)
+                Instance.refreshWorkspace(mainWs as Workspace)
+
+                expect(Instance.directory).toBe(scope.directory)
+                expect((Instance.workspace as SessionWorkspace | undefined)?.type).toBe("main")
+              },
+            })
+            await Session.remove(session.id)
+          })(),
+      })
+    })
+
+    test("enforcement gates created after refresh use the new workspace", async () => {
+      await using tmp = await tmpdir({ git: true })
+      const scope = await tmp.scope()
+
+      await Instance.provide({
+        scope,
+        fn: () =>
+          using(async () => {
+            const session = await Session.create({})
+            const worktreeWs: SessionWorkspace = {
+              type: "git_worktree",
+              path: path.join(scope.directory, ".synergy-test-worktree"),
+              scopeID: scope.id,
+              worktreeID: "wt_test",
+              name: "test-worktree",
+            }
+
+            await SessionManager.run(session.id, async () => {
+              await Session.updateWorkspace(session.id, worktreeWs)
+              Instance.refreshWorkspace(worktreeWs as Workspace)
+
+              const gate = EnforcementGate.create({
+                activeWorkspace: Instance.directory,
+                workspaceType: Instance.workspace?.type === "git_worktree" ? "worktree" : "main",
+                profileId: "autonomous",
+              })
+
+              expect(gate.getWorkspace()).toBe(worktreeWs.path)
+              expect(gate.evaluate("write", { filePath: path.join(worktreeWs.path, "src/file.ts") }).decision).toBe(
+                "allow",
+              )
+              expect(gate.evaluate("write", { filePath: path.join(scope.directory, "src/file.ts") }).decision).toBe(
+                "deny",
+              )
+            })
+
+            await Session.remove(session.id)
           })(),
       })
     })

--- a/packages/synergy/test/util/context.test.ts
+++ b/packages/synergy/test/util/context.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { Context } from "../../src/util/context"
+
+describe("Context", () => {
+  test("update changes the current value within a provided context only", async () => {
+    const context = Context.create<{ value: string }>("test.context")
+
+    await context.provide({ value: "initial" }, async () => {
+      expect(context.use()).toEqual({ value: "initial" })
+
+      context.update({ value: "updated" })
+      expect(context.use()).toEqual({ value: "updated" })
+      expect(context.tryUse()).toEqual({ value: "updated" })
+    })
+
+    await context.provide({ value: "fresh" }, async () => {
+      expect(context.use()).toEqual({ value: "fresh" })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Refresh runtime `Instance.workspace` after worktree enter/leave updates session storage, so same-turn tools use the new boundary.
- Add `Context.update()` overlay support and ensure legacy sessions get a main workspace fallback in `SessionManager.run()`.
- Add tests covering context updates, mid-turn workspace refresh, and enforcement gate boundary behavior.

## Validation
- `cd packages/synergy && bun test test/util/context.test.ts test/session/workspace.test.ts test/project/worktree.test.ts test/tool/worktree-enter.test.ts test/tool/worktree-leave.test.ts test/tool/worktree-list.test.ts`
- `cd packages/synergy && bun run typecheck`
- `cd packages/synergy && npx prettier --check src/util/context.ts src/scope/instance.ts src/project/worktree.ts src/session/manager.ts test/util/context.test.ts test/session/workspace.test.ts`