### PR TITLE
fix(engram): experience panel empty + unify memory filter bar style

### DIFF
--- a/packages/app/src/components/engram/experience-view.tsx
+++ b/packages/app/src/components/engram/experience-view.tsx
@@ -376,7 +376,7 @@ export function ExperienceView(props: {
   }
 
   return (
-    <div class="flex flex-col flex-1 min-h-0 -mx-6">
+    <div class="h-full flex flex-col -mx-6">
       <div class="shrink-0 px-6 mb-3">
         <Show
           when={!selecting()}

--- a/packages/app/src/components/engram/memory-view.tsx
+++ b/packages/app/src/components/engram/memory-view.tsx
@@ -200,7 +200,7 @@ export function MemoryView(props: {
           />
         }
       >
-        <div class={`flex items-center gap-1.5 flex-wrap mb-3 px-3 py-2.5 ${engramInsetClass}`}>
+        <div class="flex items-center gap-1.5 flex-wrap mb-3">
           <For each={MEMORY_CATEGORIES}>
             {(cat) => {
               const count = () => categoryCounts().get(cat) ?? 0


### PR DESCRIPTION
## Summary

Two engram library panel fixes.

### 1. Experience panel was always empty (root cause: VList zero-height)
The ExperienceView used a virtual list (`VList`) but its container had zero height because the root div relied on `flex-1`, while its parent (`AppPanel.Body`) is `overflow-y-auto` (block layout, not a flex container). `flex-1` had no effect, so `VList` rendered nothing — even though data loaded successfully (1474 records confirmed in DB and via API).

MemoryView worked because it uses plain `<For>` (no height requirement). ExperienceView needs `VList` for the larger dataset, which requires a concrete height.

**Fix:** Replace `flex-1` with `h-full` on the root div so it fills `AppPanel.Body`'s height directly, giving the inner flex-1 VList container a real height.

### 2. Unify memory filter chip bar with experience and skills
The memory view wrapped its category filter chips (User, self, interaction...) in an inset background container (`px-3 py-2.5` + `engramInsetClass`), while experience and skills views use a flat `flex items-center gap-1.5 flex-wrap mb-3` layout. Dropped the inset wrapper so all three library views share the same filter bar style.

## Test plan
- [x] Open Library → Experiences: panel now shows records (was empty)
- [x] Open Library → Memories: filter chips (User, self, interaction...) match the flat style of Experiences/Skills
- [x] Confirm no regressions in memory card rendering