### PR TITLE
Render artifacts and add local diagnostics

### DIFF
--- a/packages/app/src/components/diagnostics-panel.tsx
+++ b/packages/app/src/components/diagnostics-panel.tsx
@@ -1,0 +1,243 @@
+import { createResource, For, Show } from "solid-js"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { Panel } from "@/components/panel"
+import { useGlobalSDK } from "@/context/global-sdk"
+
+type DiagnosticsSummary = {
+  generatedAt?: string
+  logs?: {
+    dev?: string
+    daemon?: string
+    devArchives?: string[]
+  }
+  traces?: {
+    directory?: string
+    files?: string[]
+    recentErrors?: unknown[]
+  }
+  lock?: {
+    lock?: { pid?: number; mode?: string; cwd?: string }
+    inspection?: {
+      alive?: boolean
+      healthy?: boolean
+      ppid?: number
+      cpu?: number
+      elapsed?: string
+      listeningPorts?: number[]
+      command?: string
+    }
+  }
+  processes?: {
+    active?: unknown[]
+    finished?: unknown[]
+  }
+  sessions?: {
+    pendingReply?: Array<{ sessionID?: string; updated?: number }>
+  }
+}
+
+export function DiagnosticsPanel() {
+  const globalSDK = useGlobalSDK()
+  const [summary, { refetch }] = createResource(async () => {
+    const result = await globalSDK.client.observability.diagnostics.summary()
+    return result.data as DiagnosticsSummary
+  })
+
+  return (
+    <Panel.Root>
+      <Panel.Header>
+        <Panel.HeaderRow>
+          <Panel.Title>Diagnostics</Panel.Title>
+          <Panel.Actions>
+            <Panel.Action icon="refresh-ccw" title="Refresh" onClick={() => refetch()} />
+          </Panel.Actions>
+        </Panel.HeaderRow>
+      </Panel.Header>
+
+      <Show when={!summary.loading} fallback={<Panel.Loading />}>
+        <Panel.Body>
+          <div class="flex flex-col gap-3">
+            <SummaryGrid summary={summary()} />
+            <RuntimeLock summary={summary()} />
+            <RecentErrors summary={summary()} />
+            <PendingSessions summary={summary()} />
+            <Paths summary={summary()} />
+          </div>
+        </Panel.Body>
+      </Show>
+    </Panel.Root>
+  )
+}
+
+function SummaryGrid(props: { summary?: DiagnosticsSummary }) {
+  const errors = () => props.summary?.traces?.recentErrors?.length ?? 0
+  const pending = () => props.summary?.sessions?.pendingReply?.length ?? 0
+  const active = () => props.summary?.processes?.active?.length ?? 0
+  const traces = () => props.summary?.traces?.files?.length ?? 0
+  return (
+    <div class="grid grid-cols-2 gap-2">
+      <Metric label="Errors" value={errors()} tone={errors() > 0 ? "warning" : "default"} />
+      <Metric label="Pending" value={pending()} tone={pending() > 0 ? "warning" : "default"} />
+      <Metric label="Processes" value={active()} tone={active() > 0 ? "active" : "default"} />
+      <Metric label="Trace files" value={traces()} />
+    </div>
+  )
+}
+
+function Metric(props: { label: string; value: number; tone?: "default" | "warning" | "active" }) {
+  return (
+    <div class="rounded-lg border border-border-weaker-base bg-surface-raised-base p-3">
+      <div
+        classList={{
+          "text-20-medium": true,
+          "text-text-strong": !props.tone || props.tone === "default",
+          "text-icon-warning-base": props.tone === "warning",
+          "text-icon-accent-base": props.tone === "active",
+        }}
+      >
+        {props.value}
+      </div>
+      <div class="text-11-regular text-text-weaker mt-0.5">{props.label}</div>
+    </div>
+  )
+}
+
+function RuntimeLock(props: { summary?: DiagnosticsSummary }) {
+  const lock = () => props.summary?.lock?.lock
+  const inspection = () => props.summary?.lock?.inspection
+  return (
+    <Section title="Runtime Lock" icon="server">
+      <Show
+        when={lock()}
+        fallback={<div class="text-12-regular text-text-weaker px-0.5 py-1">No runtime lock present</div>}
+      >
+        {(item) => (
+          <div class="flex flex-col gap-2 text-12-regular">
+            <Row label="PID" value={String(item().pid ?? "-")} />
+            <Row label="Mode" value={item().mode ?? "-"} />
+            <Row label="Alive" value={String(inspection()?.alive ?? "unknown")} />
+            <Row label="Healthy" value={String(inspection()?.healthy ?? "unknown")} />
+            <Row label="CPU" value={inspection()?.cpu === undefined ? "-" : `${inspection()!.cpu}%`} />
+            <Show when={inspection()?.listeningPorts?.length}>
+              <Row label="Ports" value={inspection()!.listeningPorts!.join(", ")} />
+            </Show>
+            <Show when={item().cwd}>
+              <PathLine value={item().cwd!} />
+            </Show>
+          </div>
+        )}
+      </Show>
+    </Section>
+  )
+}
+
+function RecentErrors(props: { summary?: DiagnosticsSummary }) {
+  const errors = () => props.summary?.traces?.recentErrors ?? []
+  return (
+    <Section title="Recent Errors" icon="shield-alert">
+      <Show when={errors().length > 0} fallback={<div class="text-12-regular text-text-weaker">No recent errors</div>}>
+        <div class="flex flex-col gap-2">
+          <For each={errors().slice(0, 5)}>
+            {(event) => {
+              const item = event as { iso?: string; type?: string; sessionID?: string; callID?: string }
+              return (
+                <div class="rounded-lg bg-surface-inset-base/60 p-2.5">
+                  <div class="text-12-medium text-text-strong truncate">{item.type ?? "error"}</div>
+                  <div class="text-11-regular text-text-weaker truncate">{item.iso ?? ""}</div>
+                  <Show when={item.sessionID || item.callID}>
+                    <div class="text-11-regular text-text-weaker truncate">
+                      {[item.sessionID, item.callID].filter(Boolean).join(" / ")}
+                    </div>
+                  </Show>
+                </div>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
+    </Section>
+  )
+}
+
+function PendingSessions(props: { summary?: DiagnosticsSummary }) {
+  const sessions = () => props.summary?.sessions?.pendingReply ?? []
+  return (
+    <Section title="Pending Sessions" icon="clock">
+      <Show
+        when={sessions().length > 0}
+        fallback={<div class="text-12-regular text-text-weaker">No pending replies</div>}
+      >
+        <div class="flex flex-col gap-2">
+          <For each={sessions().slice(0, 5)}>
+            {(session) => (
+              <div class="flex items-center gap-2 rounded-lg bg-surface-inset-base/60 p-2.5">
+                <Icon name="message-square" size="small" class="text-icon-weak shrink-0" />
+                <div class="min-w-0 flex-1">
+                  <div class="text-12-medium text-text-strong truncate">{session.sessionID ?? "session"}</div>
+                  <div class="text-11-regular text-text-weaker">{formatTime(session.updated)}</div>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </Section>
+  )
+}
+
+function Paths(props: { summary?: DiagnosticsSummary }) {
+  return (
+    <Section title="Files" icon="file-text">
+      <div class="flex flex-col gap-2">
+        <Show when={props.summary?.logs?.dev}>
+          <PathLine label="Dev log" value={props.summary!.logs!.dev!} />
+        </Show>
+        <Show when={props.summary?.logs?.daemon}>
+          <PathLine label="Daemon log" value={props.summary!.logs!.daemon!} />
+        </Show>
+        <Show when={props.summary?.traces?.directory}>
+          <PathLine label="Trace dir" value={props.summary!.traces!.directory!} />
+        </Show>
+      </div>
+    </Section>
+  )
+}
+
+function Section(props: { title: string; icon: string; children: any }) {
+  return (
+    <div class="rounded-lg border border-border-weaker-base bg-surface-base p-3.5">
+      <div class="flex items-center gap-2 mb-3">
+        <Icon name={props.icon as any} size="small" class="text-icon-weak" />
+        <span class="text-12-medium text-text-strong">{props.title}</span>
+      </div>
+      {props.children}
+    </div>
+  )
+}
+
+function Row(props: { label: string; value: string }) {
+  return (
+    <div class="flex items-center justify-between gap-3">
+      <span class="text-text-weaker">{props.label}</span>
+      <span class="text-text-base truncate">{props.value}</span>
+    </div>
+  )
+}
+
+function PathLine(props: { label?: string; value: string }) {
+  return (
+    <div class="min-w-0">
+      <Show when={props.label}>
+        <div class="text-11-medium text-text-weaker mb-1">{props.label}</div>
+      </Show>
+      <div class="rounded-md bg-surface-inset-base/70 px-2 py-1.5 text-11-regular text-text-weak break-all">
+        {props.value}
+      </div>
+    </div>
+  )
+}
+
+function formatTime(value?: number) {
+  if (!value) return "-"
+  return new Date(value).toLocaleString()
+}

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -423,6 +423,21 @@ export function Sidebar(props: SidebarProps) {
             </Show>
           </button>
         </Tooltip>
+        <Tooltip value="Diagnostics" placement="right">
+          <button
+            type="button"
+            classList={{
+              "sb-global-btn": true,
+              "sb-global-active": panel.active() === "diagnostics",
+            }}
+            onClick={() => panel.toggle("diagnostics")}
+          >
+            <Icon name="stethoscope" size="normal" />
+            <Show when={isExpanded()}>
+              <span class="sb-action-label">Diagnostics</span>
+            </Show>
+          </button>
+        </Tooltip>
       </div>
       <Tooltip value="Plugins" placement="right">
         <button

--- a/packages/app/src/context/panel.tsx
+++ b/packages/app/src/context/panel.tsx
@@ -9,11 +9,21 @@ export interface PanelDef {
   icon: IconName
 }
 
-export const PANELS: PanelDef[] = listGlobalPanels().map((p) => ({
-  id: p.id,
-  label: p.label,
-  icon: p.icon as IconName,
-}))
+const BUILTIN_PANELS: PanelDef[] = [
+  { id: "agenda", label: "Agenda", icon: "clock" },
+  { id: "engram", label: "Library", icon: "book-open" },
+  { id: "lucid", label: "Lucid", icon: "sparkles" },
+  { id: "diagnostics", label: "Diagnostics", icon: "stethoscope" },
+]
+
+export const PANELS: PanelDef[] = [
+  ...BUILTIN_PANELS,
+  ...listGlobalPanels().map((p) => ({
+    id: p.id,
+    label: p.label,
+    icon: p.icon as IconName,
+  })),
+]
 
 export const { use: usePanel, provider: PanelProvider } = createSimpleContext({
   name: "Panel",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -30,6 +30,7 @@ import { EngramPanel } from "@/components/engram"
 import { AgendaPanel } from "@/components/agenda"
 
 import { LucidPanel } from "@/components/lucid-panel"
+import { DiagnosticsPanel } from "@/components/diagnostics-panel"
 import { ConnectionBanner } from "@/components/connection-banner"
 import { getGlobalPanel } from "@/plugin"
 import { SandboxIframe } from "@/plugin/sandbox"
@@ -472,6 +473,9 @@ function GlobalPanelSwitch() {
       </Match>
       <Match when={panel.active() === "lucid"}>
         <LucidPanel />
+      </Match>
+      <Match when={panel.active() === "diagnostics"}>
+        <DiagnosticsPanel />
       </Match>
       <Match when={panel.hasSlot(panel.active()!)}>{panel.slot(panel.active()!)}</Match>
       <Match when={!!getGlobalPanel(panel.active()!)}>

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -256,6 +256,7 @@ import type {
   NoteRemoveResponses,
   NoteUpdateErrors,
   NoteUpdateResponses,
+  ObservabilityDiagnosticsSummaryResponses,
   Part as Part2,
   PartDeleteErrors,
   PartDeleteResponses,
@@ -2226,6 +2227,24 @@ export class Global extends HeyApiClient {
   session = new Session({ client: this.client })
 
   nav = new Nav({ client: this.client })
+}
+
+export class Diagnostics extends HeyApiClient {
+  /**
+   * Get local diagnostics summary
+   *
+   * Get a readonly local diagnostics summary for the Synergy server.
+   */
+  public summary<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<ObservabilityDiagnosticsSummaryResponses, unknown, ThrowOnError>({
+      url: "/global/diagnostics",
+      ...options,
+    })
+  }
+}
+
+export class Observability extends HeyApiClient {
+  diagnostics = new Diagnostics({ client: this.client })
 }
 
 export class Credentials extends HeyApiClient {
@@ -8284,6 +8303,8 @@ export class SynergyClient extends HeyApiClient {
   }
 
   global = new Global({ client: this.client })
+
+  observability = new Observability({ client: this.client })
 
   holos = new Holos({ client: this.client })
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -160,6 +160,10 @@ export type StatsSnapshot = {
   watermark: number
 }
 
+export type DiagnosticsSummary = {
+  [key: string]: unknown
+}
+
 export type HolosLoginResponse = {
   url: string
 }
@@ -1720,6 +1724,28 @@ export type SandboxConfig = {
 }
 
 /**
+ * Local logs, traces, and diagnostics settings
+ */
+export type ObservabilityConfig = {
+  /**
+   * Enable local observability trace JSONL events (default: true)
+   */
+  enabled?: boolean
+  /**
+   * Days to retain local trace files (default: 7)
+   */
+  retentionDays?: number
+  /**
+   * Maximum total trace storage in bytes (default: 250MB)
+   */
+  maxBytes?: number
+  /**
+   * Milliseconds without tool activity before emitting a stalled-tool trace event
+   */
+  stalledToolMs?: number
+}
+
+/**
  * Holos platform configuration
  */
 export type HolosConfig = {
@@ -2010,6 +2036,7 @@ export type Config = {
     [key: string]: ChannelFeishuConfig
   }
   sandbox?: SandboxConfig
+  observability?: ObservabilityConfig
   controlProfile?: ControlProfileId
   holos?: HolosConfig
   email?: EmailConfig
@@ -5187,6 +5214,23 @@ export type GlobalStatsProgressResponses = {
 }
 
 export type GlobalStatsProgressResponse = GlobalStatsProgressResponses[keyof GlobalStatsProgressResponses]
+
+export type ObservabilityDiagnosticsSummaryData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/diagnostics"
+}
+
+export type ObservabilityDiagnosticsSummaryResponses = {
+  /**
+   * Diagnostics summary
+   */
+  200: DiagnosticsSummary
+}
+
+export type ObservabilityDiagnosticsSummaryResponse =
+  ObservabilityDiagnosticsSummaryResponses[keyof ObservabilityDiagnosticsSummaryResponses]
 
 export type GlobalDisposeData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -789,6 +789,31 @@
         ]
       }
     },
+    "/global/diagnostics": {
+      "get": {
+        "operationId": "observability.diagnostics.summary",
+        "summary": "Get local diagnostics summary",
+        "description": "Get a readonly local diagnostics summary for the Synergy server.",
+        "responses": {
+          "200": {
+            "description": "Diagnostics summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiagnosticsSummary"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createSynergyClient } from \"@ericsanchezok/synergy-sdk\"\n\nconst client = createSynergyClient()\nawait client.observability.diagnostics.summary({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/global/dispose": {
       "post": {
         "operationId": "global.dispose",
@@ -15992,6 +16017,13 @@
           "watermark"
         ]
       },
+      "DiagnosticsSummary": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string"
+        },
+        "additionalProperties": {}
+      },
       "HolosLoginResponse": {
         "type": "object",
         "properties": {
@@ -18515,6 +18547,35 @@
         },
         "additionalProperties": false
       },
+      "ObservabilityConfig": {
+        "description": "Local logs, traces, and diagnostics settings",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "description": "Enable local observability trace JSONL events (default: true)",
+            "type": "boolean"
+          },
+          "retentionDays": {
+            "description": "Days to retain local trace files (default: 7)",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "maxBytes": {
+            "description": "Maximum total trace storage in bytes (default: 250MB)",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "stalledToolMs": {
+            "description": "Milliseconds without tool activity before emitting a stalled-tool trace event",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "additionalProperties": false
+      },
       "HolosConfig": {
         "description": "Holos platform configuration",
         "type": "object",
@@ -18966,6 +19027,9 @@
           },
           "sandbox": {
             "$ref": "#/components/schemas/SandboxConfig"
+          },
+          "observability": {
+            "$ref": "#/components/schemas/ObservabilityConfig"
           },
           "controlProfile": {
             "$ref": "#/components/schemas/ControlProfileId"

--- a/packages/synergy/src/cli/cmd/diagnostics.ts
+++ b/packages/synergy/src/cli/cmd/diagnostics.ts
@@ -1,0 +1,52 @@
+import { cmd } from "./cmd"
+import { Diagnostics } from "@/observability/diagnostics"
+import { UI } from "../ui"
+
+export const DiagnosticsCommand = cmd({
+  command: "diagnostics",
+  describe: "create a local diagnostics package",
+  builder: (yargs) =>
+    yargs
+      .option("session", {
+        type: "string",
+        describe: "include trace events for a specific session",
+      })
+      .option("since", {
+        type: "string",
+        describe: "include trace events since a duration like 30m, 2h, or 7d",
+      })
+      .option("output", {
+        alias: "o",
+        type: "string",
+        describe: "path for the generated .tar.gz package",
+      }),
+  handler: async (args) => {
+    const sinceMs = args.since ? parseDuration(args.since) : undefined
+    if (args.since && sinceMs === undefined) {
+      UI.error(`Invalid --since duration: ${args.since}`)
+      process.exitCode = 1
+      return
+    }
+
+    const result = await Diagnostics.createPackage({
+      sessionID: args.session,
+      sinceMs,
+      output: args.output,
+    })
+
+    UI.println(`Diagnostics package: ${result.output}`)
+    UI.println(`  Trace files: ${result.summary.traces.files.length}`)
+    UI.println(`  Recent errors: ${result.summary.traces.recentErrors.length}`)
+    UI.println(`  Pending sessions: ${result.summary.sessions.pendingReply.length}`)
+    UI.println(`  Active processes: ${result.summary.processes.active.length}`)
+  },
+})
+
+function parseDuration(input: string) {
+  const match = input.trim().match(/^(\d+)(ms|s|m|h|d)?$/)
+  if (!match) return undefined
+  const value = Number(match[1])
+  const unit = match[2] ?? "ms"
+  const scale = unit === "ms" ? 1 : unit === "s" ? 1000 : unit === "m" ? 60_000 : unit === "h" ? 3_600_000 : 86_400_000
+  return Date.now() - value * scale
+}

--- a/packages/synergy/src/cli/cmd/logs.ts
+++ b/packages/synergy/src/cli/cmd/logs.ts
@@ -6,6 +6,8 @@ import { DaemonLogRotate } from "../../daemon/log-rotate"
 import { UI } from "../ui"
 import fs from "fs/promises"
 import path from "path"
+import { Log } from "../../util/log"
+import { Observability } from "../../observability"
 
 export const LogsCommand = cmd({
   command: "logs",
@@ -39,11 +41,81 @@ export const LogsCommand = cmd({
       .option("archive", {
         type: "number",
         describe: "read a specific archive by index (0 = most recent)",
+      })
+      .option("dev", {
+        type: "boolean",
+        default: false,
+        describe: "read the local development log instead of daemon logs",
+      })
+      .option("trace-id", {
+        type: "string",
+        describe: "filter observability events by trace id",
+      })
+      .option("session", {
+        type: "string",
+        describe: "filter observability events by session id",
+      })
+      .option("tool-call", {
+        type: "string",
+        describe: "filter observability events by tool call id",
+      })
+      .option("since", {
+        type: "string",
+        describe: "filter observability events since a duration like 30m, 2h, or 7d",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "print observability events as JSON",
       }),
   handler: async (args) => {
     if (args.tail <= 0 || !Number.isInteger(args.tail)) {
       UI.println(`error: --tail must be a positive integer, got ${args.tail}`)
       process.exit(1)
+    }
+
+    const wantsTrace =
+      Boolean(args.traceId) || Boolean(args.session) || Boolean(args.toolCall) || Boolean(args.since) || args.json
+    if (wantsTrace) {
+      const since = args.since ? parseSince(args.since) : undefined
+      if (args.since && since === undefined) {
+        UI.println(`error: invalid --since duration: ${args.since}`)
+        process.exit(1)
+      }
+      const events = await Observability.query({
+        traceId: args.traceId,
+        sessionID: args.session,
+        callID: args.toolCall,
+        since,
+        limit: args.tail,
+      })
+      if (args.json) {
+        for (const event of events.reverse()) process.stdout.write(JSON.stringify(event) + "\n")
+        return
+      }
+      if (events.length === 0) {
+        UI.println("(no trace events found)")
+        return
+      }
+      for (const event of events.reverse()) {
+        const pieces = [
+          event.iso,
+          event.level ? event.level.toUpperCase() : "INFO",
+          event.type,
+          event.traceId ? `trace=${event.traceId}` : undefined,
+          event.sessionID ? `session=${event.sessionID}` : undefined,
+          event.callID ? `call=${event.callID}` : undefined,
+          event.tool ? `tool=${event.tool}` : undefined,
+        ].filter(Boolean)
+        UI.println(pieces.join(" "))
+        if (event.data) UI.println("  " + JSON.stringify(event.data))
+      }
+      return
+    }
+
+    if (args.dev) {
+      await printDevLog(args)
+      return
     }
 
     const status = await Daemon.status()
@@ -111,6 +183,67 @@ export const LogsCommand = cmd({
   },
 })
 
+async function printDevLog(args: {
+  tail: number
+  follow?: boolean
+  level?: string
+  service?: string
+  grep?: string
+  archive?: number
+}) {
+  const filePath = Log.devFile()
+  UI.println(`Dev log: ${UI.Style.TEXT_DIM}${filePath}${UI.Style.TEXT_NORMAL}`)
+  const filter = buildFilter(args.level, args.service, args.grep)
+
+  if (args.archive !== undefined) {
+    const archives = await Log.listDevArchives()
+    if (archives.length === 0) {
+      UI.println("no dev log archives found")
+      return
+    }
+    if (args.archive < 0 || args.archive >= archives.length) {
+      UI.println(`error: archive index must be 0-${archives.length - 1}, got ${args.archive}`)
+      process.exit(1)
+    }
+    const content = await DaemonLogTail.tailFile(archives[args.archive], args.tail)
+    if (!content) UI.println("(archive is empty)")
+    else process.stdout.write(applyFilter(content, filter) + "\n")
+    return
+  }
+
+  const exists = await fs.stat(filePath).catch(() => null)
+  if (!exists) {
+    UI.println(`log file not found: ${filePath}`)
+    return
+  }
+
+  if (args.follow) {
+    await DaemonLogTail.followFile(filePath, args.tail, (chunk) => {
+      if (filter) {
+        const filtered = applyFilter(chunk.replace(/\n$/, ""), filter)
+        if (filtered) process.stdout.write(filtered + "\n")
+      } else {
+        process.stdout.write(chunk)
+      }
+    })
+    return
+  }
+
+  const content = await DaemonLogTail.tailFile(filePath, args.tail)
+  if (!content) UI.println("(no log output yet)")
+  else process.stdout.write(applyFilter(content, filter) + "\n")
+
+  const archives = await Log.listDevArchives()
+  if (archives.length > 0) {
+    UI.println()
+    UI.println(
+      `  ${archives.length} dev log archive(s) in ${UI.Style.TEXT_DIM}${path.dirname(archives[0])}${UI.Style.TEXT_NORMAL}`,
+    )
+    for (const archive of archives)
+      UI.println(`    ${UI.Style.TEXT_DIM}${path.basename(archive)}${UI.Style.TEXT_NORMAL}`)
+  }
+}
+
 function buildFilter(level?: string, service?: string, grep?: string): ((line: string) => boolean) | null {
   const filters: ((line: string) => boolean)[] = []
   if (level) {
@@ -132,4 +265,13 @@ function buildFilter(level?: string, service?: string, grep?: string): ((line: s
 function applyFilter(content: string, filter: ((line: string) => boolean) | null): string {
   if (!filter) return content
   return content.split("\n").filter(filter).join("\n")
+}
+
+function parseSince(input: string) {
+  const match = input.trim().match(/^(\d+)(ms|s|m|h|d)?$/)
+  if (!match) return undefined
+  const value = Number(match[1])
+  const unit = match[2] ?? "ms"
+  const scale = unit === "ms" ? 1 : unit === "s" ? 1000 : unit === "m" ? 60_000 : unit === "h" ? 3_600_000 : 86_400_000
+  return Date.now() - value * scale
 }

--- a/packages/synergy/src/cli/cmd/server.ts
+++ b/packages/synergy/src/cli/cmd/server.ts
@@ -5,6 +5,8 @@ import { UI } from "../ui"
 import { FormatError, FormatUnknownError } from "../error"
 import { Log } from "../../util/log"
 import { ServerProcessLock } from "../../daemon/server-process-lock"
+import { Server } from "../../server/server"
+import type { RuntimeOptions } from "../../server/runtime"
 
 export const ServerCommand = cmd({
   command: ["$0", "server"],
@@ -27,8 +29,9 @@ export const ServerCommand = cmd({
       }),
   describe: "start synergy server",
   handler: async (args) => {
+    let network: RuntimeOptions["network"] | undefined
     try {
-      const network = await resolveNetworkOptions(args)
+      network = await resolveNetworkOptions(args)
       const managedService = args.managedService
 
       await runServerRuntime({
@@ -50,15 +53,31 @@ export const ServerCommand = cmd({
       })
 
       if (error instanceof ServerProcessLock.AlreadyRunningError) {
+        const healthUrl = displayUrl(network?.hostname ?? Server.DEFAULT_HOST, network?.port ?? Server.DEFAULT_PORT)
+        const inspection = await ServerProcessLock.inspect(error.lock, { healthUrl }).catch(() => undefined)
         UI.error(`Another Synergy server process is already running (pid ${error.lock.pid})`)
         UI.println(`  Existing mode: ${error.lock.mode}`)
         UI.println(`  Existing cwd: ${error.lock.cwd}`)
         UI.println(`  Existing command: ${error.lock.command.join(" ")}`)
+        UI.println(`  Lock file: ${ServerProcessLock.path()}`)
+        if (inspection) {
+          UI.println(
+            `  PID state: alive=${inspection.alive} healthy=${inspection.healthy ?? "unknown"} ppid=${inspection.ppid ?? "?"} pgid=${inspection.pgid ?? "?"} cpu=${inspection.cpu ?? "?"}% elapsed=${inspection.elapsed ?? "?"}`,
+          )
+          if (inspection.listeningPorts?.length) {
+            UI.println(`  Listening ports: ${inspection.listeningPorts.join(", ")}`)
+          }
+          if (inspection.command) UI.println(`  Process command: ${inspection.command}`)
+          if (inspection.alive && inspection.healthy === false) {
+            UI.println()
+            UI.println("  The process is alive but did not respond to /global/health.")
+          }
+        }
         UI.println()
         UI.println("  Next:")
         UI.println("    Stop the other server process before running `synergy server`")
         UI.println("    If it is the managed background service, run `synergy stop`")
-        UI.println("    Otherwise kill the process and retry")
+        UI.println(`    Otherwise run: kill ${error.lock.pid}`)
         process.exitCode = 1
         return
       }
@@ -80,3 +99,11 @@ export const ServerCommand = cmd({
     }
   },
 })
+
+function displayUrl(hostname: string, port: number) {
+  const displayHost = hostname === "0.0.0.0" ? "127.0.0.1" : hostname === "::" ? "::1" : hostname
+  const url = new URL("http://127.0.0.1")
+  url.hostname = displayHost
+  url.port = String(port)
+  return url.toString().replace(/\/$/, "")
+}

--- a/packages/synergy/src/cli/cmd/status.ts
+++ b/packages/synergy/src/cli/cmd/status.ts
@@ -1,15 +1,60 @@
 import { cmd } from "./cmd"
 import { Daemon } from "../../daemon"
 import { DaemonOutput } from "../../daemon/output"
+import { ServerProcessLock } from "../../daemon/server-process-lock"
+import { ProcessRegistry } from "../../process/registry"
+import { Observability } from "../../observability"
+import { UI } from "../ui"
 
 export const StatusCommand = cmd({
   command: "status",
   describe: "show synergy background service status",
-  handler: async () => {
+  builder: (yargs) =>
+    yargs.option("verbose", {
+      type: "boolean",
+      default: false,
+      describe: "show lock, health, trace, and local process details",
+    }),
+  handler: async (args) => {
     const status = await Daemon.status()
     DaemonOutput.printStatus(status)
+    if (args.verbose) {
+      await printVerbose(status.url)
+    }
     if (status.runtime === "failed" || status.runtime === "unknown") {
       process.exitCode = 1
     }
   },
 })
+
+async function printVerbose(healthUrl: string) {
+  UI.println()
+  UI.println("Diagnostics")
+  const lock = await ServerProcessLock.read().catch(() => undefined)
+  if (!lock) {
+    UI.println("  Runtime lock: none")
+  } else {
+    UI.println(`  Runtime lock: pid=${lock.pid} mode=${lock.mode} cwd=${lock.cwd}`)
+    const inspection = await ServerProcessLock.inspect(lock, { healthUrl }).catch(() => undefined)
+    if (inspection) {
+      UI.println(
+        `  Process: alive=${inspection.alive} healthy=${inspection.healthy ?? "unknown"} ppid=${inspection.ppid ?? "?"} cpu=${inspection.cpu ?? "?"}% elapsed=${inspection.elapsed ?? "?"}`,
+      )
+      if (inspection.listeningPorts?.length) {
+        UI.println(`  Listening ports: ${inspection.listeningPorts.join(", ")}`)
+      }
+      if (inspection.command) UI.println(`  Command: ${inspection.command}`)
+    }
+  }
+
+  const active = ProcessRegistry.listActive()
+  const finished = ProcessRegistry.listFinished()
+  UI.println(`  Local active processes: ${active.length}`)
+  UI.println(`  Local finished processes: ${finished.length}`)
+
+  const recentErrors = (await Observability.query({ limit: 100 })).filter(
+    (event) => event.level === "error" || event.type.endsWith(".error") || event.type.includes("error"),
+  )
+  UI.println(`  Trace dir: ${Observability.dir()}`)
+  UI.println(`  Recent trace errors: ${recentErrors.length}`)
+}

--- a/packages/synergy/src/config/config.ts
+++ b/packages/synergy/src/config/config.ts
@@ -58,6 +58,8 @@ export namespace Config {
   export type Holos = Schema.Holos
   export const SandboxConfig = Schema.SandboxConfig
   export type SandboxConfig = Schema.SandboxConfig
+  export const ObservabilityConfig = Schema.ObservabilityConfig
+  export type ObservabilityConfig = Schema.ObservabilityConfig
   export const Channel = Schema.Channel
   export type Channel = Schema.Channel
   export const EmailSmtp = Schema.EmailSmtp

--- a/packages/synergy/src/config/domain.ts
+++ b/packages/synergy/src/config/domain.ts
@@ -97,6 +97,7 @@ export namespace ConfigDomain {
       "question",
       "compaction",
       "experimental",
+      "observability",
     ]),
   ] as const satisfies Definition[]
 

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -279,6 +279,22 @@ export const SandboxConfig = z
   .meta({ ref: "SandboxConfig" })
 export type SandboxConfig = z.infer<typeof SandboxConfig>
 
+export const ObservabilityConfig = z
+  .object({
+    enabled: z.boolean().optional().describe("Enable local observability trace JSONL events (default: true)"),
+    retentionDays: z.number().int().positive().optional().describe("Days to retain local trace files (default: 7)"),
+    maxBytes: z.number().int().positive().optional().describe("Maximum total trace storage in bytes (default: 250MB)"),
+    stalledToolMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Milliseconds without tool activity before emitting a stalled-tool trace event"),
+  })
+  .strict()
+  .meta({ ref: "ObservabilityConfig" })
+export type ObservabilityConfig = z.infer<typeof ObservabilityConfig>
+
 export const Channel = z.discriminatedUnion("type", [ChannelFeishu])
 export type Channel = z.infer<typeof Channel>
 
@@ -1251,6 +1267,7 @@ export const Info = z
       .optional()
       .describe("Channel configurations for messaging platform integrations"),
     sandbox: SandboxConfig.optional().describe("Sandbox configuration for workspace boundary enforcement"),
+    observability: ObservabilityConfig.optional().describe("Local logs, traces, and diagnostics settings"),
     controlProfile: ControlProfileId.optional().describe("Default control profile applied to all agents"),
     holos: Holos.optional().describe("Holos platform configuration"),
     email: Email.optional().describe("Outgoing email configuration"),

--- a/packages/synergy/src/daemon/server-process-lock.ts
+++ b/packages/synergy/src/daemon/server-process-lock.ts
@@ -1,5 +1,9 @@
 import fs from "fs/promises"
 import { DaemonPaths } from "./paths"
+import { execFile } from "child_process"
+import { promisify } from "util"
+
+const execFileAsync = promisify(execFile)
 
 export namespace ServerProcessLock {
   export interface LockInfo {
@@ -15,6 +19,22 @@ export namespace ServerProcessLock {
       super(`Another Synergy server process is already running (pid ${lock.pid})`)
       this.name = "AlreadyRunningError"
     }
+  }
+
+  export interface ProcessInspection {
+    alive: boolean
+    pid: number
+    ppid?: number
+    pgid?: number
+    stat?: string
+    cpu?: number
+    memory?: number
+    elapsed?: string
+    command?: string
+    listeningPorts?: number[]
+    healthy?: boolean
+    healthUrl?: string
+    error?: string
   }
 
   export async function acquire() {
@@ -45,17 +65,11 @@ export namespace ServerProcessLock {
       }
     }
 
-    process.once("exit", () => {
-      void release()
-    })
-    process.once("SIGINT", () => {
-      void release()
-    })
-    process.once("SIGTERM", () => {
-      void release()
-    })
-
     return { release }
+  }
+
+  export function path() {
+    return DaemonPaths.runtimeLock()
   }
 
   export async function read(): Promise<LockInfo | undefined> {
@@ -70,6 +84,58 @@ export namespace ServerProcessLock {
       return true
     } catch {
       return false
+    }
+  }
+
+  export async function inspect(lock: LockInfo, input?: { healthUrl?: string }): Promise<ProcessInspection> {
+    if (!(await isPidAlive(lock.pid))) {
+      return { alive: false, pid: lock.pid }
+    }
+    const result: ProcessInspection = { alive: true, pid: lock.pid }
+    if (process.platform !== "win32") {
+      const ps = await execFileAsync("ps", [
+        "-p",
+        String(lock.pid),
+        "-o",
+        "pid=,ppid=,pgid=,stat=,%cpu=,%mem=,etime=,command=",
+      ]).catch((error) => ({ stdout: "", stderr: String(error) }))
+      const line = ps.stdout.trim()
+      if (line) {
+        const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+([\s\S]+)$/)
+        if (match) {
+          result.ppid = Number(match[2])
+          result.pgid = Number(match[3])
+          result.stat = match[4]
+          result.cpu = Number(match[5])
+          result.memory = Number(match[6])
+          result.elapsed = match[7]
+          result.command = match[8]
+        }
+      }
+      const lsof = await execFileAsync("lsof", ["-nP", "-Pan", "-p", String(lock.pid), "-iTCP", "-sTCP:LISTEN"]).catch(
+        () => ({ stdout: "" }),
+      )
+      result.listeningPorts = Array.from(lsof.stdout.matchAll(/TCP [^:]+:(\d+) \(LISTEN\)/g)).map((m) => Number(m[1]))
+    }
+    if (input?.healthUrl) {
+      result.healthUrl = input.healthUrl
+      result.healthy = await health(input.healthUrl)
+    }
+    return result
+  }
+
+  async function health(url: string) {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 1200)
+    try {
+      const res = await fetch(new URL("/global/health", url), { signal: controller.signal })
+      if (!res.ok) return false
+      const payload = (await res.json().catch(() => undefined)) as { healthy?: boolean } | undefined
+      return payload?.healthy === true
+    } catch {
+      return false
+    } finally {
+      clearTimeout(timeout)
     }
   }
 }

--- a/packages/synergy/src/index.ts
+++ b/packages/synergy/src/index.ts
@@ -33,6 +33,7 @@ import { PrepareCommand, BuildCommand } from "./cli/cmd/prepare"
 import { StatusCommand } from "./cli/cmd/status"
 import { LogsCommand } from "./cli/cmd/logs"
 import { DoctorCommand } from "./cli/cmd/doctor"
+import { DiagnosticsCommand } from "./cli/cmd/diagnostics"
 
 import { PluginCommand } from "./cli/cmd/plugin"
 import { DataCommand, MigrateCommand } from "./cli/cmd/data"
@@ -109,7 +110,7 @@ const cli = yargs(hideBin(process.argv))
 
     await Log.init({
       print: process.argv.includes("--print-logs"),
-      dev: Installation.isLocal(),
+      dev: Installation.isLocal() && isServerCommand(),
       level: (() => {
         if (opts.logLevel) return opts.logLevel as Log.Level
         if (process.env.LOG_LEVEL && ["DEBUG", "INFO", "WARN", "ERROR"].includes(process.env.LOG_LEVEL))
@@ -157,6 +158,7 @@ const cli = yargs(hideBin(process.argv))
   .command(BuildCommand)
   .command(StatusCommand)
   .command(LogsCommand)
+  .command(DiagnosticsCommand)
   .command(PluginCommand)
   .command(DataCommand)
   .command(DoctorCommand)
@@ -198,6 +200,10 @@ function isLongRunningCommand() {
     return process.argv.includes("-f") || process.argv.includes("--follow")
   }
   return false
+}
+
+function isServerCommand() {
+  return (firstPositionalArg() ?? "server") === "server"
 }
 
 try {

--- a/packages/synergy/src/observability/diagnostics.ts
+++ b/packages/synergy/src/observability/diagnostics.ts
@@ -1,0 +1,219 @@
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "os"
+import { Log } from "@/util/log"
+import { Global } from "@/global"
+import { DaemonPaths } from "@/daemon/paths"
+import { ServerProcessLock } from "@/daemon/server-process-lock"
+import { ProcessRegistry } from "@/process/registry"
+import { Observability } from "."
+
+export namespace Diagnostics {
+  export interface Summary {
+    generatedAt: string
+    logs: {
+      current?: string
+      dev?: string
+      daemon?: string
+      devArchives: string[]
+    }
+    traces: {
+      directory: string
+      files: string[]
+      recentErrors: Observability.Event[]
+    }
+    lock?: {
+      path: string
+      lock?: ServerProcessLock.LockInfo
+      inspection?: ServerProcessLock.ProcessInspection
+    }
+    processes: {
+      active: Array<ReturnType<typeof summarizeProcess>>
+      finished: Array<ReturnType<typeof summarizeFinishedProcess>>
+    }
+    sessions: {
+      pendingReply: Array<{
+        sessionID: string
+        path: string
+        updated?: number
+      }>
+    }
+  }
+
+  export interface PackageOptions {
+    sessionID?: string
+    sinceMs?: number
+    output?: string
+  }
+
+  export async function summary(): Promise<Summary> {
+    const lock = await ServerProcessLock.read().catch(() => undefined)
+    const inspection = lock
+      ? await ServerProcessLock.inspect(lock, { healthUrl: "http://127.0.0.1:4096" }).catch(() => undefined)
+      : undefined
+    const traceEvents = await Observability.query({ limit: 200 })
+    const recentErrors = traceEvents.filter(
+      (event) => event.level === "error" || event.type.endsWith(".error") || event.type.includes("error"),
+    )
+
+    return {
+      generatedAt: new Date().toISOString(),
+      logs: {
+        current: Log.file(),
+        dev: Log.devFile(),
+        daemon: DaemonPaths.logFile(),
+        devArchives: await Log.listDevArchives().catch(() => []),
+      },
+      traces: {
+        directory: Observability.dir(),
+        files: await Observability.listFiles().catch(() => []),
+        recentErrors: recentErrors.slice(0, 50),
+      },
+      lock: {
+        path: ServerProcessLock.path(),
+        lock,
+        inspection,
+      },
+      processes: {
+        active: ProcessRegistry.listActive().map(summarizeProcess),
+        finished: ProcessRegistry.listFinished().map(summarizeFinishedProcess),
+      },
+      sessions: {
+        pendingReply: await pendingSessions().catch(() => []),
+      },
+    }
+  }
+
+  export async function createPackage(options: PackageOptions = {}) {
+    const stamp = timestamp()
+    const output = path.resolve(options.output ?? path.join(process.cwd(), `synergy-diagnostics-${stamp}.tar.gz`))
+    const tmp = await fs.mkdtemp(path.join(tmpdir(), "synergy-diagnostics-"))
+    const root = path.join(tmp, "bundle")
+    await fs.mkdir(path.join(root, "logs"), { recursive: true })
+    await fs.mkdir(path.join(root, "traces"), { recursive: true })
+
+    const info = await summary()
+    await fs.writeFile(path.join(root, "summary.json"), JSON.stringify(info, null, 2) + "\n")
+
+    const logFiles = [info.logs.current, info.logs.dev, info.logs.daemon, ...info.logs.devArchives].filter(
+      (item): item is string => Boolean(item),
+    )
+    for (const file of unique(logFiles)) {
+      await copyTextFile(file, path.join(root, "logs", path.basename(file)))
+    }
+
+    const traceEvents = await Observability.query({
+      sessionID: options.sessionID,
+      since: options.sinceMs,
+      limit: 5000,
+    })
+    const traceBody = traceEvents.map((event) => JSON.stringify(event)).join("\n")
+    await fs.writeFile(path.join(root, "traces", "filtered.jsonl"), traceBody ? traceBody + "\n" : "")
+
+    for (const file of await Observability.listFiles().catch(() => [])) {
+      await copyTextFile(file, path.join(root, "traces", path.basename(file)))
+    }
+
+    const pluginState = path.join(Global.Path.data, "plugin-runtime-state.json")
+    await copyTextFile(pluginState, path.join(root, "plugin-runtime-state.json")).catch(() => {})
+
+    const lockFile = ServerProcessLock.path()
+    await copyTextFile(lockFile, path.join(root, "runtime-lock.json")).catch(() => {})
+
+    await fs.mkdir(path.dirname(output), { recursive: true })
+    const proc = Bun.spawn(["tar", "-czf", output, "-C", root, "."], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const code = await proc.exited
+    if (code !== 0) {
+      const stderr = await new Response(proc.stderr).text().catch(() => "")
+      throw new Error(`failed to create diagnostics package: ${stderr || `tar exited ${code}`}`)
+    }
+    await fs.rm(tmp, { recursive: true, force: true }).catch(() => {})
+    return { output, summary: info }
+  }
+
+  function summarizeProcess(proc: ProcessRegistry.Process) {
+    return {
+      id: proc.id,
+      pid: proc.pid,
+      command: proc.command,
+      description: proc.description,
+      cwd: proc.cwd,
+      startedAt: proc.startedAt,
+      backgrounded: proc.backgrounded,
+      outputChars: proc.output.length,
+      tail: Observability.sanitizeText(proc.tail),
+      truncated: proc.truncated,
+    }
+  }
+
+  function summarizeFinishedProcess(proc: ProcessRegistry.FinishedProcess) {
+    return {
+      id: proc.id,
+      command: proc.command,
+      description: proc.description,
+      cwd: proc.cwd,
+      status: proc.status,
+      startedAt: proc.startedAt,
+      endedAt: proc.endedAt,
+      exitCode: proc.exitCode,
+      exitSignal: proc.exitSignal,
+      outputChars: proc.output.length,
+      tail: Observability.sanitizeText(proc.tail),
+      truncated: proc.truncated,
+    }
+  }
+
+  async function copyTextFile(src: string, dest: string) {
+    const stat = await fs.stat(src).catch(() => undefined)
+    if (!stat) return
+    if (!stat.isFile()) return
+    const text = await fs.readFile(src, "utf8").catch(() => "")
+    await fs.writeFile(dest, Observability.sanitizeText(text))
+  }
+
+  async function pendingSessions() {
+    const root = path.join(Global.Path.data, "sessions")
+    const result: Summary["sessions"]["pendingReply"] = []
+    await walk(root, async (file) => {
+      if (!file.endsWith("info.json")) return
+      const data = await fs.readFile(file, "utf8").catch(() => "")
+      if (!data.includes('"pendingReply"')) return
+      const json = JSON.parse(data) as { id?: string; pendingReply?: boolean; time?: { updated?: number } }
+      if (!json.pendingReply || !json.id) return
+      result.push({ sessionID: json.id, path: file, updated: json.time?.updated })
+    })
+    return result.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0)).slice(0, 50)
+  }
+
+  async function walk(dir: string, visit: (file: string) => Promise<void>) {
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    await Promise.all(
+      entries.map(async (entry) => {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) return walk(full, visit)
+        if (entry.isFile()) return visit(full)
+      }),
+    )
+  }
+
+  function unique(items: string[]) {
+    return [...new Set(items)]
+  }
+
+  function timestamp() {
+    const date = new Date()
+    const pad = (n: number) => String(n).padStart(2, "0")
+    return (
+      String(date.getFullYear()) +
+      pad(date.getMonth() + 1) +
+      pad(date.getDate()) +
+      "-" +
+      pad(date.getHours()) +
+      pad(date.getMinutes()) +
+      pad(date.getSeconds())
+    )
+  }
+}

--- a/packages/synergy/src/observability/index.ts
+++ b/packages/synergy/src/observability/index.ts
@@ -1,0 +1,207 @@
+import fs from "fs/promises"
+import path from "path"
+import { Global } from "@/global"
+
+export namespace Observability {
+  const TRACE_DIR = path.join(Global.Path.state, "observability", "traces")
+  const DEFAULT_RETENTION_DAYS = 7
+  const DEFAULT_MAX_BYTES = 250 * 1024 * 1024
+  const MAX_STRING_LENGTH = 4096
+  const MAX_OBJECT_KEYS = 48
+  const MAX_ARRAY_LENGTH = 32
+  const CLEANUP_INTERVAL_MS = 60_000
+  let lastCleanupAt = 0
+  const SENSITIVE_KEYS = new Set([
+    "token",
+    "secret",
+    "password",
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "apikey",
+    "api_key",
+    "accesstoken",
+    "refreshtoken",
+    "agentsecret",
+  ])
+
+  export interface Event {
+    time: number
+    iso: string
+    type: string
+    traceId?: string
+    sessionID?: string
+    messageID?: string
+    callID?: string
+    tool?: string
+    processId?: string
+    pid?: number
+    cwd?: string
+    scopeID?: string
+    rid?: string
+    level?: "debug" | "info" | "warn" | "error"
+    data?: Record<string, unknown>
+  }
+
+  export interface Query {
+    traceId?: string
+    sessionID?: string
+    callID?: string
+    since?: number
+    limit?: number
+    level?: Event["level"]
+  }
+
+  export function traceId(prefix = "trc") {
+    return `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`
+  }
+
+  export function dir() {
+    return TRACE_DIR
+  }
+
+  export function fileForDate(date = new Date()) {
+    return path.join(TRACE_DIR, `${date.toISOString().slice(0, 10)}.jsonl`)
+  }
+
+  export async function emit(type: string, input: Omit<Event, "type" | "time" | "iso"> = {}) {
+    const event: Event = {
+      ...input,
+      type,
+      time: Date.now(),
+      iso: new Date().toISOString(),
+      data: input.data ? sanitizeRecord(input.data) : undefined,
+    }
+    await fs.mkdir(TRACE_DIR, { recursive: true }).catch(() => {})
+    await fs.appendFile(fileForDate(), JSON.stringify(event) + "\n", "utf8").catch(() => {})
+    scheduleCleanup()
+    return event
+  }
+
+  export async function listFiles() {
+    const entries = await fs.readdir(TRACE_DIR).catch((): string[] => [])
+    return entries
+      .filter((name) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(name))
+      .sort()
+      .map((name) => path.join(TRACE_DIR, name))
+  }
+
+  export async function query(input: Query = {}) {
+    const limit = Math.max(1, Math.min(input.limit ?? 500, 5000))
+    const files = (await listFiles()).reverse()
+    const result: Event[] = []
+    for (const file of files) {
+      const text = await Bun.file(file)
+        .text()
+        .catch(() => "")
+      if (!text) continue
+      const lines = text.split(/\r?\n/).filter(Boolean).reverse()
+      for (const line of lines) {
+        const event = parseLine(line)
+        if (!event) continue
+        if (input.since && event.time < input.since) continue
+        if (input.traceId && event.traceId !== input.traceId) continue
+        if (input.sessionID && event.sessionID !== input.sessionID) continue
+        if (input.callID && event.callID !== input.callID) continue
+        if (input.level && event.level !== input.level) continue
+        result.push(event)
+        if (result.length >= limit) return result
+      }
+    }
+    return result
+  }
+
+  export async function cleanup(opts?: { retentionDays?: number; maxBytes?: number }) {
+    const retentionDays = opts?.retentionDays ?? DEFAULT_RETENTION_DAYS
+    const maxBytes = opts?.maxBytes ?? DEFAULT_MAX_BYTES
+    const files = await listFiles()
+    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000
+    const stats = await Promise.all(
+      files.map(async (file) => ({
+        file,
+        stat: await fs.stat(file).catch(() => undefined),
+      })),
+    )
+    for (const item of stats) {
+      if (item.stat && item.stat.mtimeMs < cutoff) {
+        await fs.rm(item.file, { force: true }).catch(() => {})
+      }
+    }
+    const remaining = stats
+      .filter((item) => item.stat && item.stat.mtimeMs >= cutoff)
+      .sort((a, b) => (b.stat?.mtimeMs ?? 0) - (a.stat?.mtimeMs ?? 0))
+    let total = 0
+    for (const item of remaining) {
+      total += item.stat?.size ?? 0
+      if (total > maxBytes) {
+        await fs.rm(item.file, { force: true }).catch(() => {})
+      }
+    }
+  }
+
+  function scheduleCleanup() {
+    const now = Date.now()
+    if (now - lastCleanupAt < CLEANUP_INTERVAL_MS) return
+    lastCleanupAt = now
+    cleanup().catch(() => {})
+  }
+
+  export function sanitizeRecord(input: Record<string, unknown>): Record<string, unknown> {
+    return sanitizeValue(input, 0, new Set()) as Record<string, unknown>
+  }
+
+  export function sanitizeText(text: string) {
+    return text
+      .replace(/(?<=(token|secret|password|authorization|api[_-]?key|cookie)=)[^\s"'&]+/gi, "[redacted]")
+      .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, "$1[redacted]")
+  }
+
+  function parseLine(line: string): Event | undefined {
+    try {
+      return JSON.parse(line) as Event
+    } catch {
+      return undefined
+    }
+  }
+
+  function isSensitiveKey(key: string) {
+    return SENSITIVE_KEYS.has(key.toLowerCase().replace(/[-_]/g, ""))
+  }
+
+  function sanitizeValue(value: unknown, depth: number, seen: Set<object>): unknown {
+    if (value === null || value === undefined) return value
+    if (typeof value === "string") {
+      const clean = sanitizeText(value)
+      return clean.length > MAX_STRING_LENGTH
+        ? `${clean.slice(0, MAX_STRING_LENGTH)}...(truncated ${clean.length - MAX_STRING_LENGTH} chars)`
+        : clean
+    }
+    if (typeof value === "number" || typeof value === "boolean") return value
+    if (typeof value === "bigint") return value.toString()
+    if (typeof value === "symbol") return value.toString()
+    if (typeof value === "function") return "[Function]"
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: sanitizeText(value.message),
+        stack: value.stack ? sanitizeText(value.stack).slice(0, MAX_STRING_LENGTH) : undefined,
+      }
+    }
+    if (typeof value !== "object") return String(value)
+    if (depth >= 6) return "[depth limit]"
+    if (seen.has(value)) return "[circular]"
+    seen.add(value)
+    if (Array.isArray(value)) {
+      const items = value.slice(0, MAX_ARRAY_LENGTH).map((item) => sanitizeValue(item, depth + 1, seen))
+      if (value.length > MAX_ARRAY_LENGTH) items.push(`...(${value.length - MAX_ARRAY_LENGTH} more)`)
+      return items
+    }
+    const entries = Object.entries(value as Record<string, unknown>)
+    const result: Record<string, unknown> = {}
+    for (const [key, val] of entries.slice(0, MAX_OBJECT_KEYS)) {
+      result[key] = isSensitiveKey(key) ? "[redacted]" : sanitizeValue(val, depth + 1, seen)
+    }
+    if (entries.length > MAX_OBJECT_KEYS) result["..."] = `${entries.length - MAX_OBJECT_KEYS} more keys`
+    return result
+  }
+}

--- a/packages/synergy/src/process/registry.ts
+++ b/packages/synergy/src/process/registry.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "child_process"
 import { Log } from "../util/log"
 import { Identifier } from "../id/id"
+import { Observability } from "../observability"
 
 const log = Log.create({ service: "process.registry" })
 
@@ -34,6 +35,7 @@ export namespace ProcessRegistry {
     exitSignal?: NodeJS.Signals | number | null
     exited: boolean
     backgrounded: boolean
+    lastOutputAt?: number
   }
 
   export interface FinishedProcess {
@@ -83,6 +85,15 @@ export namespace ProcessRegistry {
     running.set(id, proc)
     startSweeper()
     log.info("process created", { id, command: opts.command })
+    void Observability.emit("process.created", {
+      processId: id,
+      pid: proc.pid,
+      cwd: opts.cwd,
+      data: {
+        command: opts.command,
+        description: opts.description,
+      },
+    })
     return proc
   }
 
@@ -103,11 +114,20 @@ export namespace ProcessRegistry {
       proc.output = newOutput
     }
     proc.tail = proc.output.slice(-TAIL_CHARS)
+    proc.lastOutputAt = Date.now()
   }
 
   export function markBackgrounded(proc: Process) {
     proc.backgrounded = true
     log.info("process backgrounded", { id: proc.id })
+    void Observability.emit("process.backgrounded", {
+      processId: proc.id,
+      pid: proc.pid,
+      cwd: proc.cwd,
+      data: {
+        command: proc.command,
+      },
+    })
   }
 
   export function markExited(proc: Process, exitCode: number | null, exitSignal: NodeJS.Signals | number | null) {
@@ -139,15 +159,47 @@ export namespace ProcessRegistry {
     }
 
     log.info("process exited", { id: proc.id, status, exitCode, exitSignal })
+    void Observability.emit("process.exit", {
+      processId: proc.id,
+      pid: proc.pid,
+      cwd: proc.cwd,
+      level: status === "failed" ? "error" : "info",
+      data: {
+        status,
+        command: proc.command,
+        exitCode,
+        exitSignal,
+        outputChars: proc.output.length,
+        tail: proc.tail,
+        truncated: proc.truncated,
+      },
+    })
   }
 
   export function remove(id: string) {
+    const proc = running.get(id)
     running.delete(id)
     finished.delete(id)
+    if (proc) {
+      void Observability.emit("process.removed", {
+        processId: proc.id,
+        pid: proc.pid,
+        cwd: proc.cwd,
+        data: {
+          command: proc.command,
+          outputChars: proc.output.length,
+          tail: proc.tail,
+        },
+      })
+    }
   }
 
   export function listRunning(): Process[] {
     return Array.from(running.values()).filter((s) => s.backgrounded)
+  }
+
+  export function listActive(): Process[] {
+    return Array.from(running.values()).sort((a, b) => b.startedAt - a.startedAt)
   }
 
   export function listFinished(): FinishedProcess[] {
@@ -194,16 +246,44 @@ export namespace ProcessRegistry {
     const procs = Array.from(running.values()).filter((p) => !p.exited && p.child)
     if (procs.length === 0) return
     log.info("killing all running processes", { count: procs.length })
+    void Observability.emit("process.kill_all.start", {
+      data: {
+        count: procs.length,
+        processIds: procs.map((proc) => proc.id),
+      },
+    })
     await Promise.all(
       procs.map(async (proc) => {
         if (!proc.child) return
         try {
           const { Shell } = await import("../util/shell")
+          await Observability.emit("process.kill", {
+            processId: proc.id,
+            pid: proc.pid,
+            cwd: proc.cwd,
+            data: {
+              command: proc.command,
+            },
+          })
           await Shell.killTree(proc.child, { exited: () => proc.exited })
         } catch (err) {
           log.error("failed to kill process", { id: proc.id, error: err })
+          void Observability.emit("process.kill.error", {
+            processId: proc.id,
+            pid: proc.pid,
+            cwd: proc.cwd,
+            level: "error",
+            data: {
+              error: err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : String(err),
+            },
+          })
         }
       }),
     )
+    void Observability.emit("process.kill_all.end", {
+      data: {
+        count: procs.length,
+      },
+    })
   }
 }

--- a/packages/synergy/src/server/observability-route.ts
+++ b/packages/synergy/src/server/observability-route.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import z from "zod"
+import { Diagnostics } from "@/observability/diagnostics"
+
+export const ObservabilityRoute = new Hono().get(
+  "/diagnostics",
+  describeRoute({
+    summary: "Get local diagnostics summary",
+    description: "Get a readonly local diagnostics summary for the Synergy server.",
+    operationId: "observability.diagnostics.summary",
+    responses: {
+      200: {
+        description: "Diagnostics summary",
+        content: {
+          "application/json": {
+            schema: resolver(z.record(z.string(), z.any()).meta({ ref: "DiagnosticsSummary" })),
+          },
+        },
+      },
+    },
+  }),
+  async (c) => c.json(await Diagnostics.summary()),
+)

--- a/packages/synergy/src/server/runtime.ts
+++ b/packages/synergy/src/server/runtime.ts
@@ -14,6 +14,7 @@ import { ServerProcessLock } from "../daemon/server-process-lock"
 import { StartupReporter } from "../cli/startup-reporter"
 import { Flag } from "../flag/flag"
 import { GlobalRuntime } from "./global-runtime"
+import { Observability } from "../observability"
 
 const log = Log.create({ service: "server-runtime" })
 
@@ -43,7 +44,17 @@ export async function run(options: RuntimeOptions) {
   })
   reporter?.migration(migration)
 
-  await ServerProcessLock.acquire()
+  const processLock = await ServerProcessLock.acquire()
+  await Observability.cleanup().catch(() => {})
+  await Observability.emit("server.start", {
+    data: {
+      pid: process.pid,
+      cwd: process.cwd(),
+      launchCwd: startupScopeLabel(),
+      mode: process.env.SYNERGY_DAEMON === "1" ? "daemon" : "server",
+      network: options.network,
+    },
+  })
 
   // Holos login: intentionally skipped at CLI startup.
   // Users can log in via Web UI sidebar Holos panel or 'synergy holos login'.
@@ -85,7 +96,7 @@ export async function run(options: RuntimeOptions) {
     renderBanner({ server, network: options.network, reporter: reporter ?? StartupReporter.create(), statuses })
   }
 
-  registerShutdown(server)
+  registerShutdown(server, processLock.release)
 
   if (process.env.SYNERGY_DAEMON === "1") {
     DaemonLogRotate.start()
@@ -286,35 +297,112 @@ function displayUrl(hostname: string, port: number) {
   return url.toString().replace(/\/$/, "")
 }
 
-function registerShutdown(server: { stop: (closeActiveConnections?: boolean) => Promise<void> }) {
+function registerShutdown(
+  server: { stop: (closeActiveConnections?: boolean) => Promise<void> },
+  releaseLock: () => Promise<void>,
+) {
   let shuttingDown = false
 
   const gracefulShutdown = async (signal: string) => {
     if (shuttingDown) {
+      await Observability.emit("shutdown.force_exit", {
+        level: "error",
+        data: { signal, reason: "duplicate signal" },
+      })
       process.exit(1)
       return
     }
 
     shuttingDown = true
     log.info("received signal, shutting down gracefully", { signal })
+    await Observability.emit("shutdown.signal", {
+      data: {
+        signal,
+        pid: process.pid,
+      },
+    })
+
+    let phase = "start"
 
     const forceExitTimeout = setTimeout(() => {
-      log.warn("graceful shutdown timed out, forcing exit")
-      process.exit(1)
+      void (async () => {
+        log.warn("graceful shutdown timed out, forcing exit")
+        await Observability.emit("shutdown.force_exit", {
+          level: "error",
+          data: {
+            signal,
+            phase,
+            reason: "timeout",
+          },
+        })
+        await releaseLock().catch(() => {})
+        Log.flush()
+        process.exit(1)
+      })()
     }, 5000)
     forceExitTimeout.unref()
 
     try {
+      phase = "stop log rotate"
+      await Observability.emit("shutdown.phase", { data: { phase } })
       DaemonLogRotate.stop()
+
+      phase = "kill running processes"
+      await Observability.emit("shutdown.phase", { data: { phase } })
       await ProcessRegistry.killAllRunning()
+
+      phase = "stop global runtime"
+      await Observability.emit("shutdown.phase", { data: { phase } })
       await GlobalRuntime.stop()
+
+      phase = "dispose scopes"
+      await Observability.emit("shutdown.phase", { data: { phase } })
       await ScopeRuntime.disposeAll()
+
+      phase = "server stop"
+      await Observability.emit("shutdown.phase", { data: { phase } })
       await server.stop()
+
+      phase = "release lock"
+      await Observability.emit("shutdown.phase", { data: { phase } })
+      await releaseLock()
+
+      phase = "complete"
+      await Observability.emit("server.stop", { data: { signal, pid: process.pid } })
     } catch (error) {
       log.error("error during graceful shutdown", { error })
+      await Observability.emit("shutdown.error", {
+        level: "error",
+        data: {
+          signal,
+          phase,
+          error:
+            error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),
+        },
+      })
+    }
+
+    if (phase !== "complete") {
+      try {
+        phase = "release lock"
+        await Observability.emit("shutdown.phase", { data: { phase, afterError: true } })
+        await releaseLock()
+      } catch (error) {
+        log.error("failed to release server process lock", { error })
+        await Observability.emit("shutdown.error", {
+          level: "error",
+          data: {
+            signal,
+            phase,
+            error:
+              error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),
+          },
+        })
+      }
     }
 
     clearTimeout(forceExitTimeout)
+    Log.flush()
     process.exit(0)
   }
 

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -68,6 +68,8 @@ import { SandboxReadinessRoute } from "./sandbox-readiness-route"
 import { BrowserRoute } from "./browser-route"
 import { BlueprintRoute } from "./blueprint"
 import { RuntimeReload } from "../runtime/reload"
+import { ObservabilityRoute } from "./observability-route"
+import { Observability } from "@/observability"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -320,6 +322,16 @@ export namespace Server {
                 status: c.res.status,
                 duration: Date.now() - start,
               })
+              void Observability.emit("http.request", {
+                rid: requestId,
+                level: c.res.status >= 500 ? "error" : c.res.status >= 400 ? "warn" : "info",
+                data: {
+                  method: c.req.method,
+                  path: reqPath,
+                  status: c.res.status,
+                  duration: Date.now() - start,
+                },
+              })
             }
           }
         })
@@ -455,6 +467,7 @@ export namespace Server {
         )
         .route("/global/git", GitRoute)
         .route("/global/stats", StatsRoute)
+        .route("/global", ObservabilityRoute)
         .get(
           "/global/event/ws",
           (() => {

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -16,6 +16,7 @@ import { Config } from "@/config/config"
 import { PermissionNext } from "@/permission/next"
 import { ExperienceEncoder } from "@/engram/experience-encoder"
 import { Question } from "@/question"
+import { Observability } from "@/observability"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -77,6 +78,15 @@ export namespace SessionProcessor {
     }
     async function settleToolPart(part: MessageV2.ToolPart, outcome: ToolOutcome) {
       const startTime = toolStartTime(part)
+      await Observability.emit("tool.settle.start", {
+        sessionID: input.sessionID,
+        messageID: input.assistantMessage.id,
+        callID: part.callID,
+        tool: part.tool,
+        data: {
+          status: outcome.status,
+        },
+      })
       if (outcome.status === "completed") {
         await Session.updatePart({
           ...part,
@@ -102,6 +112,16 @@ export namespace SessionProcessor {
           },
         })
       }
+      await Observability.emit("tool.settle.end", {
+        sessionID: input.sessionID,
+        messageID: input.assistantMessage.id,
+        callID: part.callID,
+        tool: part.tool,
+        level: outcome.status === "error" ? "error" : "info",
+        data: {
+          status: outcome.status,
+        },
+      })
     }
 
     const result = {
@@ -116,6 +136,19 @@ export namespace SessionProcessor {
       },
       async process(streamInput: LLM.StreamInput) {
         log.info("process")
+        const turnTraceId = Observability.traceId("turn")
+        const turnStartedAt = Date.now()
+        await Observability.emit("session.turn.start", {
+          traceId: turnTraceId,
+          sessionID: input.sessionID,
+          messageID: input.assistantMessage.id,
+          data: {
+            parentID: input.assistantMessage.parentID,
+            agent: input.assistantMessage.agent,
+            model: input.model.id,
+            providerID: input.model.providerID,
+          },
+        })
         const shouldBreak = (await Config.current()).experimental?.continue_loop_on_deny !== true
         while (true) {
           try {
@@ -426,6 +459,18 @@ export namespace SessionProcessor {
             if (retry !== undefined && attempt < SessionRetry.RETRY_MAX_ATTEMPTS) {
               attempt++
               const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
+              await Observability.emit("session.turn.retry", {
+                traceId: turnTraceId,
+                sessionID: input.sessionID,
+                messageID: input.assistantMessage.id,
+                level: "warn",
+                data: {
+                  attempt,
+                  delay,
+                  retry,
+                  error,
+                },
+              })
               SessionManager.setStatus(input.sessionID, {
                 type: "retry",
                 attempt,
@@ -436,6 +481,15 @@ export namespace SessionProcessor {
               continue
             }
             input.assistantMessage.error = error
+            await Observability.emit("session.turn.error", {
+              traceId: turnTraceId,
+              sessionID: input.sessionID,
+              messageID: input.assistantMessage.id,
+              level: "error",
+              data: {
+                error,
+              },
+            })
             Bus.publish(SessionEvent.Error, {
               sessionID: input.assistantMessage.sessionID,
               error: input.assistantMessage.error,
@@ -511,6 +565,19 @@ export namespace SessionProcessor {
             },
             {},
           )
+          await Observability.emit("session.turn.end", {
+            traceId: turnTraceId,
+            sessionID: input.sessionID,
+            messageID: input.assistantMessage.id,
+            level: input.assistantMessage.error ? "error" : "info",
+            data: {
+              finish: input.assistantMessage.finish,
+              blocked,
+              error: input.assistantMessage.error,
+              durationMs: Date.now() - turnStartedAt,
+              pendingTools: pendingExecutions.size,
+            },
+          })
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"
           return "continue"

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -32,10 +32,13 @@ import { Config } from "@/config/config"
 import { ControlProfileCompiler } from "@/control-profile/compiler"
 import { ApprovalPolicy, type ApprovalMetadata } from "@/control-profile/approval"
 import { ExecutionBudget } from "@/util/execution-budget"
+import { Observability } from "@/observability"
 
 export namespace ToolResolver {
   const log = Log.create({ service: "tool.resolver" })
   const neverAbort = new AbortController().signal
+  const DEFAULT_STALLED_TOOL_MS = 30_000
+  const TOOL_HEARTBEAT_MS = 15_000
 
   export interface Input {
     agent: Agent.Info
@@ -194,6 +197,120 @@ export namespace ToolResolver {
 
   function toolTiming(ctx: Tool.Context): ToolTiming {
     return (ctx.extra as any).toolTiming as ToolTiming
+  }
+
+  interface ToolTrace {
+    traceId: string
+    phase(
+      type: string,
+      phase: string,
+      data?: Record<string, unknown>,
+      level?: Observability.Event["level"],
+    ): Promise<void>
+    end(data?: Record<string, unknown>): Promise<void>
+    error(error: unknown, data?: Record<string, unknown>): Promise<void>
+    dispose(): void
+  }
+
+  async function startToolTrace(
+    input: Input,
+    ctx: Tool.Context,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<ToolTrace> {
+    const traceId = Observability.traceId("tool")
+    ;(ctx.extra as any).traceId = traceId
+    const startedAt = Date.now()
+    let phase = "start"
+    let lastActivity = startedAt
+    let stalled = false
+    const stalledMs = await stalledToolMs()
+    const base = () => ({
+      traceId,
+      sessionID: input.sessionID,
+      messageID: input.processor.message.id,
+      callID: ctx.callID,
+      tool: toolName,
+      cwd: ScopeContext.current.directory,
+      scopeID: ScopeContext.current.scope.id,
+    })
+    const emit = (type: string, data?: Record<string, unknown>, level?: Observability.Event["level"]) =>
+      Observability.emit(type, {
+        ...base(),
+        level,
+        data: {
+          phase,
+          elapsedMs: Date.now() - startedAt,
+          ...data,
+        },
+      })
+
+    await emit("tool.start", { args })
+
+    const heartbeat = setInterval(() => {
+      void emit("tool.heartbeat", {
+        idleMs: Date.now() - lastActivity,
+      })
+    }, TOOL_HEARTBEAT_MS)
+    const stale = setInterval(
+      () => {
+        const idleMs = Date.now() - lastActivity
+        if (!stalled && idleMs >= stalledMs) {
+          stalled = true
+          void emit(
+            "tool.stalled",
+            {
+              idleMs,
+              thresholdMs: stalledMs,
+            },
+            "warn",
+          )
+        }
+      },
+      Math.max(5_000, Math.min(stalledMs, TOOL_HEARTBEAT_MS)),
+    )
+    if (typeof heartbeat === "object" && "unref" in heartbeat) heartbeat.unref()
+    if (typeof stale === "object" && "unref" in stale) stale.unref()
+
+    return {
+      traceId,
+      async phase(type, nextPhase, data, level) {
+        phase = nextPhase
+        lastActivity = Date.now()
+        await emit(type, data, level)
+      },
+      async end(data) {
+        phase = "end"
+        lastActivity = Date.now()
+        await emit("tool.end", data)
+      },
+      async error(error, data) {
+        phase = "error"
+        lastActivity = Date.now()
+        await emit(
+          "tool.error",
+          {
+            ...data,
+            error:
+              error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),
+          },
+          "error",
+        )
+      },
+      dispose() {
+        clearInterval(heartbeat)
+        clearInterval(stale)
+      },
+    }
+  }
+
+  async function stalledToolMs() {
+    try {
+      const cfg = await Config.current()
+      return cfg.observability?.stalledToolMs ?? DEFAULT_STALLED_TOOL_MS
+    } catch {
+      return DEFAULT_STALLED_TOOL_MS
+    }
   }
 
   function approvalTime(timing: ToolTiming): ApprovalMetadata["time"] {
@@ -677,6 +794,7 @@ export namespace ToolResolver {
             inputSchema: jsonSchema(schema),
             async execute(args, options) {
               const ctx = context(args, options)
+              let toolTrace: ToolTrace | undefined
               let resolveExecution!: (outcome: SessionProcessor.ToolOutcome) => void
               const executionPromise = new Promise<SessionProcessor.ToolOutcome>((r) => {
                 resolveExecution = r
@@ -684,6 +802,7 @@ export namespace ToolResolver {
               runtimeInput.processor.trackExecution(options.toolCallId, executionPromise)
 
               try {
+                toolTrace = await startToolTrace(runtimeInput, ctx, item.id, args as Record<string, unknown>)
                 const workspace = ScopeContext.current.directory
                 const workspaceInfo = ScopeContext.current.workspace
                 const interaction = runtimeInput.session?.interaction
@@ -707,15 +826,27 @@ export namespace ToolResolver {
                   profileId,
                   readRoots: [synergyRoot],
                 })
+                await toolTrace.phase("tool.resolver.ready", "resolver ready", {
+                  profileId,
+                  workspace,
+                  workspaceType: workspaceInfo?.type ?? "scope",
+                })
 
                 const envelope = gate.evaluate(item.id, args as Record<string, any>)
                 await applyGateApproval(ctx, gate, envelope, item.id, args as Record<string, any>, runtimeInput.session)
+                await toolTrace.phase("tool.approval.resolved", "approval resolved", {
+                  decision: envelope.decision,
+                  capabilities: envelope.capabilities.map((cap) => cap.class),
+                })
 
                 const timeoutCfg = await TimeoutConfig.resolve()
                 const toolTimeoutMs = timeoutCfg.toolOverrides[item.id] ?? timeoutCfg.toolDefaultMs
                 const combinedAbort = startExecutionBudget(ctx, toolTimeoutMs)
                 ctx.abort = combinedAbort
                 await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>)
+                await toolTrace.phase("tool.execution.started", "execution started", {
+                  timeoutMs: toolTimeoutMs,
+                })
                 const toolCtx = { ...ctx, abort: combinedAbort }
                 using toolTimer = log.time("tool.execute", { tool: item.id, callID: options.toolCallId })
 
@@ -724,6 +855,11 @@ export namespace ToolResolver {
                 if (item.id === "bash") {
                   const sandbox = gate.getSandbox()
                   if (sandbox.mode !== "none" && !shouldBypassShellSandbox(ctx)) {
+                    await toolTrace.phase("tool.sandbox.prepare", "sandbox prepare", {
+                      mode: sandbox.mode,
+                      backend: sandbox.backend,
+                      fallback: sandbox.fallback,
+                    })
                     const bashCommand = ((args as Record<string, any>)?.command as string) ?? ""
                     // Register externally-approved roots into the gate so the
                     // policy engine can aggregate them with auto-approved paths.
@@ -754,10 +890,16 @@ export namespace ToolResolver {
                     // Store wrapper in context for bash tool to use
                     ;(toolCtx.extra as any).sandboxWrapper = sandboxWrapper
                     ;(toolCtx.extra as any).sandboxFallback = sandbox.fallback
+                    await toolTrace.phase("tool.sandbox.prepared", "sandbox prepared", {
+                      skipReason: sandboxWrapper.skipReason,
+                      command: sandboxWrapper.command,
+                      args: sandboxWrapper.args,
+                    })
                   }
                 }
 
                 // ── Plugin: tool.execute.before ────────────────────────
+                await toolTrace.phase("plugin.runtime.before.start", "plugin before start")
                 await Plugin.trigger(
                   "tool.execute.before",
                   {
@@ -769,7 +911,14 @@ export namespace ToolResolver {
                     args,
                   },
                 )
+                await toolTrace.phase("plugin.runtime.before.end", "plugin before end")
+                await toolTrace.phase("tool.execute.start", "tool execute start")
                 const result = await item.execute(args, toolCtx)
+                await toolTrace.phase("tool.execute.end", "tool execute end", {
+                  outputChars: result.output.length,
+                  attachmentCount: result.attachments?.length ?? 0,
+                })
+                await toolTrace.phase("plugin.runtime.after.start", "plugin after start")
                 await Plugin.trigger(
                   "tool.execute.after",
                   {
@@ -779,6 +928,7 @@ export namespace ToolResolver {
                   },
                   result,
                 )
+                await toolTrace.phase("plugin.runtime.after.end", "plugin after end")
                 resolveExecution({
                   status: "completed",
                   input: args,
@@ -790,6 +940,10 @@ export namespace ToolResolver {
                       : (result.metadata ?? {}),
                     attachments: result.attachments,
                   },
+                })
+                await toolTrace.end({
+                  outputChars: result.output.length,
+                  attachmentCount: result.attachments?.length ?? 0,
                 })
                 return result
               } catch (error) {
@@ -812,8 +966,10 @@ export namespace ToolResolver {
                   error: formatErrorForModel(error),
                   metadata: approvalFromContext(ctx) ? { approval: approvalFromContext(ctx) } : undefined,
                 })
+                await toolTrace?.error(error)
                 throw error
               } finally {
+                toolTrace?.dispose()
                 disposeExecutionBudget(ctx)
               }
             },
@@ -851,6 +1007,7 @@ export namespace ToolResolver {
               ...item,
               execute: async (args, opts) => {
                 const ctx = context(args, opts)
+                let toolTrace: ToolTrace | undefined
                 let resolveExecution!: (outcome: SessionProcessor.ToolOutcome) => void
                 const executionPromise = new Promise<SessionProcessor.ToolOutcome>((r) => {
                   resolveExecution = r
@@ -858,6 +1015,7 @@ export namespace ToolResolver {
                 runtimeInput.processor.trackExecution(opts.toolCallId, executionPromise)
 
                 try {
+                  toolTrace = await startToolTrace(runtimeInput, ctx, key, args as Record<string, unknown>)
                   const workspace = ScopeContext.current.directory
                   const workspaceInfo = ScopeContext.current.workspace
                   const interaction = runtimeInput.session?.interaction
@@ -880,16 +1038,29 @@ export namespace ToolResolver {
                     pluginApprovals: pluginGateData.approvals,
                     profileId,
                   })
+                  await toolTrace.phase("tool.resolver.ready", "resolver ready", {
+                    profileId,
+                    workspace,
+                    workspaceType: workspaceInfo?.type ?? "scope",
+                  })
                   const envelope = gate.evaluate(key, args as Record<string, any>)
                   await applyGateApproval(ctx, gate, envelope, key, args as Record<string, any>, runtimeInput.session)
+                  await toolTrace.phase("tool.approval.resolved", "approval resolved", {
+                    decision: envelope.decision,
+                    capabilities: envelope.capabilities.map((cap) => cap.class),
+                  })
 
                   const timeoutCfg = await TimeoutConfig.resolve()
                   const toolTimeoutMs = timeoutCfg.toolOverrides[key] ?? timeoutCfg.toolDefaultMs
                   const combinedAbort = startExecutionBudget(ctx, toolTimeoutMs)
                   ctx.abort = combinedAbort
                   await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>)
+                  await toolTrace.phase("tool.execution.started", "execution started", {
+                    timeoutMs: toolTimeoutMs,
+                  })
                   using toolTimer = log.time("tool.execute", { tool: key, callID: opts.toolCallId })
 
+                  await toolTrace.phase("plugin.runtime.before.start", "plugin before start")
                   await Plugin.trigger(
                     "tool.execute.before",
                     {
@@ -901,9 +1072,15 @@ export namespace ToolResolver {
                       args,
                     },
                   )
+                  await toolTrace.phase("plugin.runtime.before.end", "plugin before end")
 
+                  await toolTrace.phase("tool.execute.start", "tool execute start")
                   const result = await execute(args, { ...opts, abortSignal: combinedAbort })
+                  await toolTrace.phase("tool.execute.end", "tool execute end", {
+                    contentCount: result.content.length,
+                  })
 
+                  await toolTrace.phase("plugin.runtime.after.start", "plugin after start")
                   await Plugin.trigger(
                     "tool.execute.after",
                     {
@@ -913,6 +1090,7 @@ export namespace ToolResolver {
                     },
                     result,
                   )
+                  await toolTrace.phase("plugin.runtime.after.end", "plugin after end")
 
                   const textParts: string[] = []
                   const attachments: MessageV2.FilePart[] = []
@@ -953,6 +1131,11 @@ export namespace ToolResolver {
                     },
                   })
 
+                  await toolTrace.end({
+                    outputChars: output.output.length,
+                    attachmentCount: output.attachments.length,
+                    contentCount: output.content.length,
+                  })
                   return output
                 } catch (error) {
                   if (error instanceof EnforcementError.SandboxBlocked) {
@@ -974,8 +1157,10 @@ export namespace ToolResolver {
                     error: formatErrorForModel(error),
                     metadata: approvalFromContext(ctx) ? { approval: approvalFromContext(ctx) } : undefined,
                   })
+                  await toolTrace?.error(error)
                   throw error
                 } finally {
+                  toolTrace?.dispose()
                   disposeExecutionBudget(ctx)
                 }
               },

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -15,6 +15,7 @@ import { ShellSafety } from "@/enforcement/shell-safety"
 import { ArtifactPromotion } from "../artifact-promotion"
 import type { MessageV2 } from "@/session/message-v2"
 import type { BashResult } from "./shared"
+import { Observability } from "@/observability"
 
 /**
  * Derive a human-readable abort reason from an AbortSignal's .reason.
@@ -71,8 +72,30 @@ export const LocalBashBackend: BashBackend = {
     log.info("bash tool using shell", { shell })
 
     const cwd = params.workdir || ScopeContext.current.directory
+    const traceId = ((ctx.extra as any)?.traceId as string | undefined) ?? Observability.traceId("bash")
+    let regProc: ProcessRegistry.Process | undefined
+    const trace = (type: string, data?: Record<string, unknown>, level?: Observability.Event["level"]) =>
+      Observability.emit(type, {
+        traceId,
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+        callID: ctx.callID,
+        tool: "bash",
+        processId: regProc?.id,
+        pid: regProc?.pid,
+        cwd,
+        scopeID: ScopeContext.current.scope.id,
+        level,
+        data,
+      })
+
+    await trace("bash.parser.start", {
+      command: params.command,
+      shell,
+    })
     const tree = await parser().then((p) => p.parse(params.command))
     if (!tree) {
+      await trace("bash.parser.error", { reason: "parse returned empty tree" }, "error")
       throw new Error("Failed to parse command")
     }
     const patterns = new Set<string>()
@@ -103,14 +126,25 @@ export const LocalBashBackend: BashBackend = {
     } finally {
       tree.delete()
     }
+    await trace("bash.parser.end", {
+      patternCount: patterns.size,
+      patterns: Array.from(patterns),
+    })
 
     if (patterns.size > 0 && (ctx.extra as any)?.shellBypassSandbox !== true) {
+      await trace("bash.permission.ask", {
+        patterns: Array.from(patterns),
+        capability: ShellSafety.capability(params.command),
+      })
       await ctx.ask({
         permission: "bash",
         patterns: Array.from(patterns),
         metadata: {
           capability: ShellSafety.capability(params.command),
         },
+      })
+      await trace("bash.permission.resolved", {
+        patterns: Array.from(patterns),
       })
     }
 
@@ -120,13 +154,41 @@ export const LocalBashBackend: BashBackend = {
     const sandboxWarning = (ctx.extra as any)?.sandboxWarning as string | undefined
     const warnOutput = (base: string) => (sandboxWarning ? `[Sandbox unavailable: ${sandboxWarning}]\n\n${base}` : base)
     const withArtifacts = async (result: BashResult): Promise<BashResult> => {
+      await trace("artifact.promotion.start", {
+        outputChars: result.output.length,
+      })
       const attachments = await ArtifactPromotion.promote({
         output: result.output,
         cwd,
         sessionID: ctx.sessionID,
         messageID: ctx.messageID,
         tool: "bash",
-      }).catch((): MessageV2.FilePart[] => [])
+      })
+        .then(async (items) => {
+          await trace("artifact.promotion.end", {
+            attachmentCount: items.length,
+            attachments: items.map((item) => ({
+              filename: item.filename,
+              mime: item.mime,
+              size: (item.metadata as Record<string, unknown> | undefined)?.size,
+              url: item.url,
+            })),
+          })
+          return items
+        })
+        .catch(async (error): Promise<MessageV2.FilePart[]> => {
+          await trace(
+            "artifact.promotion.error",
+            {
+              error:
+                error instanceof Error
+                  ? { name: error.name, message: error.message, stack: error.stack }
+                  : String(error),
+            },
+            "error",
+          )
+          return []
+        })
       if (attachments.length === 0) return result
       return {
         ...result,
@@ -143,10 +205,13 @@ export const LocalBashBackend: BashBackend = {
       }
     }
     // ── ProcessRegistry setup (shared across both paths) ──────────
-    const regProc = ProcessRegistry.create({
+    regProc = ProcessRegistry.create({
       command: params.command,
       description: params.description,
       cwd,
+    })
+    await trace("bash.process.registered", {
+      processId: regProc.id,
     })
 
     ctx.metadata({
@@ -181,7 +246,14 @@ export const LocalBashBackend: BashBackend = {
       }
     }
 
+    let sawOutput = false
     const append = (chunk: Buffer) => {
+      if (!sawOutput) {
+        sawOutput = true
+        void trace("bash.first_output", {
+          bytes: chunk.length,
+        })
+      }
       ProcessRegistry.appendOutput(regProc, chunk.toString())
       scheduleMetadata()
     }
@@ -191,6 +263,10 @@ export const LocalBashBackend: BashBackend = {
     // sandbox denial detection, and temp cleanup — all in one call.
     if (sandboxWrapper && !sandboxWrapper.skipReason && !params.background && !params.yieldSeconds) {
       try {
+        await trace("bash.sandbox.execute.start", {
+          command: sandboxWrapper.command,
+          args: sandboxWrapper.args,
+        })
         const result = await SandboxBackend.executeAsync(sandboxWrapper, {
           fallbackPolicy: sandboxFallback ?? "warn",
           env: sandboxEnv,
@@ -200,6 +276,11 @@ export const LocalBashBackend: BashBackend = {
           maxOutputBytes: 1024 * 1024, // 1 MB
           onStdout: append,
           onStderr: append,
+        })
+        await trace("bash.sandbox.execute.end", {
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          outputChars: regProc.output.length,
         })
 
         if (metadataDirty) flushMetadata()
@@ -233,6 +314,13 @@ export const LocalBashBackend: BashBackend = {
         })
       } catch (e: unknown) {
         ProcessRegistry.remove(regProc.id)
+        await trace(
+          "bash.sandbox.execute.error",
+          {
+            error: e instanceof Error ? { name: e.name, message: e.message, stack: e.stack } : String(e),
+          },
+          "error",
+        )
         if (e instanceof EnforcementError.SandboxBlocked) throw e
         throw e
       }
@@ -270,6 +358,14 @@ export const LocalBashBackend: BashBackend = {
     regProc.child = child
     regProc.stdin = child.stdin ?? undefined
     regProc.pid = child.pid
+    await trace("process.spawn", {
+      processId: regProc.id,
+      pid: child.pid,
+      command: params.command,
+      sandboxed: Boolean(sandboxWrapper && !sandboxWrapper.skipReason),
+      background: params.background === true,
+      yieldSeconds: params.yieldSeconds,
+    })
 
     child.stdout?.on("data", append)
     child.stderr?.on("data", append)
@@ -284,6 +380,11 @@ export const LocalBashBackend: BashBackend = {
       if (sandboxWrapper?.tempPath) {
         SandboxBackend.cleanupTemp(sandboxWrapper.tempPath)
       }
+      void trace("bash.child.exit", {
+        exitCode: code,
+        exitSignal: signal,
+        outputChars: regProc?.output.length ?? 0,
+      })
     })
 
     if (params.background) {
@@ -366,6 +467,13 @@ export const LocalBashBackend: BashBackend = {
         if (sandboxWrapper?.tempPath) {
           SandboxBackend.cleanupTemp(sandboxWrapper.tempPath)
         }
+        void trace(
+          "bash.child.error",
+          {
+            error: { name: error.name, message: error.message, stack: error.stack },
+          },
+          "error",
+        )
         reject(error)
       })
     })

--- a/packages/synergy/src/util/log.ts
+++ b/packages/synergy/src/util/log.ts
@@ -55,6 +55,14 @@ export namespace Log {
     return logpath
   }
 
+  export function devFile() {
+    return path.join(Global.Path.log, "dev.log")
+  }
+
+  export async function listDevArchives() {
+    return (await listArchives(Global.Path.log, /^dev\.\d{8}-\d{6}(?:\.\d+)?\.log$/)).map((item) => item.path)
+  }
+
   let initialized = false
   const buffered: string[] = []
   let write = (msg: string) => {
@@ -82,6 +90,9 @@ export namespace Log {
       Global.Path.log,
       options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
     )
+    if (options.dev) {
+      await archiveDevLog(logpath)
+    }
     await openWriter(logpath)
     initialized = true
     flushBuffered()
@@ -114,6 +125,45 @@ export namespace Log {
     } catch {
       write = (msg: string) => {
         process.stderr.write(msg)
+      }
+    }
+  }
+
+  async function archiveDevLog(filePath: string) {
+    const stat = await fs.stat(filePath).catch(() => undefined)
+    if (!stat || stat.size === 0) return
+    const timestamp = new Date().toISOString().replace(/[-:]/g, "").replace("T", "-").slice(0, 15)
+    const archivePath = path.join(path.dirname(filePath), `dev.${timestamp}.log`)
+    await fs.rename(filePath, archivePath).catch(async () => {
+      const fallback = path.join(path.dirname(filePath), `dev.${timestamp}.${process.pid}.log`)
+      await fs.rename(filePath, fallback).catch(() => {})
+    })
+    await cleanupDevArchives(path.dirname(filePath))
+  }
+
+  async function listArchives(dir: string, pattern: RegExp) {
+    const entries = await fs.readdir(dir).catch((): string[] => [])
+    const archives = await Promise.all(
+      entries
+        .filter((name) => pattern.test(name))
+        .map(async (name) => ({
+          name,
+          path: path.join(dir, name),
+          stat: await fs.stat(path.join(dir, name)).catch(() => undefined),
+        })),
+    )
+    return archives
+      .filter((item): item is { name: string; path: string; stat: NonNullable<(typeof item)["stat"]> } => !!item.stat)
+      .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs)
+  }
+
+  async function cleanupDevArchives(dir: string) {
+    const archives = await listArchives(dir, /^dev\.\d{8}-\d{6}(?:\.\d+)?\.log$/)
+    let total = 0
+    for (let i = 0; i < archives.length; i++) {
+      total += archives[i].stat.size
+      if (i >= 10 || total > 200 * 1024 * 1024) {
+        await fs.rm(archives[i].path, { force: true }).catch(() => {})
       }
     }
   }

--- a/packages/synergy/test/observability/observability.test.ts
+++ b/packages/synergy/test/observability/observability.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+
+const originalTestHome = process.env.SYNERGY_TEST_HOME
+
+describe("observability", () => {
+  let home: string
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-observability-"))
+    process.env.SYNERGY_TEST_HOME = home
+  })
+
+  afterEach(async () => {
+    if (originalTestHome === undefined) delete process.env.SYNERGY_TEST_HOME
+    else process.env.SYNERGY_TEST_HOME = originalTestHome
+    await fs.rm(home, { recursive: true, force: true })
+  })
+
+  test("archives dev log before reopening it", async () => {
+    const { Log } = await import("../../src/util/log")
+    const devFile = Log.devFile()
+    await fs.mkdir(path.dirname(devFile), { recursive: true })
+    await fs.writeFile(devFile, "old dev log\n", "utf8")
+
+    await Log.init({ print: false, dev: true })
+    Log.flush()
+
+    const archives = await Log.listDevArchives()
+    expect(archives.length).toBe(1)
+    expect(await fs.readFile(archives[0], "utf8")).toBe("old dev log\n")
+    expect(await fs.readFile(devFile, "utf8")).not.toContain("old dev log")
+  })
+
+  test("writes sanitized queryable trace events", async () => {
+    const { Observability } = await import("../../src/observability")
+    await fs.rm(Observability.dir(), { recursive: true, force: true })
+
+    await Observability.emit("tool.start", {
+      traceId: "trace-test",
+      sessionID: "ses-test",
+      callID: "call-test",
+      tool: "bash",
+      data: {
+        token: "plain-secret",
+        output: "Bearer abc.def",
+      },
+    })
+
+    const events = await Observability.query({ traceId: "trace-test", sessionID: "ses-test", callID: "call-test" })
+    expect(events.length).toBe(1)
+    expect(events[0].data?.token).toBe("[redacted]")
+    expect(JSON.stringify(events[0].data)).not.toContain("abc.def")
+  })
+
+  test("releases server process lock explicitly", async () => {
+    const { ServerProcessLock } = await import("../../src/daemon/server-process-lock")
+    await fs.rm(ServerProcessLock.path(), { force: true })
+
+    const acquired = await ServerProcessLock.acquire()
+    expect((await ServerProcessLock.read())?.pid).toBe(process.pid)
+
+    await acquired.release()
+    expect(await ServerProcessLock.read()).toBeUndefined()
+  })
+
+  test("creates a local diagnostics package", async () => {
+    const { Observability } = await import("../../src/observability")
+    const { Diagnostics } = await import("../../src/observability/diagnostics")
+    await Observability.emit("session.turn.error", {
+      sessionID: "ses-diagnostics",
+      level: "error",
+      data: {
+        password: "super-secret",
+      },
+    })
+
+    const output = path.join(home, "diagnostics.tar.gz")
+    const result = await Diagnostics.createPackage({ output })
+    const stat = await fs.stat(result.output)
+    expect(stat.isFile()).toBe(true)
+    expect(stat.size).toBeGreaterThan(0)
+    expect(result.summary.traces.recentErrors.length).toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
## Summary

- render promoted file artifacts consistently across assistant file parts, tool attachments, and user attachments
- add local observability traces, dev log archiving, shutdown/lock diagnostics, and tool/process/session trace events
- add diagnostics CLI/status/log filtering plus a read-only Web diagnostics panel backed by the generated SDK

## Tests

- `bun run --cwd packages/synergy typecheck`
- `bun run --cwd packages/sdk/js typecheck`
- `bun run --cwd packages/app typecheck`
- `bun run typecheck`
- `cd packages/synergy && bun test test/observability/observability.test.ts test/server/openapi.test.ts`
- `bun run --cwd packages/app build`

## Notes

- The repository-wide pre-push formatter currently reports an unrelated existing issue in `packages/app/src/components/note-panel.tsx`; this PR leaves that file untouched.
