### PR TITLE
fix: Settings → Manage models crash + empty model list

### DIFF
--- a/packages/app/src/components/dialog/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog/dialog-select-model.tsx
@@ -2,7 +2,8 @@ import { Component, createMemo, JSX, Show } from "solid-js"
 import { ToolbarSelectorPopover } from "@/components/toolbar-selector"
 import { useLocal, type LocalModel } from "@/context/local"
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
-import { popularProviders } from "@/hooks/use-providers"
+import { popularProviders, useProviders } from "@/hooks/use-providers"
+import { useGlobalSync } from "@/context/global-sync"
 import { Button } from "@ericsanchezok/synergy-ui/button"
 import { Switch } from "@ericsanchezok/synergy-ui/switch"
 import { Tag } from "@ericsanchezok/synergy-ui/tag"
@@ -110,14 +111,44 @@ const ConnectedModelManager: Component<{
   provider?: string
   onSelect?: () => void
 }> = (props) => {
-  const local = useLocal()
+  const globalSync = useGlobalSync()
+  const providers = useProviders()
 
+  // Build the connected model list from global provider data so the panel
+  // shows models even when opened outside the per-directory LocalProvider
+  // (e.g. from Settings → Manage models).
   const models = createMemo(() =>
-    local.model
+    providers
       .all()
+      .flatMap((p) =>
+        Object.values(p.models).map((m) => ({
+          ...m,
+          provider: p,
+          name: m.name.replace("(latest)", "").trim(),
+          latest: m.name.includes("(latest)"),
+        })),
+      )
+      .filter((model) =>
+        providers
+          .connected()
+          .map((p) => p.id)
+          .includes(model.provider.id),
+      )
       .filter((model) => (props.provider ? model.provider.id === props.provider : true))
       .sort((a, b) => a.name.localeCompare(b.name)),
   )
+
+  // Local preferences (quick switcher membership) are only available inside
+  // a directory route. When opened from a global context, these are no-ops.
+  const local = (() => {
+    try {
+      return useLocal()
+    } catch {
+      return undefined
+    }
+  })()
+
+  const currentModel = () => local?.model.current()
 
   return (
     <List
@@ -125,13 +156,13 @@ const ConnectedModelManager: Component<{
       emptyMessage="No connected model results"
       key={(x) => `${x.provider.id}:${x.id}`}
       items={models}
-      current={local.model.current()}
+      current={currentModel()}
       filterKeys={["provider.name", "name", "id"]}
       groupBy={(x) => x.provider.name}
       sortGroupsBy={sortGroups}
       onSelect={(x) => {
         if (!x) return
-        local.model.set({ modelID: x.id, providerID: x.provider.id }, { recent: true })
+        local?.model.set({ modelID: x.id, providerID: x.provider.id }, { recent: true })
         props.onSelect?.()
       }}
     >
@@ -141,9 +172,9 @@ const ConnectedModelManager: Component<{
           <div class="flex items-center gap-x-3 shrink-0" onClick={(e) => e.stopPropagation()}>
             <span class="text-12-regular text-text-weak">Quick</span>
             <Switch
-              checked={local.model.inQuickSwitcher({ modelID: model.id, providerID: model.provider.id })}
+              checked={local?.model.inQuickSwitcher({ modelID: model.id, providerID: model.provider.id }) ?? false}
               onChange={(checked) => {
-                local.model.setQuickSwitcher({ modelID: model.id, providerID: model.provider.id }, checked)
+                local?.model.setQuickSwitcher({ modelID: model.id, providerID: model.provider.id }, checked)
               }}
             />
           </div>

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -231,7 +231,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         return map
       })
 
-      const fallbackModel = createMemo(() => {
+      const fallbackModel = createMemo((): ModelKey | undefined => {
         if (sync.data.config.model) {
           const [providerID, modelID] = sync.data.config.model.split("/")
           if (isModelValid({ providerID, modelID })) {
@@ -257,7 +257,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
         }
 
-        throw new Error("No default model found")
+        // No model available yet (e.g. user is still configuring providers, or
+        // the connected provider has no default model mapping). Returning
+        // undefined lets the current() memo resolve gracefully instead of
+        // throwing — which previously crashed the entire UI when the user
+        // opened Settings → Manage models with no valid model configured.
+        return undefined
       })
 
       const current = createMemo(() => {
@@ -343,7 +348,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         set(model: ModelKey | undefined, options?: { recent?: boolean }) {
           batch(() => {
             const currentAgent = agent.current()
-            if (currentAgent) setEphemeral("model", currentAgent.name, model ?? fallbackModel())
+            if (currentAgent) {
+              const resolved = model ?? fallbackModel()
+              if (resolved) setEphemeral("model", currentAgent.name, resolved)
+            }
             if (model) updateQuickSwitcherPreference(model, true)
             if (options?.recent && model) {
               const uniq = uniqueBy([model, ...store.recent], (x) => x.providerID + x.modelID)


### PR DESCRIPTION
## Summary

修复从 Settings → Models → Manage models 打开对话框时的两个 bug。

### Bug 1: 前端崩溃
`fallbackModel` memo 在没有可用模型时 \`throw new Error("No default model found")\`。由于 \`current()\` memo 依赖它，异常会沿渲染树传播，导致整个前端崩溃——例如在未配置任何模型时点击 Manage models。

**修复**：返回 \`undefined\` 而非抛异常；\`current()\` 已有 undefined 守卫。同时守护 \`model.set()\` 中消费 \`fallbackModel()\` 的路径。

### Bug 2: 面板不显示任何模型
\`DialogSelectModel\` 的 \`ConnectedModelManager\` 用 \`useLocal().model.all()\` 构建列表，但 \`LocalProvider\` 只包裹 directory 路由内容。从 Settings 打开时（通过全局 dialog portal 渲染），\`useLocal()\` 在 provider context 之外，返回空列表 → 面板没有任何模型。

**修复**：模型列表改从全局数据构建（\`useProviders()\` + \`useGlobalSync()\`），\`useLocal()\` 只用于 quick-switcher 偏好且用 try/catch 包裹，在 context 不可用时降级为 no-op（带安全默认值）。

## Test plan
- [x] Settings → Models → Manage models 正常打开，不再崩溃
- [x] 面板显示所有已连接 provider 的模型
- [x] Quick switcher 开关在有 directory 路由时正常工作
- [ ] 从其他入口（toolbar selector、command palette）打开 Manage models 也正常