### PR TITLE
Optimize prompt cache boundary handling

### DIFF
--- a/packages/synergy/src/provider/transform.ts
+++ b/packages/synergy/src/provider/transform.ts
@@ -22,6 +22,10 @@ export namespace ProviderTransform {
     tool?: string
   }
 
+  interface MessageOptions {
+    systemCacheBreakpoint?: number
+  }
+
   export function sanitizeSurrogates(content: string) {
     return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
   }
@@ -177,9 +181,16 @@ export namespace ProviderTransform {
     return msgs
   }
 
-  function applyCaching(msgs: ModelMessage[], providerID: string): ModelMessage[] {
-    const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
-    const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
+  function applyCaching(msgs: ModelMessage[], providerID: string, options?: MessageOptions): ModelMessage[] {
+    const selected: ModelMessage[] =
+      options?.systemCacheBreakpoint === undefined
+        ? [
+            ...msgs.filter((msg) => msg.role === "system").slice(0, 2),
+            ...msgs.filter((msg) => msg.role !== "system").slice(-2),
+          ]
+        : [msgs.filter((msg) => msg.role === "system")[options.systemCacheBreakpoint]].filter(
+            (msg) => msg !== undefined,
+          )
 
     const providerOptions = {
       anthropic: {
@@ -196,7 +207,7 @@ export namespace ProviderTransform {
       },
     }
 
-    for (const msg of unique([...system, ...final])) {
+    for (const msg of unique(selected)) {
       const shouldUseContentOptions = providerID !== "anthropic" && Array.isArray(msg.content) && msg.content.length > 0
 
       if (shouldUseContentOptions) {
@@ -313,7 +324,7 @@ export namespace ProviderTransform {
     }
   }
 
-  export function message(msgs: ModelMessage[], model: Provider.Model) {
+  export function message(msgs: ModelMessage[], model: Provider.Model, options?: MessageOptions) {
     msgs = unsupportedParts(msgs, model)
     msgs = normalizeMessages(msgs, model)
     if (
@@ -322,7 +333,7 @@ export namespace ProviderTransform {
       model.api.id.includes("claude") ||
       model.api.npm === "@ai-sdk/anthropic"
     ) {
-      msgs = applyCaching(msgs, model.providerID)
+      msgs = applyCaching(msgs, model.providerID, options)
     }
 
     return msgs

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -583,15 +583,27 @@ export namespace Session {
       metadata: z.custom<ProviderMetadata>().optional(),
     }),
     (input) => {
-      const cachedInputTokens = input.usage.cachedInputTokens ?? 0
+      const providerCacheHitTokens = providerMetadataNumber(input.metadata, [
+        ["deepseek", "prompt_cache_hit_tokens"],
+        ["openaiCompatible", "prompt_cache_hit_tokens"],
+        ["openai-compatible", "prompt_cache_hit_tokens"],
+        ["openai", "prompt_cache_hit_tokens"],
+      ])
+      const providerCacheMissTokens = providerMetadataNumber(input.metadata, [
+        ["deepseek", "prompt_cache_miss_tokens"],
+        ["openaiCompatible", "prompt_cache_miss_tokens"],
+        ["openai-compatible", "prompt_cache_miss_tokens"],
+        ["openai", "prompt_cache_miss_tokens"],
+      ])
+      const cachedInputTokens = input.usage.cachedInputTokens ?? providerCacheHitTokens ?? 0
       const excludesCachedTokens = !!(input.metadata?.["anthropic"] || input.metadata?.["bedrock"])
-      const adjustedInputTokens = excludesCachedTokens
-        ? (input.usage.inputTokens ?? 0)
-        : (input.usage.inputTokens ?? 0) - cachedInputTokens
       const safe = (value: number) => {
         if (!Number.isFinite(value)) return 0
         return value
       }
+      const adjustedInputTokens =
+        providerCacheMissTokens ??
+        (excludesCachedTokens ? (input.usage.inputTokens ?? 0) : (input.usage.inputTokens ?? 0) - cachedInputTokens)
 
       const tokens = {
         input: safe(adjustedInputTokens),
@@ -626,6 +638,21 @@ export namespace Session {
       }
     },
   )
+
+  function providerMetadataNumber(metadata: ProviderMetadata | undefined, paths: string[][]): number | undefined {
+    for (const path of paths) {
+      let current: unknown = metadata
+      for (const segment of path) {
+        if (!current || typeof current !== "object") {
+          current = undefined
+          break
+        }
+        current = (current as Record<string, unknown>)[segment]
+      }
+      if (typeof current === "number" && Number.isFinite(current)) return current
+    }
+    return undefined
+  }
 
   export async function findForEndpoint(endpoint: SessionEndpoint.Info) {
     return SessionManager.getSession(endpoint)

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -473,9 +473,11 @@ export namespace SessionInvoke {
         // Layered system prompt assembly: stable → semi-stable → dynamic
         // This ordering maximizes prompt caching by keeping static content first.
         const systemParts: string[] = []
+        let systemCacheBreakpoint: number | undefined
 
         // Layer 1: Static — AGENTS.md instructions (stable within session)
         systemParts.push(...customParts)
+        if (systemParts.length > 0) systemCacheBreakpoint = systemParts.length - 1
 
         // Layer 1.5: Semi-static — permission context (stable per session)
         try {
@@ -496,6 +498,7 @@ export namespace SessionInvoke {
           if (resolved.valid) {
             const ctx = buildPermissionContext(resolved, workspace)
             systemParts.push(ctx)
+            systemCacheBreakpoint = systemParts.length - 1
           }
         } catch {
           // Profile resolution failure is non-fatal — skip permission context
@@ -585,6 +588,7 @@ export namespace SessionInvoke {
         const promptPlan = await PromptBudgeter.buildPlan({
           model,
           system: systemParts,
+          systemCacheBreakpoint,
           messages: preparedMessages,
           toolDefinitions,
         })
@@ -647,6 +651,7 @@ export namespace SessionInvoke {
           abort: combinedAbort,
           sessionID,
           system: promptPlan.system,
+          systemCacheBreakpoint: promptPlan.systemCacheBreakpoint,
           messages: promptPlan.messages,
           tools,
           model,

--- a/packages/synergy/src/session/llm.ts
+++ b/packages/synergy/src/session/llm.ts
@@ -106,6 +106,7 @@ export namespace LLM {
     model: Provider.Model
     agent: Agent.Info
     system: string[]
+    systemCacheBreakpoint?: number
     abort: AbortSignal
     messages: ModelMessage[]
     small?: boolean
@@ -134,25 +135,18 @@ export namespace LLM {
     const systemTimer = l.time("system.assembly")
 
     const system: string[] = []
+    const baseSystem = input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)
+    const baseSystemLength = baseSystem.length
 
     // Part 1: Agent prompt (most stable, always first for caching)
     // Kept separate from custom parts so the static agent prompt can be
     // cached independently even when dynamic parts (env block with timestamps)
     // change on each invoke.
-    if (input.agent.prompt) {
-      system.push(input.agent.prompt)
-    } else {
-      system.push(...SystemPrompt.provider(input.model))
-    }
+    system.push(...baseSystem)
 
     // Part 2: All custom system parts from invoke.ts (ordered static → dynamic)
-    const customSystem = [...input.system, ...(input.user.system ? [input.user.system] : [])]
-      .filter((x) => x)
-      .join("\n")
-
-    if (customSystem) {
-      system.push(customSystem)
-    }
+    system.push(...input.system.filter((x) => x))
+    if (input.user.system) system.push(input.user.system)
 
     const original = clone(system)
     await Plugin.trigger("experimental.chat.system.transform", {}, { system })
@@ -269,7 +263,12 @@ export namespace LLM {
             async transformParams(args) {
               if (args.type === "stream") {
                 // @ts-expect-error
-                args.params.prompt = ProviderTransform.message(args.params.prompt, input.model)
+                args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, {
+                  systemCacheBreakpoint:
+                    input.systemCacheBreakpoint === undefined
+                      ? undefined
+                      : baseSystemLength + input.systemCacheBreakpoint,
+                })
               }
               return args.params
             },

--- a/packages/synergy/src/session/prompt-budgeter.ts
+++ b/packages/synergy/src/session/prompt-budgeter.ts
@@ -14,12 +14,14 @@ export namespace PromptBudgeter {
   export interface PromptPlanInput {
     model: Provider.Model
     system: string[]
+    systemCacheBreakpoint?: number
     messages: ModelMessage[]
     toolDefinitions: ToolResolver.Definition[]
   }
 
   export interface PromptPlan {
     system: string[]
+    systemCacheBreakpoint?: number
     messages: ModelMessage[]
     toolDefinitions: ToolResolver.Definition[]
   }
@@ -68,9 +70,16 @@ export namespace PromptBudgeter {
 
     return {
       system: normalizedSystem,
+      systemCacheBreakpoint: normalizeCacheBreakpoint(input.systemCacheBreakpoint, normalizedSystem.length),
       messages: ProviderTransform.message(input.messages, input.model),
       toolDefinitions: input.toolDefinitions,
     }
+  }
+
+  function normalizeCacheBreakpoint(index: number | undefined, length: number): number | undefined {
+    if (index === undefined || length === 0) return undefined
+    if (!Number.isInteger(index) || index < 0) return undefined
+    return Math.min(index, length - 1)
   }
 
   export function budget(

--- a/packages/synergy/test/provider/transform.test.ts
+++ b/packages/synergy/test/provider/transform.test.ts
@@ -75,6 +75,76 @@ describe("ProviderTransform.options - setCacheKey", () => {
   })
 })
 
+describe("ProviderTransform.message - Anthropic cache boundary", () => {
+  const mockModel = {
+    id: "anthropic/claude-3-5-sonnet",
+    providerID: "anthropic",
+    api: {
+      id: "claude-3-5-sonnet-20241022",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: "Claude 3.5 Sonnet",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: {
+      input: 0.003,
+      output: 0.015,
+      cache: { read: 0.0003, write: 0.00375 },
+    },
+    limit: {
+      context: 200000,
+      output: 8192,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("places cache control only on the selected stable system block", () => {
+    const msgs = [
+      { role: "system", content: "agent prompt" },
+      { role: "system", content: "AGENTS.md" },
+      { role: "system", content: "permission context" },
+      { role: "system", content: "dynamic env time" },
+      { role: "user", content: "hello" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, mockModel, { systemCacheBreakpoint: 2 })
+
+    expect(result[0].providerOptions?.anthropic?.cacheControl).toBeUndefined()
+    expect(result[1].providerOptions?.anthropic?.cacheControl).toBeUndefined()
+    expect(result[2].providerOptions?.anthropic?.cacheControl).toEqual({ type: "ephemeral" })
+    expect(result[3].providerOptions?.anthropic?.cacheControl).toBeUndefined()
+    expect(result[4].providerOptions?.anthropic?.cacheControl).toBeUndefined()
+  })
+
+  test("keeps legacy cache markers when no boundary is provided", () => {
+    const msgs = [
+      { role: "system", content: "agent prompt" },
+      { role: "system", content: "custom system" },
+      { role: "system", content: "dynamic env time" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, mockModel)
+
+    expect(result[0].providerOptions?.anthropic?.cacheControl).toEqual({ type: "ephemeral" })
+    expect(result[1].providerOptions?.anthropic?.cacheControl).toEqual({ type: "ephemeral" })
+    expect(result[2].providerOptions?.anthropic?.cacheControl).toBeUndefined()
+    expect(result[3].providerOptions?.anthropic?.cacheControl).toEqual({ type: "ephemeral" })
+    expect(result[4].providerOptions?.anthropic?.cacheControl).toEqual({ type: "ephemeral" })
+  })
+})
+
 describe("ProviderTransform.maxOutputTokens", () => {
   test("returns 32k when modelLimit > 32k", () => {
     const modelLimit = 100000

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -94,6 +94,27 @@ describe("session.getUsage", () => {
     expect(result.tokens.cache.read).toBe(200)
   })
 
+  test("extracts DeepSeek prompt cache metadata", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+      },
+      metadata: {
+        openaiCompatible: {
+          prompt_cache_hit_tokens: 256,
+          prompt_cache_miss_tokens: 744,
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(744)
+    expect(result.tokens.cache.read).toBe(256)
+  })
+
   test("handles anthropic cache write metadata", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const result = Session.getUsage({


### PR DESCRIPTION
## Summary
- preserve stable system prompt blocks through prompt budgeting and LLM streaming
- add an explicit stable system cache breakpoint for Anthropic cache control
- record DeepSeek/OpenAI-compatible prompt cache hit/miss metadata in usage accounting

## Tests
- bun test test/provider/transform.test.ts test/session/compaction.test.ts
- git diff --check

## Notes
- bun run --cwd packages/synergy typecheck currently fails on an unrelated existing issue: src/browser/install.ts(119): unused @ts-expect-error directive.