### PR TITLE
Unify tool timeout metadata

### DIFF
--- a/packages/synergy/src/browser/downloads.ts
+++ b/packages/synergy/src/browser/downloads.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright"
+import { ToolTimeout } from "@/tool/timeout"
 
 function nextId(): string {
   return `dl-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
@@ -49,7 +50,10 @@ export namespace BrowserDownloads {
 
   const TERMINAL_STATES: ReadonlySet<DownloadRecord["state"]> = new Set(["completed", "failed", "blocked"])
 
-  export async function waitForDownload(id: string, timeoutMs = 30_000): Promise<DownloadRecord> {
+  export async function waitForDownload(
+    id: string,
+    timeoutMs: number = ToolTimeout.DEFAULTS.browserDownloadsWaitMs,
+  ): Promise<DownloadRecord> {
     const rec = get(id)
     if (!rec) throw new Error(`Download record ${id} not found`)
     if (TERMINAL_STATES.has(rec.state)) return rec
@@ -91,7 +95,11 @@ export namespace BrowserDownloads {
     })
   }
 
-  export async function waitForPageDownload(page: Page, id: string, timeoutMs = 30_000): Promise<DownloadRecord> {
+  export async function waitForPageDownload(
+    page: Page,
+    id: string,
+    timeoutMs: number = ToolTimeout.DEFAULTS.browserDownloadsWaitMs,
+  ): Promise<DownloadRecord> {
     return waitForDownload(id, timeoutMs)
   }
 }

--- a/packages/synergy/src/browser/screenshot.ts
+++ b/packages/synergy/src/browser/screenshot.ts
@@ -1,5 +1,6 @@
 import type { Page } from "playwright"
 import { BrowserLocator } from "./locator"
+import { ToolTimeout } from "@/tool/timeout"
 
 export namespace BrowserScreenshot {
   export interface ResolvedBounds {
@@ -64,7 +65,7 @@ export namespace BrowserScreenshot {
     const format = opts?.format ?? "png"
 
     try {
-      await pwLocator.waitFor({ state: "attached", timeout: 5_000 })
+      await pwLocator.waitFor({ state: "attached", timeout: ToolTimeout.DEFAULTS.browserLocatorMs })
       const buf = (await pwLocator.screenshot({ type: format })) as Buffer
       const box = await pwLocator.boundingBox()
       return {

--- a/packages/synergy/src/browser/tab.ts
+++ b/packages/synergy/src/browser/tab.ts
@@ -9,6 +9,7 @@ import { BrowserInputDispatcher, type BrowserKeyInput, type BrowserMouseInput } 
 import { BrowserDownloads } from "./downloads.js"
 import { BrowserStorage } from "./storage.js"
 import type { BrowserOwner } from "./owner.js"
+import { ToolTimeout } from "@/tool/timeout"
 
 export interface AccessibilityElement {
   ref: string
@@ -822,7 +823,7 @@ export class BrowserTabImpl implements BrowserTab {
   // ── wait ───────────────────────────────────────────────────────────
 
   async waitFor(condition: WaitCondition, timeoutMs?: number): Promise<boolean> {
-    const timeout = timeoutMs ?? 10_000
+    const timeout = timeoutMs ?? ToolTimeout.DEFAULTS.browserWaitMs
     const start = Date.now()
 
     while (Date.now() - start < timeout) {

--- a/packages/synergy/src/browser/wait.ts
+++ b/packages/synergy/src/browser/wait.ts
@@ -2,6 +2,7 @@ import type { Page } from "playwright"
 import type { BrowserTab } from "./tab.js"
 import { BrowserLocator } from "./locator.js"
 import type { Locator } from "playwright"
+import { ToolTimeout } from "@/tool/timeout"
 
 type LocatorInput = BrowserLocator.LocatorInput
 type ResolvedElement = BrowserLocator.ResolvedElement
@@ -13,7 +14,7 @@ export namespace BrowserWait {
     signal?: AbortSignal
   }
 
-  const DEFAULT_TIMEOUT = 30_000
+  const DEFAULT_TIMEOUT = ToolTimeout.DEFAULTS.browserHelperWaitMs
   const DEFAULT_POLL = 100
 
   // ── helpers ──────────────────────────────────────────────────────

--- a/packages/synergy/src/mcp/index.ts
+++ b/packages/synergy/src/mcp/index.ts
@@ -30,6 +30,7 @@ import {
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
+  const toolCallTimeouts = new Map<string, number | undefined>()
 
   // ── Public schemas/events (re-exposed via the MCP namespace) ────────
   // These are declared here to satisfy the public API surface; the actual
@@ -100,6 +101,10 @@ export namespace MCP {
 
   export function ensureStarted(): void {
     McpSupervisor.ensureStarted()
+  }
+
+  export function toolCallTimeout(toolName: string): number | undefined {
+    return toolCallTimeouts.get(toolName)
   }
 
   // ── Lifecycle ───────────────────────────────────────────────────────
@@ -214,6 +219,7 @@ export namespace MCP {
   export async function tools(): Promise<Record<string, Tool>> {
     await McpSupervisor.ready()
     const result: Record<string, Tool> = {}
+    toolCallTimeouts.clear()
     const cfg = await Config.current()
     const callTimeout = cfg.experimental?.mcp_timeout
 
@@ -225,11 +231,10 @@ export namespace MCP {
         const sanitizedClientName = handle.name.replace(/[^a-zA-Z0-9_-]/g, "_")
         const sanitizedToolName = mcpTool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
         const perServerCallTimeout = await resolveCallTimeout(handle.name)
-        result[sanitizedClientName + "_" + sanitizedToolName] = await convertMcpTool(
-          mcpTool,
-          handle.client,
-          perServerCallTimeout ?? callTimeout,
-        )
+        const toolName = sanitizedClientName + "_" + sanitizedToolName
+        const effectiveCallTimeout = perServerCallTimeout ?? callTimeout
+        toolCallTimeouts.set(toolName, effectiveCallTimeout)
+        result[toolName] = await convertMcpTool(mcpTool, handle.client, effectiveCallTimeout)
       }
     }
 

--- a/packages/synergy/src/question/index.ts
+++ b/packages/synergy/src/question/index.ts
@@ -7,9 +7,10 @@ import { SessionInteraction } from "@/session/interaction"
 import { ScopeContext } from "@/scope/context"
 import { ScopedState } from "@/scope/scoped-state"
 import { Log } from "@/util/log"
+import { ToolTimeout } from "@/tool/timeout"
 import z from "zod"
 
-export const DEFAULT_TIMEOUT = 1800
+export const DEFAULT_TIMEOUT = ToolTimeout.DEFAULTS.questionMs / 1_000
 
 export namespace Question {
   const log = Log.create({ service: "question" })

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -16,6 +16,7 @@ import { Config } from "@/config/config"
 import { PermissionNext } from "@/permission/next"
 import { ExperienceEncoder } from "@/library/experience-encoder"
 import { Question } from "@/question"
+import { ToolTimeout } from "@/tool/timeout"
 import { Observability } from "@/observability"
 
 export namespace SessionProcessor {
@@ -94,7 +95,10 @@ export namespace SessionProcessor {
             status: "completed",
             input: outcome.input,
             output: outcome.result.output,
-            metadata: outcome.result.metadata,
+            metadata: ToolTimeout.preserveMetadata(
+              part.state.status === "running" ? part.state.metadata : undefined,
+              outcome.result.metadata,
+            )!,
             title: outcome.result.title,
             time: { start: startTime, end: Date.now() },
             attachments: outcome.result.attachments,
@@ -107,7 +111,10 @@ export namespace SessionProcessor {
             status: "error",
             input: outcome.input,
             error: outcome.error,
-            metadata: outcome.metadata,
+            metadata: ToolTimeout.preserveMetadata(
+              part.state.status === "running" ? part.state.metadata : undefined,
+              outcome.metadata,
+            ),
             time: { start: startTime, end: Date.now() },
           },
         })

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -16,6 +16,7 @@ import { ProviderTransform } from "@/provider/transform"
 import type { Provider } from "@/provider/provider"
 import { Tool } from "@/tool/tool"
 import { ToolRegistry } from "@/tool/registry"
+import { ToolTimeout } from "@/tool/timeout"
 import { Log } from "@/util/log"
 import { TimeoutConfig } from "@/util/timeout-config"
 import { Session } from "."
@@ -372,7 +373,7 @@ export namespace ToolResolver {
       state: {
         ...match.state,
         title: state.title ?? match.state.title,
-        metadata: state.metadata ?? match.state.metadata,
+        metadata: ToolTimeout.preserveMetadata(match.state.metadata, state.metadata) ?? match.state.metadata,
         status: "running",
         input: args,
         time: {
@@ -383,7 +384,12 @@ export namespace ToolResolver {
     Object.assign(match, updated)
   }
 
-  async function markExecutionStarted(input: Input, ctx: Tool.Context, args: Record<string, any>) {
+  async function markExecutionStarted(
+    input: Input,
+    ctx: Tool.Context,
+    args: Record<string, any>,
+    toolTimeout: ToolTimeout.Metadata,
+  ) {
     const timing = toolTiming(ctx)
     if (timing.executionStartedAt !== undefined) return
 
@@ -399,8 +405,10 @@ export namespace ToolResolver {
     const match = ctx.callID ? input.processor.partFromToolCall(ctx.callID) : undefined
     const metadata = {
       ...(match?.state.status === "running" ? (match.state.metadata ?? {}) : {}),
+      toolTimeout,
       ...(approvalFromContext(ctx) ? { approval: approvalFromContext(ctx) } : {}),
     }
+    ;(ctx.extra as any).toolTimeout = toolTimeout
     await updateRunningToolPart(input, ctx, args, {
       metadata,
       start: timing.executionStartedAt,
@@ -835,9 +843,14 @@ export namespace ToolResolver {
 
                 const timeoutCfg = await TimeoutConfig.resolve()
                 const toolTimeoutMs = timeoutCfg.toolOverrides[item.id] ?? timeoutCfg.toolDefaultMs
+                const toolTimeout = ToolTimeout.metadataForTool({
+                  tool: item.id,
+                  args: args as Record<string, any>,
+                  executionBudgetMs: toolTimeoutMs,
+                })
                 const combinedAbort = startExecutionBudget(ctx, toolTimeoutMs)
                 ctx.abort = combinedAbort
-                await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>)
+                await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>, toolTimeout)
                 await toolTrace.phase("tool.execution.started", "execution started", {
                   timeoutMs: toolTimeoutMs,
                 })
@@ -1046,9 +1059,15 @@ export namespace ToolResolver {
 
                   const timeoutCfg = await TimeoutConfig.resolve()
                   const toolTimeoutMs = timeoutCfg.toolOverrides[key] ?? timeoutCfg.toolDefaultMs
+                  const toolTimeout = ToolTimeout.metadataForTool({
+                    tool: key,
+                    args: args as Record<string, any>,
+                    executionBudgetMs: toolTimeoutMs,
+                    mcpCallTimeoutMs: MCP.toolCallTimeout(key),
+                  })
                   const combinedAbort = startExecutionBudget(ctx, toolTimeoutMs)
                   ctx.abort = combinedAbort
-                  await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>)
+                  await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>, toolTimeout)
                   await toolTrace.phase("tool.execution.started", "execution started", {
                     timeoutMs: toolTimeoutMs,
                   })

--- a/packages/synergy/src/tool/agenda-schedule.ts
+++ b/packages/synergy/src/tool/agenda-schedule.ts
@@ -6,6 +6,7 @@ import { AgendaDedup } from "../agenda/dedup"
 import { SessionManager } from "../session/manager"
 import { ScopeContext } from "../scope/context"
 import DESCRIPTION from "./agenda-schedule.txt"
+import { ToolTimeout } from "./timeout"
 
 const parameters = z.object({
   title: z.string().describe("Task title"),
@@ -108,7 +109,12 @@ export const AgendaScheduleTool = Tool.define("agenda_schedule", {
     return {
       title: item.title,
       output: lines.join("\n"),
-      metadata: { id: item.id, status: item.status } as Record<string, any>,
+      metadata: {
+        id: item.id,
+        status: item.status,
+        scheduledTimeoutMs: item.timeout,
+        scheduledTimeoutLabel: ToolTimeout.scheduledTimeoutLabel(item.timeout),
+      } as Record<string, any>,
     }
   },
 })

--- a/packages/synergy/src/tool/agenda-update.ts
+++ b/packages/synergy/src/tool/agenda-update.ts
@@ -4,6 +4,7 @@ import { Tool } from "./tool"
 import { Agenda, AgendaTypes } from "../agenda"
 import { ScopeContext } from "../scope/context"
 import DESCRIPTION from "./agenda-update.txt"
+import { ToolTimeout } from "./timeout"
 
 const parameters = z.object({
   id: z.string().describe("Agenda item ID to update"),
@@ -65,7 +66,12 @@ export const AgendaUpdateTool = Tool.define("agenda_update", {
     return {
       title: item.title,
       output: lines.join("\n"),
-      metadata: { id: item.id, status: item.status } as Record<string, any>,
+      metadata: {
+        id: item.id,
+        status: item.status,
+        scheduledTimeoutMs: item.timeout,
+        scheduledTimeoutLabel: ToolTimeout.scheduledTimeoutLabel(item.timeout),
+      } as Record<string, any>,
     }
   },
 })

--- a/packages/synergy/src/tool/arxiv.ts
+++ b/packages/synergy/src/tool/arxiv.ts
@@ -3,8 +3,9 @@ import path from "path"
 import { Tool } from "./tool"
 import { Flag } from "../flag/flag"
 import { ScopeContext } from "../scope/context"
+import { ToolTimeout } from "./timeout"
 
-const DEFAULT_TIMEOUT = 30 * 1000
+const DEFAULT_TIMEOUT = ToolTimeout.DEFAULTS.arxivSearchMs
 const ARXIV_PDF_BASE = "https://arxiv.org/pdf"
 
 interface Paper {
@@ -192,7 +193,7 @@ Examples of valid arXiv IDs:
 
     const url = `${ARXIV_PDF_BASE}/${params.arxivId}.pdf`
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 60 * 1000)
+    const timeoutId = setTimeout(() => controller.abort(), ToolTimeout.DEFAULTS.arxivDownloadMs)
 
     const response = await fetch(url, {
       signal: AbortSignal.any([controller.signal, ctx.abort]),

--- a/packages/synergy/src/tool/ast-grep/types.ts
+++ b/packages/synergy/src/tool/ast-grep/types.ts
@@ -1,3 +1,5 @@
+import { ToolTimeout } from "../timeout"
+
 // Supported languages (25 total)
 export const AST_GREP_LANGUAGES = [
   "bash",
@@ -61,7 +63,7 @@ export interface SgResult {
 }
 
 // Limits
-export const DEFAULT_TIMEOUT_MS = 60_000
+export const DEFAULT_TIMEOUT_MS = ToolTimeout.DEFAULTS.astGrepMs
 export const DEFAULT_MAX_OUTPUT_BYTES = 1 * 1024 * 1024
 export const DEFAULT_MAX_MATCHES = 500
 

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -16,6 +16,7 @@ import { ArtifactPromotion } from "../artifact-promotion"
 import type { MessageV2 } from "@/session/message-v2"
 import type { BashResult } from "./shared"
 import { Observability } from "@/observability"
+import { ToolTimeout } from "../timeout"
 
 /**
  * Derive a human-readable abort reason from an AbortSignal's .reason.
@@ -272,7 +273,7 @@ export const LocalBashBackend: BashBackend = {
           env: sandboxEnv,
           cwd,
           signal: ctx.abort,
-          timeoutMs: 3_600_000, // 60-minute hard ceiling
+          timeoutMs: ToolTimeout.DEFAULTS.bashHardCeilingMs, // 60-minute hard ceiling
           maxOutputBytes: 1024 * 1024, // 1 MB
           onStdout: append,
           onStderr: append,
@@ -447,7 +448,7 @@ export const LocalBashBackend: BashBackend = {
       }
     }
 
-    const HARD_BASH_CEILING_MS = 3_600_000 // 60 minutes absolute hard limit
+    const HARD_BASH_CEILING_MS = ToolTimeout.DEFAULTS.bashHardCeilingMs // 60 minutes absolute hard limit
 
     const kill = () => Shell.killTree(child, { exited: () => exited })
 

--- a/packages/synergy/src/tool/browser-download.ts
+++ b/packages/synergy/src/tool/browser-download.ts
@@ -7,6 +7,7 @@ import { BrowserOwner } from "../browser/owner"
 import { BrowserPolicy } from "../browser/policy"
 import { ScopeContext } from "../scope/context"
 import { Global } from "../global"
+import { ToolTimeout } from "./timeout"
 
 const MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024 // 100MB
 
@@ -79,7 +80,10 @@ export const BrowserDownloadTool = Tool.define("browser_download", {
 
     // Fetch the URL
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(new Error("Download timeout after 120s")), 120_000)
+    const timeoutId = setTimeout(
+      () => controller.abort(new Error("Download timeout after 120s")),
+      ToolTimeout.DEFAULTS.browserDownloadMs,
+    )
 
     let response: Response
     try {

--- a/packages/synergy/src/tool/browser-read.ts
+++ b/packages/synergy/src/tool/browser-read.ts
@@ -5,6 +5,7 @@ import { BrowserLocator } from "../browser/locator"
 import { truncateHTML, domSnapshot, pageText, elementAttributes, computedStyle, visibleDOM } from "../browser/page-read"
 import type { BrowserTab } from "../browser/tab"
 import type { Page, Locator } from "playwright"
+import { ToolTimeout } from "./timeout"
 
 const parameters = z.object({
   type: z
@@ -194,7 +195,7 @@ async function readDOM(tab: BrowserTab, locator?: LocatorInput): Promise<string>
   if (tab.page) {
     const pwLocator = BrowserLocator.toPlaywrightLocator(tab.page, locator)
     try {
-      await pwLocator.waitFor({ state: "attached", timeout: 5_000 })
+      await pwLocator.waitFor({ state: "attached", timeout: ToolTimeout.DEFAULTS.browserLocatorMs })
       const html = (await pwLocator.evaluate((el) => (el as HTMLElement).outerHTML)) as string
       return html
     } catch {
@@ -226,7 +227,7 @@ async function extractAttributesRaw(tab: BrowserTab, locator: LocatorInput): Pro
   if (tab.page) {
     const pwLocator = BrowserLocator.toPlaywrightLocator(tab.page, locator)
     try {
-      await pwLocator.waitFor({ state: "attached", timeout: 5_000 })
+      await pwLocator.waitFor({ state: "attached", timeout: ToolTimeout.DEFAULTS.browserLocatorMs })
       const attrs = (await pwLocator.evaluate((el) => {
         const result: Record<string, string> = {}
         for (const attr of (el as HTMLElement).attributes) {
@@ -264,7 +265,7 @@ async function resolveComputedStyles(tab: BrowserTab, locator: LocatorInput): Pr
   if (tab.page) {
     const pwLocator = BrowserLocator.toPlaywrightLocator(tab.page, locator)
     try {
-      await pwLocator.waitFor({ state: "attached", timeout: 5_000 })
+      await pwLocator.waitFor({ state: "attached", timeout: ToolTimeout.DEFAULTS.browserLocatorMs })
       const styles = (await pwLocator.evaluate((el) => {
         const computed = getComputedStyle(el as HTMLElement)
         const result: Record<string, string> = {}

--- a/packages/synergy/src/tool/browser-wait.ts
+++ b/packages/synergy/src/tool/browser-wait.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import { Tool } from "./tool"
 import { BrowserToolHelper } from "./browser-shared"
+import { ToolTimeout } from "./timeout"
 
 const waitConditionSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("load") }),
@@ -17,9 +18,11 @@ export const BrowserWaitTool = Tool.define("browser_wait", {
       .number()
       .int()
       .min(500)
-      .max(60000)
-      .default(10000)
-      .describe("Timeout in milliseconds. Max 60000. Default 10000."),
+      .max(ToolTimeout.DEFAULTS.browserWaitMaxMs)
+      .default(ToolTimeout.DEFAULTS.browserWaitMs)
+      .describe(
+        `Timeout in milliseconds. Max ${ToolTimeout.DEFAULTS.browserWaitMaxMs}. Default ${ToolTimeout.DEFAULTS.browserWaitMs}.`,
+      ),
     tabId: z.string().optional().describe("Tab ID. Uses the active tab if omitted."),
   }),
   async execute(params, ctx) {

--- a/packages/synergy/src/tool/connect.ts
+++ b/packages/synergy/src/tool/connect.ts
@@ -2,8 +2,9 @@ import z from "zod"
 import { MetaProtocolEnv } from "@ericsanchezok/meta-protocol"
 import { Tool } from "./tool"
 import { RemoteExecution } from "./remote-execution"
+import { ToolTimeout } from "./timeout"
 
-const CONNECT_TIMEOUT_MS = 30_000
+const CONNECT_TIMEOUT_MS = ToolTimeout.DEFAULTS.connectMs
 
 const parameters = z.object({
   action: z.enum(["open", "close", "status", "list"]).describe("Remote session action to perform"),

--- a/packages/synergy/src/tool/glob.ts
+++ b/packages/synergy/src/tool/glob.ts
@@ -4,6 +4,7 @@ import { Tool } from "./tool"
 import DESCRIPTION from "./glob.txt"
 import { Ripgrep } from "../file/ripgrep"
 import { ScopeContext } from "../scope/context"
+import { ToolTimeout } from "./timeout"
 
 export const GlobTool = Tool.define("glob", {
   description: DESCRIPTION,
@@ -29,7 +30,7 @@ export const GlobTool = Tool.define("glob", {
     let search = params.path ?? ScopeContext.current.directory
     search = path.isAbsolute(search) ? search : path.resolve(ScopeContext.current.directory, search)
 
-    const TIMEOUT_MS = 15_000
+    const TIMEOUT_MS = ToolTimeout.DEFAULTS.globMs
     const limit = 100
     const files = []
     let truncated = false

--- a/packages/synergy/src/tool/lookat.ts
+++ b/packages/synergy/src/tool/lookat.ts
@@ -9,10 +9,11 @@ import { Agent } from "../agent/agent"
 import { ScopeContext } from "../scope/context"
 import DESCRIPTION from "./lookat.txt"
 import { Asset } from "../asset/asset"
+import { ToolTimeout } from "./timeout"
 
 const MULTIMODAL_AGENT = "multimodal-looker"
 const MAX_IMAGES = 5
-const DEFAULT_TIMEOUT_S = 120
+const DEFAULT_TIMEOUT_S = ToolTimeout.DEFAULTS.lookAtMs / 1_000
 
 const parameters = z.object({
   file_path: z

--- a/packages/synergy/src/tool/ls.ts
+++ b/packages/synergy/src/tool/ls.ts
@@ -4,6 +4,7 @@ import * as path from "path"
 import DESCRIPTION from "./ls.txt"
 import { ScopeContext } from "../scope/context"
 import { Ripgrep } from "../file/ripgrep"
+import { ToolTimeout } from "./timeout"
 
 export const IGNORE_PATTERNS = [
   "node_modules/",
@@ -51,7 +52,7 @@ export const ListTool = Tool.define("list", {
       },
     })
 
-    const TIMEOUT_MS = 15_000
+    const TIMEOUT_MS = ToolTimeout.DEFAULTS.listMs
     const ignoreGlobs = IGNORE_PATTERNS.map((p) => `!${p}*`).concat(params.ignore?.map((p) => `!${p}`) || [])
     const files = []
     let timedOut = false

--- a/packages/synergy/src/tool/process.ts
+++ b/packages/synergy/src/tool/process.ts
@@ -6,6 +6,7 @@ import { RemoteExecution } from "./remote-execution"
 import { LocalProcessBackend } from "./process/local"
 import { RemoteProcessBackend } from "./process/remote"
 import type { ProcessMetadata, ProcessParams } from "./process/shared"
+import { ToolTimeout } from "./timeout"
 
 const parameters = z.object({
   action: z
@@ -17,7 +18,10 @@ const parameters = z.object({
   offset: z.number().optional().describe("Line offset for log retrieval"),
   limit: z.number().optional().describe("Number of lines to retrieve for log"),
   block: z.boolean().optional().describe("Wait for process to exit before returning (for poll action)"),
-  timeout: z.number().optional().describe("Max seconds to wait when block is true (default: 30)"),
+  timeout: z
+    .number()
+    .optional()
+    .describe(`Max seconds to wait when block is true (default: ${ToolTimeout.DEFAULTS.processPollWaitMs / 1_000})`),
   envID: MetaProtocolEnv.EnvID.optional().describe(
     "Optional execution environment ID. Omit for local execution; provide one to target a remote execution backend.",
   ),

--- a/packages/synergy/src/tool/process/local.ts
+++ b/packages/synergy/src/tool/process/local.ts
@@ -6,6 +6,7 @@ import { ScopeContext } from "@/scope/context"
 import { ArtifactPromotion } from "../artifact-promotion"
 import type { Tool } from "../tool"
 import type { MessageV2 } from "@/session/message-v2"
+import { ToolTimeout } from "../timeout"
 
 export namespace LocalProcessBackend {
   export async function execute(params: ProcessParams, ctx?: Tool.Context): Promise<ProcessResult> {
@@ -65,7 +66,7 @@ export namespace LocalProcessBackend {
     switch (action) {
       case "poll": {
         if (proc && !proc.exited && params.block) {
-          await waitForExit(processId, (params.timeout ?? 30) * 1000)
+          await waitForExit(processId, (params.timeout ?? ToolTimeout.DEFAULTS.processPollWaitMs / 1_000) * 1000)
         }
 
         const current = ProcessRegistry.get(processId)

--- a/packages/synergy/src/tool/question.ts
+++ b/packages/synergy/src/tool/question.ts
@@ -3,11 +3,13 @@ import { Tool } from "./tool"
 import { Question, DEFAULT_TIMEOUT } from "../question"
 import { Config } from "../config/config"
 import DESCRIPTION from "./question.txt"
+import { ToolTimeout } from "./timeout"
 
 interface QuestionMetadata {
   answers: Question.Answer[]
   timedOut: boolean
   timeout?: number
+  toolTimeout?: ToolTimeout.Metadata
   createdAt?: number
 }
 
@@ -22,9 +24,14 @@ export const QuestionTool = Tool.define<typeof parameters, QuestionMetadata>("qu
     const cfg = await Config.current()
     const configuredTimeout = cfg.question?.timeout
     const timeout = configuredTimeout === 0 ? undefined : (configuredTimeout ?? DEFAULT_TIMEOUT)
+    const toolTimeout = ToolTimeout.withOperation(
+      (ctx.extra as any)?.toolTimeout,
+      timeout === undefined ? undefined : timeout * 1_000,
+      "question",
+    )
     const createdAt = Date.now()
 
-    ctx.metadata({ metadata: { answers: [], timedOut: false, timeout, createdAt } })
+    ctx.metadata({ metadata: { answers: [], timedOut: false, timeout, createdAt, toolTimeout } })
 
     let answers: Question.Answer[]
     let timedOut = false
@@ -49,7 +56,7 @@ export const QuestionTool = Tool.define<typeof parameters, QuestionMetadata>("qu
         title: "Question timed out",
         output:
           "The user did not respond within the timeout period. They may be busy or away from the keyboard. Use your best judgment to proceed — you may continue without user input, use a sensible default, or skip the step that required this answer.",
-        metadata: { answers, timedOut, timeout, createdAt },
+        metadata: { answers, timedOut, timeout, createdAt, toolTimeout },
       }
     }
 
@@ -63,7 +70,7 @@ export const QuestionTool = Tool.define<typeof parameters, QuestionMetadata>("qu
     return {
       title: `Asked ${params.questions.length} question${params.questions.length > 1 ? "s" : ""}`,
       output: `User has answered your questions: ${formatted}. You can now continue with the user's answers in mind.`,
-      metadata: { answers, timedOut, timeout, createdAt },
+      metadata: { answers, timedOut, timeout, createdAt, toolTimeout },
     }
   },
 })

