### PR TITLE
fix(session): prevent worktree snapshot stalls

### DIFF
--- a/packages/synergy/src/project/git-health.ts
+++ b/packages/synergy/src/project/git-health.ts
@@ -36,6 +36,7 @@ export namespace GitHealth {
   let _generation = 0
   const CACHE_TTL_MS = 5 * 60 * 1000
   const GIT_COMMAND_TIMEOUT_MS = 2_000
+  const SCAN_TIMEOUT_MS = 3_000
   const LARGE_FILE_STAT_BATCH_SIZE = 64
 
   // ---------------------------------------------------------------------------
@@ -49,6 +50,20 @@ export namespace GitHealth {
   function cacheKey(cwd: string): string {
     const dir = normalizeDir(cwd)
     return _aliases.get(dir) ?? dir
+  }
+
+  function remainingMs(deadline: number): number {
+    return Math.max(0, deadline - Date.now())
+  }
+
+  async function withTimeoutValue<T>(promise: Promise<T>, ms: number, value: T): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const fallback = new Promise<T>((resolve) => {
+      timer = setTimeout(() => resolve(value), ms)
+    })
+    return Promise.race([promise, fallback]).finally(() => {
+      if (timer) clearTimeout(timer)
+    })
   }
 
   async function gitText(cwd: string, args: string[]): Promise<string | undefined> {
@@ -211,7 +226,7 @@ export namespace GitHealth {
   // Dimension 4: large_files
   // Thresholds: >10MB→warn, >50MB→critical
   // ---------------------------------------------------------------------------
-  async function checkLargeFiles(cwd: string): Promise<Issue | undefined> {
+  async function checkLargeFiles(cwd: string, deadline: number): Promise<Issue | undefined> {
     const result = (await gitText(cwd, ["ls-files", "-z"])) ?? ""
 
     const fileNames = result.split("\0").filter(Boolean)
@@ -223,15 +238,19 @@ export namespace GitHealth {
     const large: { path: string; size: number }[] = []
 
     for (let i = 0; i < cappedNames.length; i += LARGE_FILE_STAT_BATCH_SIZE) {
+      if (Date.now() >= deadline) break
       const batch = cappedNames.slice(i, i + LARGE_FILE_STAT_BATCH_SIZE)
-      const stats = await Promise.all(
-        batch.map(async (fileName) => {
-          const filePath = path.join(cwd, fileName)
-          const stat = await Bun.file(filePath)
-            .stat()
-            .catch(() => undefined)
-          return stat ? { fileName, stat } : undefined
-        }),
+      const stats = await withTimeoutValue(
+        Promise.all(
+          batch.map(async (fileName) => {
+            const filePath = path.join(cwd, fileName)
+            const stat = await fs.promises.lstat(filePath).catch(() => undefined)
+            if (!stat || stat.isSymbolicLink()) return undefined
+            return { fileName, stat }
+          }),
+        ),
+        remainingMs(deadline),
+        [],
       )
       for (const result of stats) {
         if (result && result.stat.size > 10 * 1024 * 1024) {
@@ -311,14 +330,14 @@ export namespace GitHealth {
   // catches hand-crafted test fixture objects.
   // Thresholds: 50→warn, 200→critical
   // ---------------------------------------------------------------------------
-  async function checkGcNeeded(cwd: string, gitDir: string): Promise<Issue | undefined> {
+  async function checkGcNeeded(cwd: string, gitDir: string, deadline: number): Promise<Issue | undefined> {
     const output = (await gitText(cwd, ["count-objects", "-v"])) ?? ""
 
     const countMatch = output.match(/count:\s*(\d+)/)
     const sizeMatch = output.match(/size:\s*(\d+)/)
 
     const gitCount = countMatch ? parseInt(countMatch[1]) : 0
-    const diskCount = countLooseObjectsOnDisk(gitDir)
+    const diskCount = Date.now() >= deadline ? 0 : countLooseObjectsOnDisk(gitDir)
     const looseObjects = Math.max(gitCount, diskCount)
     const size = sizeMatch ? parseInt(sizeMatch[1]) : 0
 
@@ -340,17 +359,22 @@ export namespace GitHealth {
 
   async function scan(cwd: string): Promise<{ dir: string; issues: Issue[] }> {
     const fallbackDir = normalizeDir(cwd)
+    const deadline = Date.now() + SCAN_TIMEOUT_MS
     const repo = await resolveRepo(fallbackDir)
     if (!repo) return { dir: fallbackDir, issues: [] }
 
-    const results = await Promise.all([
+    const remaining = remainingMs(deadline)
+    if (remaining === 0) return { dir: repo.root, issues: [] }
+
+    const checks: Promise<Issue | Issue[] | undefined>[] = [
       checkDiff(repo.root),
       checkUntracked(repo.root),
-      checkLargeFiles(repo.root),
+      checkLargeFiles(repo.root, deadline),
       checkExtraBranches(repo.root),
       checkDetachedHead(repo.root),
-      checkGcNeeded(repo.root, repo.gitDir),
-    ])
+      checkGcNeeded(repo.root, repo.gitDir, deadline),
+    ]
+    const results = await withTimeoutValue(Promise.all(checks), remaining, [])
 
     const issues = results.flat().filter((i): i is Issue => i !== undefined)
     return { dir: repo.root, issues }
@@ -418,9 +442,9 @@ export namespace GitHealth {
   }
 
   export function invalidate(cwd?: string): void {
-    _generation++
-    _refreshing.clear()
     if (cwd === undefined) {
+      _generation++
+      _refreshing.clear()
       _cache.clear()
       _aliases.clear()
       _lastDir = undefined
@@ -432,6 +456,8 @@ export namespace GitHealth {
     _cache.delete(dir)
     _cache.delete(key)
     _aliases.delete(dir)
+    _refreshing.delete(dir)
+    _refreshing.delete(key)
     if (_lastDir === dir || _lastDir === key) _lastDir = undefined
   }
 }

--- a/packages/synergy/src/session/loop-signals.ts
+++ b/packages/synergy/src/session/loop-signals.ts
@@ -4,7 +4,7 @@ import { Session } from "."
 import { Identifier } from "../id/id"
 import { MessageV2 } from "./message-v2"
 import { Log } from "@/util/log"
-
+import { Instance } from "../scope/instance"
 const log = Log.create({ service: "session.loop-signals" })
 
 // ─── shared helpers ────────────────────────────────────────────────
@@ -214,7 +214,7 @@ LoopJob.register({
     return ranBash ? [{ type: "git_health_cache_invalidator" }] : []
   },
   async execute() {
-    GitHealth.invalidate()
+    GitHealth.invalidate(Instance.directory)
     return "pass"
   },
 })

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -302,7 +302,7 @@ export namespace SessionProcessor {
                   throw value.error
 
                 case "start-step":
-                  snapshot = await Snapshot.track(input.sessionID)
+                  snapshot = await Snapshot.track(input.sessionID, input.abort)
                   await Session.updatePart({
                     id: Identifier.ascending("part"),
                     messageID: input.assistantMessage.id,
@@ -324,7 +324,7 @@ export namespace SessionProcessor {
                   await Session.updatePart({
                     id: Identifier.ascending("part"),
                     reason: value.finishReason,
-                    snapshot: await Snapshot.track(input.sessionID),
+                    snapshot: await Snapshot.track(input.sessionID, input.abort),
                     messageID: input.assistantMessage.id,
                     sessionID: input.assistantMessage.sessionID,
                     type: "step-finish",
@@ -333,7 +333,10 @@ export namespace SessionProcessor {
                   })
                   await Session.updateMessage(input.assistantMessage)
                   if (snapshot) {
-                    const patch = await Snapshot.patch(snapshot, input.sessionID, { indexFresh: true })
+                    const patch = await Snapshot.patch(snapshot, input.sessionID, {
+                      indexFresh: true,
+                      signal: input.abort,
+                    })
                     if (patch.files.length) {
                       await Session.updatePart({
                         id: Identifier.ascending("part"),
@@ -439,7 +442,7 @@ export namespace SessionProcessor {
             })
           }
           if (snapshot) {
-            const patch = await Snapshot.patch(snapshot, input.sessionID)
+            const patch = await Snapshot.patch(snapshot, input.sessionID, { signal: input.abort })
             if (patch.files.length) {
               await Session.updatePart({
                 id: Identifier.ascending("part"),

--- a/packages/synergy/src/session/snapshot.ts
+++ b/packages/synergy/src/session/snapshot.ts
@@ -9,33 +9,109 @@ import { Instance } from "../scope/instance"
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
+  const SNAPSHOT_TIMEOUT_MS = 10_000
 
-  export async function track(sessionID: string) {
+  function spawnSignal(timeoutMs: number, parentSignal?: AbortSignal): { signal: AbortSignal; cleanup: () => void } {
+    const controller = new AbortController()
+    const timer = setTimeout(
+      () => controller.abort(new DOMException("Snapshot git command timed out", "TimeoutError")),
+      timeoutMs,
+    )
+    let onAbort: (() => void) | undefined
+    const cleanup = () => {
+      clearTimeout(timer)
+      if (parentSignal && onAbort) parentSignal.removeEventListener("abort", onAbort)
+    }
+    if (parentSignal) {
+      if (parentSignal.aborted) {
+        cleanup()
+        return { signal: AbortSignal.abort(parentSignal.reason), cleanup }
+      }
+      onAbort = () => {
+        cleanup()
+        controller.abort(parentSignal.reason)
+      }
+      parentSignal.addEventListener("abort", onAbort, { once: true })
+    }
+    controller.signal.addEventListener("abort", cleanup, { once: true })
+    return { signal: controller.signal, cleanup }
+  }
+
+  async function gitSpawn(
+    args: string[],
+    cwd: string,
+    env?: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<{ exitCode: number; text: string }> {
+    const childSignal = spawnSignal(SNAPSHOT_TIMEOUT_MS, signal)
+    try {
+      const proc = Bun.spawn(args, {
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: env ? { ...process.env, ...env } : process.env,
+        signal: childSignal.signal,
+      })
+      const stdout = new Response(proc.stdout).text()
+      const stderr = new Response(proc.stderr).text().catch(() => "")
+      const [text, exitCode] = await Promise.all([stdout, proc.exited])
+      await stderr
+      return { exitCode, text }
+    } catch (err) {
+      log.debug("git spawn failed", { args, cwd, error: String(err) })
+      return { exitCode: -1, text: "" }
+    } finally {
+      childSignal.cleanup()
+    }
+  }
+
+  export async function track(sessionID: string, signal?: AbortSignal): Promise<string | undefined> {
     if (Instance.scope.type !== "project" || Instance.scope.vcs !== "git") return
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir(sessionID)
     if (await fs.mkdir(git, { recursive: true })) {
-      await $`git init`
-        .env({
-          ...process.env,
-          GIT_DIR: git,
-          GIT_WORK_TREE: Instance.directory,
-        })
-        .quiet()
-        .nothrow()
-      // Configure git to not convert line endings on Windows
-      await $`git --git-dir ${git} config core.autocrlf false`.quiet().nothrow()
+      const initResult = await gitSpawn(
+        ["git", "init"],
+        Instance.directory,
+        { GIT_DIR: git, GIT_WORK_TREE: Instance.directory },
+        signal,
+      )
+      if (initResult.exitCode !== 0) {
+        log.warn("track init failed", { exitCode: initResult.exitCode })
+        return undefined
+      }
+      await gitSpawn(
+        ["git", "--git-dir", git, "config", "core.autocrlf", "false"],
+        Instance.directory,
+        undefined,
+        signal,
+      )
       log.info("initialized")
     }
-    await $`git --git-dir ${git} --work-tree ${Instance.directory} add .`.quiet().cwd(Instance.directory).nothrow()
-    const hash = await $`git --git-dir ${git} --work-tree ${Instance.directory} write-tree`
-      .quiet()
-      .cwd(Instance.directory)
-      .nothrow()
-      .text()
+    const addResult = await gitSpawn(
+      ["git", "--git-dir", git, "--work-tree", Instance.directory, "add", "."],
+      Instance.directory,
+      undefined,
+      signal,
+    )
+    if (addResult.exitCode !== 0) {
+      log.warn("track add failed", { exitCode: addResult.exitCode })
+      return undefined
+    }
+    const writeResult = await gitSpawn(
+      ["git", "--git-dir", git, "--work-tree", Instance.directory, "write-tree"],
+      Instance.directory,
+      undefined,
+      signal,
+    )
+    if (writeResult.exitCode !== 0 || !writeResult.text.trim()) {
+      log.warn("track write-tree failed", { exitCode: writeResult.exitCode })
+      return undefined
+    }
+    const hash = writeResult.text.trim()
     log.info("tracking", { hash, cwd: Instance.directory, git })
-    return hash.trim()
+    return hash
   }
 
   export const Patch = z.object({
@@ -44,31 +120,54 @@ export namespace Snapshot {
   })
   export type Patch = z.infer<typeof Patch>
 
-  export async function patch(hash: string, sessionID: string, opts?: { indexFresh?: boolean }): Promise<Patch> {
+  export async function patch(
+    hash: string,
+    sessionID: string,
+    opts?: { indexFresh?: boolean; signal?: AbortSignal },
+  ): Promise<Patch> {
     const git = gitdir(sessionID)
     if (!opts?.indexFresh) {
-      await $`git add .`
-        .env({ ...process.env, GIT_DIR: git, GIT_WORK_TREE: Instance.directory })
-        .quiet()
-        .cwd(Instance.directory)
-        .nothrow()
+      const addResult = await gitSpawn(
+        ["git", "--git-dir", git, "--work-tree", Instance.directory, "add", "."],
+        Instance.directory,
+        undefined,
+        opts?.signal,
+      )
+      if (addResult.exitCode !== 0) {
+        log.warn("patch add failed", { hash, exitCode: addResult.exitCode })
+        return { hash, files: [] }
+      }
     }
-    const result = await $`git -c core.autocrlf=false diff --no-ext-diff --name-only ${hash} -- .`
-      .env({ ...process.env, GIT_DIR: git, GIT_WORK_TREE: Instance.directory })
-      .quiet()
-      .cwd(Instance.directory)
-      .nothrow()
+    const diffResult = await gitSpawn(
+      [
+        "git",
+        "-c",
+        "core.autocrlf=false",
+        "--git-dir",
+        git,
+        "--work-tree",
+        Instance.directory,
+        "diff",
+        "--no-ext-diff",
+        "--name-only",
+        hash,
+        "--",
+        ".",
+      ],
+      Instance.directory,
+      undefined,
+      opts?.signal,
+    )
 
-    // If git diff fails, return empty patch
-    if (result.exitCode !== 0) {
-      log.warn("failed to get diff", { hash, exitCode: result.exitCode, stderr: result.stderr.toString() })
+    if (diffResult.exitCode !== 0) {
+      log.warn("failed to get diff", { hash, exitCode: diffResult.exitCode })
       return { hash, files: [] }
     }
 
-    const files = result.text()
+    const filesText = diffResult.text
     return {
       hash,
-      files: files
+      files: filesText
         .trim()
         .split("\n")
         .map((x) => x.trim())

--- a/packages/synergy/test/project/git-health-scoped-invalidation-contract.test.ts
+++ b/packages/synergy/test/project/git-health-scoped-invalidation-contract.test.ts
@@ -1,0 +1,165 @@
+// ---------------------------------------------------------------------------
+// git-health-scoped-invalidation-contract.test.ts
+//
+// Tests verifying the scoped-invalidation contract of GitHealth.invalidate(cwd)
+// vs. GitHealth.invalidate().
+//
+// Root cause: the git_health_cache_invalidator in loop-signals.ts calls
+// GitHealth.invalidate() with no directory argument. This globally clears
+// _cache, _refreshing, and bumps _generation for ALL directories.
+//
+// In a worktree environment with multiple active sessions in different
+// directories (main checkout + worktree), this kills in-flight refresh
+// deduplication and discards cache-write results for unrelated directories.
+//
+// Fix: the invalidator should call GitHealth.invalidate(Instance.directory).
+//
+// This test lives in test/project/ to stay close to the GitHealth module
+// and avoid the session import chain (which requires workspace packages
+// not installed in worktrees).
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test, beforeAll } from "bun:test"
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import os from "node:os"
+import { $ } from "bun"
+
+// ---------------------------------------------------------------------------
+// Dynamic import — GitHealth module only, no session chain
+// ---------------------------------------------------------------------------
+type GitHealthModule = typeof import("../../src/project/git-health")
+let GitHealth: GitHealthModule["GitHealth"]
+
+beforeAll(async () => {
+  const mod = await import("../../src/project/git-health")
+  GitHealth = mod.GitHealth
+})
+
+// ---------------------------------------------------------------------------
+// Local Issue interface
+// ---------------------------------------------------------------------------
+interface Issue {
+  dimension:
+    | "diff_lines"
+    | "diff_files"
+    | "untracked"
+    | "large_files"
+    | "extra_branches"
+    | "detached_head"
+    | "gc_needed"
+  level: "warn" | "critical"
+  message: string
+  detail: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Git repo fixture helpers
+// ---------------------------------------------------------------------------
+interface TestRepo {
+  path: string
+  cleanup: () => void
+}
+
+function makeRepo(): TestRepo {
+  const dir = mkdtempSync(join(os.tmpdir(), "synergy-test-gh-scope-"))
+  return { path: dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+async function gitInit(dir: string): Promise<void> {
+  mkdirSync(dir, { recursive: true })
+  await $`git init`.cwd(dir).quiet()
+  await $`git config user.email test@synergy.dev`.cwd(dir).quiet()
+  await $`git config user.name "Test Agent"`.cwd(dir).quiet()
+}
+
+async function gitEmptyCommit(dir: string, message = "test commit"): Promise<void> {
+  await $`git commit --allow-empty -m ${message}`.cwd(dir).quiet()
+}
+
+// ===========================================================================
+// Contract: scoped invalidate(cwd) preserves other directories
+// ===========================================================================
+
+describe("GitHealth.invalidate — scoped vs global contract", () => {
+  test("invalidate(cwd) clears only the specified directory's cache; other dirs survive", async () => {
+    const repoA = makeRepo()
+    const repoB = makeRepo()
+    try {
+      // repoA: clean repo
+      await gitInit(repoA.path)
+      await gitEmptyCommit(repoA.path, "root")
+
+      // repoB: has detectable issues (detached HEAD)
+      await gitInit(repoB.path)
+      await gitEmptyCommit(repoB.path, "root")
+      await $`git checkout --detach`.cwd(repoB.path).quiet()
+
+      // Populate caches for both
+      await GitHealth.check(repoA.path)
+      await GitHealth.check(repoB.path)
+
+      // Verify repoB is cached (returns without re-scanning)
+      const issuesB1 = await GitHealth.check(repoB.path)
+      const detachedB1 = issuesB1.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedB1, "detached head should be cached").toBeDefined()
+
+      // Scoped invalidate on repoA only
+      GitHealth.invalidate(repoA.path)
+
+      // repoB should STILL return cached result (not re-scanned)
+      const issuesB2 = await GitHealth.check(repoB.path)
+      const detachedB2 = issuesB2.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedB2, "scoped invalidate on repoA must not clear repoB cache").toBeDefined()
+
+      // repoA should re-scan (cache was cleared)
+      // Add files so re-scan detects something different
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repoA.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+      const issuesA2 = await GitHealth.check(repoA.path)
+      const untrackedA = issuesA2.find((i: Issue) => i.dimension === "untracked")
+      expect(untrackedA, "re-scan on repoA should find new untracked files").toBeDefined()
+    } finally {
+      repoA.cleanup()
+      repoB.cleanup()
+      GitHealth.invalidate()
+    }
+  })
+
+  test("invalidate() without cwd clears caches for all directories", async () => {
+    const repoA = makeRepo()
+    const repoB = makeRepo()
+    try {
+      await gitInit(repoA.path)
+      await gitEmptyCommit(repoA.path, "root")
+
+      await gitInit(repoB.path)
+      await gitEmptyCommit(repoB.path, "root")
+      await $`git checkout --detach`.cwd(repoB.path).quiet()
+
+      // Populate caches
+      await GitHealth.check(repoA.path)
+      await GitHealth.check(repoB.path)
+
+      // Global invalidate
+      GitHealth.invalidate()
+
+      // Both should re-scan now
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repoA.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+      const issuesA = await GitHealth.check(repoA.path)
+      const untrackedA = issuesA.find((i: Issue) => i.dimension === "untracked")
+      expect(untrackedA, "after global invalidate, repoA should re-scan").toBeDefined()
+
+      const issuesB = await GitHealth.check(repoB.path)
+      const detachedB = issuesB.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedB, "after global invalidate, repoB should re-scan").toBeDefined()
+    } finally {
+      repoA.cleanup()
+      repoB.cleanup()
+      GitHealth.invalidate()
+    }
+  })
+})

--- a/packages/synergy/test/project/git-health-session-stall-regression.test.ts
+++ b/packages/synergy/test/project/git-health-session-stall-regression.test.ts
@@ -1,0 +1,251 @@
+// ---------------------------------------------------------------------------
+// git-health-session-stall-regression.test.ts
+//
+// Regression tests for the GitHealth invalidation behavior that contributed
+// to session loop stalls in worktree environments.
+//
+// Root cause context:
+//   1. loop-signals.ts calls GitHealth.invalidate() (global, no args) after
+//      every bash command, which bumps _generation and clears _refreshing
+//      for ALL directories — not just the current Instance.directory.
+//   2. This kills in-flight refresh deduplication and discards cache-write
+//      results for unrelated directories.
+//   3. Combined with Snapshot.track() hanging on git add (no timeout),
+//      this creates a stall where the session loop appears "busy" forever.
+//
+// Contract under test:
+//   - invalidate(cwd) MUST only affect the specified directory's cached
+//     entries and aliases. It MUST NOT:
+//       a) Clear _refreshing entries for other directories (kills dedupe)
+//       b) Bump _generation globally (discards in-flight scan cache writes)
+//   - invalidate() (no args, global) MAY clear everything, but the
+//     git_health_cache_invalidator in loop-signals.ts should be changed
+//     to use the scoped form: invalidate(Instance.directory).
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test, beforeAll } from "bun:test"
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import os from "node:os"
+import { $ } from "bun"
+
+// ---------------------------------------------------------------------------
+// Dynamic import
+// ---------------------------------------------------------------------------
+type GitHealthModule = typeof import("../../src/project/git-health")
+let GitHealth: GitHealthModule["GitHealth"]
+
+beforeAll(async () => {
+  const mod = await import("../../src/project/git-health")
+  GitHealth = mod.GitHealth
+})
+
+// ---------------------------------------------------------------------------
+// Local Issue interface
+// ---------------------------------------------------------------------------
+interface Issue {
+  dimension:
+    | "diff_lines"
+    | "diff_files"
+    | "untracked"
+    | "large_files"
+    | "extra_branches"
+    | "detached_head"
+    | "gc_needed"
+  level: "warn" | "critical"
+  message: string
+  detail: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Git repo fixture helpers
+// ---------------------------------------------------------------------------
+interface TestRepo {
+  path: string
+  cleanup: () => void
+}
+
+function makeRepo(): TestRepo {
+  const dir = mkdtempSync(join(os.tmpdir(), "synergy-test-gh-stall-"))
+  return { path: dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+async function gitInit(dir: string): Promise<void> {
+  mkdirSync(dir, { recursive: true })
+  await $`git init`.cwd(dir).quiet()
+  await $`git config user.email test@synergy.dev`.cwd(dir).quiet()
+  await $`git config user.name "Test Agent"`.cwd(dir).quiet()
+}
+
+async function gitEmptyCommit(dir: string, message = "test commit"): Promise<void> {
+  await $`git commit --allow-empty -m ${message}`.cwd(dir).quiet()
+}
+
+// ===========================================================================
+// Test: scoped invalidate preserves other directory's cache
+// ===========================================================================
+
+describe("GitHealth.invalidate(cwd) — scoped cache preservation", () => {
+  test("invalidate(dirA) does not clear cached results for dirB", async () => {
+    const repoA = makeRepo()
+    const repoB = makeRepo()
+    try {
+      // repoA: clean
+      await gitInit(repoA.path)
+      await gitEmptyCommit(repoA.path, "root")
+
+      // repoB: detached HEAD (creates a detectable issue)
+      await gitInit(repoB.path)
+      await gitEmptyCommit(repoB.path, "root")
+      await $`git checkout --detach`.cwd(repoB.path).quiet()
+
+      // Populate cache for both
+      await GitHealth.check(repoA.path)
+      await GitHealth.check(repoB.path)
+
+      // Pollute repoA with untracked files (would be detected if re-scanned)
+      for (let i = 1; i <= 50; i++) {
+        writeFileSync(join(repoA.path, `untracked-${i}.tmp`), `temp ${i}`)
+      }
+
+      // Scoped invalidate on repoA only
+      GitHealth.invalidate(repoA.path)
+
+      // repoA: should re-scan and find the new untracked files
+      const issuesA = await GitHealth.check(repoA.path)
+      const untrackedA = issuesA.find((i: Issue) => i.dimension === "untracked")
+      expect(untrackedA, "repoA should detect untracked after scoped invalidate").toBeDefined()
+
+      // repoB: should still have cached result (detached head)
+      // If scoped invalidate leaked globally, check(repoB.path) would
+      // return cache-missed empty results instead of the cached issues.
+      const issuesB = await GitHealth.check(repoB.path)
+      const detachedB = issuesB.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedB, "repoB cache should survive scoped invalidate on repoA").toBeDefined()
+    } finally {
+      repoA.cleanup()
+      repoB.cleanup()
+      GitHealth.invalidate()
+    }
+  })
+})
+
+// ===========================================================================
+// Test: scoped invalidate does not kill in-flight refresh for another dir
+// ===========================================================================
+
+describe("GitHealth.invalidate(cwd) — in-flight refresh preservation", () => {
+  test("invalidate(dirA) does not prevent inflight refresh on dirB from populating cache", async () => {
+    const repoA = makeRepo()
+    const repoB = makeRepo()
+    try {
+      // repoA: clean
+      await gitInit(repoA.path)
+      await gitEmptyCommit(repoA.path, "root")
+
+      // repoB: detached HEAD so it has detectable issues
+      await gitInit(repoB.path)
+      await gitEmptyCommit(repoB.path, "root")
+      await $`git checkout --detach`.cwd(repoB.path).quiet()
+
+      // Clear state
+      GitHealth.invalidate()
+
+      // Start a refresh on repoB and capture the promise
+      const refreshB = GitHealth.refresh(repoB.path)
+
+      // Immediately invalidate repoA (scoped)
+      GitHealth.invalidate(repoA.path)
+
+      // Wait for repoB refresh to complete
+      const issuesB = await refreshB
+      expect(issuesB.length, "repoB refresh should complete with issues").toBeGreaterThan(0)
+
+      // After the refresh completes, the cache should be populated.
+      // The current implementation bumps _generation in invalidate()
+      // even when scoped, which causes the generation check in refresh()
+      // to discard the cache write. This is the BUG.
+      //
+      // Expected RED: injectCached returns undefined because cache
+      // was never populated (generation mismatch).
+      const cached = GitHealth.injectCached(repoB.path)
+      expect(cached, "injectCached should return cached result after refresh completes").toBeDefined()
+    } finally {
+      repoA.cleanup()
+      repoB.cleanup()
+      GitHealth.invalidate()
+    }
+  })
+
+  test("invalidate(dirA) does not break deduplication for concurrent refresh on dirB", async () => {
+    const repoA = makeRepo()
+    const repoB = makeRepo()
+    try {
+      await gitInit(repoA.path)
+      await gitEmptyCommit(repoA.path, "root")
+
+      await gitInit(repoB.path)
+      await gitEmptyCommit(repoB.path, "root")
+
+      GitHealth.invalidate()
+
+      // Start two concurrent refreshes on repoB — second should dedupe
+      const first = GitHealth.refresh(repoB.path)
+      const second = GitHealth.refresh(repoB.path)
+      expect(second, "concurrent refreshes should dedupe").toBe(first)
+
+      // Now invalidate repoA (scoped) while repoB refresh is in-flight
+      GitHealth.invalidate(repoA.path)
+
+      // A third concurrent refresh on repoB should STILL dedupe to the
+      // original in-flight promise. Currently, invalidate() clears
+      // _refreshing globally, so this returns a new, unrelated promise.
+      const third = GitHealth.refresh(repoB.path)
+      expect(third, "deduplication should survive scoped invalidate on another dir").toBe(first)
+
+      await first
+    } finally {
+      repoA.cleanup()
+      repoB.cleanup()
+      GitHealth.invalidate()
+    }
+  })
+})
+
+// ===========================================================================
+// Test: global invalidate should allow in-flight refreshes to complete
+// ===========================================================================
+
+describe("GitHealth.invalidate() — global invalidation inflight contract", () => {
+  test("global invalidate does not discard already-in-flight scan results", async () => {
+    const repo = makeRepo()
+    try {
+      await gitInit(repo.path)
+      await gitEmptyCommit(repo.path, "root")
+
+      // Detach HEAD for a detectable issue
+      await $`git checkout --detach`.cwd(repo.path).quiet()
+
+      GitHealth.invalidate()
+
+      // Start a refresh
+      const refresh = GitHealth.refresh(repo.path)
+
+      // Global invalidate (what loop-signals currently does)
+      GitHealth.invalidate()
+
+      // The in-flight refresh should still resolve with the scan results
+      const issues = await refresh
+      expect(issues.length, "refresh should complete with issues").toBeGreaterThan(0)
+
+      // Whether or not the cache is populated after global invalidate is a
+      // design choice. The important invariant is that the promise resolves
+      // and the data is not lost.
+      const detachedIssue = issues.find((i: Issue) => i.dimension === "detached_head")
+      expect(detachedIssue, "detached head should be detected").toBeDefined()
+    } finally {
+      repo.cleanup()
+      GitHealth.invalidate()
+    }
+  })
+})

--- a/packages/synergy/test/session/snapshot-timeout-regression.test.ts
+++ b/packages/synergy/test/session/snapshot-timeout-regression.test.ts
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------
+// snapshot-timeout-regression.test.ts
+//
+// Regression test for Snapshot.track() timeout / fail-open behavior.
+//
+// Root cause context:
+//   Snapshot.track() and Snapshot.patch() run git add/write-tree/diff from the
+//   session processor stream loop. These operations must be bounded because a
+//   large worktree or stuck git index lock can otherwise stall the whole
+//   session loop.
+//
+//   Expected behavior: normal snapshot operations stay fast on small repos, and
+//   production snapshot git commands fail open through timeout/AbortSignal
+//   guards instead of blocking the session indefinitely.
+//
+// Testing strategy:
+//   1. Integration test: verify normal Snapshot.track() completes within a
+//      reasonable wall-clock time.
+//   2. Integration test: verify Snapshot.patch() also stays bounded on a small
+//      repo and still reports changed files.
+//   3. Keep timeout behavior centralized in Snapshot's git command helper so
+//      future direct shell calls don't re-enter the hot path unbounded.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, test, beforeAll } from "bun:test"
+import path from "path"
+import { Snapshot } from "../../src/session/snapshot"
+import { Instance } from "../../src/scope/instance"
+import { Global } from "../../src/global"
+import { tmpdir } from "../fixture/fixture"
+import { Identifier } from "../../src/id/id"
+
+function fakeSessionID(): string {
+  return Identifier.descending("session")
+}
+
+// ===========================================================================
+// Regression test: Snapshot.track() completes within timeout
+// ===========================================================================
+
+describe("Snapshot.track() — completes within reasonable time", () => {
+  test("track() on a small git repo returns a hash in under 2 seconds", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        // Write a few files
+        await Bun.write(path.join(tmp.path, "a.txt"), "content a")
+        await Bun.write(path.join(tmp.path, "b.txt"), "content b")
+
+        const sessionID = fakeSessionID()
+
+        const start = Date.now()
+        const hash = await Snapshot.track(sessionID)
+        const elapsed = Date.now() - start
+
+        expect(hash, "track() should return a tree hash").toBeTruthy()
+        expect(typeof hash, "hash should be a string").toBe("string")
+        expect((hash as string).length, "tree hash should be 40 chars").toBe(40)
+
+        // The operation should complete in under 2 seconds for a trivial repo.
+        // If this fails, it means the git commands are hanging.
+        expect(elapsed, "track() should complete in under 2s").toBeLessThan(2000)
+      },
+    })
+  })
+
+  test("patch() on a small repo completes in under 2 seconds", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const sessionID = fakeSessionID()
+
+        await Bun.write(path.join(tmp.path, "a.txt"), "version 1")
+        const hash = await Snapshot.track(sessionID)
+        expect(hash).toBeTruthy()
+
+        await Bun.write(path.join(tmp.path, "a.txt"), "version 2")
+
+        const start = Date.now()
+        const patch = await Snapshot.patch(hash!, sessionID)
+        const elapsed = Date.now() - start
+
+        expect(elapsed, "patch() should complete in under 2s").toBeLessThan(2000)
+        expect(patch.files.length, "patch should detect changed file").toBeGreaterThan(0)
+      },
+    })
+  })
+})

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -339,11 +339,12 @@ export function SessionTurn(
   const status = createMemo(() => data.store.session_status[props.sessionID] ?? idle)
   const working = createMemo(() => {
     if (!isLastUserMessage()) return false
-    // Canonical truth: the last assistant message is incomplete
     const last = lastAssistantMessage()
-    if (last?.time.completed == null) return true
-    // Runtime overlay — for the brief window where a new turn has started
-    // but the assistant message hasn't been created in the store yet
+    if (last?.time.completed == null) {
+      const s = data.store.session_status[props.sessionID]
+      if (s && s.type === "idle") return false
+      return true
+    }
     const s = data.store.session_status[props.sessionID]
     if (s && s.type !== "idle") return true
     return false


### PR DESCRIPTION
## Summary
- Scope GitHealth invalidation and add a bounded background scan budget so worktree health refreshes do not amplify snapshot stalls.
- Add timeout/abort fail-open handling to hot-path snapshot git commands used during session processing.
- Stop frontend turn timers from looking active when session status is idle but the assistant message is incomplete.

## Validation
- bun test test/project/git-health-session-stall-regression.test.ts
- bun test test/project/git-health-scoped-invalidation-contract.test.ts
- bun test test/project/git-health.test.ts
- prettier --check on touched files

## Notes
- snapshot-timeout-regression.test.ts is added but currently blocked in this worktree by a pre-existing workspace dependency resolution gap for @ericsanchezok/synergy-util/error.
- git-health-invalidation.test.ts is also blocked by a pre-existing decimal.js workspace dependency gap.