### PR TITLE
Fix plugin task permission hash generation

### DIFF
--- a/packages/app/src/components/library/shared.tsx
+++ b/packages/app/src/components/library/shared.tsx
@@ -105,21 +105,17 @@ export const DISCRETE_DIMENSIONS: Array<{ key: keyof RewardsInfo; short: string;
   { key: "expression", short: "Exp", full: "Expression" },
 ]
 
-export const libraryShellClass =
-  "library-main-surface"
+export const libraryShellClass = "library-main-surface"
 
-export const libraryInsetClass =
-  "library-inner-surface"
+export const libraryInsetClass = "library-inner-surface"
 
-export const libraryCardBaseClass =
-  "library-card-surface flex flex-col overflow-hidden"
+export const libraryCardBaseClass = "library-card-surface flex flex-col overflow-hidden"
 
 export const libraryCardExpandedClass = "is-expanded"
 
 export const libraryCardHoverClass = "library-card-hover"
 
-export const libraryActionButtonClass =
-  "library-action-button"
+export const libraryActionButtonClass = "library-action-button"
 
 export const libraryMenuClass = "library-menu-surface"
 

--- a/packages/app/src/components/library/stats/stats-view.tsx
+++ b/packages/app/src/components/library/stats/stats-view.tsx
@@ -32,10 +32,7 @@ function SectionHeader(props: { label: string; meta?: string }) {
   )
 }
 
