### PR TITLE
fix(ui): DAG animation, orphaned frames, compact todolist, island expand

### DIFF
--- a/packages/app/src/components/engram/experience-view.tsx
+++ b/packages/app/src/components/engram/experience-view.tsx
@@ -376,7 +376,7 @@ export function ExperienceView(props: {
   }
 
   return (
-    <div class="flex flex-col flex-1 min-h-0 -mx-6">
+    <div class="h-full flex flex-col -mx-6">
       <div class="shrink-0 px-6 mb-3">
         <Show
           when={!selecting()}

--- a/packages/app/src/components/session/session-progress-dag.tsx
+++ b/packages/app/src/components/session/session-progress-dag.tsx
@@ -8,6 +8,7 @@ import type { DagSummary } from "./session-progress-summary"
 interface SessionProgressDagProps {
   sessionID: string
   summary: DagSummary
+  frozen?: boolean
   class?: string
 }
 
@@ -92,6 +93,7 @@ export function SessionProgressDag(props: SessionProgressDagProps) {
           nodes={nodes()}
           ready={props.summary.ready}
           variant="panel"
+          frozen={props.frozen}
           selectedNodeId={selectedNodeId()}
           onSelectNode={handleSelectNode}
           focusNodeId={focusNodeId()}

--- a/packages/app/src/components/session/session-progress-dag.tsx
+++ b/packages/app/src/components/session/session-progress-dag.tsx
@@ -88,7 +88,7 @@ export function SessionProgressDag(props: SessionProgressDagProps) {
 
   return (
     <Show when={nodes().length > 0} fallback={<div class="text-text-weaker text-xs px-3 py-2">No active plan</div>}>
-      <div class={props.class}>
+      <div class={props.class ? `${props.class} h-full` : "h-full"}>
         <DagGraph
           nodes={nodes()}
           ready={props.summary.ready}

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -113,7 +113,7 @@
 .session-progress-island-panel {
   display: flex;
   max-height: min(68vh, 720px);
-  min-height: 420px;
+  min-height: min(280px, 50vh);
   flex-direction: column;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);
   animation: session-progress-island-panel-in 220ms cubic-bezier(0.2, 0, 0, 1) both;
@@ -125,7 +125,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 9px 16px 6px;
+  padding: 7px 12px 5px;
   color: var(--color-text-subtle);
   font-size: 12px;
 }
@@ -134,7 +134,7 @@
   display: flex;
   flex: 0 0 auto;
   gap: 4px;
-  padding: 0 16px 8px;
+  padding: 0 12px 6px;
 }
 
 .session-progress-island-tab {
@@ -161,7 +161,7 @@
   min-height: 0;
   flex: 1 1 auto;
   overflow: hidden;
-  padding: 0 10px 10px;
+  padding: 0 6px 8px;
 }
 
 @keyframes session-progress-island-enter {

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -107,38 +107,45 @@
   transform: rotate(180deg);
 }
 
+/* Expand/collapse via CSS grid rows trick. The wrapper is a grid with one
+   row whose height transitions between 0fr (collapsed) and 1fr (expanded).
+   The panel inside is the grid item — it must have min-height:0 so the row
+   can collapse to zero regardless of the content's intrinsic size. */
 .session-progress-island-panel-wrap {
   display: grid;
-  grid-template-rows: 0fr;
+  /* minmax(0, 0fr) — the explicit 0 minimum lets the track collapse fully
+     to zero regardless of the content's intrinsic min-content height.
+     (Bare "0fr" expands to "minmax(auto, 0fr)" whose minimum is min-content,
+     which the DAG graph's fixed viewport height would pin open.) */
+  grid-template-rows: minmax(0, 0fr);
   opacity: 0;
-  visibility: hidden;
   pointer-events: none;
   transition:
     grid-template-rows 240ms cubic-bezier(0.2, 0, 0, 1),
-    opacity 200ms ease-out;
+    opacity 240ms ease-out;
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
-  grid-template-rows: 1fr;
+  grid-template-rows: minmax(0, 1fr);
   opacity: 1;
-  visibility: visible;
   pointer-events: auto;
 }
 
-/* The panel itself sits in the single grid row. min-height: 0 lets the row
-   collapse to 0fr cleanly; overflow hidden clips content while collapsing. */
+/* Panel is the grid item. overflow:hidden clips content while the row
+   animates. min-height:0 is mandatory for the 0fr collapse to work. */
 .session-progress-island-panel {
   display: flex;
   min-height: 0;
-  max-height: min(68vh, 720px);
   flex-direction: column;
   overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);
 }
 
-/* When expanded, let the panel settle to a comfortable min height */
+/* Cap the expanded panel height. Applied only when expanded so it never
+   fights the 0fr collapse. */
 .session-progress-island-panel-wrap[data-expanded="true"] .session-progress-island-panel {
-  min-height: min(280px, 50vh);
+  max-height: min(68vh, 720px);
+  min-height: min(220px, 44vh);
 }
 
 .session-progress-island-panel-topline {

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -209,7 +209,7 @@
   min-height: 0;
   flex: 1 1 auto;
   overflow: hidden;
-  padding: 0 6px 8px;
+  padding: 0 6px;
 }
 
 @keyframes session-progress-island-enter {

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -121,13 +121,13 @@
    triggers style recalc or layout. */
 .session-progress-island-panel-wrap {
   position: relative;
-  max-height: 0;
+  height: 0;
   overflow: hidden;
-  transition: max-height 240ms cubic-bezier(0.2, 0, 0, 1);
+  transition: height 240ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
-  max-height: min(68vh, 720px);
+  height: min(68vh, 720px);
 }
 
 .session-progress-island-panel {

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -107,34 +107,30 @@
   transform: rotate(180deg);
 }
 
-/* Expand/collapse: the wrapper animates max-height, but the panel subtree
-   uses content-visibility so that when collapsed it is entirely skipped by
-   style/layout/paint — no per-frame UpdateLayoutTree for the 5000+ DAG
-   elements. When expanded, content-visibility: visible re-engages rendering.
+/* Expand/collapse panel.
 
-   This is the fix verified by Chrome trace: grid 0fr→1fr caused ~80ms
-   UpdateLayoutTree (8361 elements) per frame; contain+max-height reduced it
-   to ~50ms (5905 elements); content-visibility:hidden while collapsed brings
-   the collapsed-state subtree to near-zero. */
+   No height transition: a Chrome trace showed that any height/max-height
+   animation triggers a full-page UpdateLayoutTree (~6400 elements, 50-90ms
+   each) because the panel's size change is treated as potentially affecting
+   its 6000+ siblings in the session view. This caused severe jank regardless
+   of contain, content-visibility, or grid-rows tricks.
+
+   Instead: collapse/expand the panel instantly (display toggled by JS via the
+   data-expanded attribute), and animate only opacity + a small translate for
+   a lightweight entrance. The surface container's width/border-radius still
+   animates smoothly (cheap — affects only the surface itself), so the visible
+   "pill growing into a panel" effect is preserved. The content fade is fast
+   (120ms) so there's no perceptible delay. */
 .session-progress-island-panel-wrap {
-  contain: strict;
-  overflow: hidden;
-  content-visibility: hidden;
-  contain-intrinsic-size: 0 0;
-  opacity: 0;
-  max-height: 0;
-  pointer-events: none;
-  transition:
-    max-height 240ms cubic-bezier(0.2, 0, 0, 1),
-    opacity 200ms ease-out;
+  display: none;
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
-  content-visibility: visible;
-  contain-intrinsic-size: auto min(68vh, 720px);
-  opacity: 1;
-  max-height: min(68vh, 720px);
-  pointer-events: auto;
+  display: block;
+}
+
+.session-progress-island-panel-wrap[data-expanded="true"] .session-progress-island-panel {
+  animation: session-progress-island-panel-fade-in 140ms cubic-bezier(0.2, 0, 0, 1) both;
 }
 
 .session-progress-island-panel {
@@ -144,6 +140,17 @@
   flex-direction: column;
   overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);
+}
+
+@keyframes session-progress-island-panel-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .session-progress-island-panel-topline {
@@ -199,18 +206,6 @@
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes session-progress-island-panel-in {
-  /* Reserved — panel visibility is now driven by the grid-rows transition
-     on .session-progress-island-panel-wrap. Kept as a no-op so any external
-     references don't break. */
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 1;
   }
 }
 

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -1,5 +1,15 @@
 .session-progress-island {
-  position: relative;
+  /* Absolutely positioned above the prompt input so that expanding the
+     island does NOT change the prompt dock's height. Previously the island
+     was in normal flow inside the dock, so expanding it grew the dock,
+     which changed the --prompt-height CSS var, which re-laid-out the
+     entire message list (~7000 elements, 60-80ms per expand). Now the
+     island floats as an overlay: visually it covers messages above, but
+     the dock height (and thus --prompt-height) stays constant. */
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
   z-index: 2;
   display: flex;
   width: 100%;

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -107,50 +107,54 @@
   transform: rotate(180deg);
 }
 
-/* Expand/collapse panel.
+/* Expand/collapse with the panel taken out of normal flow.
 
-   No height transition: a Chrome trace showed that any height/max-height
-   animation triggers a full-page UpdateLayoutTree (~6400 elements, 50-90ms
-   each) because the panel's size change is treated as potentially affecting
-   its 6000+ siblings in the session view. This caused severe jank regardless
-   of contain, content-visibility, or grid-rows tricks.
+   5 Chrome traces showed the DAG panel's ~7000 DOM elements make any height
+   animation expensive when the panel is in flow (grid 0fr→1fr, max-height,
+   contain, content-visibility all recalc'd thousands of elements per frame),
+   and display:none caused a 60ms cold-layout on each toggle.
 
-   Instead: collapse/expand the panel instantly (display toggled by JS via the
-   data-expanded attribute), and animate only opacity + a small translate for
-   a lightweight entrance. The surface container's width/border-radius still
-   animates smoothly (cheap — affects only the surface itself), so the visible
-   "pill growing into a panel" effect is preserved. The content fade is fast
-   (120ms) so there's no perceptible delay. */
+   Solution: position:absolute the panel so it never participates in the
+   wrapper's layout. The wrapper animates its own height via max-height (cheap
+   — it's an empty container). The panel is always rendered (no cold layout),
+   animating only opacity + a compositor-friendly transform. Neither property
+   triggers style recalc or layout. */
 .session-progress-island-panel-wrap {
-  display: none;
+  position: relative;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 240ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
-  display: block;
-}
-
-.session-progress-island-panel-wrap[data-expanded="true"] .session-progress-island-panel {
-  animation: session-progress-island-panel-fade-in 140ms cubic-bezier(0.2, 0, 0, 1) both;
+  max-height: min(68vh, 720px);
 }
 
 .session-progress-island-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  min-height: min(220px, 44vh);
-  max-height: min(68vh, 720px);
+  height: min(68vh, 720px);
   flex-direction: column;
   overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-8px);
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms cubic-bezier(0.2, 0, 0, 1);
 }
 
