### PR TITLE
feat(agenda): add session wake indicator showing upcoming agenda-woken activations

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -68,6 +68,7 @@ import {
   computePromptWorkingSummary,
 } from "@/components/session/session-status-shared"
 import { computeWorkingPhrase, titlecaseStatusLabel } from "@ericsanchezok/synergy-ui/session-status"
+import { SessionAgendaWakeIndicator } from "@/components/session/wake-indicator"
 
 type InlinePart = TextPart | FileAttachmentPart
 
@@ -1904,6 +1905,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     <div class="relative z-0 size-full _max-h-[320px] flex flex-col gap-3 overflow-visible">
       <Show when={params.id}>
         <div class="absolute -top-3 right-5 z-20 flex items-center gap-1.5">
+          <SessionAgendaWakeIndicator sessionID={params.id!} />
           <Tooltip placement="top" value={layout.terminal.opened() ? "Hide terminal" : "Open terminal"}>
             <button
               type="button"

--- a/packages/app/src/components/session/wake-indicator.css
+++ b/packages/app/src/components/session/wake-indicator.css
@@ -1,0 +1,188 @@
+.session-agenda-wake-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.session-agenda-wake-trigger {
+  --wake-accent: oklch(0.7 0.13 65);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  height: 1.5rem;
+  padding: 0 0.6rem;
+  border: 1px solid color-mix(in oklch, var(--border-base) 72%, var(--wake-accent) 28%);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--surface-raised-stronger-non-alpha) 84%, var(--wake-accent) 16%);
+  color: var(--text-base);
+  box-shadow: 0 1px 3px color-mix(in oklch, var(--background-base) 80%, black 20%);
+  transition:
+    background-color 160ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 160ms cubic-bezier(0.2, 0, 0, 1),
+    color 160ms cubic-bezier(0.2, 0, 0, 1),
+    transform 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.session-agenda-wake-trigger:hover,
+.session-agenda-wake-trigger[data-expanded="true"] {
+  border-color: color-mix(in oklch, var(--border-base) 52%, var(--wake-accent) 48%);
+  background: color-mix(in oklch, var(--surface-raised-base-hover) 78%, var(--wake-accent) 22%);
+  color: var(--text-strong);
+}
+
+.session-agenda-wake-trigger:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.session-agenda-wake-trigger:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--border-selected) 72%, var(--wake-accent) 28%);
+  outline-offset: 2px;
+}
+
+.session-agenda-wake-trigger [data-component="icon"] {
+  color: color-mix(in oklch, var(--text-base) 72%, var(--wake-accent) 28%);
+}
+
+.session-agenda-wake-text {
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.session-agenda-wake-divider {
+  width: 1px;
+  height: 1rem;
+  background: var(--border-weak);
+}
+
+.session-agenda-wake-panel {
+  width: min(22rem, calc(100vw - 2rem));
+  border: 1px solid var(--border-base);
+  border-radius: 1rem;
+  background: var(--surface-raised-stronger-non-alpha);
+  box-shadow: 0 18px 50px rgb(0 0 0 / 0.28);
+}
+
+.session-agenda-wake-panel [data-slot="popover-body"] {
+  padding: 0;
+}
+
+.session-agenda-wake-panel-body {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.session-agenda-wake-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 1rem 0.75rem;
+  border-bottom: 1px solid var(--border-weak);
+}
+
+.session-agenda-wake-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text-strong);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.session-agenda-wake-panel-description {
+  color: var(--text-weak);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.session-agenda-wake-list {
+  max-height: 21rem;
+  overflow-y: auto;
+}
+
+.session-agenda-wake-row {
+  display: grid;
+  grid-template-columns: 0.5rem minmax(0, 1fr);
+  gap: 0.65rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-weak);
+  text-align: left;
+}
+
+.session-agenda-wake-row:last-child {
+  border-bottom: 0;
+}
+
+.session-agenda-wake-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  margin-top: 0.4rem;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--text-weak) 78%, var(--wake-accent, oklch(0.7 0.13 65)) 22%);
+}
+
+.session-agenda-wake-row:first-child .session-agenda-wake-dot {
+  background: var(--wake-accent, oklch(0.7 0.13 65));
+}
+
+.session-agenda-wake-row-main {
+  min-width: 0;
+}
+
+.session-agenda-wake-time {
+  color: color-mix(in oklch, var(--text-base) 78%, oklch(0.7 0.13 65) 22%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.session-agenda-wake-title {
+  margin-top: 0.15rem;
+  color: var(--text-strong);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-agenda-wake-meta {
+  margin-top: 0.2rem;
+  color: var(--text-weak);
+  font-size: 0.72rem;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-agenda-wake-footer {
+  padding: 0.65rem 1rem 0.75rem;
+  border-top: 1px solid var(--border-weak);
+}
+
+.session-agenda-wake-footer-button {
+  width: 100%;
+  color: var(--text-interactive-base);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-align: center;
+  transition: color 140ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.session-agenda-wake-footer-button:hover {
+  color: var(--text-strong);
+}
+
+@media (max-width: 640px) {
+  .session-agenda-wake-trigger {
+    padding: 0 0.5rem;
+  }
+
+  .session-agenda-wake-text span[data-full-label] {
+    display: none;
+  }
+}

--- a/packages/app/src/components/session/wake-indicator.tsx
+++ b/packages/app/src/components/session/wake-indicator.tsx
@@ -1,0 +1,215 @@
+import { createEffect, createMemo, createResource, createSignal, For, on, onCleanup, Show } from "solid-js"
+import type { SessionAgendaItem, SessionAgendaResponse } from "@ericsanchezok/synergy-sdk/client"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { Popover } from "@ericsanchezok/synergy-ui/popover"
+import { Tooltip } from "@ericsanchezok/synergy-ui/tooltip"
+import { useSDK } from "@/context/sdk"
+import "./wake-indicator.css"
+
+interface Props {
+  sessionID: string
+}
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+function formatWakeTime(nextRunAt: number | null): string {
+  if (nextRunAt === null) return "条件触发"
+
+  const delta = nextRunAt - Date.now()
+  if (delta < MINUTE) return "即将触发"
+  if (delta < HOUR) return `${Math.ceil(delta / MINUTE)} 分钟后`
+  if (delta < DAY) return `${Math.ceil(delta / HOUR)} 小时后`
+
+  const date = new Date(nextRunAt)
+  const now = new Date()
+  const tomorrow = new Date(now)
+  tomorrow.setDate(now.getDate() + 1)
+
+  const sameDay =
+    date.getFullYear() === tomorrow.getFullYear() &&
+    date.getMonth() === tomorrow.getMonth() &&
+    date.getDate() === tomorrow.getDate()
+  const time = date.toLocaleTimeString("zh-CN", { hour: "2-digit", minute: "2-digit", hour12: false })
+  if (sameDay) return `明天 ${time}`
+
+  return date.toLocaleString("zh-CN", {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+}
+
+function statusLabel(status: SessionAgendaItem["status"]): string {
+  return status === "active" ? "活跃" : "待触发"
+}
+
+function formatDuration(value: string | undefined): string | undefined {
+  const match = value?.match(/^(\d+)(ms|s|m|h|d|w)$/)
+  if (!match) return value
+  const amount = Number(match[1])
+  const unit = match[2]
+  const labels: Record<string, string> = {
+    ms: "毫秒",
+    s: "秒",
+    m: "分钟",
+    h: "小时",
+    d: "天",
+    w: "周",
+  }
+  return `${amount} ${labels[unit] ?? unit}`
+}
+
+function triggerLabel(item: SessionAgendaItem): string {
+  const labels = item.triggers.map((trigger) => {
+    switch (trigger.type) {
+      case "at":
+        return "一次性"
+      case "delay":
+        return `延迟 ${formatDuration(trigger.delay) ?? ""}`.trim()
+      case "every":
+        return `每 ${formatDuration(trigger.interval) ?? ""}`.trim()
+      case "cron":
+        return "定时计划"
+      case "watch":
+        return "条件触发"
+      case "webhook":
+        return "Webhook 触发"
+    }
+  })
+  return labels.length > 0 ? labels.join("、") : "待触发"
+}
+
+function itemTargetsSession(item: { origin?: { sessionID?: string } } | undefined, sessionID: string): boolean {
+  return item?.origin?.sessionID === sessionID
+}
+
+export function SessionAgendaWakeIndicator(props: Props) {
+  const sdk = useSDK()
+  const [open, setOpen] = createSignal(false)
+  const [showAll, setShowAll] = createSignal(false)
+  const [lastResponse, setLastResponse] = createSignal<SessionAgendaResponse>()
+
+  const [response, { refetch }] = createResource(
+    () => props.sessionID,
+    async (sessionID) => {
+      const result = await sdk.client.session.agenda({ sessionID, limit: 6 })
+      return result.data
+    },
+  )
+
+  createEffect(
+    on(
+      () => props.sessionID,
+      () => {
+        setOpen(false)
+        setShowAll(false)
+        setLastResponse(undefined)
+      },
+    ),
+  )
+
+  createEffect(() => {
+    const data = response()
+    if (data) setLastResponse(data)
+  })
+
+  const unsubCreated = sdk.event.on("agenda.item.created", (event) => {
+    if (itemTargetsSession(event.properties.item, props.sessionID)) refetch()
+  })
+  const unsubUpdated = sdk.event.on("agenda.item.updated", (event) => {
+    if (itemTargetsSession(event.properties.item, props.sessionID)) refetch()
+  })
+  // Deleted agenda events only include item ID and scope, so refetch conservatively.
+  const unsubDeleted = sdk.event.on("agenda.item.deleted", () => refetch())
+  onCleanup(() => {
+    unsubCreated()
+    unsubUpdated()
+    unsubDeleted()
+  })
+
+  const agenda = createMemo(() => lastResponse())
+  const visible = createMemo(() => agenda()?.hasActiveAgenda ?? false)
+  const displayedItems = createMemo(() => {
+    const items = agenda()?.items ?? []
+    return showAll() ? items : items.slice(0, 3)
+  })
+  const nextWakeLabel = createMemo(() => formatWakeTime(agenda()?.items[0]?.nextRunAt ?? null))
+
+  function handleOpenChange(open: boolean) {
+    setOpen(open)
+    if (!open) setShowAll(false)
+    if (open) refetch()
+  }
+
+  return (
+    <Show when={visible()}>
+      <div class="session-agenda-wake-group">
+        <Popover
+          open={open()}
+          onOpenChange={handleOpenChange}
+          placement="top-end"
+          gutter={8}
+          class="session-agenda-wake-panel"
+          trigger={
+            <Tooltip placement="top" value={`定时唤醒：${agenda()?.count ?? 0} 项，最近 ${nextWakeLabel()}`}>
+              <button
+                type="button"
+                class="session-agenda-wake-trigger"
+                data-expanded={open() ? "true" : "false"}
+                aria-label={`定时唤醒，${agenda()?.count ?? 0} 项待唤醒，点击查看详情`}
+              >
+                <Icon name="clock" size="small" />
+                <span class="session-agenda-wake-text">
+                  {agenda()?.count ?? 0}
+                  <span data-full-label> 次唤醒</span>
+                </span>
+              </button>
+            </Tooltip>
+          }
+        >
+          <div class="session-agenda-wake-panel-body">
+            <div class="session-agenda-wake-panel-header">
+              <div class="session-agenda-wake-panel-title">
+                <Icon name="clock" size="small" />
+                <span>定时唤醒</span>
+              </div>
+              <div class="session-agenda-wake-panel-description">
+                这个会话接下来会被 {agenda()?.count ?? 0} 个任务唤醒
+              </div>
+            </div>
+            <div class="session-agenda-wake-list">
+              <For each={displayedItems()}>
+                {(item) => (
+                  <div class="session-agenda-wake-row">
+                    <span class="session-agenda-wake-dot" aria-hidden="true" />
+                    <div class="session-agenda-wake-row-main">
+                      <div class="session-agenda-wake-time">{formatWakeTime(item.nextRunAt)}</div>
+                      <div class="session-agenda-wake-title" title={item.title}>
+                        {item.title}
+                      </div>
+                      <div class="session-agenda-wake-meta">
+                        {triggerLabel(item)} · {statusLabel(item.status)}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+            <Show when={(agenda()?.items.length ?? 0) > 3}>
+              <div class="session-agenda-wake-footer">
+                <button type="button" class="session-agenda-wake-footer-button" onClick={() => setShowAll(!showAll())}>
+                  {showAll() ? "收起" : `查看全部 ${agenda()?.items.length ?? 0} 项`}
+                </button>
+              </div>
+            </Show>
+          </div>
+        </Popover>
+        <div class="session-agenda-wake-divider" />
+      </div>
+    </Show>
+  )
+}

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -261,6 +261,8 @@ import type {
   ScopeUpdateResponses,
   SessionAbortErrors,
   SessionAbortResponses,
+  SessionAgendaErrors,
+  SessionAgendaResponses,
   SessionChildrenErrors,
   SessionChildrenResponses,
   SessionCommandErrors,
@@ -1233,6 +1235,40 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionDagResponses, SessionDagErrors, ThrowOnError>({
       url: "/session/{sessionID}/dag",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get session agenda wakeups
+   *
+   * Retrieve agenda items that can wake the specified session.
+   */
+  public agenda<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      limit?: number
+      offset?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "limit" },
+            { in: "query", key: "offset" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionAgendaResponses, SessionAgendaErrors, ThrowOnError>({
+      url: "/session/{sessionID}/agenda",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2302,6 +2302,57 @@ export type DagNode = {
   result?: string
 }
 
+export type SessionAgendaTrigger = {
+  type: "cron" | "every" | "at" | "delay" | "watch" | "webhook"
+  /**
+   * Interval for every triggers, e.g. '30m'
+   */
+  interval?: string
+  /**
+   * Delay for delay triggers, e.g. '2h'
+   */
+  delay?: string
+}
+
+export type SessionAgendaItem = {
+  /**
+   * Agenda item ID
+   */
+  itemID: string
+  /**
+   * Agenda item title
+   */
+  title: string
+  status: "active" | "pending"
+  /**
+   * Next scheduled activation time, or null for open-ended triggers
+   */
+  nextRunAt: number | null
+  /**
+   * Trigger types that can activate this agenda item
+   */
+  triggerTypes: Array<"cron" | "every" | "at" | "delay" | "watch" | "webhook">
+  /**
+   * Display-safe trigger details for client-side formatting
+   */
+  triggers: Array<SessionAgendaTrigger>
+  /**
+   * Whether this agenda item is globally visible
+   */
+  global: boolean
+}
+
+export type SessionAgendaResponse = {
+  sessionID: string
+  count: number
+  hasActiveAgenda: boolean
+  items: Array<SessionAgendaItem>
+  offset: number
+  limit: number
+  total: number
+  hasMore: boolean
+}
+
 export type UserMessage = {
   id: string
   sessionID: string
@@ -5749,6 +5800,44 @@ export type SessionDagResponses = {
 }
 
 export type SessionDagResponse = SessionDagResponses[keyof SessionDagResponses]
+
+export type SessionAgendaData = {
+  body?: never
+  path: {
+    /**
+     * Session ID
+     */
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    limit?: number
+    offset?: number
+  }
+  url: "/session/{sessionID}/agenda"
+}
+
+export type SessionAgendaErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionAgendaError = SessionAgendaErrors[keyof SessionAgendaErrors]
+
+export type SessionAgendaResponses = {
+  /**
+   * Session agenda wakeups
+   */
+  200: SessionAgendaResponse
+}
+
+export type SessionAgendaResponse2 = SessionAgendaResponses[keyof SessionAgendaResponses]
 
 export type SessionInitData = {
   body?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3157,6 +3157,89 @@
         ]
       }
     },
+    "/session/{sessionID}/agenda": {
+      "get": {
+        "operationId": "session.agenda",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Session ID"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 6,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            }
+          }
+        ],
+        "summary": "Get session agenda wakeups",
+        "description": "Retrieve agenda items that can wake the specified session.",
+        "responses": {
+          "200": {
+            "description": "Session agenda wakeups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionAgendaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createSynergyClient } from \"@ericsanchezok/synergy-sdk\"\n\nconst client = createSynergyClient()\nawait client.session.agenda({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/init": {
       "post": {
         "operationId": "session.init",
@@ -15648,6 +15731,113 @@
           }
         },
         "required": ["id", "content", "status", "deps"]
+      },
+      "SessionAgendaTrigger": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["cron", "every", "at", "delay", "watch", "webhook"]
+          },
+          "interval": {
+            "description": "Interval for every triggers, e.g. '30m'",
+            "type": "string"
+          },
+          "delay": {
+            "description": "Delay for delay triggers, e.g. '2h'",
+            "type": "string"
+          }
+        },
+        "required": ["type"]
+      },
+      "SessionAgendaItem": {
+        "type": "object",
+        "properties": {
+          "itemID": {
+            "description": "Agenda item ID",
+            "type": "string"
+          },
+          "title": {
+            "description": "Agenda item title",
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "pending"]
+          },
+          "nextRunAt": {
+            "description": "Next scheduled activation time, or null for open-ended triggers",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "triggerTypes": {
+            "description": "Trigger types that can activate this agenda item",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["cron", "every", "at", "delay", "watch", "webhook"]
+            }
+          },
+          "triggers": {
+            "description": "Display-safe trigger details for client-side formatting",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SessionAgendaTrigger"
+            }
+          },
+          "global": {
+            "description": "Whether this agenda item is globally visible",
+            "type": "boolean"
+          }
+        },
+        "required": ["itemID", "title", "status", "nextRunAt", "triggerTypes", "triggers", "global"]
+      },
+      "SessionAgendaResponse": {
+        "type": "object",
+        "properties": {
+          "sessionID": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "hasActiveAgenda": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SessionAgendaItem"
+            }
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        },
+        "required": ["sessionID", "count", "hasActiveAgenda", "items", "offset", "limit", "total", "hasMore"]
       },
       "UserMessage": {
         "type": "object",

--- a/packages/synergy/src/agenda/store.ts
+++ b/packages/synergy/src/agenda/store.ts
@@ -540,6 +540,67 @@ export namespace AgendaStore {
     return result
   }
 
+  function toSessionAgendaTrigger(trigger: AgendaTypes.Trigger): AgendaTypes.SessionAgendaTrigger {
+    switch (trigger.type) {
+      case "every":
+        return { type: trigger.type, interval: trigger.interval }
+      case "delay":
+        return { type: trigger.type, delay: trigger.delay }
+      default:
+        return { type: trigger.type }
+    }
+  }
+
+  function toSessionAgendaItem(item: AgendaTypes.Item): AgendaTypes.SessionAgendaItem {
+    if (item.status !== "active" && item.status !== "pending") {
+      throw new Error(`Cannot project non-wakeup agenda item '${item.id}' with status '${item.status}'`)
+    }
+
+    return {
+      itemID: item.id,
+      title: item.title,
+      status: item.status,
+      nextRunAt: item.state.nextRunAt ?? null,
+      triggerTypes: item.triggers.map((trigger) => trigger.type),
+      triggers: item.triggers.map(toSessionAgendaTrigger),
+      global: item.global,
+    }
+  }
+
+  export async function listForSessionWakeups(input: {
+    sessionID: string
+    scopeID: string
+    limit: number
+    offset: number
+    now?: number
+  }): Promise<AgendaTypes.SessionAgendaResponse> {
+    const now = input.now ?? Date.now()
+    const items = await listForScope(input.scopeID)
+    const matching = items
+      .filter((item) => item.status === "active" || item.status === "pending")
+      .filter((item) => item.wake !== false && item.silent !== true)
+      .filter((item) => item.origin.sessionID === input.sessionID)
+      .filter((item) => item.state.nextRunAt === undefined || item.state.nextRunAt > now)
+      .sort((a, b) => {
+        const aNext = a.state.nextRunAt ?? Number.POSITIVE_INFINITY
+        const bNext = b.state.nextRunAt ?? Number.POSITIVE_INFINITY
+        return aNext - bNext
+      })
+
+    const total = matching.length
+    const paged = input.limit === 0 ? [] : matching.slice(input.offset, input.offset + input.limit)
+    return {
+      sessionID: input.sessionID,
+      count: total,
+      hasActiveAgenda: total > 0,
+      items: paged.map(toSessionAgendaItem),
+      offset: input.offset,
+      limit: input.limit,
+      total,
+      hasMore: input.offset + paged.length < total,
+    }
+  }
+
   export async function loadActive(): Promise<AgendaTypes.Item[]> {
     const scopeIDs = await Storage.scan(["agenda", "items"])
     const batches = await Promise.all(scopeIDs.map((scopeID) => list(scopeID)))

--- a/packages/synergy/src/agenda/types.ts
+++ b/packages/synergy/src/agenda/types.ts
@@ -304,6 +304,45 @@ export namespace AgendaTypes {
     .meta({ ref: "AgendaActivityPage" })
   export type ActivityPage = z.infer<typeof ActivityPage>
 
+  export const SessionAgendaTriggerType = z.enum(["cron", "every", "at", "delay", "watch", "webhook"])
+  export type SessionAgendaTriggerType = z.infer<typeof SessionAgendaTriggerType>
+
+  export const SessionAgendaTrigger = z
+    .object({
+      type: SessionAgendaTriggerType,
+      interval: z.string().optional().describe("Interval for every triggers, e.g. '30m'"),
+      delay: z.string().optional().describe("Delay for delay triggers, e.g. '2h'"),
+    })
+    .meta({ ref: "SessionAgendaTrigger" })
+  export type SessionAgendaTrigger = z.infer<typeof SessionAgendaTrigger>
+
+  export const SessionAgendaItem = z
+    .object({
+      itemID: z.string().describe("Agenda item ID"),
+      title: z.string().describe("Agenda item title"),
+      status: z.enum(["active", "pending"]),
+      nextRunAt: z.number().nullable().describe("Next scheduled activation time, or null for open-ended triggers"),
+      triggerTypes: z.array(SessionAgendaTriggerType).describe("Trigger types that can activate this agenda item"),
+      triggers: z.array(SessionAgendaTrigger).describe("Display-safe trigger details for client-side formatting"),
+      global: z.boolean().describe("Whether this agenda item is globally visible"),
+    })
+    .meta({ ref: "SessionAgendaItem" })
+  export type SessionAgendaItem = z.infer<typeof SessionAgendaItem>
+
+  export const SessionAgendaResponse = z
+    .object({
+      sessionID: z.string(),
+      count: z.number().int().min(0),
+      hasActiveAgenda: z.boolean(),
+      items: z.array(SessionAgendaItem),
+      offset: z.number().int().min(0),
+      limit: z.number().int().min(0),
+      total: z.number().int().min(0),
+      hasMore: z.boolean(),
+    })
+    .meta({ ref: "SessionAgendaResponse" })
+  export type SessionAgendaResponse = z.infer<typeof SessionAgendaResponse>
+
   // ---------------------------------------------------------------------------
   // Fired signal — runtime representation of a trigger activation
   // ---------------------------------------------------------------------------

--- a/packages/synergy/src/server/session.ts
+++ b/packages/synergy/src/server/session.ts
@@ -16,6 +16,7 @@ import { Snapshot } from "../session/snapshot"
 import { Agent } from "../agent/agent"
 import { Instance } from "../scope/instance"
 import { Log } from "../util/log"
+import { AgendaStore, AgendaTypes } from "../agenda"
 import { errors } from "./error"
 
 const log = Log.create({ service: "session" })
@@ -230,6 +231,50 @@ export const SessionRoute = new Hono()
       const sessionID = c.req.valid("param").sessionID
       const nodes = await Dag.get(sessionID)
       return c.json(nodes)
+    },
+  )
+  .get(
+    "/:sessionID/agenda",
+    describeRoute({
+      summary: "Get session agenda wakeups",
+      description: "Retrieve agenda items that can wake the specified session.",
+      operationId: "session.agenda",
+      responses: {
+        200: {
+          description: "Session agenda wakeups",
+          content: {
+            "application/json": {
+              schema: resolver(AgendaTypes.SessionAgendaResponse),
+            },
+          },
+        },
+        ...errors(400, 404),
+      },
+    }),
+    validator(
+      "param",
+      z.object({
+        sessionID: z.string().meta({ description: "Session ID" }),
+      }),
+    ),
+    validator(
+      "query",
+      z.object({
+        limit: z.coerce.number().int().min(0).max(50).default(6),
+        offset: z.coerce.number().int().min(0).default(0),
+      }),
+    ),
+    async (c) => {
+      const { sessionID } = c.req.valid("param")
+      const { limit, offset } = c.req.valid("query")
+      const session = await Session.get(sessionID)
+      const result = await AgendaStore.listForSessionWakeups({
+        sessionID,
+        scopeID: session.scope.id,
+        limit,
+        offset,
+      })
+      return c.json(result)
     },
   )
   .post(

--- a/packages/synergy/test/server/session-agenda.test.ts
+++ b/packages/synergy/test/server/session-agenda.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test } from "bun:test"
+import { AgendaStore } from "../../src/agenda/store"
+import { Identifier } from "../../src/id/id"
+import { Instance } from "../../src/scope/instance"
+import { Scope } from "../../src/scope"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { StoragePath } from "../../src/storage/path"
+import { Storage } from "../../src/storage/storage"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+type TestAgendaItemInput = {
+  title: string
+  sessionID?: string
+  status?: "active" | "pending" | "paused" | "done" | "cancelled"
+  wake?: boolean
+  silent?: boolean
+  global?: boolean
+  nextRunAt?: number | null
+}
+
+function withProjectScope(fn: (scope: Scope) => Promise<void>) {
+  return async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+    await Instance.provide({ scope, fn: async () => fn(scope) })
+  }
+}
+
+async function createAgendaItem(input: TestAgendaItemInput) {
+  const future = Date.now() + 86_400_000
+  const item = await AgendaStore.create({
+    title: input.title,
+    prompt: "Run the scheduled test task.",
+    triggers: [{ type: "at", at: future }],
+    sessionID: input.sessionID,
+    wake: input.wake ?? true,
+    silent: input.silent ?? false,
+    global: input.global ?? false,
+    createdBy: "agent",
+  })
+
+  const storageScopeID = Identifier.asScopeID(input.global ? "global" : Instance.scope.id)
+  await Storage.update(StoragePath.agendaItem(storageScopeID, item.id), (draft: any) => {
+    if (input.status) draft.status = input.status
+    if (input.nextRunAt === null) delete draft.state.nextRunAt
+    else if (input.nextRunAt !== undefined) draft.state.nextRunAt = input.nextRunAt
+  })
+
+  return item
+}
+
+async function getSessionAgenda(sessionID: string, query = "") {
+  const app = Server.App()
+  const suffix = query ? `?${query}` : ""
+  const response = await app.request(`/session/${sessionID}/agenda${suffix}`)
+  const text = await response.text()
+  const contentType = response.headers.get("content-type") ?? ""
+  const body = contentType.includes("application/json") && text ? JSON.parse(text) : undefined
+  return { response, body }
+}
+
+describe("GET /session/:sessionID/agenda", () => {
+  test(
+    "returns the session wakeup response shape",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "Agenda wakeups" })
+      const item = await createAgendaItem({ title: "Morning check", sessionID: session.id })
+
+      const { response, body } = await getSessionAgenda(session.id)
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        sessionID: session.id,
+        count: 1,
+        hasActiveAgenda: true,
+        items: [
+          {
+            itemID: item.id,
+            title: "Morning check",
+            status: "active",
+            nextRunAt: expect.any(Number),
+            triggerTypes: ["at"],
+            triggers: [{ type: "at" }],
+            global: false,
+          },
+        ],
+        offset: 0,
+        limit: 6,
+        total: 1,
+        hasMore: false,
+      })
+
+      await Session.remove(session.id)
+    }),
+  )
+
+  test(
+    "returns an empty result when the session has no matching agenda items",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "No wakeups" })
+
+      const { response, body } = await getSessionAgenda(session.id)
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        sessionID: session.id,
+        count: 0,
+        hasActiveAgenda: false,
+        items: [],
+        offset: 0,
+        limit: 6,
+        total: 0,
+        hasMore: false,
+      })
+
+      await Session.remove(session.id)
+    }),
+  )
+
+  test(
+    "filters to agenda items that can wake the requested session",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "Target session" })
+      const otherSession = await Session.create({ title: "Other session" })
+      const future = Date.now() + 86_400_000
+      const includedActive = await createAgendaItem({ title: "Active", sessionID: session.id, nextRunAt: future })
+      const includedPending = await createAgendaItem({
+        title: "Pending",
+        sessionID: session.id,
+        status: "pending",
+        nextRunAt: future + 1_000,
+      })
+      const includedOpenEnded = await createAgendaItem({
+        title: "Open ended",
+        sessionID: session.id,
+        nextRunAt: null,
+      })
+      const excludedPaused = await createAgendaItem({ title: "Paused", sessionID: session.id, status: "paused" })
+      const excludedDone = await createAgendaItem({ title: "Done", sessionID: session.id, status: "done" })
+      const excludedWakeFalse = await createAgendaItem({ title: "No wake", sessionID: session.id, wake: false })
+      const excludedSilent = await createAgendaItem({ title: "Silent", sessionID: session.id, silent: true })
+      const excludedOverdue = await createAgendaItem({
+        title: "Overdue",
+        sessionID: session.id,
+        nextRunAt: Date.now() - 60_000,
+      })
+      const excludedOtherSession = await createAgendaItem({ title: "Other", sessionID: otherSession.id })
+
+      const { response, body } = await getSessionAgenda(session.id)
+      const ids = body.items.map((item: any) => item.itemID)
+
+      expect(response.status).toBe(200)
+      expect(ids).toEqual([includedActive.id, includedPending.id, includedOpenEnded.id])
+      expect(ids).not.toContain(excludedPaused.id)
+      expect(ids).not.toContain(excludedDone.id)
+      expect(ids).not.toContain(excludedWakeFalse.id)
+      expect(ids).not.toContain(excludedSilent.id)
+      expect(ids).not.toContain(excludedOverdue.id)
+      expect(ids).not.toContain(excludedOtherSession.id)
+      expect(body.total).toBe(3)
+      expect(body.hasActiveAgenda).toBe(true)
+
+      await Session.remove(otherSession.id)
+      await Session.remove(session.id)
+    }),
+  )
+
+  test(
+    "includes global agenda items only when they target the requested session",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "Global target" })
+      const otherSession = await Session.create({ title: "Global other" })
+      const localItem = await createAgendaItem({ title: "Local", sessionID: session.id })
+      const globalItem = await createAgendaItem({ title: "Global", sessionID: session.id, global: true })
+      const otherGlobalItem = await createAgendaItem({
+        title: "Other global",
+        sessionID: otherSession.id,
+        global: true,
+      })
+
+      const { response, body } = await getSessionAgenda(session.id)
+      const ids = body.items.map((item: any) => item.itemID)
+
+      expect(response.status).toBe(200)
+      expect(ids).toContain(localItem.id)
+      expect(ids).toContain(globalItem.id)
+      expect(ids).not.toContain(otherGlobalItem.id)
+      expect(body.total).toBe(2)
+
+      await Session.remove(otherSession.id)
+      await Session.remove(session.id)
+    }),
+  )
+
+  test(
+    "sorts upcoming wakeups by nextRunAt ascending with open-ended items last",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "Sorted wakeups" })
+      const base = Date.now() + 86_400_000
+      const middle = await createAgendaItem({ title: "Middle", sessionID: session.id, nextRunAt: base + 2_000 })
+      const earliest = await createAgendaItem({ title: "Earliest", sessionID: session.id, nextRunAt: base + 1_000 })
+      const openEnded = await createAgendaItem({ title: "Open ended", sessionID: session.id, nextRunAt: null })
+      const latest = await createAgendaItem({ title: "Latest", sessionID: session.id, nextRunAt: base + 3_000 })
+
+      const { response, body } = await getSessionAgenda(session.id)
+
+      expect(response.status).toBe(200)
+      expect(body.items.map((item: any) => item.itemID)).toEqual([earliest.id, middle.id, latest.id, openEnded.id])
+
+      await Session.remove(session.id)
+    }),
+  )
+
+  test(
+    "supports count-only and paginated queries",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "Paginated wakeups" })
+      const base = Date.now() + 86_400_000
+      const items = []
+      for (let index = 0; index < 5; index++) {
+        items.push(
+          await createAgendaItem({
+            title: `Wakeup ${index}`,
+            sessionID: session.id,
+            nextRunAt: base + index * 1_000,
+          }),
+        )
+      }
+
+      const countOnly = await getSessionAgenda(session.id, "limit=0")
+      expect(countOnly.response.status).toBe(200)
+      expect(countOnly.body.items).toEqual([])
+      expect(countOnly.body.count).toBe(5)
+      expect(countOnly.body.total).toBe(5)
+      expect(countOnly.body.hasActiveAgenda).toBe(true)
+      expect(countOnly.body.hasMore).toBe(true)
+
+      const page = await getSessionAgenda(session.id, "limit=2&offset=2")
+      expect(page.response.status).toBe(200)
+      expect(page.body.items.map((item: any) => item.itemID)).toEqual([items[2].id, items[3].id])
+      expect(page.body.offset).toBe(2)
+      expect(page.body.limit).toBe(2)
+      expect(page.body.total).toBe(5)
+      expect(page.body.hasMore).toBe(true)
+
+      await Session.remove(session.id)
+    }),
+  )
+
+  test(
+    "validates query parameters and missing sessions",
+    withProjectScope(async () => {
+      const session = await Session.create({ title: "Validation" })
+
+      const negativeOffset = await getSessionAgenda(session.id, "offset=-1")
+      const oversizedLimit = await getSessionAgenda(session.id, "limit=51")
+      const missingSession = await getSessionAgenda("ses_missing_session_agenda")
+
+      expect(negativeOffset.response.status).toBe(400)
+      expect(oversizedLimit.response.status).toBe(400)
+      expect(missingSession.response.status).toBe(404)
+
+      await Session.remove(session.id)
+    }),
+  )
+})


