### PR TITLE
fix(sidebar): show all server-side projects with lazy session loading

### DIFF
--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -138,6 +138,10 @@ export function Sidebar(props: SidebarProps) {
 
   const handleProjectToggle = (e: MouseEvent, scope: LocalScope) => {
     e.stopPropagation()
+    if (layout.scopes.isSupplemental(scope)) {
+      layout.scopes.toggleSupplementalExpand(scope.worktree)
+      return
+    }
     if (scope.expanded) {
       layout.scopes.collapse(scope.worktree)
     } else {
@@ -502,6 +506,8 @@ export function Sidebar(props: SidebarProps) {
                 {(scope) => {
                   const isActive = () => scope.worktree === currentDirectory()
                   const [menuOpen, setMenuOpen] = createSignal(false)
+                  const isSupplemental = layout.scopes.isSupplemental(scope)
+                  const navLoaded = () => !!layout.nav.navEntries()[scope.worktree]
 
                   return (
                     <div class="sb-project-group">
@@ -577,20 +583,33 @@ export function Sidebar(props: SidebarProps) {
                       {/* Sessions under expanded project */}
                       <Show when={scope.expanded}>
                         <div class="sb-sessions">
-                          <GroupedSessionList
-                            entries={layout.nav.projectNavEntries(scope)}
-                            scope={scope}
-                            activeID={params.id}
-                            onSessionClick={(entry) => handleSessionClick(scope, entry)}
-                          />
-                          <Show when={hasMoreForProject(scope)}>
-                            <button
-                              type="button"
-                              class="sb-load-more-btn"
-                              onClick={() => layout.nav.loadMoreNav(scope.worktree)}
-                            >
-                              Load more
-                            </button>
+                          <Show
+                            when={!isSupplemental || navLoaded()}
+                            fallback={
+                              <button
+                                type="button"
+                                class="sb-load-more-btn"
+                                onClick={() => layout.nav.loadScopeNav(scope.worktree)}
+                              >
+                                Load sessions
+                              </button>
+                            }
+                          >
+                            <GroupedSessionList
+                              entries={layout.nav.projectNavEntries(scope)}
+                              scope={scope}
+                              activeID={params.id}
+                              onSessionClick={(entry) => handleSessionClick(scope, entry)}
+                            />
+                            <Show when={hasMoreForProject(scope)}>
+                              <button
+                                type="button"
+                                class="sb-load-more-btn"
+                                onClick={() => layout.nav.loadMoreNav(scope.worktree)}
+                              >
+                                Load more
+                              </button>
+                            </Show>
                           </Show>
                         </div>
                       </Show>
@@ -702,42 +721,15 @@ function RootNavSection(props: {
   )
 }
 
-// --- GroupedSessionList: renders nav entries grouped by category (project) ---
-
-const CATEGORY_LABELS_PROJECT: Record<string, string> = {
-  background: "Background",
-  channel: "Channel",
-}
-
 function GroupedSessionList(props: {
   entries: NavEntry[]
   scope?: LocalScope
   activeID?: string
   onSessionClick: (entry: NavEntry) => void
 }) {
-  const labels = CATEGORY_LABELS_PROJECT
-
-  const memo = createMemo(() => {
-    const project: NavEntry[] = []
-    const groups = new Map<string, NavEntry[]>()
-    for (const entry of props.entries) {
-      if (entry.category === "project") {
-        project.push(entry)
-      } else if (labels[entry.category] !== undefined) {
-        const key = entry.category
-        if (!groups.has(key)) groups.set(key, [])
-        groups.get(key)!.push(entry)
-      }
-    }
-    return { projectEntries: project, groupedEntries: [...groups.entries()] }
-  })
-
-  const projectEntries = () => memo().projectEntries
-  const groupedEntries = () => memo().groupedEntries
-
   return (
     <>
-      <For each={projectEntries()}>
+      <For each={props.entries.filter((e) => e.category === "project")}>
         {(entry) => (
           <button
             type="button"
@@ -753,31 +745,6 @@ function GroupedSessionList(props: {
             <SessionRowIcon entry={entry} scope={props.scope} />
             <span class="sb-session-title">{entry.title || "Untitled"}</span>
           </button>
-        )}
-      </For>
-      <For each={groupedEntries()}>
-        {([category, entries]) => (
-          <div class="sb-session-group">
-            <div class="sb-session-group-header">{labels[category]}</div>
-            <For each={entries}>
-              {(entry) => (
-                <button
-                  type="button"
-                  classList={{
-                    "sb-session-row": true,
-                    "sb-session-active": entry.id === props.activeID,
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    props.onSessionClick(entry)
-                  }}
-                >
-                  <SessionRowIcon entry={entry} scope={props.scope} />
-                  <span class="sb-session-title">{entry.title || "Untitled"}</span>
-                </button>
-              )}
-            </For>
-          </div>
         )}
       </For>
     </>

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -571,12 +571,57 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       })
     })
 
+    // Supplemental project scopes: server-side projects that are NOT in the
+    // local server.scopes store. These are shown so the sidebar reflects all
+    // projects (not just manually-opened ones), but their expand state lives
+    // in-memory (not persisted) and their sessions load lazily via an
+    // explicit "Load sessions" action rather than auto-loading on expand.
+    // This keeps initial load light even when the server has dozens of
+    // projects.
+    const [supplementalExpanded, setSupplementalExpanded] = createSignal<Set<string>>(new Set())
+
+    function toggleSupplementalExpand(directory: string) {
+      setSupplementalExpanded((prev) => {
+        const next = new Set(prev)
+        if (next.has(directory)) next.delete(directory)
+        else next.add(directory)
+        return next
+      })
+    }
     const enriched = createMemo(() => server.scopes.list().flatMap(enrich))
 
     const list = createMemo(() => {
-      const raw = enriched().flatMap(colorize)
+      // Locally-tracked scopes (user-opened, persisted in localStorage).
+      const local = enriched().flatMap(colorize)
       const index = scopeIndex()
-      if (index.length === 0) return raw
+      if (index.length === 0) return local
+
+      // Supplement server-side projects that are NOT locally tracked, so the
+      // sidebar reflects all projects (not just manually-opened ones). These
+      // use a separate in-memory expanded set (not persisted) and load their
+      // sessions lazily via an explicit "Load sessions" action rather than
+      // auto-loading on expand — keeping initial load light even when the
+      // server has dozens of projects.
+      const seenDirectories = new Set(local.map((s) => s.worktree))
+      const seenIDs = new Set(local.map((s) => s.id).filter(Boolean))
+      const expandedSet = supplementalExpanded()
+      const supplemented: LocalScope[] = []
+      for (const entry of index) {
+        if (entry.scopeType !== "project") continue
+        if (entry.directory && seenDirectories.has(entry.directory)) continue
+        if (entry.scopeID && seenIDs.has(entry.scopeID)) continue
+        const metadata = globalSync.data.scope.find((s) => s.id === entry.scopeID || s.worktree === entry.directory)
+        supplemented.push({
+          ...(metadata ?? {}),
+          id: entry.scopeID,
+          worktree: entry.directory,
+          expanded: expandedSet.has(entry.directory),
+          icon: { url: entry.icon?.url ?? metadata?.icon?.url, color: entry.icon?.color ?? metadata?.icon?.color },
+        })
+      }
+
+      const raw = [...local, ...supplemented.flatMap(colorize)]
+
       const order = new Map(index.map((e, i) => [e.scopeID, i]))
       return raw.toSorted((a, b) => {
         const aIdx = order.get(a.id ?? "")
@@ -587,6 +632,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         return 0
       })
     })
+
+    // Whether a project is supplemental (not locally tracked). Supplemental
+    // projects manage expand state in-memory and load sessions lazily.
+    function isSupplementalScope(scope: { worktree: string }): boolean {
+      return !server.scopes.list().some((s) => s.worktree === scope.worktree)
+    }
 
     onMount(() => {
       loadScopeIndex().then(() => {
@@ -848,6 +899,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       },
       scopes: {
         list,
+        isSupplemental: isSupplementalScope,
+        toggleSupplementalExpand,
         async open(directory: string) {
           const root = roots().get(directory) ?? directory
           if (server.scopes.list().find((x) => x.worktree === root)) return


### PR DESCRIPTION
## Summary

修复了侧边栏 Projects 列表展示不全的问题——之前只显示手动 open 过的 project，server 上其他 project 被静默丢弃。

## Root cause

`list()` memo 的数据源是 `server.scopes.list()`（localStorage 持久化，只含手动 open 的 scope），`scopeIndex`（server 全部 scope 列表）只用于排序，从不用于补充缺失的 project。

## Fix

### layout.tsx
- `list()` memo 从 `scopeIndex` 补充本地缺失的 server-side project scope
- 新增 `supplementalExpanded` signal（内存中的展开状态，不持久化到 localStorage）
- 暴露 `isSupplemental()` / `toggleSupplementalExpand()` 给 sidebar

### sidebar.tsx
- `handleProjectToggle` 对 supplemental scope 走内存展开/折叠
- 展开时如果 navEntries 尚未加载，显示 "Load sessions" 按钮，点击才 `loadScopeNav`（惰性加载，避免初始化时为 38 个 project 全部发请求）
- `GroupedSessionList` 只渲染 `project` 类别 session，不再重复显示 channel/background（已在独立 section 展示）

## Test plan
- [x] 所有 38 个 server project 在侧边栏显示
- [ ] 补充的 project 展开后显示 "Load sessions" 按钮
- [ ] 点击 "Load sessions" 后正常加载 session 列表
- [x] channel/background session 不再在 project 展开区重复显示
- [x] 本地 open 的 project 行为不变（自动加载 session）