-@keyframes session-progress-island-panel-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.session-progress-island-panel-wrap[data-expanded="true"] .session-progress-island-panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition:
+    opacity 220ms ease-out 40ms,
+    transform 240ms cubic-bezier(0.2, 0, 0, 1) 40ms;
 }
 
 .session-progress-island-panel-topline {

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -137,7 +137,7 @@
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
-  height: min(68vh, 720px);
+  height: min(52vh, 560px);
 }
 
 .session-progress-island-panel {
@@ -146,7 +146,7 @@
   left: 0;
   right: 0;
   display: flex;
-  height: min(68vh, 720px);
+  height: min(52vh, 560px);
   flex-direction: column;
   overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -107,45 +107,38 @@
   transform: rotate(180deg);
 }
 
-/* Expand/collapse via CSS grid rows trick. The wrapper is a grid with one
-   row whose height transitions between 0fr (collapsed) and 1fr (expanded).
-   The panel inside is the grid item — it must have min-height:0 so the row
-   can collapse to zero regardless of the content's intrinsic size. */
+/* Expand/collapse via max-height + opacity, scoped with `contain`.
+
+   Why not the grid 0fr→1fr trick: the fr unit is a flexible size that
+   Chrome treats as potentially affecting the whole document, so each
+   animation frame triggered an UpdateLayoutTree across 8000+ elements
+   (~80ms each, causing severe jank — verified via Chrome trace). A
+   concrete max-height value scopes the reflow, and `contain` isolates
+   the panel subtree so style recalc stays local to the panel. */
 .session-progress-island-panel-wrap {
-  display: grid;
-  /* minmax(0, 0fr) — the explicit 0 minimum lets the track collapse fully
-     to zero regardless of the content's intrinsic min-content height.
-     (Bare "0fr" expands to "minmax(auto, 0fr)" whose minimum is min-content,
-     which the DAG graph's fixed viewport height would pin open.) */
-  grid-template-rows: minmax(0, 0fr);
+  contain: layout style paint;
+  overflow: hidden;
   opacity: 0;
+  max-height: 0;
   pointer-events: none;
   transition:
-    grid-template-rows 240ms cubic-bezier(0.2, 0, 0, 1),
-    opacity 240ms ease-out;
+    max-height 240ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 200ms ease-out;
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
-  grid-template-rows: minmax(0, 1fr);
   opacity: 1;
+  max-height: min(68vh, 720px);
   pointer-events: auto;
 }
 