### PR DESCRIPTION
## Summary
- New `GET /session/:sessionID/agenda` backend endpoint that returns agenda items scheduled to wake a specific session
- Filtering: active/pending, wake on, not silent, matching origin session, future or open-ended triggers
- Display-safe response projection (no prompt/origin/webhook tokens/execution state)
- Small warm time-capsule UI entrance in composer accessory row, alongside Terminal/QuickActions
- Read-only popover panel showing next 3 (expandable to 6) upcoming wakeups with Chinese formatting
- Trigger labels formatted locally on the frontend from structured trigger data
- 7 targeted backend tests covering empty, filtering, global items, sort, pagination, validation

## Changes
- `packages/synergy/src/agenda/types.ts` — new `SessionAgendaItem`, `SessionAgendaResponse`, `SessionAgendaTrigger` schemas
- `packages/synergy/src/agenda/store.ts` — `listForSessionWakeups` query with scope scan, filtering, sort, pagination
- `packages/synergy/src/server/session.ts` — new `GET /:sessionID/agenda` route
- `packages/synergy/test/server/session-agenda.test.ts` — 7 tests
- `packages/app/src/components/session/wake-indicator.tsx` + CSS — SolidJS component with popover
- `packages/app/src/components/prompt-input.tsx` — indicator wired into composer accessory row
- SDK regenerate — `client.session.agenda()` method

## Verification
- Targeted backend tests: 7 pass
- Full `packages/synergy` test suite: 2670 pass
- `bun run typecheck`: clean across all 8 packages
- Prettier format check: clean
- API compatibility review: zero breaking changes, purely additive