### PR TITLE
fix: notes panel — session width, hover, tag scrollbar, tool state

### DIFF
--- a/packages/app/src/components/note-panel.css
+++ b/packages/app/src/components/note-panel.css
@@ -1,0 +1,39 @@
+/* Smooth hover lift/shadow on note cards using project motion tokens */
+.note-card,
+.mini-note-card {
+  transition:
+    transform var(--motion-duration-base) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-base) var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard),
+    background-color var(--motion-duration-base) var(--motion-ease-standard);
+}
+
+/* Horizontal scrollbar for the tag filter bar when tags overflow */
+.notes-tag-bar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--icon-weak-base) transparent;
+}
+
+.notes-tag-bar::-webkit-scrollbar {
+  height: 4px;
+}
+
+.notes-tag-bar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.notes-tag-bar::-webkit-scrollbar-thumb {
+  background-color: var(--icon-weak-base);
+  border-radius: var(--radius-full);
+}
+
+.notes-tag-bar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--icon-weak-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .note-card,
+  .mini-note-card {
+    transition: none;
+  }
+}

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -26,6 +26,7 @@ import type { NoteInfo, NoteMetaInfo, NoteMetaScopeGroup } from "@ericsanchezok/
 import { getScopeLabel } from "@/utils/scope"
 import { assetHttpUrl } from "@/utils/asset-url"
 import { relativeTime } from "@/utils/time"
+import "./note-panel.css"
 
 function attachNoteDragData(e: DragEvent, note: NoteMetaInfo) {
   const title = note.title || "Untitled"
@@ -58,7 +59,7 @@ function NoteCard(props: { note: NoteMetaInfo; originName?: string; onClick: () 
   return (
     <button
       type="button"
-      class="group relative flex w-full flex-col overflow-hidden rounded-[1.1rem] border border-border-weak-base bg-surface-raised-base text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-border-weak-hover hover:bg-surface-raised-base-hover hover:shadow-md active:scale-[0.985] cursor-pointer"
+      class="group note-card relative flex w-full flex-col overflow-hidden rounded-[1.1rem] border border-border-weak-base bg-surface-raised-base text-left shadow-sm hover:-translate-y-0.5 hover:border-border-weak-hover hover:bg-surface-raised-base-hover hover:shadow-md active:scale-[0.985] cursor-pointer"
       draggable={true}
       onDragStart={(e) => attachNoteDragData(e, props.note)}
       onClick={props.onClick}
@@ -146,7 +147,7 @@ function MiniNoteCard(props: { note: NoteMetaInfo; originName?: string; onClick:
   return (
     <button
       type="button"
-      class="min-w-0 rounded-xl border border-border-weak-base bg-surface-raised-base px-3 py-2.5 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-border-weak-hover hover:bg-surface-raised-base-hover hover:shadow-md active:scale-[0.985]"
+      class="mini-note-card min-w-0 rounded-xl border border-border-weak-base bg-surface-raised-base px-3 py-2.5 text-left shadow-sm hover:-translate-y-0.5 hover:border-border-weak-hover hover:bg-surface-raised-base-hover hover:shadow-md active:scale-[0.985]"
       draggable={true}
       onDragStart={(e) => attachNoteDragData(e, props.note)}
       onClick={props.onClick}
@@ -478,7 +479,7 @@ export function NotePanel() {
             </div>
 
             <Show when={allTags().length > 0}>
-              <div class="mt-2 flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              <div class="notes-tag-bar mt-2 flex items-center gap-1.5 overflow-x-auto">
                 <Show when={selectedTags().size > 0}>
                   <button
                     type="button"

--- a/packages/app/src/context/workspace.tsx
+++ b/packages/app/src/context/workspace.tsx
@@ -52,7 +52,9 @@ export const { use: useWorkspace, provider: WorkspaceProvider } = createSimpleCo
           ws().setActive(toolId)
           ws().open()
         } else if (ws().active() === toolId) {
-          ws().setActive(null)
+          // Keep the active tool set so the panel content (e.g. NotePanel
+          // expanded sections, scroll position) survives close/reopen.
+          // Only close the drawer; clearing active would remount the tool.
           ws().close()
         } else {
           ws().setActive(toolId)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -826,18 +826,11 @@ function SessionPageContent() {
 
           <div
             class="@container relative min-w-0 flex flex-col min-h-0 h-full bg-background-stronger pt-3 pb-0 md:py-3"
-            data-compact={isDesktop() && workspaceOpen() ? "true" : undefined}
             classList={{
-              "flex-none": isDesktop() && workspaceOpen(),
-              "flex-1": !(isDesktop() && workspaceOpen()),
+              "flex-1": !(isDesktop() && showTabs()),
             }}
             style={{
-              width:
-                isDesktop() && workspaceOpen()
-                  ? `max(${WORKSPACE_SESSION_MIN_WIDTH}px, calc(100% - ${workspace().width()}px))`
-                  : isDesktop() && showTabs()
-                    ? `${layout.session.width()}px`
-                    : undefined,
+              width: isDesktop() && showTabs() ? `${layout.session.width()}px` : undefined,
               "min-width": isDesktop() && workspaceOpen() ? `${WORKSPACE_SESSION_MIN_WIDTH}px` : undefined,
               "--prompt-height": store.promptHeight ? `${store.promptHeight}px` : undefined,
             }}


### PR DESCRIPTION
## Summary

Fixes several notes panel interaction issues surfaced during review of the workspace dock redesign.

### Problems fixed

1. **Session width snap on drawer open/close** — When the workspace drawer opened/closed, its width animates over 300ms via CSS transition, but the session content snapped to its final width instantly (`flex-none` + `width: calc(100% - drawerWidth)`), creating a visible gap on open and overlap on close during the transition. Switched the session container to `flex-1` so it naturally tracks the drawer's animated width frame-by-frame. *(session.tsx)*

2. **Note card hover too stiff** — NoteCard and MiniNoteCard used Tailwind's `transition-all` (150ms, `cubic-bezier(0.4,0,0.2,1)`), fast and mechanical, inconsistent with the project's motion tokens. Moved the hover transition to scoped `.note-card` / `.mini-note-card` classes in a new `note-panel.css`, animating only transform, box-shadow, border-color, and background-color with `--motion-duration-base` (180ms) and `--motion-ease-standard`. Honors `prefers-reduced-motion`. *(note-panel.tsx, note-panel.css)*

3. **Tag filter bar scrollbar hidden** — The tag filter bar above the notes list scrolled horizontally when there were many tags, but its scrollbar was hidden (`scrollbar-width:none` / `::-webkit-scrollbar:hidden`), so users couldn't discover or grab the scroll affordance. Added a `.notes-tag-bar` class with a thin 4px horizontal thumb. *(note-panel.tsx, note-panel.css)*

4. **Tool state lost on panel close/reopen** — Toggling the active tool to close the panel also cleared the active tool id, which unmounted the tool component (e.g. NotePanel). Reopening remounted it fresh, resetting ephemeral state like expanded scope sections and scroll position. Now `toggle` only closes the drawer and keeps the active tool set, so `<Dynamic>` does not remount. Escape / drag-collapse already went through `closePanel()` which never cleared active, so only the toggle path had this bug. *(workspace.tsx)*

## Test

- [x] `tsgo -b` typecheck passes
- [x] `prettier --check` passes on all changed files
- [x] Manual: open/close workspace drawer — session width animates smoothly with no gap/overlap
- [x] Manual: hover a note card — smooth lift/shadow transition
- [x] Manual: with many tags — tag filter bar shows a thin horizontal scrollbar
- [x] Manual: expand a scope section, close panel, reopen — expanded state preserved