-/* Panel is the grid item. overflow:hidden clips content while the row
-   animates. min-height:0 is mandatory for the 0fr collapse to work. */
 .session-progress-island-panel {
   display: flex;
-  min-height: 0;
+  min-height: min(220px, 44vh);
+  max-height: min(68vh, 720px);
   flex-direction: column;
   overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);
-}
-
-/* Cap the expanded panel height. Applied only when expanded so it never
-   fights the 0fr collapse. */
-.session-progress-island-panel-wrap[data-expanded="true"] .session-progress-island-panel {
-  max-height: min(68vh, 720px);
-  min-height: min(220px, 44vh);
 }
 
 .session-progress-island-panel-topline {

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -107,17 +107,20 @@
   transform: rotate(180deg);
 }
 
-/* Expand/collapse via max-height + opacity, scoped with `contain`.
+/* Expand/collapse: the wrapper animates max-height, but the panel subtree
+   uses content-visibility so that when collapsed it is entirely skipped by
+   style/layout/paint — no per-frame UpdateLayoutTree for the 5000+ DAG
+   elements. When expanded, content-visibility: visible re-engages rendering.
 
-   Why not the grid 0fr→1fr trick: the fr unit is a flexible size that
-   Chrome treats as potentially affecting the whole document, so each
-   animation frame triggered an UpdateLayoutTree across 8000+ elements
-   (~80ms each, causing severe jank — verified via Chrome trace). A
-   concrete max-height value scopes the reflow, and `contain` isolates
-   the panel subtree so style recalc stays local to the panel. */
+   This is the fix verified by Chrome trace: grid 0fr→1fr caused ~80ms
+   UpdateLayoutTree (8361 elements) per frame; contain+max-height reduced it
+   to ~50ms (5905 elements); content-visibility:hidden while collapsed brings
+   the collapsed-state subtree to near-zero. */
 .session-progress-island-panel-wrap {
-  contain: layout style paint;
+  contain: strict;
   overflow: hidden;
+  content-visibility: hidden;
+  contain-intrinsic-size: 0 0;
   opacity: 0;
   max-height: 0;
   pointer-events: none;
@@ -127,6 +130,8 @@
 }
 
 .session-progress-island-panel-wrap[data-expanded="true"] {
+  content-visibility: visible;
+  contain-intrinsic-size: auto min(68vh, 720px);
   opacity: 1;
   max-height: min(68vh, 720px);
   pointer-events: auto;

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -15,12 +15,9 @@
   border-radius: 999px;
   color: var(--color-text-base);
   background: color-mix(in srgb, var(--color-surface-raised-stronger) 74%, transparent);
-  transform-origin: bottom center;
   transition:
-    max-width 190ms cubic-bezier(0.2, 0, 0, 1),
-    border-radius 190ms cubic-bezier(0.2, 0, 0, 1),
-    transform 190ms cubic-bezier(0.2, 0, 0, 1),
-    opacity 160ms ease-out;
+    max-width 240ms cubic-bezier(0.2, 0, 0, 1),
+    border-radius 240ms cubic-bezier(0.2, 0, 0, 1);
   animation: session-progress-island-enter 180ms cubic-bezier(0.2, 0, 0, 1) both;
 }
 
@@ -110,13 +107,38 @@
   transform: rotate(180deg);
 }
 
+.session-progress-island-panel-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    grid-template-rows 240ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 200ms ease-out;
+}
+
+.session-progress-island-panel-wrap[data-expanded="true"] {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+/* The panel itself sits in the single grid row. min-height: 0 lets the row
+   collapse to 0fr cleanly; overflow hidden clips content while collapsing. */
 .session-progress-island-panel {
   display: flex;
+  min-height: 0;
   max-height: min(68vh, 720px);
-  min-height: min(280px, 50vh);
   flex-direction: column;
+  overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--color-border-weak-base) 54%, transparent);
-  animation: session-progress-island-panel-in 220ms cubic-bezier(0.2, 0, 0, 1) both;
+}
+
+/* When expanded, let the panel settle to a comfortable min height */
+.session-progress-island-panel-wrap[data-expanded="true"] .session-progress-island-panel {
+  min-height: min(280px, 50vh);
 }
 
 .session-progress-island-panel-topline {
@@ -176,15 +198,14 @@
 }
 
 @keyframes session-progress-island-panel-in {
+  /* Reserved — panel visibility is now driven by the grid-rows transition
+     on .session-progress-island-panel-wrap. Kept as a no-op so any external
+     references don't break. */
   from {
-    opacity: 0;
-    transform: translateY(10px) scaleY(0.985);
-    clip-path: inset(0 0 10px 0 round 22px);
+    opacity: 1;
   }
   to {
     opacity: 1;
-    transform: translateY(0) scaleY(1);
-    clip-path: inset(0 0 0 0 round 22px);
   }
 }
 
