### PR TITLE
feat(cortex): enable session reuse via session_id parameter

### DIFF
--- a/packages/synergy/src/agent/prompt/synergy-max/base.txt
+++ b/packages/synergy/src/agent/prompt/synergy-max/base.txt
@@ -400,7 +400,7 @@ For subagent tasks that would benefit from isolation, pass `worktree: {{ create:
 
 ## Writing Delegation Briefs
 
-Subagents are stateless — they know nothing about your conversation. Every brief should include:
+Subagents start fresh by default — they know nothing about your conversation. Use `session_id` to reuse an existing session and preserve context across invocations. Every brief should include:
 
 ```md
 ## Task

--- a/packages/synergy/src/agent/prompt/synergy/base.txt
+++ b/packages/synergy/src/agent/prompt/synergy/base.txt
@@ -207,7 +207,7 @@ You can also delegate for **review and refinement**: do the work yourself, then 
 
 ## Writing Effective Delegation Prompts
 
-The #1 cause of delegation failure is insufficient context. Subagents are stateless — they know nothing about your conversation history or what you've learned.
+The #1 cause of delegation failure is insufficient context. Subagents start fresh by default — they know nothing about your conversation history or what you've learned (unless you use `session_id` to reuse a prior session, which preserves its message history).
 
 **Every delegation prompt should include:**
 

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun"
 
+import { BusyError } from "../session/error"
 import { Worktree } from "../project/worktree"
 import { Bus } from "../bus"
 import { Config } from "../config/config"
@@ -55,32 +56,55 @@ export namespace Cortex {
       new Set([...(config.experimental?.primary_tools ?? []), ...DEFAULT_SUBAGENT_BLOCKED_TOOLS]),
     )
 
-    const session = await Session.create({
-      scope: parent.scope as import("@/scope").Scope,
-      parentID: input.parentSessionID,
-      title: `[Cortex] ${input.description} (@${input.agent})`,
-      permission: [
-        { permission: "question", pattern: "*", action: "deny" },
-        ...(executionRole === "delegated_subagent"
-          ? blockedTools.map((tool) => ({
-              pattern: "*",
-              action: "deny" as const,
-              permission: tool,
-            }))
-          : []),
-      ],
-      cortex: {
-        parentSessionID: input.parentSessionID,
-        parentMessageID: input.parentMessageID,
-        description: input.description,
-        agent: input.agent,
-        executionRole,
-        status: "queued",
-        startedAt: Date.now(),
-      },
-      workspace: (parent as import("../session/types").Info).workspace,
-    })
+    let session: import("../session/types").Info
 