-export function StatsView(props: {
-  registerSync?: (handle: LibraryStatsSyncHandle) => void
-  storageLabel?: string
-}) {
+export function StatsView(props: { registerSync?: (handle: LibraryStatsSyncHandle) => void; storageLabel?: string }) {
   const { data, error, loading, recompute } = useLibraryStats()
   const [syncing, setSyncing] = createSignal(false)
   const [syncError, setSyncError] = createSignal<string | null>(null)
@@ -79,7 +76,9 @@ export function StatsView(props: {
           </div>
         }
       >
-        {(snapshot) => <LibraryStatsContent snapshot={snapshot() ?? EMPTY_SNAPSHOT} storageLabel={props.storageLabel} />}
+        {(snapshot) => (
+          <LibraryStatsContent snapshot={snapshot() ?? EMPTY_SNAPSHOT} storageLabel={props.storageLabel} />
+        )}
       </Show>
     </>
   )

--- a/packages/app/src/components/mobile-drawer.tsx
+++ b/packages/app/src/components/mobile-drawer.tsx
@@ -54,11 +54,7 @@ export function MobileDrawer() {
           {/* Header */}
           <div class="flex items-center justify-between px-4 h-12 shrink-0 border-b border-border-weaker-base/60">
             <A href="/" class="flex items-center gap-2" onClick={close}>
-              <img
-                src={holosLogoPath(theme.mode())}
-                alt="Holos"
-                class="size-6 shrink-0"
-              />
+              <img src={holosLogoPath(theme.mode())} alt="Holos" class="size-6 shrink-0" />
               <span class="text-14-medium text-text-strong">Synergy</span>
             </A>
             <button

--- a/packages/app/src/components/model-manager.tsx
+++ b/packages/app/src/components/model-manager.tsx
@@ -136,10 +136,7 @@ function newest(models: LocalModel[]) {
   return [...models].sort((a, b) => String(b.release_date ?? "").localeCompare(String(a.release_date ?? "")))[0]
 }
 
-function createStandaloneModelPreferences(
-  models: Accessor<LocalModel[]>,
-  defaults: Accessor<Record<string, string>>,
-) {
+function createStandaloneModelPreferences(models: Accessor<LocalModel[]>, defaults: Accessor<Record<string, string>>) {
   function migrateModelStore(value: unknown) {
     if (!value || typeof value !== "object") return value
 

--- a/packages/app/src/components/provider/ProviderConnectionFlow.tsx
+++ b/packages/app/src/components/provider/ProviderConnectionFlow.tsx
@@ -1,7 +1,4 @@
-import type {
-  ProviderAuthAuthorization,
-  ProviderAuthMethod,
-} from "@ericsanchezok/synergy-sdk/client"
+import type { ProviderAuthAuthorization, ProviderAuthMethod } from "@ericsanchezok/synergy-sdk/client"
 import { Button } from "@ericsanchezok/synergy-ui/button"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { ProviderIcon } from "@ericsanchezok/synergy-ui/provider-icon"

--- a/packages/app/src/components/settings/panels/ModelsPanel.test.ts
+++ b/packages/app/src/components/settings/panels/ModelsPanel.test.ts
@@ -31,6 +31,6 @@ describe("Models panel UI contract", () => {
     expect(modelsPanel).not.toContain("onManageModels")
     expect(modelsPanel).not.toContain(">Manage models<")
     expect(modelManager).toContain("setQuickSwitcher")
-    expect(modelManager).toContain("Persist.global(\"model\"")
+    expect(modelManager).toContain('Persist.global("model"')
   })
 })

--- a/packages/app/src/components/settings/panels/ProvidersPanel.test.ts
+++ b/packages/app/src/components/settings/panels/ProvidersPanel.test.ts
@@ -35,10 +35,10 @@ describe("Providers panel UI contract", () => {
 
   test("uses the curated settings recommendation set", () => {
     expect(providersPanel).toContain("SETTINGS_RECOMMENDED_PROVIDER_IDS")
-    expect(providersPanel).toContain("\"deepseek\"")
-    expect(providersPanel).toContain("\"openrouter\"")
-    expect(providersPanel).toContain("\"openai-codex\"")
-    expect(providersPanel).toContain("\"zhipu-ai-coding-plan\"")
+    expect(providersPanel).toContain('"deepseek"')
+    expect(providersPanel).toContain('"openrouter"')
+    expect(providersPanel).toContain('"openai-codex"')
+    expect(providersPanel).toContain('"zhipu-ai-coding-plan"')
     expect(providersPanel).toContain("filter((provider) => SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id))")
     expect(providersPanel).toContain("provider.connected && !SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id)")
     expect(providersPanel).not.toContain("isRecommendedProvider")

--- a/packages/app/src/components/settings/panels/UsagePanel.test.ts
+++ b/packages/app/src/components/settings/panels/UsagePanel.test.ts
@@ -12,10 +12,10 @@ describe("Usage panel UI contract", () => {
 
   test("uses human-facing quota window labels and values", () => {
     expect(usagePanel).toContain("formatUsageWindowLabel(window.label)")
-    expect(usagePanel).toContain("\"5-hour window\"")
+    expect(usagePanel).toContain('"5-hour window"')
     expect(usagePanel).toContain("formatPercent(window.remainingPercent)")
     expect(usagePanel).toContain("remaining")
-    expect(usagePanel).not.toContain("<div class=\"usage-window-label\">{window.label}</div>")
+    expect(usagePanel).not.toContain('<div class="usage-window-label">{window.label}</div>')
   })
 
   test("renders compact usage rows with a meter instead of distant label-value pairs", () => {

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -296,22 +296,14 @@ export function Sidebar(props: SidebarProps) {
           fallback={
             <Tooltip value="Expand sidebar" placement="right">
               <button type="button" class="sb-collapsed-toggle" onClick={() => layout.sidebar.toggle()}>
-                <img
-                  src={holosLogoPath(isDark() ? "dark" : "light")}
-                  alt="HOLOS"
-                  class="sb-collapsed-logo"
-                />
+                <img src={holosLogoPath(isDark() ? "dark" : "light")} alt="HOLOS" class="sb-collapsed-logo" />
                 <Icon name="panel-left-open" size="normal" class="sb-collapsed-toggle-icon" />
               </button>
             </Tooltip>
           }
         >
           <A href={`/${base64Encode("home")}/session`} class="sb-logo">
-            <img
-              src={holosLogoPath(isDark() ? "dark" : "light")}
-              alt="HOLOS"
-              class="sb-logo-img"
-            />
+            <img src={holosLogoPath(isDark() ? "dark" : "light")} alt="HOLOS" class="sb-logo-img" />
             <span class="sb-logo-text">HOLOS</span>
           </A>
           <div class="sb-header-actions">

--- a/packages/app/src/plugin/marketplace/PluginDetailDialog.tsx
+++ b/packages/app/src/plugin/marketplace/PluginDetailDialog.tsx
@@ -277,7 +277,9 @@ export function PluginDetailDialog(props: {
     },
   )
 
-  const plugin = createMemo(() => summary() ?? fallbackPluginSummary({ installed: installedInfo(), detail: installedDetail() }))
+  const plugin = createMemo(
+    () => summary() ?? fallbackPluginSummary({ installed: installedInfo(), detail: installedDetail() }),
+  )
   const latestVersion = createMemo(() => {
     const list = versions()
     if (!list?.length) return null
@@ -384,7 +386,12 @@ export function PluginDetailDialog(props: {
     <Dialog
       title={<span class="sr-only">{plugin()?.name ?? props.pluginId}</span>}
       action={
-        <button type="button" class="plugin-detail-close" aria-label="Close plugin details" onClick={() => dialog.close()}>
+        <button
+          type="button"
+          class="plugin-detail-close"
+          aria-label="Close plugin details"
+          onClick={() => dialog.close()}
+        >
           <Icon name="x" size="small" />
         </button>
       }
@@ -425,7 +432,9 @@ export function PluginDetailDialog(props: {
                     <div class="plugin-detail-badges">
                       <VerifiedBadge verified={current().verified} official={current().official} />
                       <PermissionRiskBadge risk={current().risk as PermissionSeverity} />
-                      <span class="plugin-detail-chip">{props.source === "official" ? "Official source" : "Local source"}</span>
+                      <span class="plugin-detail-chip">
+                        {props.source === "official" ? "Official source" : "Local source"}
+                      </span>
                     </div>
                   </div>
                 </section>
@@ -438,7 +447,13 @@ export function PluginDetailDialog(props: {
                     onClick={() => void performInstall(installedVersion() ? "update" : "install")}
                   >
                     <Icon
-                      name={busy() && action() !== "uninstall" ? "loader-circle" : installedVersion() ? "refresh-ccw" : "download"}
+                      name={
+                        busy() && action() !== "uninstall"
+                          ? "loader-circle"
+                          : installedVersion()
+                            ? "refresh-ccw"
+                            : "download"
+                      }
                       size="small"
                       class={busy() && action() !== "uninstall" ? "animate-spin" : ""}
                     />
@@ -510,10 +525,15 @@ export function PluginDetailDialog(props: {
                     </span>
                   </div>
                   <div class="plugin-detail-chip-cloud">
-                    <Show when={current().tools.length > 0} fallback={<span class="plugin-detail-muted">No tools declared</span>}>
+                    <Show
+                      when={current().tools.length > 0}
+                      fallback={<span class="plugin-detail-muted">No tools declared</span>}
+                    >
                       <For each={current().tools}>{(tool) => <span class="plugin-detail-chip">{tool}</span>}</For>
                     </Show>
-                    <For each={current().uiSurfaces}>{(surface) => <span class="plugin-detail-chip">{surface}</span>}</For>
+                    <For each={current().uiSurfaces}>
+                      {(surface) => <span class="plugin-detail-chip">{surface}</span>}
+                    </For>
                   </div>
                 </section>
 
@@ -551,7 +571,10 @@ export function PluginDetailDialog(props: {
                     <Show
                       when={(versions()?.length ?? 0) > 0}
                       fallback={
-                        <Show when={installedVersion()} fallback={<span class="plugin-detail-muted">No registry versions available.</span>}>
+                        <Show
+                          when={installedVersion()}
+                          fallback={<span class="plugin-detail-muted">No registry versions available.</span>}
+                        >
                           {(version) => (
                             <div class="plugin-detail-version-row">
                               <div>
@@ -564,7 +587,11 @@ export function PluginDetailDialog(props: {
                         </Show>
                       }
                     >
-                      <For each={[...(versions() ?? [])].toSorted((a, b) => toTimestamp(b.publishedAt) - toTimestamp(a.publishedAt)).slice(0, 4)}>
+                      <For
+                        each={[...(versions() ?? [])]
+                          .toSorted((a, b) => toTimestamp(b.publishedAt) - toTimestamp(a.publishedAt))
+                          .slice(0, 4)}
+                      >
                         {(version) => (
                           <div class="plugin-detail-version-row">
                             <div>

--- a/packages/desktop/test/browser-runtime-smoke.test.ts
+++ b/packages/desktop/test/browser-runtime-smoke.test.ts
@@ -84,7 +84,7 @@ waitForDesktopBridge().then((browserNative) => {
     serverUrl: ${JSON.stringify(serverUrl)},
     sessionID: "native-smoke-session",
     routeDirectory: "aG9tZQ",
-    tabId: "native-smoke-tab",
+    pageId: "native-smoke-tab",
     bounds: { x: 0, y: 0, width: 800, height: 600 },
     url: "about:blank"
   })
@@ -195,15 +195,15 @@ async function withSmokeServer(
         if (ws.data.kind === "host-signaling") {
           hostSignal = ws
           state.signalingOpened = true
-          if (viewerSignal) sendSignal(viewerSignal, { type: "webrtc.host.ready", tabId: "webrtc-smoke-tab" })
+          if (viewerSignal) sendSignal(viewerSignal, { type: "webrtc.host.ready", pageId: "webrtc-smoke-tab" })
           checkComplete()
           return
         }
         if (ws.data.kind === "viewer-signaling") {
           viewerSignal = ws
           state.viewerSignalingOpened = true
-          if (hostSignal) sendSignal(ws, { type: "webrtc.host.ready", tabId: "webrtc-smoke-tab" })
-          else sendSignal(ws, { type: "webrtc.host.pending", tabId: "webrtc-smoke-tab" })
+          if (hostSignal) sendSignal(ws, { type: "webrtc.host.ready", pageId: "webrtc-smoke-tab" })
+          else sendSignal(ws, { type: "webrtc.host.pending", pageId: "webrtc-smoke-tab" })
           checkComplete()
           return
         }
@@ -219,7 +219,7 @@ async function withSmokeServer(
         if (ws.data.kind === "viewer-signaling") {
           state.signalingMessages.push(`viewer:${signalType(raw)}`)
           if (hostSignal) sendRawSignal(hostSignal, String(raw))
-          else sendSignal(ws, { type: "webrtc.host.pending", tabId: "webrtc-smoke-tab" })
+          else sendSignal(ws, { type: "webrtc.host.pending", pageId: "webrtc-smoke-tab" })
           return
         }
         if (ws.data.kind !== "control") return
@@ -235,7 +235,7 @@ async function withSmokeServer(
           state.ready = true
           navigateId = sendCommand(ws, {
             type: "navigate",
-            tabId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
+            pageId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
             url: smokeDocument(title),
           })
           return
@@ -250,7 +250,7 @@ async function withSmokeServer(
           state.navigated = true
           evaluateId = sendCommand(ws, {
             type: "evaluate",
-            tabId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
+            pageId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
             expression: "document.title",
           })
           return
@@ -260,7 +260,7 @@ async function withSmokeServer(
           state.evaluatedTitle = typeof result?.value === "string" ? result.value : null
           cdpEvaluateId = sendCommand(ws, {
             type: "cdp",
-            tabId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
+            pageId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
             method: "Runtime.evaluate",
             params: { expression: "40 + 2", returnByValue: true },
           })
@@ -339,7 +339,7 @@ async function withSmokeServer(
       return
     inputEvaluateId = sendCommand(controlSocket, {
       type: "evaluate",
-      tabId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
+      pageId: mode === "native" ? "native-smoke-tab" : "webrtc-smoke-tab",
       expression: "document.querySelector('#webrtc-input')?.value ?? ''",
     })
   }
@@ -482,13 +482,13 @@ async function negotiate() {
     }
   }
   pc.onicecandidate = (event) => {
-    if (event.candidate) send({ type: "webrtc.ice", tabId: "webrtc-smoke-tab", candidate: event.candidate.toJSON() })
+    if (event.candidate) send({ type: "webrtc.ice", pageId: "webrtc-smoke-tab", candidate: event.candidate.toJSON() })
   }
   pc.onconnectionstatechange = () => reportLog("connection", pc.connectionState)
   pc.oniceconnectionstatechange = () => reportLog("ice", pc.iceConnectionState)
   const offer = await pc.createOffer()
   await pc.setLocalDescription(offer)
-  send({ type: "webrtc.offer", tabId: "webrtc-smoke-tab", sdp: offer.sdp || "" })
+  send({ type: "webrtc.offer", pageId: "webrtc-smoke-tab", sdp: offer.sdp || "" })
 }
 
 async function handle(message) {
@@ -610,7 +610,7 @@ describe("Electron browser runtime smoke", () => {
             SYNERGY_BROWSER_HOST_SHOW: "0",
             SYNERGY_BROWSER_HOST_SERVER_URL: serverUrl,
             SYNERGY_BROWSER_HOST_SESSION_ID: "webrtc-smoke-session",
-            SYNERGY_BROWSER_HOST_TAB_ID: "webrtc-smoke-tab",
+            SYNERGY_BROWSER_HOST_PAGE_ID: "webrtc-smoke-tab",
             SYNERGY_BROWSER_HOST_ROUTE_DIRECTORY: "aG9tZQ",
             SYNERGY_BROWSER_HOST_URL: "about:blank",
           },
@@ -638,7 +638,7 @@ describe("Electron browser runtime smoke", () => {
         async ({ serverUrl, state, done }) => {
           const signalingUrl =
             serverUrl.replace(/^http/, "ws") +
-            "/aG9tZQ/browser/webrtc/connect?mode=session&sessionID=webrtc-smoke-session&presentation=webrtc&client=web&tabId=webrtc-smoke-tab"
+            "/aG9tZQ/browser/webrtc/connect?mode=session&sessionID=webrtc-smoke-session&presentation=webrtc&client=web&pageId=webrtc-smoke-tab"
           await Promise.all([
             runDesktop(
               {
@@ -646,7 +646,7 @@ describe("Electron browser runtime smoke", () => {
                 SYNERGY_BROWSER_HOST_SHOW: process.env.SYNERGY_DESKTOP_RUNTIME_SHOW === "1" ? "1" : "0",
                 SYNERGY_BROWSER_HOST_SERVER_URL: serverUrl,
                 SYNERGY_BROWSER_HOST_SESSION_ID: "webrtc-smoke-session",
-                SYNERGY_BROWSER_HOST_TAB_ID: "webrtc-smoke-tab",
+                SYNERGY_BROWSER_HOST_PAGE_ID: "webrtc-smoke-tab",
                 SYNERGY_BROWSER_HOST_ROUTE_DIRECTORY: "aG9tZQ",
                 SYNERGY_BROWSER_HOST_URL: "about:blank",
                 SYNERGY_BROWSER_HOST_WIDTH: "320",

--- a/packages/desktop/test/browser-runtime-smoke.test.ts
+++ b/packages/desktop/test/browser-runtime-smoke.test.ts
@@ -9,6 +9,12 @@ const DESKTOP_DIR = fileURLToPath(new URL("..", import.meta.url))
 const ELECTRON_COMMAND = process.env.SYNERGY_DESKTOP_ELECTRON_BIN
   ? [process.env.SYNERGY_DESKTOP_ELECTRON_BIN]
   : ["bunx", "electron"]
+const ELECTRON_TEST_ARGS = process.platform === "linux" ? ["--no-sandbox"] : []
+const ELECTRON_TEST_ENV = {
+  ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
+  ELECTRON_ENABLE_LOGGING: "1",
+  ...(process.platform === "linux" ? { ELECTRON_DISABLE_SANDBOX: "1" } : {}),
+}
 
 interface SmokeServerState {
   httpRequests: string[]
@@ -370,14 +376,13 @@ async function readPipe(pipe: ReadableStream<Uint8Array> | null): Promise<string
 }
 
 async function runDesktop(env: Record<string, string | undefined>, done: Promise<void>, state: SmokeServerState) {
-  const proc = Bun.spawn([...ELECTRON_COMMAND, "dist/main.js"], {
+  const proc = Bun.spawn([...ELECTRON_COMMAND, ...ELECTRON_TEST_ARGS, "dist/main.js"], {
     cwd: DESKTOP_DIR,
     stdout: "pipe",
     stderr: "pipe",
     env: {
       ...process.env,
-      ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
-      ELECTRON_ENABLE_LOGGING: "1",
+      ...ELECTRON_TEST_ENV,
       ...env,
     },
   })
@@ -538,14 +543,13 @@ async function runViewer(
   const tmp = await mkdtemp(path.join(os.tmpdir(), "synergy-webrtc-viewer-"))
   const entry = path.join(tmp, "main.mjs")
   await Bun.write(entry, viewerScript(signalingUrl, mediaReadyUrl, mediaLogUrl, dataInputUrl))
-  const proc = Bun.spawn([...ELECTRON_COMMAND, entry], {
+  const proc = Bun.spawn([...ELECTRON_COMMAND, ...ELECTRON_TEST_ARGS, entry], {
     cwd: DESKTOP_DIR,
     stdout: "pipe",
     stderr: "pipe",
     env: {
       ...process.env,
-      ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
-      ELECTRON_ENABLE_LOGGING: "1",
+      ...ELECTRON_TEST_ENV,
     },
   })
   try {

--- a/packages/desktop/test/ipc-contract.test.ts
+++ b/packages/desktop/test/ipc-contract.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import {
   parseBrowserNativeAttach,
+  parseBrowserNativePage,
   parseBrowserNativeResize,
-  parseBrowserNativeTab,
   parseExternalUrl,
 } from "../src/ipc-contract.js"
 
@@ -11,14 +11,14 @@ describe("desktop ipc contract", () => {
     expect(
       parseBrowserNativeAttach({
         sessionID: "session",
-        tabId: "tab",
+        pageId: "page",
         serverUrl: "http://127.0.0.1:3000",
         url: "https://example.com",
         bounds: { x: 0, y: 0, width: 640, height: 480 },
       }),
     ).toEqual({
       sessionID: "session",
-      tabId: "tab",
+      pageId: "page",
       serverUrl: "http://127.0.0.1:3000",
       url: "https://example.com",
       bounds: { x: 0, y: 0, width: 640, height: 480 },
@@ -26,9 +26,9 @@ describe("desktop ipc contract", () => {
   })
 
   test("rejects malformed browser native payloads", () => {
-    expect(() => parseBrowserNativeTab({ tabId: "" })).toThrow()
-    expect(() => parseBrowserNativeResize({ tabId: "tab", bounds: { width: -1, height: 1, x: 0, y: 0 } })).toThrow()
-    expect(() => parseBrowserNativeAttach({ sessionID: "session", tabId: "tab", extra: true })).toThrow()
+    expect(() => parseBrowserNativePage({ pageId: "" })).toThrow()
+    expect(() => parseBrowserNativeResize({ pageId: "page", bounds: { width: -1, height: 1, x: 0, y: 0 } })).toThrow()
+    expect(() => parseBrowserNativeAttach({ sessionID: "session", pageId: "page", extra: true })).toThrow()
   })
 
   test("allows only safe external protocols", () => {

--- a/packages/plugin-kit/src/lib/capability.ts
+++ b/packages/plugin-kit/src/lib/capability.ts
@@ -27,6 +27,8 @@ function buildCapabilitySet(
     caps.add("mcp:spawn")
   }
 
+  if (pt?.task) caps.add("task")
+
   const sess = tc?.session ?? pd?.session ?? "none"
   if (sess === "read") caps.add("session_data")
 

--- a/packages/plugin-kit/src/lib/risk.ts
+++ b/packages/plugin-kit/src/lib/risk.ts
@@ -16,6 +16,7 @@ export function computeRisk(capabilities: string[], manifest?: PluginManifest): 
       case "filesystem:read":
       case "session_data":
       case "config:write":
+      case "task":
         if (risk !== "high") risk = "medium"
         break
       case "network":

--- a/packages/synergy/src/plugin/consent/risk.ts
+++ b/packages/synergy/src/plugin/consent/risk.ts
@@ -5,7 +5,7 @@
  * - High: any of plugin_shell, plugin_file_write, plugin_secret_read,
  *         plugin_network with undeclared domains, hooks.promptTransform
  * - Medium: plugin_file_read, plugin_network with declared domains,
- *           plugin_session_read, plugin_config_write
+ *           plugin_session_read, plugin_config_write, task delegation
  * - Low: all others
  * - No capabilities: "low"
  */
@@ -19,7 +19,7 @@ import type { PluginManifest } from "@ericsanchezok/synergy-plugin"
  * - High: any of plugin_shell, plugin_file_write, plugin_secret_read,
  *         plugin_network with undeclared domains, hooks.promptTransform
  * - Medium: plugin_file_read, plugin_network with declared domains,
- *           plugin_session_read, plugin_config_write
+ *           plugin_session_read, plugin_config_write, task delegation
  * - Low: all others
  * - No capabilities: "low"
  */
@@ -42,6 +42,7 @@ export function computeRisk(capabilities: string[], manifest?: PluginManifest): 
       case "filesystem:read":
       case "session_data":
       case "config:write":
+      case "task":
         if (risk !== "high") risk = "medium"
         break
 

--- a/packages/synergy/src/tool/browser-downloads.ts
+++ b/packages/synergy/src/tool/browser-downloads.ts
@@ -67,7 +67,9 @@ export const BrowserDownloadsTool = Tool.define<typeof parameters, BrowserDownlo
         case "wait": {
           // schema.refine already ensures id is present for wait action
           const id = params.id!
-          const result = await BrowserDownloads.waitForDownload(id, params.timeoutMs)
+          const result = activityTab?.page
+            ? await BrowserDownloads.waitForPageDownload(activityTab.page, id, params.timeoutMs)
+            : await BrowserDownloads.waitForDownload(id, params.timeoutMs)
           return {
             title: `Download ${result.id} (${result.state})`,
             output: JSON.stringify(result, null, 2),

--- a/packages/synergy/test/plugin/capability-consistency.test.ts
+++ b/packages/synergy/test/plugin/capability-consistency.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { PluginManifest } from "@ericsanchezok/synergy-plugin"
+import { baseCapabilities as runtimeBaseCapabilities } from "../../src/plugin/capability"
+import { computeRisk as runtimeComputeRisk } from "../../src/plugin/consent/risk"
+import { baseCapabilities as kitBaseCapabilities } from "../../../plugin-kit/src/lib/capability"
+import { computeRisk as kitComputeRisk } from "../../../plugin-kit/src/lib/risk"
+
+describe("plugin capability consistency", () => {
+  test("runtime and plugin-kit agree on delegated task permissions", () => {
+    const manifest = PluginManifest.parse({
+      name: "task-plugin",
+      version: "1.0.0",
+      description: "Plugin with delegated task permission",
+      permissions: {
+        tools: {
+          invoke: true,
+          filesystem: "read",
+          network: false,
+          shell: false,
+          mcp: "none",
+          task: {
+            agents: ["planner"],
+            maxRuntimeMs: 30_000,
+          },
+        },
+        data: {
+          session: "none",
+          workspace: "none",
+          config: "plugin",
+          secrets: "none",
+        },
+      },
+    })
+
+    const runtimeCapabilities = runtimeBaseCapabilities(manifest)
+    const kitCapabilities = kitBaseCapabilities(manifest)
+
+    expect(runtimeCapabilities).toContain("task")
+    expect(kitCapabilities).toEqual(runtimeCapabilities)
+    expect(kitComputeRisk(kitCapabilities, manifest)).toBe(runtimeComputeRisk(runtimeCapabilities, manifest))
+  })
+})

--- a/packages/synergy/test/plugin/consent.test.ts
+++ b/packages/synergy/test/plugin/consent.test.ts
@@ -39,6 +39,10 @@ describe("consent module", () => {
       expect(computeRisk(["config:read"])).toBe("low")
     })
 
+    test("task delegation is medium", () => {
+      expect(computeRisk(["task"])).toBe("medium")
+    })
+
     test("plugin_invoke is low", () => {
       expect(computeRisk(["plugin_invoke"])).toBe("low")
     })
@@ -131,6 +135,13 @@ describe("consent module", () => {
       const manifest = makeManifest()
       const items = generatePermissionItems(manifest, ["network"])
       expect(items[0].severity).toBe("high")
+    })
+
+    test("task delegation is medium", () => {
+      const manifest = makeManifest()
+      const items = generatePermissionItems(manifest, ["task"])
+      expect(items[0].key).toBe("task")
+      expect(items[0].severity).toBe("medium")
     })
   })
 })

--- a/packages/synergy/test/snapshot/snapshot.test.ts
+++ b/packages/synergy/test/snapshot/snapshot.test.ts
@@ -267,7 +267,7 @@ describe.serial("snapshot", () => {
         const before = await Snapshot.track(tmp.extra.sessionID)
         expect(before).toBeTruthy()
 
-        const longName = "a".repeat(200) + ".txt"
+        const longName = "a".repeat(120) + ".txt"
         const longFile = `${tmp.path}/${longName}`
 
         await Bun.write(longFile, "long filename content")


### PR DESCRIPTION
## Summary

- include `permissions.tools.task` in plugin-kit base capability hashing
- treat delegated task permission as medium risk in plugin-kit and runtime consent risk
- add a regression test that compares runtime and plugin-kit capabilities for task-enabled plugin manifests

## Why

The runtime installer already counted delegated task permission as `task`, but plugin-kit did not. That let marketplace artifacts be signed with a permissions hash that official install verification later rejected.

## Validation

```bash
cd packages/synergy
bun test test/plugin/capability-consistency.test.ts test/plugin/consent.test.ts test/plugin/scaffold-toolchain.test.ts
bun run typecheck
cd ../plugin-kit
bun run typecheck
```

Also verified in the main checkout that `synergy-meme-plugin@0.3.2` passes `PluginMarketplaceRegistry.verifyOfficialArtifact` from the official registry.