@@ -202,12 +223,12 @@
   .session-progress-island-surface,
   .session-progress-island-header,
   .session-progress-island-chevron,
-  .session-progress-island-tab {
+  .session-progress-island-tab,
+  .session-progress-island-panel-wrap {
     transition: none;
   }
 
   .session-progress-island-surface,
-  .session-progress-island-panel,
   .session-progress-island[data-tone="running"]
     .session-progress-island-indicator
     [data-slot="progress-circle-progress"] {

--- a/packages/app/src/components/session/session-progress-island.tsx
+++ b/packages/app/src/components/session/session-progress-island.tsx
@@ -114,7 +114,11 @@ export function SessionProgressIsland(props: SessionProgressIslandProps) {
           />
         </button>
 
-        <Show when={props.expanded}>
+        <div
+          class="session-progress-island-panel-wrap"
+          data-expanded={props.expanded ? "true" : "false"}
+          aria-hidden={!props.expanded}
+        >
           <div id="session-progress-island-panel" class="session-progress-island-panel">
             <div class="session-progress-island-panel-topline">
               <span>Current work</span>
@@ -137,7 +141,7 @@ export function SessionProgressIsland(props: SessionProgressIslandProps) {
 
             <div class="session-progress-island-body">{props.children}</div>
           </div>
-        </Show>
+        </div>
       </div>
     </div>
   )

--- a/packages/app/src/components/session/session-progress-panel.tsx
+++ b/packages/app/src/components/session/session-progress-panel.tsx
@@ -53,17 +53,22 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
     const summary = dagSummary()
     if (!summary) return "active"
     if (summary.total === 0) return "settled"
-    if (summary.failed > 0 || summary.blocked > 0) return "active"
-    if (summary.running > 0) return "active"
     if (summary.completed >= summary.total) return "settled"
 
+    // If the session is idle with no active background tasks, the DAG is no
+    // longer making progress — treat it as settled so the panel can dismiss
+    // even when the agent forgot to mark every node terminal.
     const sessionStatus = sync.data.session_status[props.sessionID]?.type ?? "idle"
-    if (sessionStatus !== "idle") return "active"
+    if (sessionStatus === "idle") {
+      const hasActiveTask = sync.data.cortex.some(
+        (task) => task.parentSessionID === props.sessionID && (task.status === "running" || task.status === "queued"),
+      )
+      if (!hasActiveTask) return "settled"
+    }
 
-    const hasActiveTask = sync.data.cortex.some(
-      (task) => task.parentSessionID === props.sessionID && (task.status === "running" || task.status === "queued"),
-    )
-    return hasActiveTask ? "active" : "paused"
+    if (summary.failed > 0 || summary.blocked > 0) return "active"
+    if (summary.running > 0) return "active"
+    return "active"
   })
   const snapshot = createMemo(() => computeProgressIslandSnapshot(mode(), dagSummary(), todoSummary(), dagLifecycle()))
 

--- a/packages/app/src/components/session/session-progress-panel.tsx
+++ b/packages/app/src/components/session/session-progress-panel.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, on, onCleanup, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, on, onCleanup, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSync } from "@/context/sync"
 import {
@@ -122,9 +122,20 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
 
   onCleanup(clearCompletionTimer)
 
+  // While the island panel is expanding/collapsing, freeze the embedded DAG
+  // so its ResizeObserver doesn't thrash layout + auto-focus every animation
+  // frame (the panel width is changing continuously during the 240ms CSS
+  // transition, which would otherwise cause severe jank).
+  let unfreezeTimer: ReturnType<typeof setTimeout> | undefined
+  const [isAnimating, setIsAnimating] = createSignal(false)
+  onCleanup(() => clearTimeout(unfreezeTimer))
+
   const setExpanded = (expanded: boolean) => {
     clearCompletionTimer()
     setState("expanded", expanded)
+    setIsAnimating(true)
+    clearTimeout(unfreezeTimer)
+    unfreezeTimer = setTimeout(() => setIsAnimating(false), 280)
     if (!expanded && snapshot().status === "complete") {
       completionTimer = setTimeout(() => setState("visible", false), 1600)
     }
@@ -132,12 +143,15 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
 
   const renderChild = () => {
     const currentMode = mode()
+    const frozen = isAnimating()
     if (currentMode === "dag")
-      return dagSummary() ? <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} /> : null
+      return dagSummary() ? (
+        <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} frozen={frozen} />
+      ) : null
     if (currentMode === "todo")
       return todoSummary() ? <SessionProgressTodo sessionID={props.sessionID} summary={todoSummary()!} /> : null
     return state.activeTab === "dag" && dagSummary() ? (
-      <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} />
+      <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} frozen={frozen} />
     ) : todoSummary() ? (
       <SessionProgressTodo sessionID={props.sessionID} summary={todoSummary()!} />
     ) : null

--- a/packages/app/src/components/session/session-progress-panel.tsx
+++ b/packages/app/src/components/session/session-progress-panel.tsx
@@ -142,21 +142,22 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
       <SessionProgressTodo sessionID={props.sessionID} summary={todoSummary()!} />
     ) : null
   }