+    if (input.sessionID) {
+      const existing = await Session.get(input.sessionID)
+      if (!existing) {
+        throw new Error(`Session ${input.sessionID} not found`)
+      }
+      if (existing.parentID !== input.parentSessionID) {
+        throw new Error(
+          `Session ${input.sessionID} does not belong to parent session ${input.parentSessionID}. ` +
+            `Reuse is only allowed for sessions created by the same parent.`,
+        )
+      }
+      if (SessionManager.isRunning(input.sessionID)) {
+        throw new BusyError(input.sessionID)
+      }
+      session = existing
+      log.info("reusing existing session", {
+        taskID,
+        sessionID: existing.id,
+        description: input.description,
+      })
+    } else {
+      session = await Session.create({
+        scope: parent.scope as import("@/scope").Scope,
+        parentID: input.parentSessionID,
+        title: `[Cortex] ${input.description} (@${input.agent})`,
+        permission: [
+          { permission: "question", pattern: "*", action: "deny" },
+          ...(executionRole === "delegated_subagent"
+            ? blockedTools.map((tool) => ({
+                pattern: "*",
+                action: "deny" as const,
+                permission: tool,
+              }))
+            : []),
+        ],
+        cortex: {
+          parentSessionID: input.parentSessionID,
+          parentMessageID: input.parentMessageID,
+          description: input.description,
+          agent: input.agent,
+          executionRole,
+          status: "queued",
+          startedAt: Date.now(),
+        },
+        workspace: (parent as import("../session/types").Info).workspace,
+      })
+    }
     if (input.worktree?.create) {
       const parentWorkspace = (parent as import("../session/types").Info).workspace
       if (parentWorkspace?.type !== "git_worktree") {

--- a/packages/synergy/src/tool/task.ts
+++ b/packages/synergy/src/tool/task.ts
@@ -184,7 +184,7 @@ export const TaskTool = Tool.define<typeof parameters, TaskMetadata>("task", asy
             background: true,
             summary: [],
           },
-          output: `Background task launched.
+          output: `Background task dispatched.
 
 Task ID: ${task.id}
 Session ID: ${task.sessionID}

--- a/packages/synergy/src/tool/task.ts
+++ b/packages/synergy/src/tool/task.ts
@@ -21,7 +21,15 @@ const parameters = z.object({
         "Recommend also specifying what NOT to do (scope boundaries, forbidden actions) to prevent scope creep.",
     ),
   subagent_type: z.string().describe("The type of specialized agent to use for this task"),
-  session_id: z.string().describe("Existing Task session to continue").optional(),
+  session_id: z
+    .string()
+    .describe(
+      "Reuse an existing session for this task instead of creating a new one. " +
+        "The session must be idle (not currently running) and must have been created by the same parent. " +
+        "If the session is busy, the call will fail with an error — wait or use a different session. " +
+        "Omit to create a new session (default).",
+    )
+    .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
   dag_node_id: z.string().optional().describe("DAG node ID to auto-update when this task completes"),
   background: z

--- a/packages/synergy/src/tool/task.txt
+++ b/packages/synergy/src/tool/task.txt
@@ -44,7 +44,13 @@ Use **`task_list()`** to list all visible background tasks at once.
 
 1. Launch multiple agents concurrently whenever possible
 2. The result is not visible to the user - summarize it back to them
-3. Provide `session_id` to reuse an existing session (must be idle and belong to this parent). If the session is busy, the tool will error — wait for it to finish or use a different session.
+3. Provide `session_id` to reuse an existing session (must be idle and belong to this parent).
+   - **Why reuse**: The subagent retains prior conversation context, useful for iterative refinement,
+     debugging, or breaking long tasks into separate invocations without losing state.
+   - **Context hint**: Since the subagent remembers prior turns in the reused session, you do NOT
+     need to restate all context — focus your prompt on what's new or different this time.
+   - **Busy sessions**: If the session is busy, the tool will error — wait for it to finish
+     or use a different session.
 4. Clearly tell the agent whether to write code or just research
 
 ## Writing effective prompts

--- a/packages/synergy/src/tool/task.txt
+++ b/packages/synergy/src/tool/task.txt
@@ -44,7 +44,7 @@ Use **`task_list()`** to list all visible background tasks at once.
 
 1. Launch multiple agents concurrently whenever possible
 2. The result is not visible to the user - summarize it back to them
-3. Each invocation is stateless unless you provide session_id
+3. Provide `session_id` to reuse an existing session (must be idle and belong to this parent). If the session is busy, the tool will error — wait for it to finish or use a different session.
 4. Clearly tell the agent whether to write code or just research
 
 ## Writing effective prompts

--- a/packages/synergy/test/cortex/session-reuse.test.ts
+++ b/packages/synergy/test/cortex/session-reuse.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { Cortex } from "../../src/cortex"
+import { CortexTypes } from "../../src/cortex/types"
+import { Instance } from "../../src/scope/instance"
+import { Session } from "../../src/session"
+import { SessionManager } from "../../src/session/manager"
+import { BusyError } from "../../src/session/error"
+import { tmpdir } from "../fixture/fixture"
+
+describe("Cortex session reuse", () => {
+  beforeEach(() => {
+    Cortex.reset()
+  })
+
+  afterEach(() => {
+    // Clean up any lingering runtimes that may have been registered during launch
+    // (Session.create registers a runtime, and Cortex may also do so)
+  })
+
+  describe("launch with sessionID", () => {
+    test("reuses existing session when it is idle", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const parentSession = await Session.create({})
+          // Create a child session that will be reused
+          const existingChild = await Session.create({ parentID: parentSession.id })
+
+          const task = await Cortex.launch({
+            description: "Reuse task",
+            prompt: "Do something",
+            agent: "developer",
+            parentSessionID: parentSession.id,
+            parentMessageID: "msg_test01234567890abc",
+            sessionID: existingChild.id,
+          })
+
+          expect(task).toBeDefined()
+          expect(task.sessionID).toBe(existingChild.id)
+          expect(task.parentSessionID).toBe(parentSession.id)
+
+          await Cortex.cancel(task.id)
+        },
+      })
+    })
+
+    test("rejects reuse when session is busy", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const parentSession = await Session.create({})
+          const childSession = await Session.create({ parentID: parentSession.id })
+
+          // Make the child session appear busy
+          SessionManager.registerRuntime(childSession.id)
+          const runtime = SessionManager.registerRuntime(childSession.id)
+          runtime.abort = new AbortController()
+
+          try {
+            await expect(
+              Cortex.launch({
+                description: "Reuse busy",
+                prompt: "Do something",
+                agent: "developer",
+                parentSessionID: parentSession.id,
+                parentMessageID: "msg_test01234567890abc",
+                sessionID: childSession.id,
+              }),
+            ).rejects.toThrow(BusyError)
+          } finally {
+            // Clean up runtime
+            runtime.abort = undefined
+            SessionManager.unregisterRuntime(childSession.id)
+          }
+        },
+      })
+    })
+
+    test("rejects reuse when session parentID does not match launch parentSessionID", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const parentSessionA = await Session.create({})
+          const parentSessionB = await Session.create({})
+          // Child of parentA, should not be reusable from parentB
+          const childOfA = await Session.create({ parentID: parentSessionA.id })
+
+          await expect(
+            Cortex.launch({
+              description: "Wrong parent",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSessionB.id,
+              parentMessageID: "msg_test01234567890abc",
+              sessionID: childOfA.id,
+            }),
+          ).rejects.toThrow(/does not belong/)
+        },
+      })
+    })
+
+    test("rejects reuse when session does not exist", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const parentSession = await Session.create({})
+
+          await expect(
+            Cortex.launch({
+              description: "Missing session",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: "msg_test01234567890abc",
+              sessionID: "ses_nonexistent000000000000",
+            }),
+          ).rejects.toThrow(/not found/)
+        },
+      })
+    })
+  })
+
+  describe("launch without sessionID (regression)", () => {
+    test("still creates new session by default", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const parentSession = await Session.create({})
+
+          const task = await Cortex.launch({
+            description: "Default task",
+            prompt: "Do something",
+            agent: "developer",
+            parentSessionID: parentSession.id,
+            parentMessageID: "msg_test01234567890abc",
+          })
+
+          expect(task).toBeDefined()
+          // Without sessionID, it should create a new session (not match parent)
+          expect(task.sessionID).not.toBe(parentSession.id)
+
+          await Cortex.cancel(task.id)
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The `session_id` parameter on the task tool was dead code — Cortex.launch always ignored it and created a new child session. This PR wires it up.

## Changes

### Core feature
- **`cortex/manager.ts`**: `Cortex.launch()` now checks for `input.sessionID`. If provided and the session is idle and belongs to the same parent, the existing session is reused instead of creating a new one. Three safety gates:
  - Rejects busy sessions (`BusyError`)
  - Rejects sessions from a different parent
  - Rejects non-existent sessions
- Without `session_id`, behavior is unchanged — creates a new session as before.

### Message & prompt updates
- **`task.ts`**: `"Background task launched."` → `"Background task dispatched."`
- **`task.txt`**: Expanded `session_id` docs with reuse scenarios (iteration, debugging, decomposition) and a context hint (shorter prompts when reusing)
- **`synergy-max/base.txt`** & **`synergy/base.txt`**: Changed "Subagents are stateless" → "Subagents start fresh by default" with `session_id` caveat

### Tests
- **`test/cortex/session-reuse.test.ts`**: 5 new tests covering reuse, busy rejection, wrong parent, missing session, and regression

### Why this matters
Enables iterative workflows: send follow-up instructions to the same subagent without losing prior conversation context. Particularly useful for debugging chains and phased long tasks.

## Checklist
- [x] Tested locally (5/5 pass)
- [x] Existing cortex tests still pass
- [x] Backward compatible (no session_id = unchanged behavior)