### PR TITLE
Fix permanent session freezes: timed git spawns, authoritative turn deadline, provider stream timeout wiring

### DIFF
--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -593,7 +593,11 @@ export namespace Provider {
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
 
-        const timeoutMs = options["timeout"] === false ? false : (options["timeout"] ?? DEFAULT_TIMEOUT_MS)
+        // Provider-level options take precedence; otherwise use the configured
+        // idle timeout (timeout.provider.idle_sec). `false` disables it.
+        const configuredIdle = options["timeout"] !== undefined ? options["timeout"] : timeoutCfg.providerIdleMs
+        const timeoutMs =
+          configuredIdle === false ? false : ((configuredIdle as number | undefined) ?? DEFAULT_TIMEOUT_MS)
 
         let ttfbController: AbortController | null = null
         let ttfbTimer: ReturnType<typeof setTimeout> | null = null
@@ -663,9 +667,16 @@ export namespace Provider {
             timeout: false,
           })
         } catch (error) {
+          cleanupTimers()
           fetchTimer.stop({ status: "exception" })
           log.error("fetch.request.failed", { url: safeUrl, error })
           throw error
+        }
+        // First byte arrived — stop the TTFB timer so it cannot abort a
+        // healthy long-lived stream later on.
+        if (ttfbTimer) {
+          clearTimeout(ttfbTimer)
+          ttfbTimer = null
         }
         fetchTimer.stop({ status: response.ok ? "success" : "error", statusCode: response.status })
         if (!response.ok) {
@@ -679,6 +690,14 @@ export namespace Provider {
         // For streaming responses, wrap the body to reset idle timer on each chunk
         if (idleController && response.body) {
           const originalBody = response.body
+          const idleSignal = idleController.signal
+          // Aborting the fetch signal does not reliably reject a pending body
+          // read on a half-open connection, so the idle timeout must also win
+          // a race against the read itself.
+          const idleAborted = new Promise<never>((_, reject) => {
+            idleSignal.addEventListener("abort", () => reject(idleSignal.reason), { once: true })
+          })
+          idleAborted.catch(() => {})
           const resetIdle = () => {
             if (idleTimer) clearTimeout(idleTimer)
             idleTimer = setTimeout(() => {
@@ -693,7 +712,7 @@ export namespace Provider {
               const reader = originalBody.getReader()
               try {
                 while (true) {
-                  const { done, value } = await reader.read()
+                  const { done, value } = await Promise.race([reader.read(), idleAborted])
                   if (done) {
                     if (idleTimer) clearTimeout(idleTimer)
                     controller.close()
@@ -705,8 +724,13 @@ export namespace Provider {
               } catch (err) {
                 if (idleTimer) clearTimeout(idleTimer)
                 controller.error(err)
+                try {
+                  reader.cancel(err).catch(() => {})
+                } catch {}
               } finally {
-                reader.releaseLock()
+                try {
+                  reader.releaseLock()
+                } catch {}
               }
             },
             cancel() {

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -759,26 +759,51 @@ export namespace SessionInvoke {
         const processTimer = log.time("processor.process")
         const timeoutCfg = await TimeoutConfig.resolve()
         const turnDeadline = new AbortController()
+        const deadlineError = new DOMException("Turn timed out after " + timeoutCfg.invokeMs + "ms", "AbortError")
+        let rejectDeadline: (error: Error) => void
+        const deadlinePromise = new Promise<never>((_, reject) => {
+          rejectDeadline = reject
+        })
+        deadlinePromise.catch(() => {})
         const turnTimer = setTimeout(() => {
-          turnDeadline.abort(new DOMException("Turn timed out after " + timeoutCfg.invokeMs + "ms", "AbortError"))
+          turnDeadline.abort(deadlineError)
+          rejectDeadline(deadlineError)
         }, timeoutCfg.invokeMs)
         abort.addEventListener("abort", () => clearTimeout(turnTimer), { once: true })
         const combinedAbort = AbortSignal.any([abort, turnDeadline.signal])
 
-        const result = await processor.process({
-          user: lastUser,
-          agent,
-          abort: combinedAbort,
-          sessionID,
-          system: promptPlan.system,
-          systemCacheBreakpoint: promptPlan.systemCacheBreakpoint,
-          messages: promptPlan.messages,
-          tools: resolvedTools.tools,
-          activeToolIDs: resolvedTools.activeToolIDs,
-          model,
-        })
-        clearTimeout(turnTimer)
-        processTimer.stop()
+        // Race against the deadline instead of relying on abort propagation:
+        // the processor can be stuck in an await that never observes signals
+        // (e.g. a wedged subprocess), and a signal alone cannot interrupt it.
+        let result: Awaited<ReturnType<typeof processor.process>>
+        try {
+          result = await Promise.race([
+            processor.process({
+              user: lastUser,
+              agent,
+              abort: combinedAbort,
+              sessionID,
+              system: promptPlan.system,
+              systemCacheBreakpoint: promptPlan.systemCacheBreakpoint,
+              messages: promptPlan.messages,
+              tools: resolvedTools.tools,
+              activeToolIDs: resolvedTools.activeToolIDs,
+              model,
+            }),
+            deadlinePromise,
+          ])
+        } catch (error) {
+          if (error !== deadlineError) throw error
+          log.error("turn deadline exceeded, abandoning turn", { sessionID, timeoutMs: timeoutCfg.invokeMs })
+          processor.message.error = MessageV2.fromError(deadlineError, { providerID: model.providerID })
+          processor.message.time.completed = Date.now()
+          await Session.updateMessage(processor.message)
+          Bus.publish(SessionEvent.Error, { sessionID, error: processor.message.error })
+          result = "stop"
+        } finally {
+          clearTimeout(turnTimer)
+          processTimer.stop()
+        }
 
         // post-LLM jobs
         const postParts = await MessageV2.parts({ scopeID, sessionID, messageID: processor.message.id })

--- a/packages/synergy/src/session/snapshot.ts
+++ b/packages/synergy/src/session/snapshot.ts
@@ -1,4 +1,3 @@
-import { $ } from "bun"
 import path from "path"
 import fs from "fs/promises"
 import { Log } from "../util/log"
@@ -7,10 +6,15 @@ import z from "zod"
 import { Config } from "../config/config"
 import { ScopeContext } from "../scope/context"
 import { SnapshotSchema } from "./snapshot-schema"
+import { withTimeout } from "../util/timeout"
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const SNAPSHOT_TIMEOUT_MS = 10_000
+  // Extra headroom past the abort timeout: the abort signal can only kill the
+  // child process — it cannot rescue a stdout/exit collection promise that
+  // never settles, so the whole collection is raced against this deadline.
+  const SNAPSHOT_HARD_TIMEOUT_MS = SNAPSHOT_TIMEOUT_MS + 5_000
   const SNAPSHOT_MAX_FILE_BYTES = 2 * 1024 * 1024
   const EXCLUDED_DIRS = new Set([
     ".git",
@@ -86,10 +90,11 @@ export namespace Snapshot {
     cwd: string,
     env?: Record<string, string>,
     signal?: AbortSignal,
-  ): Promise<{ exitCode: number; text: string }> {
+  ): Promise<{ exitCode: number; text: string; stderr: string }> {
     const childSignal = spawnSignal(SNAPSHOT_TIMEOUT_MS, signal)
+    let proc: Bun.Subprocess<"ignore", "pipe", "pipe"> | undefined
     try {
-      const proc = Bun.spawn(args, {
+      proc = Bun.spawn(args, {
         cwd,
         stdout: "pipe",
         stderr: "pipe",
@@ -98,12 +103,18 @@ export namespace Snapshot {
       })
       const stdout = new Response(proc.stdout).text()
       const stderr = new Response(proc.stderr).text().catch(() => "")
-      const [text, exitCode] = await Promise.all([stdout, proc.exited])
-      await stderr
-      return { exitCode, text }
+      const [text, stderrText, exitCode] = await withTimeout(
+        Promise.all([stdout, stderr, proc.exited]),
+        SNAPSHOT_HARD_TIMEOUT_MS,
+        { message: `git subprocess did not settle within ${SNAPSHOT_HARD_TIMEOUT_MS}ms` },
+      )
+      return { exitCode, text, stderr: stderrText }
     } catch (err) {
-      log.debug("git spawn failed", { args, cwd, error: String(err) })
-      return { exitCode: -1, text: "" }
+      log.warn("git spawn failed", { args, cwd, error: String(err) })
+      try {
+        proc?.kill()
+      } catch {}
+      return { exitCode: -1, text: "", stderr: "" }
     } finally {
       childSignal.cleanup()
     }
@@ -113,6 +124,8 @@ export namespace Snapshot {
     if (ScopeContext.current.scope.type !== "project" || ScopeContext.current.scope.vcs !== "git") return
     const cfg = await Config.current()
     if (cfg.snapshot === false) return
+    const started = Date.now()
+    log.debug("track start", { sessionID, cwd: ScopeContext.current.directory })
     const git = gitdir(sessionID)
     if (await fs.mkdir(git, { recursive: true })) {
       const initResult = await gitSpawn(
@@ -122,7 +135,7 @@ export namespace Snapshot {
         signal,
       )
       if (initResult.exitCode !== 0) {
-        log.warn("track init failed", { exitCode: initResult.exitCode })
+        log.warn("track init failed", { sessionID, exitCode: initResult.exitCode, duration: Date.now() - started })
         return undefined
       }
       await gitSpawn(
@@ -135,7 +148,7 @@ export namespace Snapshot {
     }
     const addResult = await refreshIndex(sessionID, signal)
     if (!addResult) {
-      log.warn("track add failed")
+      log.warn("track add failed", { sessionID, duration: Date.now() - started })
       return undefined
     }
     const writeResult = await gitSpawn(
@@ -145,11 +158,11 @@ export namespace Snapshot {
       signal,
     )
     if (writeResult.exitCode !== 0 || !writeResult.text.trim()) {
-      log.warn("track write-tree failed", { exitCode: writeResult.exitCode })
+      log.warn("track write-tree failed", { sessionID, exitCode: writeResult.exitCode, duration: Date.now() - started })
       return undefined
     }
     const hash = writeResult.text.trim()
-    log.info("tracking", { hash, cwd: ScopeContext.current.directory, git })
+    log.info("tracking", { hash, cwd: ScopeContext.current.directory, git, duration: Date.now() - started })
     return hash
   }
 
@@ -164,11 +177,13 @@ export namespace Snapshot {
     sessionID: string,
     opts?: { indexFresh?: boolean; signal?: AbortSignal },
   ): Promise<Patch> {
+    const started = Date.now()
+    log.debug("patch start", { sessionID, hash })
     const git = gitdir(sessionID)
     if (!opts?.indexFresh) {
       const addResult = await refreshIndex(sessionID, opts?.signal)
       if (!addResult) {
-        log.warn("patch add failed", { hash })
+        log.warn("patch add failed", { sessionID, hash, duration: Date.now() - started })
         return { hash, files: [] }
       }
     }
@@ -194,11 +209,18 @@ export namespace Snapshot {
     )
 
     if (diffResult.exitCode !== 0) {
-      log.warn("failed to get diff", { hash, exitCode: diffResult.exitCode })
+      log.warn("failed to get diff", {
+        sessionID,
+        hash,
+        exitCode: diffResult.exitCode,
+        stderr: diffResult.stderr,
+        duration: Date.now() - started,
+      })
       return { hash, files: [] }
     }
 
     const filesText = diffResult.text
+    log.debug("patch done", { sessionID, hash, duration: Date.now() - started })
     return {
       hash,
       files: filesText
@@ -229,16 +251,25 @@ export namespace Snapshot {
           if (seen.has(file)) continue
           seen.add(file)
           const relativePath = path.relative(ScopeContext.current.directory, file).replaceAll("\\", "/")
-          const result =
-            await $`git --git-dir ${git} --work-tree ${ScopeContext.current.directory} checkout ${snapshot} -- ${relativePath}`
-              .quiet()
-              .cwd(ScopeContext.current.directory)
-              .nothrow()
+          const result = await gitSpawn(
+            [
+              "git",
+              "--git-dir",
+              git,
+              "--work-tree",
+              ScopeContext.current.directory,
+              "checkout",
+              snapshot,
+              "--",
+              relativePath,
+            ],
+            ScopeContext.current.directory,
+          )
           if (result.exitCode !== 0) {
             log.warn("failed to restore file from snapshot", {
               file,
               snapshot,
-              stderr: result.stderr.toString(),
+              stderr: result.stderr,
             })
           }
         }
@@ -254,23 +285,41 @@ export namespace Snapshot {
         if (files.has(file)) continue
         log.info("reverting", { file, hash: item.hash })
         const relativePath = path.relative(ScopeContext.current.directory, file).replaceAll("\\", "/")
-        const checkTree =
-          await $`git --git-dir ${git} --work-tree ${ScopeContext.current.directory} ls-tree ${item.hash} -- ${relativePath}`
-            .quiet()
-            .cwd(ScopeContext.current.directory)
-            .nothrow()
+        const checkTree = await gitSpawn(
+          [
+            "git",
+            "--git-dir",
+            git,
+            "--work-tree",
+            ScopeContext.current.directory,
+            "ls-tree",
+            item.hash,
+            "--",
+            relativePath,
+          ],
+          ScopeContext.current.directory,
+        )
         if (checkTree.exitCode === 0) {
-          if (checkTree.text().trim()) {
+          if (checkTree.text.trim()) {
             // File existed in snapshot — restore it
-            const result =
-              await $`git --git-dir ${git} --work-tree ${ScopeContext.current.directory} checkout ${item.hash} -- ${relativePath}`
-                .quiet()
-                .cwd(ScopeContext.current.directory)
-                .nothrow()
+            const result = await gitSpawn(
+              [
+                "git",
+                "--git-dir",
+                git,
+                "--work-tree",
+                ScopeContext.current.directory,
+                "checkout",
+                item.hash,
+                "--",
+                relativePath,
+              ],
+              ScopeContext.current.directory,
+            )
             if (result.exitCode !== 0) {
               log.warn("file existed in snapshot but checkout failed", {
                 file,
-                stderr: result.stderr.toString(),
+                stderr: result.stderr,
               })
             }
           } else {
@@ -283,7 +332,7 @@ export namespace Snapshot {
           log.warn("ls-tree failed, skipping revert for file", {
             file,
             exitCode: checkTree.exitCode,
-            stderr: checkTree.stderr.toString(),
+            stderr: checkTree.stderr,
           })
         }
         files.add(file)
@@ -291,38 +340,79 @@ export namespace Snapshot {
     }
   }
 
-  export async function diff(hash: string, sessionID: string, opts?: { indexFresh?: boolean }) {
+  export async function diff(hash: string, sessionID: string, opts?: { indexFresh?: boolean; signal?: AbortSignal }) {
     const git = gitdir(sessionID)
-    if (!opts?.indexFresh) await refreshIndex(sessionID)
-    const result =
-      await $`git -c core.autocrlf=false --git-dir ${git} --work-tree ${ScopeContext.current.directory} diff --no-ext-diff ${hash} -- .`
-        .quiet()
-        .cwd(ScopeContext.current.directory)
-        .nothrow()
+    if (!opts?.indexFresh) await refreshIndex(sessionID, opts?.signal)
+    const result = await gitSpawn(
+      [
+        "git",
+        "-c",
+        "core.autocrlf=false",
+        "--git-dir",
+        git,
+        "--work-tree",
+        ScopeContext.current.directory,
+        "diff",
+        "--no-ext-diff",
+        hash,
+        "--",
+        ".",
+      ],
+      ScopeContext.current.directory,
+      undefined,
+      opts?.signal,
+    )
 
     if (result.exitCode !== 0) {
       log.warn("failed to get diff", {
         hash,
         exitCode: result.exitCode,
-        stderr: result.stderr.toString(),
-        stdout: result.stdout.toString(),
+        stderr: result.stderr,
+        stdout: result.text,
       })
       return ""
     }
 
-    return result.text().trim()
+    return result.text.trim()
   }
 
   export const FileDiff = SnapshotSchema.FileDiff
   export type FileDiff = SnapshotSchema.FileDiff
-  export async function diffSummary(from: string, to: string, sessionID: string): Promise<FileDiff[]> {
+  export async function diffSummary(
+    from: string,
+    to: string,
+    sessionID: string,
+    signal?: AbortSignal,
+  ): Promise<FileDiff[]> {
     const git = gitdir(sessionID)
     const result: FileDiff[] = []
-    for await (const line of $`git -c core.autocrlf=false --git-dir ${git} --work-tree ${ScopeContext.current.directory} diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
-      .quiet()
-      .cwd(ScopeContext.current.directory)
-      .nothrow()
-      .lines()) {
+    const numstat = await gitSpawn(
+      [
+        "git",
+        "-c",
+        "core.autocrlf=false",
+        "--git-dir",
+        git,
+        "--work-tree",
+        ScopeContext.current.directory,
+        "diff",
+        "--no-ext-diff",
+        "--no-renames",
+        "--numstat",
+        from,
+        to,
+        "--",
+        ".",
+      ],
+      ScopeContext.current.directory,
+      undefined,
+      signal,
+    )
+    if (numstat.exitCode !== 0) {
+      log.warn("failed to get diff summary", { from, to, exitCode: numstat.exitCode, stderr: numstat.stderr })
+      return result
+    }
+    for (const line of numstat.text.split("\n")) {
       if (!line) continue
       const [additions, deletions, file] = line.split("\t")
       const isBinaryFile = additions === "-" && deletions === "-"
@@ -330,11 +420,29 @@ export namespace Snapshot {
       const deleted = isBinaryFile ? 0 : parseInt(deletions)
       const patch = isBinaryFile
         ? ""
-        : await $`git -c core.autocrlf=false --git-dir ${git} --work-tree ${ScopeContext.current.directory} diff --no-ext-diff --no-renames ${from} ${to} -- ${file}`
-            .quiet()
-            .cwd(ScopeContext.current.directory)
-            .nothrow()
-            .text()
+        : (
+            await gitSpawn(
+              [
+                "git",
+                "-c",
+                "core.autocrlf=false",
+                "--git-dir",
+                git,
+                "--work-tree",
+                ScopeContext.current.directory,
+                "diff",
+                "--no-ext-diff",
+                "--no-renames",
+                from,
+                to,
+                "--",
+                file,
+              ],
+              ScopeContext.current.directory,
+              undefined,
+              signal,
+            )
+          ).text
       result.push(
         SnapshotSchema.fromPatch({
           file,
@@ -342,8 +450,8 @@ export namespace Snapshot {
           deletions: Number.isFinite(deleted) ? deleted : 0,
           binary: isBinaryFile,
           patch,
-          beforeBytes: await objectSize(git, from, file),
-          afterBytes: await objectSize(git, to, file),
+          beforeBytes: await objectSize(git, from, file, signal),
+          afterBytes: await objectSize(git, to, file, signal),
         }),
       )
     }
@@ -361,7 +469,8 @@ export namespace Snapshot {
     )
     if (rm.exitCode !== 0) return false
 
-    const files = await includedFiles(cwd)
+    const files = await includedFiles(cwd, signal)
+    if (files === undefined) return false
     if (files.length === 0) return true
 
     const pathspec = path.join(git, "synergy-pathspec")
@@ -379,10 +488,14 @@ export namespace Snapshot {
     }
   }
 
-  async function includedFiles(cwd: string): Promise<string[]> {
-    const text = await $`git ls-files -co --exclude-standard -z`.cwd(cwd).quiet().nothrow().text()
+  async function includedFiles(cwd: string, signal?: AbortSignal): Promise<string[] | undefined> {
+    const listing = await gitSpawn(["git", "ls-files", "-co", "--exclude-standard", "-z"], cwd, undefined, signal)
+    if (listing.exitCode !== 0) {
+      log.warn("ls-files failed", { cwd, exitCode: listing.exitCode, stderr: listing.stderr })
+      return undefined
+    }
     const files: string[] = []
-    for (const raw of text.split("\0")) {
+    for (const raw of listing.text.split("\0")) {
       const rel = raw.trim()
       if (!rel || excludePath(rel)) continue
       const absolute = path.join(cwd, rel)
@@ -405,10 +518,15 @@ export namespace Snapshot {
     return `${ScopeContext.current.directory}/${rel.replaceAll("\\", "/")}`
   }
 
-  async function objectSize(git: string, tree: string, file: string): Promise<number | undefined> {
-    const result = await $`git --git-dir ${git} cat-file -s ${tree}:${file}`.quiet().nothrow()
+  async function objectSize(git: string, tree: string, file: string, signal?: AbortSignal): Promise<number | undefined> {
+    const result = await gitSpawn(
+      ["git", "--git-dir", git, "cat-file", "-s", `${tree}:${file}`],
+      ScopeContext.current.directory,
+      undefined,
+      signal,
+    )
     if (result.exitCode !== 0) return undefined
-    const parsed = Number.parseInt(result.text().trim(), 10)
+    const parsed = Number.parseInt(result.text.trim(), 10)
     return Number.isFinite(parsed) ? parsed : undefined
   }
 

--- a/packages/synergy/src/session/snapshot.ts
+++ b/packages/synergy/src/session/snapshot.ts
@@ -518,7 +518,12 @@ export namespace Snapshot {
     return `${ScopeContext.current.directory}/${rel.replaceAll("\\", "/")}`
   }
 
-  async function objectSize(git: string, tree: string, file: string, signal?: AbortSignal): Promise<number | undefined> {
+  async function objectSize(
+    git: string,
+    tree: string,
+    file: string,
+    signal?: AbortSignal,
+  ): Promise<number | undefined> {
     const result = await gitSpawn(
       ["git", "--git-dir", git, "cat-file", "-s", `${tree}:${file}`],
       ScopeContext.current.directory,


### PR DESCRIPTION
Fixes #177. Implements all five fix items from the investigation; also hardens the half-open-SSE path from #174.

## What broke

Sessions froze permanently because the fullStream consumer in `SessionProcessor.process()` got stuck inside `Snapshot.track()` → `includedFiles()`, whose `$ git ls-files` Bun Shell call had no timeout, no signal, and no logging. Every watchdog above it was ineffective: the 15-minute turn deadline only aborted a signal that the frozen await never observes, and the provider idle/TTFB timers had wiring bugs of their own. See #177 for the full evidence chain (git index mtimes, observability traces, live process forensics).

## Changes

**`fix(snapshot)` — items 1–3**
- All git invocations in `snapshot.ts` (`ls-files`, `checkout`, `ls-tree`, `diff`, `numstat`, `cat-file`) now go through `gitSpawn`, which gets a hard `Promise.race` deadline (10s abort + 5s grace) on top of the existing abort-signal timeout — an abort can only kill the child; it cannot rescue a stdout collection promise that never settles.
- The caller's `AbortSignal` is threaded through `track`/`patch`/`diff`/`diffSummary` → `refreshIndex` → `includedFiles`.
- `includedFiles` failure is now distinguished from "no files" (previously a failed listing produced an empty snapshot tree); failures propagate as `track add failed` instead.
- `track`/`patch` log entry (debug) and duration on every exit path; spawn failures log at warn with stderr.

**`fix(session)` — item 4**
- `invoke.ts` races `processor.process()` against the turn deadline. On expiry the turn is abandoned: the assistant message gets the timeout error, `SessionEvent.Error` is published, and the loop stops — instead of waiting on signal propagation into an arbitrary frozen await. A stuck subagent can no longer wedge its Cortex parent forever.

**`fix(provider)` — item 5**
- TTFB timer is cleared once the response arrives. Previously it was never cancelled on success, so the combined fetch signal would fire at `ttfb_sec` (default 600s) into any healthy long-lived stream.
- `timeout.provider.idle_sec` (`TimeoutConfig.providerIdleMs`, default 180s) is now actually wired into the idle watchdog; provider-level `timeout` options still take precedence, `false` still disables.
- Body reads race the idle abort directly and the reader is cancelled on failure — aborting the fetch signal does not reliably reject a pending `read()` on a half-open connection (the #174 scenario; both stalled provider sockets were still ESTABLISHED hours later).
- Watchdog timers are cleaned up when the fetch itself rejects.

## Behavior notes

- Default idle timeout for provider streams effectively changes from 900s to the configured `providerIdleMs` default (180s). Providers that legitimately stay silent longer can set `timeout.provider.idle_sec` or a provider-level `timeout` option.
- A failed `git ls-files` now fails the snapshot (returns `undefined` from `track`) instead of silently snapshotting an empty tree. `Snapshot.track` degrading to `undefined` was already handled by all callers.

## Testing

- `bun test test/snapshot/snapshot.test.ts` — 38 pass
- `bun test test/session/processor.test.ts` — 5 pass
- `bun test test/session/invoke.test.ts test/session/snapshot-timeout-regression.test.ts` — 6 pass
- `bun run typecheck` — no errors in touched files (pre-existing unrelated errors in `plugin-kit/src/commands/sign.ts` remain)