-
   return (
     <Show when={state.visible && mode() !== "none"}>
-      <SessionProgressIsland
-        mode={mode() as Exclude<ProgressMode, "none">}
-        snapshot={snapshot()}
-        activeLabel={activeLabel()}
-        activeTab={state.activeTab}
-        expanded={state.expanded}
-        onExpandedChange={setExpanded}
-        onTabChange={(tab) => setState("activeTab", tab)}
-        class={props.class}
-      >
-        {renderChild()}
-      </SessionProgressIsland>
+      <div class="relative w-full">
+        <SessionProgressIsland
+          mode={mode() as Exclude<ProgressMode, "none">}
+          snapshot={snapshot()}
+          activeLabel={activeLabel()}
+          activeTab={state.activeTab}
+          expanded={state.expanded}
+          onExpandedChange={setExpanded}
+          onTabChange={(tab) => setState("activeTab", tab)}
+          class={props.class}
+        >
+          {renderChild()}
+        </SessionProgressIsland>
+      </div>
     </Show>
   )
 }

--- a/packages/app/src/components/session/session-progress-panel.tsx
+++ b/packages/app/src/components/session/session-progress-panel.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, on, onCleanup, Show } from "solid-js"
+import { createEffect, createMemo, on, onCleanup, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSync } from "@/context/sync"
 import {
@@ -122,20 +122,9 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
 
   onCleanup(clearCompletionTimer)
 
-  // While the island panel is expanding/collapsing, freeze the embedded DAG
-  // so its ResizeObserver doesn't thrash layout + auto-focus every animation
-  // frame (the panel width is changing continuously during the 240ms CSS
-  // transition, which would otherwise cause severe jank).
-  let unfreezeTimer: ReturnType<typeof setTimeout> | undefined
-  const [isAnimating, setIsAnimating] = createSignal(false)
-  onCleanup(() => clearTimeout(unfreezeTimer))
-
   const setExpanded = (expanded: boolean) => {
     clearCompletionTimer()
     setState("expanded", expanded)
-    setIsAnimating(true)
-    clearTimeout(unfreezeTimer)
-    unfreezeTimer = setTimeout(() => setIsAnimating(false), 280)
     if (!expanded && snapshot().status === "complete") {
       completionTimer = setTimeout(() => setState("visible", false), 1600)
     }
@@ -143,15 +132,12 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
 
   const renderChild = () => {
     const currentMode = mode()
-    const frozen = isAnimating()
     if (currentMode === "dag")
-      return dagSummary() ? (
-        <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} frozen={frozen} />
-      ) : null
+      return dagSummary() ? <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} /> : null
     if (currentMode === "todo")
       return todoSummary() ? <SessionProgressTodo sessionID={props.sessionID} summary={todoSummary()!} /> : null
     return state.activeTab === "dag" && dagSummary() ? (
-      <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} frozen={frozen} />
+      <SessionProgressDag sessionID={props.sessionID} summary={dagSummary()!} />
     ) : todoSummary() ? (
       <SessionProgressTodo sessionID={props.sessionID} summary={todoSummary()!} />
     ) : null

--- a/packages/app/src/components/session/session-progress-summary.test.ts
+++ b/packages/app/src/components/session/session-progress-summary.test.ts
@@ -228,4 +228,19 @@ describe("computeProgressIslandSnapshot", () => {
     expect(snapshot.status).toBe("attention")
     expect(snapshot.tone).toBe("blocked")
   })
+
+  test("settled work with non-terminal nodes is hidden (orphaned frame fix)", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "pending"), n("c", "pending")])
+    const snapshot = computeProgressIslandSnapshot("dag", dag, undefined, "settled")
+
+    expect(snapshot.status).toBe("hidden")
+    expect(snapshot.total).toBe(0)
+  })
+
+  test("settled fully-completed work shows complete (not hidden)", () => {
+    const dag = computeDagSummary([n("a", "completed"), n("b", "completed")])
+    const snapshot = computeProgressIslandSnapshot("dag", dag, undefined, "settled")
+
+    expect(snapshot.status).toBe("complete")
+  })
 })

--- a/packages/app/src/components/session/session-progress-summary.test.ts
+++ b/packages/app/src/components/session/session-progress-summary.test.ts
@@ -237,6 +237,17 @@ describe("computeProgressIslandSnapshot", () => {
     expect(snapshot.total).toBe(0)
   })
 
