### PR TITLE
fix(storage): atomic JSON writes and tolerant session message stream

### DIFF
--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -645,11 +645,15 @@ export namespace MessageV2 {
       const sessionID = input.sessionID as Identifier.SessionID
       const messageIDs = await Storage.scan(StoragePath.sessionMessagesRoot(scopeID, sessionID))
       for (let i = messageIDs.length - 1; i >= 0; i--) {
-        yield await get({
-          scopeID: scopeID,
-          sessionID: input.sessionID,
-          messageID: messageIDs[i],
-        })
+        try {
+          yield await get({
+            scopeID: scopeID,
+            sessionID: input.sessionID,
+            messageID: messageIDs[i],
+          })
+        } catch (e) {
+          console.warn(`[MessageV2.stream] skipping corrupt message ${messageIDs[i]}:`, e)
+        }
       }
     },
   )

--- a/packages/synergy/src/storage/storage.ts
+++ b/packages/synergy/src/storage/storage.ts
@@ -56,7 +56,7 @@ export namespace Storage {
       using _ = await Lock.write(target)
       const content = await Bun.file(target).json()
       fn(content)
-      await Bun.write(target, JSON.stringify(content, null, 2))
+      await atomicWriteJSON(target, content)
       return content as T
     })
   }
@@ -66,7 +66,7 @@ export namespace Storage {
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
       using _ = await Lock.write(target)
-      await Bun.write(target, JSON.stringify(content, null, 2))
+      await atomicWriteJSON(target, content)
     })
   }
 
@@ -75,7 +75,10 @@ export namespace Storage {
     const target = path.join(dir, ...prefix)
     try {
       const entries = await fs.readdir(target)
-      return entries.map((e) => (e.endsWith(".json") ? e.slice(0, -5) : e)).sort()
+      return entries
+        .filter((e) => e.endsWith(".json") && !e.endsWith(".tmp.json"))
+        .map((e) => e.slice(0, -5))
+        .sort()
     } catch {
       return []
     }
@@ -112,6 +115,12 @@ export namespace Storage {
     })
   }
 
+  async function atomicWriteJSON<T>(target: string, content: T) {
+    const tmp = target + ".tmp"
+    await Bun.write(tmp, JSON.stringify(content, null, 2))
+    await fs.rename(tmp, target)
+  }
+
   const glob = new Bun.Glob("**/*")
   export async function list(prefix: string[]) {
     const dir = resolveDir()
@@ -121,7 +130,11 @@ export namespace Storage {
           cwd: path.join(dir, ...prefix),
           onlyFiles: true,
         }),
-      ).then((results) => results.map((x) => [...prefix, ...x.slice(0, -5).split(path.sep)]))
+      ).then((results) =>
+        results
+          .filter((x) => !x.endsWith(".tmp"))
+          .map((x) => [...prefix, ...x.slice(0, -5).split(path.sep)]),
+      )
       result.sort()
       return result
     } catch {

--- a/packages/synergy/test/storage/storage.test.ts
+++ b/packages/synergy/test/storage/storage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Global } from "../../src/global"
+import { Storage } from "../../src/storage/storage"
+
+function testKey(name: string) {
+  return ["test-storage", `${Date.now()}-${Math.random().toString(36).slice(2)}`, name]
+}
+
+describe("storage", () => {
+  test("write and update persist JSON through the storage API without temp leftovers", async () => {
+    const key = testKey("record")
+    const target = path.join(Global.Path.data, ...key) + ".json"
+
+    await Storage.write(key, { count: 1 })
+    await Storage.update<{ count: number }>(key, (draft) => {
+      draft.count += 1
+    })
+
+    expect(await Storage.read<{ count: number }>(key)).toEqual({ count: 2 })
+    expect(JSON.parse(await fs.readFile(target, "utf8"))).toEqual({ count: 2 })
+    expect((await fs.readdir(path.dirname(target))).some((entry) => entry.endsWith(".tmp"))).toBe(false)
+  })
+
+  test("scan and list ignore storage temp files", async () => {
+    const key = testKey("record")
+    const prefix = key.slice(0, -1)
+    const dir = path.join(Global.Path.data, ...prefix)
+
+    await Storage.write(key, { ok: true })
+    await fs.writeFile(path.join(dir, ".record.json.123.tmp"), '{"partial":')
+
+    expect(await Storage.scan(prefix)).toEqual(["record"])
+    expect(await Storage.list(prefix)).toEqual([key])
+  })
+})


### PR DESCRIPTION
## Summary
- **Atomic JSON writes**: `Storage.write/update` now uses temp+rename instead of direct `Bun.write`, preventing zero-byte/sparse-NUL corruption on abrupt shutdown/reboot.
- **Tolerant session stream**: `MessageV2.stream` skips corrupt message `info.json` instead of aborting the entire session.
- **Temp file filtering**: `Storage.scan/list` filter out `.tmp.json` files so in-progress writes are not exposed as valid records.

## Motivation
Abrupt OS reboot interrupted Synergy's non-atomic JSON writes, leaving corrupt `info.json` (zero-byte) and sparse/NUL part files. On `v2.1.3`, a single corrupt `info.json` causes the entire session to fail to load.

## Changes
- `packages/synergy/src/storage/storage.ts` — `atomicWriteJSON` helper with temp+rename; `scan`/`list` filter `.tmp.json`
- `packages/synergy/src/session/message-v2.ts` — `stream` wraps `yield await get(...)` in try/catch
- `packages/synergy/test/storage/storage.test.ts` — new regression tests

## Validation
- `bun test test/storage/storage.test.ts test/session/message-v2.test.ts` — **13 pass, 0 fail**
- `bun run typecheck` — passed
- `turbo typecheck` (full workspace) — passed