--- a/packages/synergy/src/tool/scan-files.ts
+++ b/packages/synergy/src/tool/scan-files.ts
@@ -14,12 +14,13 @@ import {
   splitDisplayLines,
   recordSeenSessionLines,
 } from "./anchored-file"
+import { ToolTimeout } from "./timeout"
 
 const DEFAULT_FILE_LIMIT = 20
 const DEFAULT_PER_FILE_LIMIT = 20
 const SINGLE_FILE_PER_FILE_LIMIT = 200
 const INTERNAL_TOTAL_CAP = 2000
-const DEFAULT_TIMEOUT_MS = 10_000
+const DEFAULT_TIMEOUT_MS = ToolTimeout.DEFAULTS.scanFilesMs
 
 function noMatchGuidance(params: { path?: string; include?: string; globs?: string[] }): string[] {
   const guidance = [

--- a/packages/synergy/src/tool/task-output.ts
+++ b/packages/synergy/src/tool/task-output.ts
@@ -1,5 +1,8 @@
 import { Tool } from "./tool"
 import z from "zod"
+import { ToolTimeout } from "./timeout"
+
+const DEFAULT_WAIT_S = ToolTimeout.DEFAULTS.taskOutputWaitMs / 1_000
 
 const parameters = z.object({
   task_id: z.string().optional().describe("Task ID from a visible background task"),
@@ -10,7 +13,7 @@ const parameters = z.object({
       "Output mode: progress for live status, tail for recent session activity, full for final output. Default: full",
     ),
   block: z.boolean().optional().describe("Wait for completion if still running"),
-  timeout: z.number().optional().describe("Max seconds to wait (default: 300)"),
+  timeout: z.number().optional().describe(`Max seconds to wait (default: ${DEFAULT_WAIT_S})`),
 })
 
 interface TaskOutputMetadata {
@@ -134,7 +137,7 @@ task_output(task_id: "ctx_abc123", block: true)
     })
 
     if ((task.status === "running" || task.status === "queued") && params.block) {
-      await Cortex.waitFor(params.task_id, params.timeout ?? 300)
+      await Cortex.waitFor(params.task_id, params.timeout ?? DEFAULT_WAIT_S)
     }
 
     const current = Cortex.getVisibleTask(ctx.sessionID, params.task_id) ?? task

--- a/packages/synergy/src/tool/task.ts
+++ b/packages/synergy/src/tool/task.ts
@@ -11,6 +11,7 @@ import { Category } from "../cortex/category"
 import { Provider } from "../provider/provider"
 import { ScopeContext } from "../scope/context"
 import { Dag } from "../session/dag"
+import { ToolTimeout } from "./timeout"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -63,7 +64,7 @@ interface TaskMetadata {
   background?: boolean
 }
 
-const SYNC_TIMEOUT_S = 300
+const SYNC_TIMEOUT_S = ToolTimeout.DEFAULTS.taskAutoBackgroundMs / 1_000
 
 async function bindDagNode(sessionID: string, nodeID: string | undefined, task: { id: string; sessionID: string }) {
   if (!nodeID) return

--- a/packages/synergy/src/tool/timeout.ts
+++ b/packages/synergy/src/tool/timeout.ts
@@ -1,0 +1,197 @@
+export namespace ToolTimeout {
+  export type Source =
+    | "execution_budget"
+    | "search"
+    | "fetch"
+    | "download"
+    | "wait"
+    | "auto_background"
+    | "question"
+    | "vision"
+    | "remote_connect"
+    | "document_extract"
+
+  export interface Metadata {
+    executionBudgetMs: number
+    operationTimeoutMs?: number
+    displayMs: number
+    source: Source
+  }
+
+  export const DEFAULTS = {
+    globMs: 15_000,
+    listMs: 15_000,
+    scanFilesMs: 10_000,
+    astGrepMs: 60_000,
+    documentExtractMs: 60_000,
+    webfetchMs: 30_000,
+    webfetchMaxMs: 120_000,
+    websearchMs: 25_000,
+    arxivSearchMs: 30_000,
+    arxivDownloadMs: 60_000,
+    browserWaitMs: 10_000,
+    browserWaitMaxMs: 60_000,
+    browserDownloadMs: 120_000,
+    browserDownloadsWaitMs: 30_000,
+    browserHelperWaitMs: 30_000,
+    browserLocatorMs: 5_000,
+    connectMs: 30_000,
+    taskAutoBackgroundMs: 300_000,
+    taskOutputWaitMs: 300_000,
+    processPollWaitMs: 30_000,
+    questionMs: 1_800_000,
+    lookAtMs: 120_000,
+    bashHardCeilingMs: 3_600_000,
+  } as const
+
+  export function create(input: {
+    executionBudgetMs: number
+    operationTimeoutMs?: number
+    source?: Source
+  }): Metadata {
+    const operationTimeoutMs = normalizeMs(input.operationTimeoutMs)
+    return {
+      executionBudgetMs: input.executionBudgetMs,
+      ...(operationTimeoutMs !== undefined ? { operationTimeoutMs } : {}),
+      displayMs: operationTimeoutMs ?? input.executionBudgetMs,
+      source: operationTimeoutMs !== undefined ? (input.source ?? "wait") : "execution_budget",
+    }
+  }
+
+  export function withOperation(
+    base: Metadata | undefined,
+    operationTimeoutMs: number | undefined,
+    source: Source,
+  ): Metadata | undefined {
+    if (!base) return undefined
+    return create({
+      executionBudgetMs: base.executionBudgetMs,
+      operationTimeoutMs,
+      source,
+    })
+  }
+
+  export function preserveMetadata(
+    existing: Record<string, any> | undefined,
+    next: Record<string, any> | undefined,
+  ): Record<string, any> | undefined {
+    if (!next) return existing
+    if (!existing?.toolTimeout) return next
+    if (next.toolTimeout !== undefined) return next
+    return { ...next, toolTimeout: existing.toolTimeout }
+  }
+
+  export function metadataForTool(input: {
+    tool: string
+    args: Record<string, any>
+    executionBudgetMs: number
+    mcpCallTimeoutMs?: number
+  }): Metadata {
+    const operation = operationForTool(input.tool, input.args, input.mcpCallTimeoutMs)
+    return create({
+      executionBudgetMs: input.executionBudgetMs,
+      operationTimeoutMs: operation?.timeoutMs,
+      source: operation?.source,
+    })
+  }
+
+  export function scheduledTimeoutLabel(timeoutMs: number | undefined): string | undefined {
+    if (timeoutMs == null || !Number.isFinite(timeoutMs) || timeoutMs <= 0) return undefined
+    return `timeout ${formatDuration(timeoutMs)}`
+  }
+
+  function operationForTool(
+    tool: string,
+    args: Record<string, any>,
+    mcpCallTimeoutMs: number | undefined,
+  ): { timeoutMs: number; source: Source } | undefined {
+    switch (tool) {
+      case "glob":
+        return { timeoutMs: DEFAULTS.globMs, source: "search" }
+      case "list":
+        return { timeoutMs: DEFAULTS.listMs, source: "search" }
+      case "scan_files":
+        return { timeoutMs: normalizeMinMs(args.timeoutMs, DEFAULTS.scanFilesMs, 1_000), source: "search" }
+      case "ast_grep":
+      case "parse_code":
+        return { timeoutMs: DEFAULTS.astGrepMs, source: "search" }
+      case "scan_document":
+        return { timeoutMs: DEFAULTS.documentExtractMs, source: "document_extract" }
+      case "webfetch":
+        return {
+          timeoutMs: Math.min(secondsToMs(args.timeout, DEFAULTS.webfetchMs), DEFAULTS.webfetchMaxMs),
+          source: "fetch",
+        }
+      case "websearch":
+        return { timeoutMs: DEFAULTS.websearchMs, source: "fetch" }
+      case "arxiv_search":
+        return { timeoutMs: DEFAULTS.arxivSearchMs, source: "fetch" }
+      case "arxiv_download":
+        return { timeoutMs: DEFAULTS.arxivDownloadMs, source: "download" }
+      case "browser_wait":
+        return {
+          timeoutMs: clampMs(args.timeout, DEFAULTS.browserWaitMs, 500, DEFAULTS.browserWaitMaxMs),
+          source: "wait",
+        }
+      case "browser_download":
+        return { timeoutMs: DEFAULTS.browserDownloadMs, source: "download" }
+      case "browser_downloads":
+        if (args.action !== "wait") return undefined
+        return {
+          timeoutMs: normalizeMs(args.timeoutMs) ?? DEFAULTS.browserDownloadsWaitMs,
+          source: "wait",
+        }
+      case "connect":
+        if (args.action !== "open" && args.action !== "close") return undefined
+        return { timeoutMs: DEFAULTS.connectMs, source: "remote_connect" }
+      case "task":
+        return { timeoutMs: DEFAULTS.taskAutoBackgroundMs, source: "auto_background" }
+      case "task_output":
+        if (!args.block) return undefined
+        return { timeoutMs: secondsToMs(args.timeout, DEFAULTS.taskOutputWaitMs), source: "wait" }
+      case "bash":
+        if (typeof args.yieldSeconds === "number" && Number.isFinite(args.yieldSeconds) && args.yieldSeconds > 0) {
+          return { timeoutMs: args.yieldSeconds * 1_000, source: "auto_background" }
+        }
+        return undefined
+      case "process":
+        if (args.action !== "poll" || !args.block) return undefined
+        return { timeoutMs: secondsToMs(args.timeout, DEFAULTS.processPollWaitMs), source: "wait" }
+      case "question":
+        return { timeoutMs: DEFAULTS.questionMs, source: "question" }
+      case "look_at":
+        return { timeoutMs: secondsToMs(args.timeout, DEFAULTS.lookAtMs), source: "vision" }
+      default:
+        if (mcpCallTimeoutMs !== undefined) return { timeoutMs: mcpCallTimeoutMs, source: "wait" }
+        return undefined
+    }
+  }
+
+  function normalizeMs(value: unknown): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined
+    return value
+  }
+
+  function normalizeMinMs(value: unknown, fallbackMs: number, minMs: number): number {
+    return Math.max(normalizeMs(value) ?? fallbackMs, minMs)
+  }
+
+  function secondsToMs(value: unknown, fallbackMs: number): number {
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return fallbackMs
+    return value * 1_000
+  }
+
+  function clampMs(value: unknown, fallbackMs: number, minMs: number, maxMs: number): number {
+    const ms = normalizeMs(value) ?? fallbackMs
+    return Math.min(Math.max(ms, minMs), maxMs)
+  }
+
+  function formatDuration(ms: number): string {
+    const seconds = Math.round(ms / 1_000)
+    if (seconds < 60) return `${seconds}s`
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    if (remainingSeconds === 0) return `${minutes}m`
+    return `${minutes}m ${remainingSeconds}s`
+  }
+}

--- a/packages/synergy/src/tool/webfetch.ts
+++ b/packages/synergy/src/tool/webfetch.ts
@@ -2,10 +2,11 @@ import z from "zod"
 import { Tool } from "./tool"
 import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
+import { ToolTimeout } from "./timeout"
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
-const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
-const MAX_TIMEOUT = 120 * 1000 // 2 minutes
+const DEFAULT_TIMEOUT = ToolTimeout.DEFAULTS.webfetchMs
+const MAX_TIMEOUT = ToolTimeout.DEFAULTS.webfetchMaxMs
 
 export const WebFetchTool = Tool.define("webfetch", {
   description: DESCRIPTION,

--- a/packages/synergy/src/tool/websearch.ts
+++ b/packages/synergy/src/tool/websearch.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import { Tool } from "./tool"
 import { Flag } from "../flag/flag"
 import DESCRIPTION from "./websearch.txt"
+import { ToolTimeout } from "./timeout"
 
 interface SearXNGResult {
   title: string
@@ -60,7 +61,7 @@ export const WebSearchTool = Tool.define("websearch", {
     if (params.timeRange) searchParams.set("time_range", params.timeRange)
 
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 25000)
+    const timeoutId = setTimeout(() => controller.abort(), ToolTimeout.DEFAULTS.websearchMs)
 
     const url = `${Flag.SYNERGY_SEARXNG_URL}/search?${searchParams}`
 

--- a/packages/synergy/src/util/document.ts
+++ b/packages/synergy/src/util/document.ts
@@ -1,11 +1,12 @@
 import * as path from "path"
 import { withTimeout } from "@/util/timeout"
+import { ToolTimeout } from "@/tool/timeout"
 
 /** File size cap for document extraction. Larger files are rejected with a clear error. */
 const MAX_FILE_BYTES = 50 * 1024 * 1024
 
 /** Default extraction timeout in milliseconds. */
-const DEFAULT_TIMEOUT_MS = 60_000
+const DEFAULT_TIMEOUT_MS = ToolTimeout.DEFAULTS.documentExtractMs
 
 /** Supported document extensions — markitdown-ts dispatches by extension. */
 const SUPPORTED_EXTENSIONS = new Set([
@@ -95,7 +96,7 @@ export namespace Document {
    * - Files exceeding the size limit.
    * - Extraction timeout.
    */
-  export async function extract(filepath: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<Extraction | null> {
+  export async function extract(filepath: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<Extraction | null> {
     const stat = await Bun.file(filepath).stat()
     if (stat.size > MAX_FILE_BYTES) {
       throw new Error(

--- a/packages/synergy/test/tool/timeout.test.ts
+++ b/packages/synergy/test/tool/timeout.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { ToolTimeout } from "../../src/tool/timeout"
+
+const executionBudgetMs = 300_000
+
+function metadata(tool: string, args: Record<string, any> = {}, mcpCallTimeoutMs?: number) {
+  return ToolTimeout.metadataForTool({
+    tool,
+    args,
+    executionBudgetMs,
+    mcpCallTimeoutMs,
+  })
+}
+
+describe("ToolTimeout", () => {
+  test("uses operation timeout for search tools", () => {
+    expect(metadata("glob")).toMatchObject({
+      executionBudgetMs,
+      operationTimeoutMs: 15_000,
+      displayMs: 15_000,
+      source: "search",
+    })
+    expect(metadata("list").operationTimeoutMs).toBe(15_000)
+    expect(metadata("scan_files").operationTimeoutMs).toBe(10_000)
+    expect(metadata("scan_files", { timeoutMs: 2_500 }).operationTimeoutMs).toBe(2_500)
+    expect(metadata("ast_grep").operationTimeoutMs).toBe(60_000)
+    expect(metadata("parse_code").operationTimeoutMs).toBe(60_000)
+  })
+
+  test("uses effective clamped timeout for webfetch", () => {
+    expect(metadata("webfetch").operationTimeoutMs).toBe(30_000)
+    expect(metadata("webfetch", { timeout: 300 })).toMatchObject({
+      operationTimeoutMs: 120_000,
+      displayMs: 120_000,
+      source: "fetch",
+    })
+  })
+
+  test("preserves 300s defaults for task tools", () => {
+    expect(metadata("task")).toMatchObject({
+      operationTimeoutMs: 300_000,
+      displayMs: 300_000,
+      source: "auto_background",
+    })
+    expect(metadata("task_output", { block: true })).toMatchObject({
+      operationTimeoutMs: 300_000,
+      displayMs: 300_000,
+      source: "wait",
+    })
+  })
+
+  test("does not invent bash timeout when yieldSeconds is absent", () => {
+    expect(metadata("bash")).toMatchObject({
+      executionBudgetMs,
+      displayMs: executionBudgetMs,
+      source: "execution_budget",
+    })
+    expect(metadata("bash").operationTimeoutMs).toBeUndefined()
+    expect(metadata("bash", { yieldSeconds: 5 })).toMatchObject({
+      operationTimeoutMs: 5_000,
+      displayMs: 5_000,
+      source: "auto_background",
+    })
+  })
+
+  test("uses operation timeout for browser, connect, and MCP waits", () => {
+    expect(metadata("browser_wait").operationTimeoutMs).toBe(10_000)
+    expect(metadata("browser_wait", { timeout: 45_000 }).operationTimeoutMs).toBe(45_000)
+    expect(metadata("browser_download").operationTimeoutMs).toBe(120_000)
+    expect(metadata("browser_downloads", { action: "wait" }).operationTimeoutMs).toBe(30_000)
+    expect(metadata("connect", { action: "open" }).operationTimeoutMs).toBe(30_000)
+    expect(metadata("connect", { action: "list" }).operationTimeoutMs).toBeUndefined()
+    expect(metadata("mcp_server_tool", {}, 20_000)).toMatchObject({
+      operationTimeoutMs: 20_000,
+      displayMs: 20_000,
+      source: "wait",
+    })
+  })
+
+  test("preserves runtime timeout metadata when tool metadata replaces the rest", () => {
+    const existing = { approval: { status: "not_required" }, toolTimeout: metadata("glob") }
+    expect(ToolTimeout.preserveMetadata(existing, { matches: 1 })).toEqual({
+      matches: 1,
+      toolTimeout: existing.toolTimeout,
+    })
+    expect(ToolTimeout.preserveMetadata(existing, undefined)).toBe(existing)
+  })
+})

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -6,6 +6,7 @@ import { ToolTrigger, type ToolTriggerProps } from "./tool/trigger"
 import { type IconName } from "./icon"
 import { ToolTextOutput } from "./tool-output-text"
 import { classifyTool } from "./tool/classifier"
+import { toolCountdown, type ToolTime } from "./tool/timeout"
 
 /** Legacy trigger value shape (pre-ToolTriggerProps). */
 interface LegacyTriggerValue {
@@ -33,6 +34,9 @@ export interface BasicToolProps {
   forceOpen?: boolean
   status?: string
   countdown?: number
+  countdownStartedAt?: number
+  metadata?: Record<string, any>
+  time?: ToolTime
   charsReceived?: number
   onSubtitleClick?: () => void
 }
@@ -95,6 +99,12 @@ export function BasicTool(props: BasicToolProps) {
     if (props.status !== "generating" || !props.charsReceived) return null
     return `${props.charsReceived.toLocaleString()} chars`
   })
+  const countdown = createMemo(() => {
+    if (props.countdown !== undefined) {
+      return { seconds: props.countdown, startedAt: props.countdownStartedAt ?? props.time?.start }
+    }
+    return toolCountdown(props.metadata, props.time)
+  })
 
   const triggerProps = createMemo(() => fromTrigger(props.trigger, props.icon, props.onSubtitleClick))
 
@@ -116,8 +126,8 @@ export function BasicTool(props: BasicToolProps) {
               <Show when={charsLabel()}>
                 <span data-slot="tool-trigger-chars">{charsLabel()}</span>
               </Show>
-              <Show when={props.countdown != null}>
-                <Countdown seconds={props.countdown!} active={active()} />
+              <Show when={countdown()}>
+                {(value) => <Countdown seconds={value().seconds} startedAt={value().startedAt} active={active()} />}
               </Show>
               <Spinner />
             </Match>
@@ -162,6 +172,7 @@ export function SmartTool(props: {
   charsReceived?: number
   hideDetails?: boolean
   metadata?: Record<string, any>
+  time?: ToolTime
   fallbackMeta?: {
     icon?: string
     title?: string
@@ -196,6 +207,8 @@ export function SmartTool(props: {
     <BasicTool
       status={props.status}
       charsReceived={props.charsReceived}
+      metadata={props.metadata}
+      time={props.time}
       trigger={{
         icon: icon(),
         title: title(),

--- a/packages/ui/src/components/countdown.tsx
+++ b/packages/ui/src/components/countdown.tsx
@@ -3,19 +3,22 @@ import { createSignal, onCleanup, Show } from "solid-js"
 export interface CountdownProps {
   seconds: number
   active: boolean
+  startedAt?: number
 }
 
 export function Countdown(props: CountdownProps) {
-  const [elapsed, setElapsed] = createSignal(0)
+  const fallbackStartedAt = Date.now()
+  const [now, setNow] = createSignal(Date.now())
 
   const timer = setInterval(() => {
-    if (props.active) setElapsed((e) => e + 1)
+    if (props.active) setNow(Date.now())
   }, 1000)
 
   onCleanup(() => clearInterval(timer))
 
-  const remaining = () => Math.max(0, props.seconds - elapsed())
-  const ratio = () => remaining() / props.seconds
+  const startedAt = () => props.startedAt ?? fallbackStartedAt
+  const remaining = () => Math.max(0, Math.ceil((startedAt() + props.seconds * 1000 - now()) / 1000))
+  const ratio = () => (props.seconds > 0 ? remaining() / props.seconds : 0)
   const expired = () => props.active && remaining() <= 0
 
   return (

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1760,6 +1760,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
       status={p.status}
       charsReceived={p.charsReceived}
       metadata={p.metadata}
+      time={p.time}
       hideDetails={p.hideDetails}
       fallbackMeta={externalFallbackLookup?.(p.tool)}
     />
@@ -1801,6 +1802,8 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               // @ts-expect-error — output exists on completed state
               output={part().state.output}
               status={part().state.status}
+              // @ts-expect-error — time exists on running/completed/error states
+              time={part().state.time}
               raw={part().state.status === "generating" ? (part().state as ToolStateGenerating).raw : undefined}
               charsReceived={charsAnimated()}
               hideDetails={props.hideDetails}

--- a/packages/ui/src/components/tool-registry-lazy.ts
+++ b/packages/ui/src/components/tool-registry-lazy.ts
@@ -12,6 +12,7 @@ export interface ToolProps {
   status?: string
   raw?: string
   charsReceived?: number
+  time?: { start?: number; end?: number; compacted?: number }
   hideDetails?: boolean
   defaultOpen?: boolean
   forceOpen?: boolean

--- a/packages/ui/src/components/tool/renders/standard.tsx
+++ b/packages/ui/src/components/tool/renders/standard.tsx
@@ -293,7 +293,6 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        countdown={props.input.timeout ?? 30}
         trigger={{
           icon: "mouse-pointer-2",
           title: "Webfetch",
@@ -326,16 +325,9 @@ ToolRegistry.register({
       if (!raw) return undefined
       return raw.length > 40 ? raw.slice(0, 37) + "…" : raw
     }
-    const countdown = () => {
-      if (props.input.background) return undefined
-      const timeout = props.input.timeout ?? 120
-      const yieldS = props.input.yieldSeconds
-      return yieldS != null ? Math.min(timeout, yieldS) : timeout
-    }
     return (
       <BasicTool
         {...props}
-        countdown={countdown()}
         trigger={{
           icon: "terminal",
           title: "Shell",
@@ -426,14 +418,9 @@ ToolRegistry.register({
     const count = () => props.input.questions?.length ?? 0
     const answers = () => props.metadata?.answers as string[][] | undefined
     const timedOut = () => props.metadata?.timedOut as boolean | undefined
-    const countdown = () => {
-      if (timedOut()) return undefined
-      return (props.metadata?.timeout ?? 1800) as number
-    }
     return (
       <BasicTool
         {...props}
-        countdown={countdown()}
         trigger={{
           icon: "message-circle",
           title: timedOut() ? "Question Timed Out" : "Questions",
@@ -506,14 +493,9 @@ ToolRegistry.register({
       if (paths.length <= 3) return paths.map(getFilename).join(", ")
       return `${paths.length} files`
     }
-    const countdown = () => {
-      if (props.metadata?.timedOut) return undefined
-      return props.input.timeout ?? 120
-    }
     return (
       <BasicTool
         {...props}
-        countdown={countdown()}
         trigger={{
           icon: "eye",
           title: props.metadata?.timedOut ? "Analysis timed out" : "Look at",
@@ -737,14 +719,9 @@ ToolRegistry.register({
       if (props.input.processId) result.push(shortId())
       return result
     }
-    const countdown = () => {
-      if (props.input.action !== "poll" || !props.input.block) return undefined
-      return props.input.timeout ?? 30
-    }
     return (
       <BasicTool
         {...props}
-        countdown={countdown()}
         trigger={{
           icon: "terminal",
           title: "Process",
@@ -801,14 +778,9 @@ ToolRegistry.register({
       const id = props.input.task_id || ""
       return id.length > 12 ? id.slice(0, 9) + "…" : id
     }
-    const countdown = () => {
-      if (!props.input.block) return undefined
-      return props.input.timeout ?? 60
-    }
     return (
       <BasicTool
         {...props}
-        countdown={countdown()}
         trigger={{
           icon: "list-todo",
           title: "Task Output",
@@ -1196,7 +1168,10 @@ ToolRegistry.register({
           icon: "calendar-days",
           title: "Schedule Agenda",
           subtitle: (props.metadata?.title || props.input.title || "") as string,
-          tags: props.metadata?.status ? [{ label: props.metadata.status as string }] : undefined,
+          tags: [
+            props.metadata?.status ? { label: props.metadata.status as string } : undefined,
+            props.metadata?.scheduledTimeoutLabel ? { label: props.metadata.scheduledTimeoutLabel as string } : undefined,
+          ].filter(Boolean) as { label: string }[],
         }}
       >
         <Show when={props.output}>
@@ -1272,7 +1247,10 @@ ToolRegistry.register({
           icon: "refresh-ccw",
           title: "Update Agenda",
           subtitle: (props.metadata?.title || props.input.id || "") as string,
-          tags: props.metadata?.status ? [{ label: props.metadata.status as string }] : undefined,
+          tags: [
+            props.metadata?.status ? { label: props.metadata.status as string } : undefined,
+            props.metadata?.scheduledTimeoutLabel ? { label: props.metadata.scheduledTimeoutLabel as string } : undefined,
+          ].filter(Boolean) as { label: string }[],
         }}
       >
         <Show when={props.output}>

--- a/packages/ui/src/components/tool/renders/task.tsx
+++ b/packages/ui/src/components/tool/renders/task.tsx
@@ -36,6 +36,9 @@ ToolRegistry.register({
     return (
       <div data-component="tool-part-wrapper" data-permission={!!childPermission()}>
         <BasicTool
+          status={props.status}
+          metadata={props.metadata}
+          time={props.time}
           defaultOpen={true}
           hideDetails={summary().length === 0}
           trigger={{

--- a/packages/ui/src/components/tool/timeout.ts
+++ b/packages/ui/src/components/tool/timeout.ts
@@ -1,0 +1,29 @@
+export interface ToolTimeoutMetadata {
+  executionBudgetMs?: number
+  operationTimeoutMs?: number
+  displayMs?: number
+  source?: string
+}
+
+export interface ToolTime {
+  start?: number
+  end?: number
+}
+
+export interface ToolCountdown {
+  seconds: number
+  startedAt?: number
+}
+
+export function toolCountdown(
+  metadata: Record<string, any> | undefined,
+  time: ToolTime | undefined,
+): ToolCountdown | undefined {
+  const timeout = metadata?.toolTimeout as ToolTimeoutMetadata | undefined
+  const displayMs = timeout?.displayMs
+  if (typeof displayMs !== "number" || !Number.isFinite(displayMs) || displayMs <= 0) return undefined
+  return {
+    seconds: Math.ceil(displayMs / 1000),
+    startedAt: typeof time?.start === "number" ? time.start : undefined,
+  }
+}

--- a/packages/ui/test/tool-timeout.test.ts
+++ b/packages/ui/test/tool-timeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { toolCountdown } from "../src/components/tool/timeout"
+
+describe("tool timeout helper", () => {
+  test("uses only metadata.toolTimeout.displayMs", () => {
+    expect(toolCountdown({ timeout: 10 }, { start: 1_000 })).toBeUndefined()
+    expect(toolCountdown({ toolTimeout: { displayMs: 15_000 } }, { start: 1_000 })).toEqual({
+      seconds: 15,
+      startedAt: 1_000,
+    })
+  })
+
+  test("keeps countdown anchored to tool start time", () => {
+    const result = toolCountdown({ toolTimeout: { displayMs: 300_000 } }, { start: 123_456 })
+    expect(result).toEqual({ seconds: 300, startedAt: 123_456 })
+  })
+
+  test("does not show countdown without a valid display timeout", () => {
+    expect(toolCountdown({}, { start: 1 })).toBeUndefined()
+    expect(toolCountdown({ toolTimeout: { displayMs: 0 } }, { start: 1 })).toBeUndefined()
+    expect(toolCountdown({ toolTimeout: { displayMs: "300000" } }, { start: 1 })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Unifies timeout metadata for Synergy tool cards by adding a backend `ToolTimeout` source of truth and a frontend metadata-only countdown helper.

- Emits `metadata.toolTimeout` when tool execution starts and preserves it through runtime metadata updates and tool settle.
- Moves existing timeout constants into the shared backend timeout source.
- Removes hardcoded frontend countdown defaults for webfetch, bash, question, look_at, process, and task_output.
- Fixes task/task_output default countdowns to 300s, bash fake 120s display, and webfetch 120s clamp display.
- Shows agenda scheduled task timeout as metadata tag instead of current tool countdown.

## Why?

Tool cards previously mixed backend execution semantics with renderer-local display guesses. That produced incorrect cards for task_output, bash, and webfetch, and made timeout behavior hard to audit. This PR keeps execution behavior unchanged while making card display data come from one backend metadata contract.

## How was it tested?

- `cd packages/synergy && bun test test/tool/timeout.test.ts`
- `cd packages/synergy && bun test test/session/processor.test.ts`
- `cd packages/synergy && bun test test/tool --dots --coverage-reporter=lcov`
- `cd packages/ui && bun test test`
- `bun run typecheck`

## Checklist

- [x] `bun run typecheck` passes
- [ ] Tests pass (`cd packages/synergy && bun test`)
- [ ] Code is formatted (`./script/format.ts`)
- [x] Documentation updated (if applicable)
- [x] No unrelated changes included