+  test("settled work with running nodes is hidden (agent forgot to mark final node)", () => {
+    // The classic orphan: agent left a self-executed node in "running" state
+    // but the session went idle. settled means the work is finished even if
+    // node statuses weren't cleaned up.
+    const dag = computeDagSummary([n("a", "completed"), n("b", "running"), n("c", "pending")])
+    const snapshot = computeProgressIslandSnapshot("dag", dag, undefined, "settled")
+
+    expect(snapshot.status).toBe("hidden")
+    expect(snapshot.total).toBe(0)
+  })
+
   test("settled fully-completed work shows complete (not hidden)", () => {
     const dag = computeDagSummary([n("a", "completed"), n("b", "completed")])
     const snapshot = computeProgressIslandSnapshot("dag", dag, undefined, "settled")

--- a/packages/app/src/components/session/session-progress-summary.ts
+++ b/packages/app/src/components/session/session-progress-summary.ts
@@ -209,10 +209,12 @@ export function computeProgressIslandSnapshot(
     }
   }
 
-  // When the DAG is settled or paused with no active work and no attention
-  // items, the panel is no longer making progress — hide it so orphaned
-  // frames (agent forgot to mark final nodes) don't linger.
-  if ((lifecycle === "paused" || lifecycle === "settled") && !dagHasAttention && active === 0) {
+  // When the DAG is settled (session idle, no active tasks), the work is
+  // finished even if the agent left nodes in non-terminal states. Hide the
+  // panel so orphaned frames don't linger. The `active === 0` guard applies
+  // only to the "paused" case (session busy but DAG waiting on deps), where
+  // running nodes genuinely indicate in-flight work.
+  if (!dagHasAttention && (lifecycle === "settled" || (lifecycle === "paused" && active === 0))) {
     return {
       status: "hidden",
       tone: "neutral",

--- a/packages/app/src/components/session/session-progress-summary.ts
+++ b/packages/app/src/components/session/session-progress-summary.ts
@@ -195,7 +195,24 @@ export function computeProgressIslandSnapshot(
   const failed = includeDag ? dag!.failed : 0
   const progressRatio = clampRatio(completed / total)
 
-  if (lifecycle === "paused" && !dagHasAttention && active === 0) {
+  if (completed >= total) {
+    return {
+      status: "complete",
+      tone: "complete",
+      completed,
+      total,
+      active,
+      pending,
+      blocked,
+      failed,
+      progressRatio: 1,
+    }
+  }
+
+  // When the DAG is settled or paused with no active work and no attention
+  // items, the panel is no longer making progress — hide it so orphaned
+  // frames (agent forgot to mark final nodes) don't linger.
+  if ((lifecycle === "paused" || lifecycle === "settled") && !dagHasAttention && active === 0) {
     return {
       status: "hidden",
       tone: "neutral",
@@ -214,19 +231,6 @@ export function computeProgressIslandSnapshot(
   }
   if (blocked > 0) {
     return { status: "attention", tone: "blocked", completed, total, active, pending, blocked, failed, progressRatio }
-  }
-  if (completed >= total) {
-    return {
-      status: "complete",
-      tone: "complete",
-      completed,
-      total,
-      active,
-      pending,
-      blocked,
-      failed,
-      progressRatio: 1,
-    }
   }
   if (active > 0) {
     return { status: "active", tone: "running", completed, total, active, pending, blocked, failed, progressRatio }

--- a/packages/app/src/components/session/session-progress-todo.tsx
+++ b/packages/app/src/components/session/session-progress-todo.tsx
@@ -96,9 +96,9 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
       {/* Header */}
       <Show
         when={summaryParts().length > 0}
-        fallback={<div class="text-text-weaker text-xs px-3 py-1.5">No active tasks</div>}
+        fallback={<div class="text-text-weaker text-xs px-2.5 py-1">No active tasks</div>}
       >
-        <div class="text-xs text-text-weaker px-3 py-1.5 shrink-0">{summaryParts().join(" · ")}</div>
+        <div class="text-xs text-text-weaker px-2.5 py-1 shrink-0">{summaryParts().join(" · ")}</div>
       </Show>
 
       {/* List */}
@@ -120,7 +120,7 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
                         toggleTodo(todo.id)
                       }
                     }}
-                    class="flex items-center gap-2.5 px-3 py-2 transition-colors cursor-pointer select-none hover:bg-surface-raised-base-hover"
+                    class="flex items-center gap-2 px-2.5 py-1.5 transition-colors cursor-pointer select-none hover:bg-surface-raised-base-hover"
                     classList={{
                       "bg-text-interactive-base/5 border-l-2 border-l-text-interactive-base": isActive(),
                     }}
@@ -155,7 +155,7 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
 
                   {/* Expanded detail for long content */}
                   <Show when={isExpanded()}>
-                    <div class="flex items-center gap-2.5 px-3 py-2 bg-surface-raised-base border-t border-border-weak-base/40">
+                    <div class="flex items-center gap-2 px-2.5 py-1.5 bg-surface-raised-base border-t border-border-weak-base/40">
                       <span class="shrink-0 text-sm leading-none text-text-weaker"> </span>
                       <span class="text-xs leading-snug text-text-base whitespace-pre-wrap break-words flex-1 min-w-0">
                         {todo.content}

--- a/packages/synergy/src/agent/prompt/synergy-max/base.txt
+++ b/packages/synergy/src/agent/prompt/synergy-max/base.txt
@@ -88,6 +88,7 @@ Use `dagpatch` for self-executed nodes, blocked work, or `memo` updates.
 Mark `blocked` when progress requires a user decision, missing environment, or missing evidence.
 
 Graft new nodes when evidence reveals missing work. Cancel downstream nodes when upstream assumptions collapse.
+Before delivering your final response, ensure every DAG node is in a terminal state (`completed`, `cancelled`, or `failed`). Use `dagpatch` to mark any self-executed nodes that are still `running`. If you abandoned an approach, cancel the leftover nodes. A clean DAG lets the progress panel dismiss itself — an orphaned `running` node leaves a stale progress frame stuck on the user's screen.
 
 ## Progressive Planning
 

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -383,8 +383,17 @@
   }
 }
 
-/* Panel variant — compact enough for embedded session progress surfaces */
+/* Panel variant — compact enough for embedded session progress surfaces.
+   contain:layout style paint isolates the DAG's ~400 nodes (~8000 DOM
+   elements) into a self-contained layout/paint context so that size changes
+   in the parent (the island panel) don't trigger style/layout recalc of the
+   DAG subtree. (Not using contain:strict/size because the DAG's height
+   depends on its content via the viewport's clamp().)
+   Verified necessary via Chrome trace: without it, the panel's height
+   transition cascaded a full-page UpdateLayoutTree (8352 elements, ~65ms). */
 .dag-graph[data-variant="panel"] {
+  contain: layout style paint;
+
   [data-slot="dag-graph-viewport"] {
     height: clamp(360px, 52vh, 620px);
   }

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -152,9 +152,22 @@
       opacity: 0.7;
     }
 
-    &[data-dragging="true"] {
+    &[data-dragging="true"],
+    &[data-zooming="true"] {
       cursor: grabbing;
     }
+  }
+
+  /* Disable layout transitions during direct user interaction (drag/zoom) so
+     the viewport stays locked to the pointer instead of lagging behind. */
+  [data-slot="dag-graph-viewport"][data-dragging="true"] [data-slot="dag-graph-stage"],
+  [data-slot="dag-graph-viewport"][data-zooming="true"] [data-slot="dag-graph-stage"] {
+    transition: none;
+  }
+
+  [data-slot="dag-graph-viewport"][data-dragging="true"] [data-slot="dag-graph-card"],
+  [data-slot="dag-graph-viewport"][data-zooming="true"] [data-slot="dag-graph-card"] {
+    transition: none;
   }
 
   [data-slot="dag-graph-stage"] {
@@ -164,6 +177,7 @@
     transform-origin: 0 0;
     will-change: transform;
     z-index: 1;
+    transition: transform 0.28s cubic-bezier(0.2, 0, 0, 1);
   }
 
   [data-slot="dag-graph-edges"] {
@@ -215,8 +229,9 @@
     flex-direction: column;
     gap: 10px;
     overflow: hidden;
-    opacity: 1;
     transition:
+      left 0.28s cubic-bezier(0.2, 0, 0, 1),
+      top 0.28s cubic-bezier(0.2, 0, 0, 1),
       border-color 0.18s ease,
       background-color 0.18s ease,
       box-shadow 0.18s ease,

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -395,7 +395,8 @@
   contain: layout style paint;
 
   [data-slot="dag-graph-viewport"] {
-    height: clamp(360px, 52vh, 620px);
+    height: 100%;
+    min-height: clamp(280px, 44vh, 520px);
   }
 }
 

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -393,10 +393,11 @@
    transition cascaded a full-page UpdateLayoutTree (8352 elements, ~65ms). */
 .dag-graph[data-variant="panel"] {
   contain: layout style paint;
+  height: 100%;
 
   [data-slot="dag-graph-viewport"] {
     height: 100%;
-    min-height: clamp(280px, 44vh, 520px);
+    min-height: 0;
   }
 }
 

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -230,8 +230,6 @@
     gap: 10px;
     overflow: hidden;
     transition:
-      left 0.28s cubic-bezier(0.2, 0, 0, 1),
-      top 0.28s cubic-bezier(0.2, 0, 0, 1),
       border-color 0.18s ease,
       background-color 0.18s ease,
       box-shadow 0.18s ease,

--- a/packages/ui/src/components/dag-graph.css
+++ b/packages/ui/src/components/dag-graph.css
@@ -183,6 +183,7 @@
     stroke: color-mix(in srgb, var(--border-base) 82%, transparent);
     stroke-width: 1.35;
     stroke-linecap: round;
+    transition: stroke 0.18s ease;
 
     &[data-status="completed"] {
       stroke: color-mix(in srgb, var(--dag-done) 74%, var(--border-base));
@@ -216,8 +217,9 @@
     overflow: hidden;
     opacity: 1;
     transition:
-      border-color 0.14s ease,
-      box-shadow 0.14s ease,
+      border-color 0.18s ease,
+      background-color 0.18s ease,
+      box-shadow 0.18s ease,
       transform 0.14s ease;
 
     &:hover {
@@ -269,6 +271,9 @@
     flex-shrink: 0;
     background: var(--text-weaker);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--text-weaker) 18%, transparent);
+    transition:
+      background-color 0.18s ease,
+      box-shadow 0.18s ease;
 
     [data-status="completed"] & {
       background: var(--border-success-base);
@@ -297,6 +302,7 @@
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.065em;
     color: var(--text-weak);
+    transition: color 0.18s ease;
 
     [data-status="completed"] & {
       color: var(--text-on-success-base);

--- a/packages/ui/src/components/dag-graph.tsx
+++ b/packages/ui/src/components/dag-graph.tsx
@@ -225,6 +225,10 @@ export function DagGraph(props: {
   focusNodeId?: string
   onViewportInteraction?: () => void
   onOpenSession?: (sessionID: string) => void
+  /* When true, the graph ignores container width changes and suppresses
+     auto-focus. Use during parent animations (e.g. panel expand/collapse) so
+     the ResizeObserver storm doesn't thrash layout + focus every frame. */
+  frozen?: boolean
 }) {
   const [containerWidth, setContainerWidth] = createSignal(0)
   const [scale, setScale] = createSignal(1)
@@ -260,7 +264,10 @@ export function DagGraph(props: {
   onMount(() => {
     if (!ref) return
     setContainerWidth(ref.clientWidth)
-    const observer = new ResizeObserver((entries) => setContainerWidth(entries[0].contentRect.width))
+    const observer = new ResizeObserver((entries) => {
+      if (props.frozen) return
+      setContainerWidth(entries[0].contentRect.width)
+    })
     observer.observe(ref)
     onCleanup(() => observer.disconnect())
     onCleanup(closeNodeInspector)
@@ -287,6 +294,7 @@ export function DagGraph(props: {
 
   createEffect(
     on([nodeIds, () => containerWidth()], () => {
+      if (props.frozen) return
       const l = layout()
       if (!viewport || hasUserMoved() || l.width === 0 || l.height === 0) return
       focusActiveNodes()

--- a/packages/ui/src/components/dag-graph.tsx
+++ b/packages/ui/src/components/dag-graph.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, createUniqueId, onCleanup, onMount } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, createUniqueId, on, onCleanup, onMount } from "solid-js"
 import { Portal } from "solid-js/web"
 import { Icon, type IconName } from "./icon"
 import { Markdown } from "./markdown"
@@ -230,6 +230,7 @@ export function DagGraph(props: {
   const [scale, setScale] = createSignal(1)
   const [pan, setPan] = createSignal({ x: 0, y: 0 })
   const [dragging, setDragging] = createSignal(false)
+  const [zooming, setZooming] = createSignal(false)
   const [hasUserMoved, setHasUserMoved] = createSignal(false)
   const [pointerMoved, setPointerMoved] = createSignal(false)
 
@@ -275,11 +276,22 @@ export function DagGraph(props: {
   const readySet = createMemo(() => new Set(props.ready ?? []))
   const counts = createMemo(() => statusCounts(nodes()))
 
-  createEffect(() => {
-    const l = layout()
-    if (!viewport || hasUserMoved() || l.width === 0 || l.height === 0) return
-    focusActiveNodes()
-  })
+  // Track the set of node IDs separately so auto-focus only fires when nodes
+  // are added or removed — not on every status change (which would cause the
+  // viewport to jump wildly as each node flips pending→running→completed).
+  const nodeIds = createMemo(() =>
+    nodes()
+      .map((n) => n.id)
+      .join("\u0001"),
+  )
+
+  createEffect(
+    on([nodeIds, () => containerWidth()], () => {
+      const l = layout()
+      if (!viewport || hasUserMoved() || l.width === 0 || l.height === 0) return
+      focusActiveNodes()
+    }),
+  )
 
   createEffect(() => {
     const focusId = props.focusNodeId
@@ -328,6 +340,15 @@ export function DagGraph(props: {
     })
   }
 
+  let zoomTimer: ReturnType<typeof setTimeout> | undefined
+  onCleanup(() => clearTimeout(zoomTimer))
+
+  function flagZooming() {
+    setZooming(true)
+    clearTimeout(zoomTimer)
+    zoomTimer = setTimeout(() => setZooming(false), 220)
+  }
+
   function zoomAt(nextScale: number, clientX?: number, clientY?: number) {
     if (!viewport) return
     const bounds = viewport.getBoundingClientRect()
@@ -338,6 +359,7 @@ export function DagGraph(props: {
     const currentPan = pan()
     const worldX = (originX - currentPan.x) / current
     const worldY = (originY - currentPan.y) / current
+    flagZooming()
     setScale(next)
     setPan({ x: originX - worldX * next, y: originY - worldY * next })
     setHasUserMoved(true)
@@ -469,6 +491,7 @@ export function DagGraph(props: {
         <div
           data-slot="dag-graph-viewport"
           data-dragging={dragging()}
+          data-zooming={zooming() ? "true" : undefined}
           ref={viewport}
           onWheel={handleWheel}
           onPointerDown={handlePointerDown}

--- a/packages/ui/src/components/dag-graph.tsx
+++ b/packages/ui/src/components/dag-graph.tsx
@@ -292,12 +292,25 @@ export function DagGraph(props: {
       .join("\u0001"),
   )
 
+  // Auto-focus when node set or container width changes. Wrapped in
+  // requestAnimationFrame so the forced reflow inside fitToNodes
+  // (viewport.getBoundingClientRect()) doesn't run synchronously inside
+  // Solid's effect batch — a sync reflow here blocked the main thread for
+  // 55-60ms per call (verified via Chrome trace stackTrace on fitToNodes).
+  let focusRaf: number | undefined
+  onCleanup(() => {
+    if (focusRaf !== undefined) cancelAnimationFrame(focusRaf)
+  })
   createEffect(
     on([nodeIds, () => containerWidth()], () => {
       if (props.frozen) return
       const l = layout()
       if (!viewport || hasUserMoved() || l.width === 0 || l.height === 0) return
-      focusActiveNodes()
+      if (focusRaf !== undefined) cancelAnimationFrame(focusRaf)
+      focusRaf = requestAnimationFrame(() => {
+        focusRaf = undefined
+        focusActiveNodes()
+      })
     }),
   )
 


### PR DESCRIPTION
## Summary

优化 session 进度面板（DAG island）的展开/收起动画性能，以及一系列 UI 修复。通过 7 轮 Chrome Trace 分析定位并解决了根因。

## 主要改动

### 1. Island 展开/收起动画——架构级性能修复（核心）
**根因**（7 轮 trace 定位）：island 在文档流中，展开时撑高 prompt dock → `ResizeObserver` 触发 `--prompt-height` 变化 → 消息列表（7894 元素）全量重算 `UpdateLayoutTree`（60-105ms/次）。

**修复**：让 island 用 `position: absolute` 真正脱离 dock 文档流。现在展开时 dock 高度不变，`--prompt-height` 不变，消息列表完全不参与重算。

### 2. DAG 动画稳定性
- 节点状态变化时的 background/stroke/color transition（之前 border 在过渡但 background 瞬变）
- auto-focus 只在节点增删时触发，不再在每次状态变化时跳视口
- `fitToNodes` 的 `getBoundingClientRect()` 用 `requestAnimationFrame` 推迟，避免 SolidJS effect 批处理内的同步 reflow（56-63ms/次）
- 拖拽/缩放时禁用 transition，保持视口跟手

### 3. Orphaned DAG frame 自动消失
agent 忘记标记最后的节点完成时，面板会永久残留。两层修复：
- 前端安全网：`dagLifecycle` 在 session idle 且无活跃 task 时返回 `settled`，自动隐藏
- Agent prompt：添加 DAG 收尾指引

### 4. 其他修复
- Sidebar project 列表增加详情（session 数、活跃时间、运行中指示）
- Todolist 面板收紧间距，匹配整体设计语言
- DAG island 高度调整（68vh → 52vh）
- DAG viewport 高度链修复（百分比高度断裂导致裁切）

## 性能验证（7 轮 Chrome Trace）

| 阶段 | elementCount | dirtyObjects | 单次耗时 |
|------|------|------|------|
| 初始（grid 0fr→1fr） | 8361 | 4558 | 69-88ms |
| contain 隔离后 | 7894 | **22** | 65-105ms |
| **脱离文档流（最终）** | **消息列表不参与** | **0** | **流畅** |

## Test plan
- [x] `bun test` 单独运行相关测试通过（2784 pass）
- [x] 展开/收起 island 确认流畅（之前的卡顿已消除）
- [x] 确认消息列表在展开时不再重排
- [x] 拖拽/缩放 DAG 确认跟手无延迟
- [ ] orphaned frame 在 session idle 后自动消失

> 注：全量 `bun test` 有 4 个 flaky 失败（cortex/dag-result × 2，sandbox/dispatch × 2），单独运行均通过，与本次改动无关（并行竞争导致）。