### PR TITLE
Unify worktree session setup flow

### DIFF
--- a/packages/app/PRODUCT.md
+++ b/packages/app/PRODUCT.md
@@ -133,6 +133,8 @@ Prompt composers should read as one grounded input surface with a quiet bottom t
 
 New-session initialization controls should sit in the composer toolbar next to the Add control as a quiet start-mode selector, not as a second row inside the typing area. Keep the selector menu data-driven so workspace mode, templates, cloud execution, and future start parameters can expand in one place while preserving the composer as a single grounded surface.
 
+New-session initialization must use a blocking workbench progress surface whenever workspace or session setup can take visible time. The user should see compact step progress for worktree creation, session preparation, and prompt dispatch, and should not be able to operate the half-initialized session until setup completes or fails cleanly.
+
 Use icons sparingly. Icons should clarify primary navigation or compact controls, not decorate every row of a form.
 
 Treat brand assets as a hierarchy, not interchangeable decoration. SII is the institutional parent, Holos is the organization and platform behind Synergy, and Synergy is the product. The Synergy product icon is the canonical app, favicon, notification, social, and external-attribution icon; Holos wordmarks may identify the backing organization/platform layer in the app shell and account surfaces, and SII marks should only identify the institute layer.

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -79,6 +79,7 @@ import {
   resolveBlueprintSlotDisplay,
   type BlueprintSlotDisplay,
 } from "@/components/prompt-input/blueprint-slot"
+import { isWorktreeWorkspaceSelection, worktreeOptionSelection } from "@/components/session/worktree-session"
 
 function sanitizePromptHistory(value: unknown) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return value
@@ -505,9 +506,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const newSessionStartOptions = createMemo<PromptStartOptionGroup[]>(() => {
     if (params.id) return []
 
-    const creatingWorktree = props.newSessionWorktree === "create"
+    const workspaceSelection = props.newSessionWorkspaceSelection ?? { mode: "current" as const }
+    const worktreeSelected = isWorktreeWorkspaceSelection(workspaceSelection)
     const canCreateWorktree = props.newSessionCanCreateWorktree ?? (!sdk.isHome && !!sdk.directory)
-    const localLabel = isHomeScope(sdk.scopeKey) ? "Home" : "Local"
+    const mainLabel = isHomeScope(sdk.scopeKey) ? "Home" : "Main checkout"
     const localDescription = isHomeScope(sdk.scopeKey) ? "Global context" : "Current checkout"
 
     return [
@@ -517,23 +519,29 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         options: [
           {
             id: "workspace.local",
-            label: localLabel,
+            label: mainLabel,
             description: localDescription,
             icon: getSemanticIcon("workspace.main"),
-            selected: !creatingWorktree,
-            onSelect: () => props.onNewSessionWorktreeChange?.("main"),
+            selected: !worktreeSelected,
+            onSelect: () => props.onNewSessionWorkspaceSelectionChange?.({ mode: "current" }),
           },
           {
             id: "workspace.worktree",
             label: "Worktree",
             description: "Isolated checkout",
             icon: getSemanticIcon("workspace.worktree"),
-            selected: creatingWorktree,
+            selected: worktreeSelected,
             disabled: !canCreateWorktree,
             tooltip: canCreateWorktree
               ? "Create an isolated worktree for this session."
               : "Choose a project to use worktree isolation.",
-            onSelect: () => props.onNewSessionWorktreeChange?.("create"),
+            onSelect: () =>
+              props.onNewSessionWorkspaceSelectionChange?.(
+                worktreeOptionSelection({
+                  currentDirectory: props.newSessionCurrentDirectory,
+                  canonicalDirectory: props.newSessionCanonicalDirectory,
+                }),
+              ),
           },
         ],
       },

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -1,4 +1,4 @@
-import type { Accessor, Setter } from "solid-js"
+import { createSignal, type Accessor, Setter } from "solid-js"
 import { produce, type SetStoreFunction } from "solid-js/store"
 import { useNavigate, useParams } from "@solidjs/router"
 import { createSynergyClient, type Message, type Part } from "@ericsanchezok/synergy-sdk/client"
@@ -6,6 +6,7 @@ import { Binary } from "@ericsanchezok/synergy-util/binary"
 import { base64Encode } from "@ericsanchezok/synergy-util/encode"
 import { getFilename } from "@ericsanchezok/synergy-util/path"
 import { showToast } from "@ericsanchezok/synergy-ui/toast"
+import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { useLocal } from "@/context/local"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
@@ -33,9 +34,18 @@ import {
 import { setCursorPosition } from "./editor-dom"
 import { createUploadedAttachmentInputPart } from "./attachment-submit"
 import type { BlueprintSlot, PromptInputMode, PromptInputProps, PromptInputStore } from "./types"
+import {
+  SessionStartProgressDialog,
+  type SessionStartProgress,
+  type SessionStartProgressStepState,
+} from "@/components/session/worktree-transition-dialog"
+import type { NewSessionWorkspaceSelection } from "@/components/session/worktree-session"
 
 type PromptSubmitInput = {
-  props: Pick<PromptInputProps, "newSessionWorktree" | "onNewSessionWorktreeReset">
+  props: Pick<
+    PromptInputProps,
+    "newSessionWorkspaceSelection" | "newSessionCanonicalDirectory" | "onNewSessionWorkspaceSelectionReset"
+  >
   uploadedAttachments: Accessor<UploadedAttachmentPart[]>
   noteAttachments: Accessor<NoteAttachmentPart[]>
   sessionAttachments: Accessor<SessionAttachmentPart[]>
@@ -65,6 +75,7 @@ function errorMessage(err: unknown) {
 
 export function usePromptSubmit(input: PromptSubmitInput) {
   const navigate = useNavigate()
+  const dialog = useDialog()
   const sdk = useSDK()
   const sync = useSync()
   const globalSync = useGlobalSync()
@@ -72,6 +83,56 @@ export function usePromptSubmit(input: PromptSubmitInput) {
   const local = useLocal()
   const prompt = usePrompt()
   const params = useParams()
+  const [startProgress, setStartProgress] = createSignal<SessionStartProgress>({
+    title: "Starting session",
+    description: "Preparing this session before sending your prompt.",
+    steps: [],
+  })
+  let startProgressOpen = false
+
+  const startProgressSteps = (
+    selection: NewSessionWorkspaceSelection,
+    active: "workspace" | "session" | "prompt",
+  ): SessionStartProgress["steps"] => {
+    const steps: Array<{ id: "workspace" | "session" | "prompt"; label: string }> = []
+    if (selection.mode === "create") steps.push({ id: "workspace", label: "Creating worktree" })
+    if (selection.mode === "existing") steps.push({ id: "workspace", label: "Preparing worktree" })
+    steps.push({ id: "session", label: "Preparing session" })
+    steps.push({ id: "prompt", label: "Sending prompt" })
+    const activeIndex = Math.max(
+      0,
+      steps.findIndex((step) => step.id === active),
+    )
+    return steps.map((step, index) => {
+      const state: SessionStartProgressStepState =
+        index < activeIndex ? "complete" : index === activeIndex ? "active" : "pending"
+      return { ...step, state }
+    })
+  }
+
+  const updateStartProgress = (selection: NewSessionWorkspaceSelection, active: "workspace" | "session" | "prompt") => {
+    setStartProgress({
+      title: selection.mode === "current" ? "Starting session" : "Starting worktree session",
+      description:
+        selection.mode === "current"
+          ? "Preparing this session before sending your prompt."
+          : "Creating and binding the worktree before sending your prompt.",
+      steps: startProgressSteps(selection, active),
+    })
+  }
+
+  const openStartProgress = (selection: NewSessionWorkspaceSelection) => {
+    updateStartProgress(selection, selection.mode === "current" ? "session" : "workspace")
+    if (startProgressOpen) return
+    startProgressOpen = true
+    dialog.push(() => SessionStartProgressDialog({ progress: startProgress }))
+  }
+
+  const closeStartProgress = () => {
+    if (!startProgressOpen) return
+    startProgressOpen = false
+    dialog.close()
+  }
 
   return async (event: Event) => {
     event.preventDefault()
@@ -113,61 +174,71 @@ export function usePromptSubmit(input: PromptSubmitInput) {
     const projectDirectory = sdk.directory
     const currentScopeKey = sdk.scopeKey
     const isNewSession = !params.id
-    const worktreeSelection = input.props.newSessionWorktree ?? "main"
+    const workspaceSelection = input.props.newSessionWorkspaceSelection ?? { mode: "current" as const }
 
     let sessionScopeKey = currentScopeKey
+    let sessionCreateScopeKey = currentScopeKey
     let client = sdk.client
 
-    if (isNewSession && !sdk.isHome && projectDirectory) {
-      if (worktreeSelection === "create") {
-        const createdWorktree = await client.worktree
-          .create({ directory: projectDirectory })
-          .then((x) => x.data)
-          .catch((err) => {
-            showToast({
-              type: "error",
-              title: "Failed to create worktree",
-              description: errorMessage(err),
-            })
-            return undefined
+    if (isNewSession) {
+      openStartProgress(workspaceSelection)
+      if (!sdk.isHome) {
+        sessionCreateScopeKey = input.props.newSessionCanonicalDirectory ?? projectDirectory ?? currentScopeKey
+        if (sessionCreateScopeKey !== currentScopeKey) {
+          client = createSynergyClient({
+            baseUrl: sdk.url,
+            fetch: platform.fetch,
+            directory: sessionCreateScopeKey,
+            throwOnError: true,
           })
-
-        if (!createdWorktree?.path) {
-          showToast({
-            type: "error",
-            title: "Failed to create worktree",
-            description: "Request failed",
-          })
-          return
+          globalSync.ensureScopeState(sessionCreateScopeKey)
         }
-        sessionScopeKey = createdWorktree.path
       }
+    }
 
-      if (worktreeSelection !== "main" && worktreeSelection !== "create") {
-        sessionScopeKey = worktreeSelection
-      }
-
-      if (sessionScopeKey !== currentScopeKey) {
+    const useSessionScopeClient = (scopeKey: string) => {
+      sessionScopeKey = scopeKey
+      if (scopeKey !== currentScopeKey) {
         client = createSynergyClient({
           baseUrl: sdk.url,
           fetch: platform.fetch,
-          directory: sessionScopeKey,
+          directory: scopeKey,
           throwOnError: true,
         })
-        globalSync.ensureScopeState(sessionScopeKey)
+        globalSync.ensureScopeState(scopeKey)
+      } else {
+        client = sdk.client
       }
-
-      input.props.onNewSessionWorktreeReset?.()
     }
+
     let createdSessionForSubmit = false
 
     let session = params.id ? sync.session.get(params.id) : undefined
     if (!session && isNewSession) {
       session = await client.session
-        .create({ controlProfile: input.selectedControlProfile() })
+        .create({
+          controlProfile: input.selectedControlProfile(),
+          workspace: workspaceSelection,
+        })
         .then((x) => x.data ?? undefined)
+        .catch((err) => {
+          showToast({
+            type: "error",
+            title: workspaceSelection.mode === "current" ? "Failed to start session" : "Failed to create worktree",
+            description: errorMessage(err),
+          })
+          closeStartProgress()
+          return undefined
+        })
       if (session) {
         createdSessionForSubmit = true
+        const workspacePath =
+          session.workspace?.type === "git_worktree" && typeof session.workspace.path === "string"
+            ? session.workspace.path
+            : sessionCreateScopeKey
+        useSessionScopeClient(workspacePath)
+        input.props.onNewSessionWorkspaceSelectionReset?.()
+        updateStartProgress(workspaceSelection, "session")
         navigate(`/${base64Encode(sessionScopeKey)}/session/${session.id}`)
       }
     }
@@ -175,7 +246,10 @@ export function usePromptSubmit(input: PromptSubmitInput) {
       await sync.session.sync(params.id)
       session = sync.session.get(params.id)
     }
-    if (!session) return
+    if (!session) {
+      closeStartProgress()
+      return
+    }
     if (isNewSession && session.controlProfile !== input.selectedControlProfile()) {
       session = await client.session
         .update({ sessionID: session.id, controlProfile: input.selectedControlProfile() })
@@ -199,6 +273,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
             await client.session.delete({ sessionID }).catch(() => undefined)
             navigate(`/${base64Encode(currentScopeKey)}/session`, { replace: true })
           }
+          closeStartProgress()
           return undefined
         })
       if (!session) return
@@ -219,6 +294,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
             await client.session.delete({ sessionID }).catch(() => undefined)
             navigate(`/${base64Encode(currentScopeKey)}/session`, { replace: true })
           }
+          closeStartProgress()
           return undefined
         })
       if (!session) return
@@ -258,6 +334,8 @@ export function usePromptSubmit(input: PromptSubmitInput) {
       navigate(`/${base64Encode(currentScopeKey)}/session`, { replace: true })
     }
 
+    if (isNewSession) updateStartProgress(workspaceSelection, "prompt")
+
     if (blueprintSlot && mode === "normal") {
       input.setBlueprintLoading(true)
       let createdLoopID: string | undefined
@@ -283,10 +361,12 @@ export function usePromptSubmit(input: PromptSubmitInput) {
 
         clearInput()
         await sdk.client.blueprint.loop.start({ id: loopID, userPrompt: userText || undefined })
+        closeStartProgress()
       } catch (err) {
         if (createdLoopID) {
           await sdk.client.blueprint.loop.cancel({ id: createdLoopID }).catch(() => undefined)
         }
+        closeStartProgress()
         showToast({
           type: "error",
           title: "Failed to start Blueprint",
@@ -309,7 +389,11 @@ export function usePromptSubmit(input: PromptSubmitInput) {
           model,
           command: text,
         })
+        .then(() => {
+          closeStartProgress()
+        })
         .catch((err) => {
+          closeStartProgress()
           showToast({
             type: "error",
             title: "Failed to send shell command",
@@ -367,7 +451,11 @@ export function usePromptSubmit(input: PromptSubmitInput) {
               })),
             ],
           })
+          .then(() => {
+            closeStartProgress()
+          })
           .catch((err) => {
+            closeStartProgress()
             showToast({
               type: "error",
               title: "Failed to send command",
@@ -606,6 +694,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
         variant,
       })
       .then((result) => {
+        closeStartProgress()
         if (result.data?.status === "queued" && optimisticAdded) {
           removeOptimisticMessage()
           optimisticAdded = false
@@ -619,6 +708,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
         }
       })
       .catch((err) => {
+        closeStartProgress()
         showToast({
           type: "error",
           title: "Failed to send prompt",

--- a/packages/app/src/components/prompt-input/types.ts
+++ b/packages/app/src/components/prompt-input/types.ts
@@ -1,4 +1,5 @@
 import type { ControlProfileId } from "@/context/input"
+import type { NewSessionWorkspaceSelection } from "@/components/session/worktree-session"
 
 export type DroppedSessionData = {
   id: string
@@ -43,10 +44,12 @@ export type PromptInputStore = {
 export interface PromptInputProps {
   class?: string
   ref?: (el: HTMLDivElement) => void
-  newSessionWorktree?: string
+  newSessionWorkspaceSelection?: NewSessionWorkspaceSelection
+  newSessionCanonicalDirectory?: string
+  newSessionCurrentDirectory?: string
   newSessionCanCreateWorktree?: boolean
-  onNewSessionWorktreeChange?: (worktree: string) => void
-  onNewSessionWorktreeReset?: () => void
+  onNewSessionWorkspaceSelectionChange?: (selection: NewSessionWorkspaceSelection) => void
+  onNewSessionWorkspaceSelectionReset?: () => void
   hideAgentSelector?: boolean
 }
 

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -16,6 +16,7 @@ import { type SessionMeta } from "@/composables/use-session-meta"
 import type { usePrompt } from "@/context/prompt"
 import type { useSync } from "@/context/sync"
 import type { useSDK } from "@/context/sdk"
+import type { NewSessionWorkspaceSelection } from "./worktree-session"
 
 export function PromptDock(props: {
   ref: (el: HTMLDivElement) => void
@@ -35,9 +36,11 @@ export function PromptDock(props: {
   forkedFromID?: string
   forkedFromTitle?: string
   backPath?: Accessor<string | undefined>
-  newSessionWorktree: Accessor<string>
-  onNewSessionWorktreeChange: (worktree: string) => void
-  onNewSessionWorktreeReset: () => void
+  newSessionWorkspaceSelection: Accessor<NewSessionWorkspaceSelection>
+  newSessionCanonicalDirectory: Accessor<string | undefined>
+  newSessionCurrentDirectory: Accessor<string | undefined>
+  onNewSessionWorkspaceSelectionChange: (selection: NewSessionWorkspaceSelection) => void
+  onNewSessionWorkspaceSelectionReset: () => void
   scopeName: Accessor<string>
   branch: Accessor<string | undefined>
   lastModified: Accessor<string | null | undefined>
@@ -155,10 +158,12 @@ export function PromptDock(props: {
                 <div class="relative">
                   <PromptInput
                     ref={props.inputRef}
-                    newSessionWorktree={props.newSessionWorktree()}
+                    newSessionWorkspaceSelection={props.newSessionWorkspaceSelection()}
+                    newSessionCanonicalDirectory={props.newSessionCanonicalDirectory()}
+                    newSessionCurrentDirectory={props.newSessionCurrentDirectory()}
                     newSessionCanCreateWorktree={!props.isGlobal}
-                    onNewSessionWorktreeChange={props.onNewSessionWorktreeChange}
-                    onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
+                    onNewSessionWorkspaceSelectionChange={props.onNewSessionWorkspaceSelectionChange}
+                    onNewSessionWorkspaceSelectionReset={props.onNewSessionWorkspaceSelectionReset}
                     hideAgentSelector={!props.meta().showInputBar}
                   />
                   <Show when={props.sessionID}>

--- a/packages/app/src/components/session/worktree-session.test.ts
+++ b/packages/app/src/components/session/worktree-session.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import {
+  defaultNewSessionWorkspaceSelection,
+  isSessionRunningForWorkspaceChange,
+  reduceWorkspaceTransitionProgress,
+  worktreeOptionSelection,
+} from "./worktree-session"
+
+describe("new session workspace selection", () => {
+  test("defaults to main checkout from the canonical project root", () => {
+    expect(
+      defaultNewSessionWorkspaceSelection({
+        currentDirectory: "/repo",
+        canonicalDirectory: "/repo",
+      }),
+    ).toEqual({ mode: "current" })
+  })
+
+  test("defaults to the existing worktree when the URL is already in a worktree", () => {
+    expect(
+      defaultNewSessionWorkspaceSelection({
+        currentDirectory: "/repo/.synergy/worktrees/feature",
+        canonicalDirectory: "/repo",
+      }),
+    ).toEqual({ mode: "existing", target: "/repo/.synergy/worktrees/feature" })
+  })
+
+  test("preserves an explicit create-new selection", () => {
+    expect(
+      defaultNewSessionWorkspaceSelection({
+        selected: { mode: "create" },
+        currentDirectory: "/repo",
+        canonicalDirectory: "/repo",
+      }),
+    ).toEqual({ mode: "create" })
+  })
+
+  test("maps the worktree option to existing when already inside a worktree", () => {
+    expect(
+      worktreeOptionSelection({
+        currentDirectory: "/repo/.synergy/worktrees/feature",
+        canonicalDirectory: "/repo",
+      }),
+    ).toEqual({ mode: "existing", target: "/repo/.synergy/worktrees/feature" })
+  })
+
+  test("maps the worktree option to create from the main checkout", () => {
+    expect(worktreeOptionSelection({ currentDirectory: "/repo", canonicalDirectory: "/repo" })).toEqual({
+      mode: "create",
+    })
+  })
+})
+
+describe("workspace change disabled state", () => {
+  test("disables for local pending state", () => {
+    expect(isSessionRunningForWorkspaceChange({ pending: true, status: { type: "idle" } })).toBe(true)
+  })
+
+  test("disables for non-idle runtime statuses", () => {
+    for (const type of ["busy", "retry", "recovering"]) {
+      expect(isSessionRunningForWorkspaceChange({ status: { type } })).toBe(true)
+    }
+  })
+
+  test("disables for session working metadata", () => {
+    expect(isSessionRunningForWorkspaceChange({ working: { status: "busy" }, status: { type: "idle" } })).toBe(true)
+  })
+
+  test("allows idle sessions without local pending state", () => {
+    expect(isSessionRunningForWorkspaceChange({ status: { type: "idle" } })).toBe(false)
+  })
+})
+
+describe("workspace transition progress reducer", () => {
+  test("advances through idle, form, loading, success, and error", () => {
+    const idle = { phase: "idle" as const }
+    const form = reduceWorkspaceTransitionProgress(idle, { type: "open", operation: "enter" })
+    expect(form).toEqual({ phase: "form", operation: "enter" })
+
+    const loading = reduceWorkspaceTransitionProgress(form, { type: "load", step: "Creating worktree" })
+    expect(loading).toEqual({ phase: "loading", operation: "enter", step: "Creating worktree" })
+
+    expect(reduceWorkspaceTransitionProgress(loading, { type: "load", step: "Duplicate" })).toBe(loading)
+
+    const success = reduceWorkspaceTransitionProgress(loading, { type: "succeed", message: "Moved" })
+    expect(success).toEqual({ phase: "success", operation: "enter", message: "Moved" })
+
+    const error = reduceWorkspaceTransitionProgress(form, { type: "fail", message: "Failed" })
+    expect(error).toEqual({ phase: "error", operation: "enter", message: "Failed" })
+  })
+})

--- a/packages/app/src/components/session/worktree-session.ts
+++ b/packages/app/src/components/session/worktree-session.ts
@@ -1,0 +1,100 @@
+export type NewSessionWorkspaceSelection =
+  | { mode: "current" }
+  | { mode: "create" }
+  | { mode: "existing"; target: string }
+
+export type WorkspaceChangeStatus = { type?: string } | undefined
+
+function normalizePathForCompare(input: string) {
+  const normalized = input.replace(/\\/g, "/").replace(/\/+$/, "")
+  return normalized.toLowerCase()
+}
+
+function isWorktreeDirectory(currentDirectory?: string, canonicalDirectory?: string) {
+  if (!currentDirectory || !canonicalDirectory) return false
+  return normalizePathForCompare(currentDirectory) !== normalizePathForCompare(canonicalDirectory)
+}
+
+export function defaultNewSessionWorkspaceSelection(input: {
+  selected?: NewSessionWorkspaceSelection
+  currentDirectory?: string
+  canonicalDirectory?: string
+}): NewSessionWorkspaceSelection {
+  if (input.selected) return input.selected
+  if (isWorktreeDirectory(input.currentDirectory, input.canonicalDirectory) && input.currentDirectory) {
+    return { mode: "existing", target: input.currentDirectory }
+  }
+  return { mode: "current" }
+}
+
+export function worktreeOptionSelection(input: {
+  currentDirectory?: string
+  canonicalDirectory?: string
+}): NewSessionWorkspaceSelection {
+  if (isWorktreeDirectory(input.currentDirectory, input.canonicalDirectory) && input.currentDirectory) {
+    return { mode: "existing", target: input.currentDirectory }
+  }
+  return { mode: "create" }
+}
+
+export function isWorktreeWorkspaceSelection(selection: NewSessionWorkspaceSelection) {
+  return selection.mode === "create" || selection.mode === "existing"
+}
+
+export function isSessionRunningForWorkspaceChange(input: {
+  pending?: boolean
+  status?: WorkspaceChangeStatus
+  working?: unknown
+}) {
+  if (input.pending) return true
+  if (input.working) return true
+  if (!input.status) return false
+  return input.status.type !== undefined && input.status.type !== "idle"
+}
+
+export type WorkspaceTransitionOperation = "enter" | "leave" | "start"
+export type WorkspaceTransitionPhase = "idle" | "form" | "loading" | "success" | "error"
+
+export type WorkspaceTransitionProgressState =
+  | { phase: "idle" }
+  | { phase: "form"; operation: WorkspaceTransitionOperation }
+  | { phase: "loading"; operation: WorkspaceTransitionOperation; step: string }
+  | { phase: "success"; operation: WorkspaceTransitionOperation; message?: string }
+  | { phase: "error"; operation: WorkspaceTransitionOperation; message: string }
+
+export type WorkspaceTransitionProgressAction =
+  | { type: "open"; operation: WorkspaceTransitionOperation }
+  | { type: "load"; operation?: WorkspaceTransitionOperation; step: string }
+  | { type: "succeed"; message?: string }
+  | { type: "fail"; message: string }
+  | { type: "reset" }
+
+export function reduceWorkspaceTransitionProgress(
+  state: WorkspaceTransitionProgressState,
+  action: WorkspaceTransitionProgressAction,
+): WorkspaceTransitionProgressState {
+  if (action.type === "reset") return { phase: "idle" }
+
+  if (action.type === "open") {
+    if (state.phase === "loading") return state
+    return { phase: "form", operation: action.operation }
+  }
+
+  if (action.type === "load") {
+    if (state.phase === "loading") return state
+    const operation = action.operation ?? (state.phase === "idle" ? "start" : state.operation)
+    return { phase: "loading", operation, step: action.step }
+  }
+
+  if (action.type === "succeed") {
+    if (state.phase !== "loading") return state
+    return { phase: "success", operation: state.operation, message: action.message }
+  }
+
+  if (action.type === "fail") {
+    if (state.phase === "idle") return state
+    return { phase: "error", operation: state.operation, message: action.message }
+  }
+
+  return state
+}

--- a/packages/app/src/components/session/worktree-transition-dialog.css
+++ b/packages/app/src/components/session/worktree-transition-dialog.css
@@ -1,0 +1,175 @@
+[data-component="dialog"]
+  [data-slot="dialog-container"]:has(> [data-slot="dialog-content"].workspace-transition-dialog) {
+  width: min(420px, calc(100vw - 32px));
+  height: auto;
+}
+
+[data-slot="dialog-content"].workspace-transition-dialog {
+  width: min(420px, calc(100vw - 32px));
+  max-width: min(420px, calc(100vw - 32px));
+  min-height: 0;
+  font-family: var(--font-family-sans);
+  letter-spacing: 0;
+}
+
+[data-slot="dialog-content"].workspace-transition-dialog [data-slot="dialog-title"] {
+  font-size: 16px;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+}
+
+[data-slot="dialog-content"].workspace-transition-dialog [data-slot="dialog-description"] {
+  margin-top: 0;
+  padding: 0 24px 2px;
+  color: var(--text-base);
+  font-size: 13px;
+  line-height: 1.45;
+  letter-spacing: 0;
+}
+
+[data-slot="dialog-content"].workspace-transition-dialog [data-slot="dialog-body"] {
+  flex: 0 0 auto;
+  overflow: visible;
+  padding: 16px 24px 20px;
+}
+
+.wtd-dialog-action-placeholder {
+  width: 28px;
+  height: 28px;
+}
+
+.wtd-form {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wtd-form [data-component="input"] {
+  width: 100%;
+}
+
+.wtd-form [data-slot="input-label"] {
+  color: var(--text-weaker);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+}
+
+.wtd-form [data-slot="input-wrapper"] {
+  background: var(--workbench-input-bg);
+}
+
+.wtd-step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.wtd-step-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 24px;
+  color: var(--text-weaker);
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  letter-spacing: 0;
+  transition:
+    opacity 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 160ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.wtd-step-row[data-state="active"] {
+  color: var(--text-base);
+}
+
+.wtd-step-row[data-state="complete"] {
+  color: var(--text-strong);
+}
+
+.wtd-step-icon {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--icon-base);
+}
+
+.wtd-step-icon[data-state="complete"] {
+  color: var(--icon-success-base);
+}
+
+.wtd-step-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklch, var(--border-base) 58%, transparent);
+}
+
+.wtd-step-spinner {
+  width: 14px;
+  height: 14px;
+}
+
+.wtd-result {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+}
+
+.wtd-result-icon {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  color: var(--icon-success-base);
+  background: var(--surface-success-soft);
+}
+
+.wtd-result-copy {
+  min-width: 0;
+  padding-top: 1px;
+}
+
+.wtd-result-title {
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+.wtd-result-description,
+.wtd-error {
+  color: var(--text-base);
+  font-size: 13px;
+  font-weight: var(--font-weight-regular);
+  line-height: 1.45;
+  letter-spacing: 0;
+}
+
+.wtd-error {
+  width: 100%;
+}
+
+.wtd-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 16px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wtd-step-row {
+    transition: none;
+  }
+}

--- a/packages/app/src/components/session/worktree-transition-dialog.tsx
+++ b/packages/app/src/components/session/worktree-transition-dialog.tsx
@@ -1,0 +1,252 @@
+import { For, Match, Show, Switch, createMemo, createSignal, onMount } from "solid-js"
+import { Button } from "@ericsanchezok/synergy-ui/button"
+import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
+import { Dialog } from "@ericsanchezok/synergy-ui/dialog"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
+import { TextField } from "@ericsanchezok/synergy-ui/text-field"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
+import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
+import { useGlobalSDK } from "@/context/global-sdk"
+import {
+  reduceWorkspaceTransitionProgress,
+  type WorkspaceTransitionProgressState,
+} from "@/components/session/worktree-session"
+import "./worktree-transition-dialog.css"
+
+export type SessionStartProgressStepState = "pending" | "active" | "complete"
+
+export type SessionStartProgress = {
+  title: string
+  description: string
+  steps: Array<{ id: string; label: string; state: SessionStartProgressStepState }>
+}
+
+function errorDescription(error: unknown) {
+  if (error && typeof error === "object" && "data" in error) {
+    const data = (error as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+  }
+  if (error instanceof Error && error.message) return error.message
+  return "Request failed"
+}
+
+function DialogCloseButton(props: { disabled?: boolean }) {
+  const dialog = useDialog()
+  return (
+    <button
+      type="button"
+      data-slot="dialog-close-button"
+      data-component="icon-button"
+      data-variant="ghost"
+      disabled={props.disabled}
+      onClick={() => {
+        if (!props.disabled) dialog.close()
+      }}
+    >
+      <Icon name="x" size="small" />
+    </button>
+  )
+}
+
+function StepIcon(props: { state: SessionStartProgressStepState }) {
+  return (
+    <span class="wtd-step-icon" data-state={props.state}>
+      <Switch>
+        <Match when={props.state === "active"}>
+          <Spinner class="wtd-step-spinner" />
+        </Match>
+        <Match when={props.state === "complete"}>
+          <Icon name={getSemanticIcon("state.success")} size="small" />
+        </Match>
+        <Match when={true}>
+          <span class="wtd-step-dot" />
+        </Match>
+      </Switch>
+    </span>
+  )
+}
+
+function StepList(props: { steps: SessionStartProgress["steps"] }) {
+  return (
+    <div class="wtd-step-list">
+      <For each={props.steps}>
+        {(step) => (
+          <div class="wtd-step-row" data-state={step.state}>
+            <StepIcon state={step.state} />
+            <span>{step.label}</span>
+          </div>
+        )}
+      </For>
+    </div>
+  )
+}
+
+export function SessionStartProgressDialog(props: { progress: () => SessionStartProgress }) {
+  const progress = () => props.progress()
+  return (
+    <Dialog
+      title={progress().title}
+      description={progress().description}
+      class="workspace-transition-dialog"
+      dismissible={false}
+      action={<span class="wtd-dialog-action-placeholder" aria-hidden="true" />}
+    >
+      <StepList steps={progress().steps} />
+    </Dialog>
+  )
+}
+
+export function WorktreeTransitionDialog(props: {
+  mode: "enter" | "leave"
+  sessionID: string
+  directory: string
+  onPendingChange?: (pending: boolean) => void
+}) {
+  const dialog = useDialog()
+  const globalSDK = useGlobalSDK()
+  const [name, setName] = createSignal("")
+  const [state, setState] = createSignal<WorkspaceTransitionProgressState>(
+    props.mode === "enter" ? { phase: "form", operation: "enter" } : { phase: "idle" },
+  )
+  const loading = createMemo(() => state().phase === "loading")
+  const title = createMemo(() => {
+    const current = state()
+    if (current.phase === "success") return current.operation === "leave" ? "Left worktree" : "Moved to worktree"
+    if (current.phase === "error")
+      return current.operation === "leave" ? "Exit worktree failed" : "Enter worktree failed"
+    return props.mode === "leave" ? "Leaving worktree" : "Move session to worktree"
+  })
+  const description = createMemo(() => {
+    const current = state()
+    if (current.phase === "success") return current.message
+    if (current.phase === "error") return current.message
+    if (props.mode === "leave") return "Returning this session to the main checkout."
+    return "Create an isolated worktree for this session."
+  })
+  const steps = createMemo<SessionStartProgress["steps"]>(() => {
+    const current = state()
+    if (current.phase !== "loading") return []
+    if (current.operation === "leave") return [{ id: "leave", label: "Leaving worktree", state: "active" }]
+    return [
+      { id: "create", label: "Creating worktree", state: "active" },
+      { id: "prepare", label: "Preparing session", state: "pending" },
+    ]
+  })
+
+  const setPending = (pending: boolean) => props.onPendingChange?.(pending)
+
+  const submit = async () => {
+    if (loading()) return
+    const operation = props.mode === "leave" ? "leave" : "enter"
+    setState((prev) =>
+      reduceWorkspaceTransitionProgress(prev, {
+        type: "load",
+        operation,
+        step: operation === "leave" ? "Leaving worktree" : "Creating worktree",
+      }),
+    )
+    setPending(true)
+    try {
+      if (props.mode === "leave") {
+        await globalSDK.client.worktree.leave({ directory: props.directory, sessionID: props.sessionID })
+        setState((prev) =>
+          reduceWorkspaceTransitionProgress(prev, {
+            type: "succeed",
+            message: "Session returned to the main checkout.",
+          }),
+        )
+        showToast({ type: "info", title: "Exited worktree", description: "Session returned to the main checkout." })
+        return
+      }
+
+      const trimmed = name().trim()
+      const result = await globalSDK.client.worktree.create({
+        directory: props.directory,
+        worktreeCreateInput: {
+          sessionID: props.sessionID,
+          bind: true,
+          name: trimmed.length > 0 ? trimmed : undefined,
+        },
+      })
+      const description = result.data?.name ? `Session is now using ${result.data.name}.` : "Worktree created."
+      setState((prev) => reduceWorkspaceTransitionProgress(prev, { type: "succeed", message: description }))
+      showToast({ type: "info", title: "Moved to worktree", description })
+    } catch (error) {
+      setState((prev) => reduceWorkspaceTransitionProgress(prev, { type: "fail", message: errorDescription(error) }))
+      showToast({
+        type: "error",
+        title: props.mode === "leave" ? "Exit worktree failed" : "Enter worktree failed",
+        description: errorDescription(error),
+      })
+    } finally {
+      setPending(false)
+    }
+  }
+
+  onMount(() => {
+    if (props.mode === "leave") void submit()
+  })
+
+  return (
+    <Dialog
+      title={title()}
+      description={description()}
+      class="workspace-transition-dialog"
+      dismissible={!loading()}
+      action={<DialogCloseButton disabled={loading()} />}
+    >
+      <Switch>
+        <Match when={state().phase === "form"}>
+          <form
+            class="wtd-form"
+            onSubmit={(event) => {
+              event.preventDefault()
+              void submit()
+            }}
+          >
+            <TextField autofocus label="Worktree name" placeholder="Auto-generated" value={name()} onChange={setName} />
+            <div class="wtd-actions">
+              <Button type="button" variant="ghost" size="small" onClick={() => dialog.close()}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" size="small">
+                Create worktree
+              </Button>
+            </div>
+          </form>
+        </Match>
+        <Match when={state().phase === "loading"}>
+          <StepList steps={steps()} />
+        </Match>
+        <Match when={state().phase === "success"}>
+          <div class="wtd-result">
+            <span class="wtd-result-icon" data-state="success">
+              <Icon name={getSemanticIcon("state.success")} size="normal" />
+            </span>
+            <div class="wtd-result-copy">
+              <div class="wtd-result-title">{props.mode === "leave" ? "Left worktree" : "Moved to worktree"}</div>
+              <div class="wtd-result-description">{description()}</div>
+            </div>
+          </div>
+          <div class="wtd-actions">
+            <Button type="button" variant="primary" size="small" onClick={() => dialog.close()}>
+              Done
+            </Button>
+          </div>
+        </Match>
+        <Match when={state().phase === "error"}>
+          <div class="wtd-error">{description()}</div>
+          <div class="wtd-actions">
+            <Button type="button" variant="ghost" size="small" onClick={() => dialog.close()}>
+              Cancel
+            </Button>
+            <Button type="button" variant="primary" size="small" onClick={() => void submit()}>
+              Try again
+            </Button>
+          </div>
+        </Match>
+      </Switch>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/top-bar/session-top-bar.tsx
+++ b/packages/app/src/components/top-bar/session-top-bar.tsx
@@ -3,12 +3,10 @@ import { useNavigate, useParams } from "@solidjs/router"
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { Popover } from "@ericsanchezok/synergy-ui/popover"
-import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { Tooltip, TooltipKeybind } from "@ericsanchezok/synergy-ui/tooltip"
 import { DialogSessionRename, ModelSelectorPopover, useConfirm } from "@/components/dialog"
 import { archiveSessionConfirm } from "@/components/dialog/confirm-copy"
 import { DialogSessionExport } from "@/components/dialog/dialog-session-export"
-import { useGlobalSDK } from "@/context/global-sdk"
 import { useLayout } from "@/context/layout"
 import { useLocal } from "@/context/local"
 import { useCommand } from "@/context/command"
@@ -18,15 +16,13 @@ import { base64Decode } from "@ericsanchezok/synergy-util/encode"
 import { isHomeScope } from "@/utils/scope"
 import { useSessionMeta } from "@/composables/use-session-meta"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
+import { WorktreeTransitionDialog } from "@/components/session/worktree-transition-dialog"
+import { isSessionRunningForWorkspaceChange } from "@/components/session/worktree-session"
 import "./session-top-bar.css"
-
-function errorDescription(error: unknown) {
-  return error instanceof Error ? error.message : "Request failed"
-}
 
 function SessionActionMenu(props: {
   isWorktree: () => boolean
-  worktreePending: () => boolean
+  worktreeDisabled: () => boolean
   onRename: () => void
   onWorktreeToggle: () => void
   onExport: () => void
@@ -69,16 +65,15 @@ function SessionActionMenu(props: {
           type="button"
           class="stb-menu-item"
           role="menuitem"
-          disabled={props.worktreePending()}
+          disabled={props.worktreeDisabled()}
+          title={props.worktreeDisabled() ? "Stop the session before changing worktree." : undefined}
           onClick={() => run(props.onWorktreeToggle)}
         >
           <Icon
             name={getSemanticIcon(props.isWorktree() ? "workspace.leaveWorktree" : "workspace.enterWorktree")}
             size="small"
           />
-          <span>
-            {props.worktreePending() ? "Updating worktree..." : props.isWorktree() ? "Exit worktree" : "Enter worktree"}
-          </span>
+          <span>{props.isWorktree() ? "Exit worktree" : "Enter worktree"}</span>
         </button>
         <button type="button" class="stb-menu-item" role="menuitem" onClick={() => run(props.onExport)}>
           <Icon name={getSemanticIcon("action.export")} size="small" />
@@ -103,7 +98,6 @@ export function SessionTopBar() {
   const navigate = useNavigate()
   const dialog = useDialog()
   const confirm = useConfirm()
-  const globalSDK = useGlobalSDK()
   const layout = useLayout()
   const local = useLocal()
   const command = useCommand()
@@ -119,6 +113,13 @@ export function SessionTopBar() {
   const sessionInfo = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const sessionDirectory = createMemo(() => sessionInfo()?.scope.directory ?? directory())
   const isWorktreeSession = createMemo(() => sessionInfo()?.workspace?.type === "git_worktree")
+  const worktreeDisabled = createMemo(() =>
+    isSessionRunningForWorkspaceChange({
+      pending: worktreePending(),
+      status: sync.data.session_status[params.id ?? ""],
+      working: sessionInfo()?.working,
+    }),
+  )
 
   const sessionHasMessages = createMemo(() => {
     if (!params.id) return false
@@ -142,35 +143,18 @@ export function SessionTopBar() {
     dialog.show(() => <DialogSessionRename session={session} directory={dir} />)
   }
 
-  const toggleWorktree = async () => {
+  const toggleWorktree = () => {
     const session = sessionInfo()
     const dir = sessionDirectory()
-    if (!session || !dir || worktreePending()) return
-    setWorktreePending(true)
-    try {
-      if (isWorktreeSession()) {
-        await globalSDK.client.worktree.leave({ directory: dir, sessionID: session.id })
-        showToast({ type: "info", title: "Exited worktree", description: "Session returned to the main checkout." })
-      } else {
-        const result = await globalSDK.client.worktree.create({
-          directory: dir,
-          worktreeCreateInput: { sessionID: session.id, bind: true },
-        })
-        showToast({
-          type: "info",
-          title: "Entered worktree",
-          description: result.data?.name ? `Session is now using ${result.data.name}.` : "Worktree created.",
-        })
-      }
-    } catch (error) {
-      showToast({
-        type: "error",
-        title: isWorktreeSession() ? "Exit worktree failed" : "Enter worktree failed",
-        description: errorDescription(error),
-      })
-    } finally {
-      setWorktreePending(false)
-    }
+    if (!session || !dir || worktreeDisabled()) return
+    dialog.show(() => (
+      <WorktreeTransitionDialog
+        mode={isWorktreeSession() ? "leave" : "enter"}
+        sessionID={session.id}
+        directory={dir}
+        onPendingChange={setWorktreePending}
+      />
+    ))
   }
 
   const archiveSession = () => {
@@ -235,9 +219,9 @@ export function SessionTopBar() {
         <Show when={!!params.id && !isGlobal()}>
           <SessionActionMenu
             isWorktree={isWorktreeSession}
-            worktreePending={worktreePending}
+            worktreeDisabled={worktreeDisabled}
             onRename={showRenameDialog}
-            onWorktreeToggle={() => void toggleWorktree()}
+            onWorktreeToggle={toggleWorktree}
             onExport={() => dialog.show(() => <DialogSessionExport />)}
             onArchive={archiveSession}
           />

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -42,6 +42,10 @@ import { WorkspaceBrowserTool } from "@/components/workspace/tool-browser"
 import { WorkspaceTerminalTool } from "@/components/workspace/tool-terminal"
 import { WorkbenchSurface } from "@/components/session/workbench-surface"
 import { SessionTopBar } from "@/components/top-bar/session-top-bar"
+import {
+  defaultNewSessionWorkspaceSelection,
+  type NewSessionWorkspaceSelection,
+} from "@/components/session/worktree-session"
 
 const handoff = {
   prompt: "",
@@ -175,7 +179,7 @@ function SessionPageContent() {
     messageId: undefined as string | undefined,
     turnStart: 0,
     mobileTab: "session" as "session" | "review",
-    newSessionWorktree: "main",
+    newSessionWorkspaceSelection: undefined as NewSessionWorkspaceSelection | undefined,
     promptHeight: 0,
   })
 
@@ -295,14 +299,14 @@ function SessionPageContent() {
     return mergeTimelineMessages([...turns, ...mailbox, ...actionCommands])
   }, emptyTimeline)
 
-  const newSessionWorktree = createMemo(() => {
-    if (store.newSessionWorktree === "create") return "create"
-    const scope = sync.scope
-    if (scope && sync.data.path.directory !== scope.worktree) return sync.data.path.directory
-    return "main"
-  })
-
   const scopeRoot = createMemo(() => sync.scope?.worktree ?? sync.data.path.directory)
+  const newSessionWorkspaceSelection = createMemo(() =>
+    defaultNewSessionWorkspaceSelection({
+      selected: store.newSessionWorkspaceSelection,
+      currentDirectory: sync.data.path.directory,
+      canonicalDirectory: scopeRoot(),
+    }),
+  )
   const scopeName = createMemo(() => getFilename(scopeRoot()))
   const branch = createMemo(() => sync.data.vcs?.branch)
   const lastModified = createMemo(() => {
@@ -927,9 +931,11 @@ function SessionPageContent() {
               forkedFromID={currentSession()?.forkedFrom?.sessionID}
               forkedFromTitle={forkedFromSession()?.title ?? currentSession()?.forkedFrom?.title}
               backPath={backPath}
-              newSessionWorktree={newSessionWorktree}
-              onNewSessionWorktreeChange={(worktree) => setStore("newSessionWorktree", worktree)}
-              onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
+              newSessionWorkspaceSelection={newSessionWorkspaceSelection}
+              newSessionCanonicalDirectory={scopeRoot}
+              newSessionCurrentDirectory={() => sync.data.path.directory}
+              onNewSessionWorkspaceSelectionChange={(selection) => setStore("newSessionWorkspaceSelection", selection)}
+              onNewSessionWorkspaceSelectionReset={() => setStore("newSessionWorkspaceSelection", undefined)}
               scopeName={scopeName}
               branch={branch}
               lastModified={lastModified}

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -415,6 +415,7 @@ import type {
   SessionUnrollbackResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SessionWorkspaceSelection,
   SkillImportErrors,
   SkillImportResponses,
   SkillImportUrlErrors,
@@ -1528,6 +1529,7 @@ export class Session extends HeyApiClient {
       title?: string
       id?: string
       controlProfile?: "guarded" | "autonomous" | "full_access"
+      workspace?: SessionWorkspaceSelection
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1542,6 +1544,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "title" },
             { in: "body", key: "id" },
             { in: "body", key: "controlProfile" },
+            { in: "body", key: "workspace" },
           ],
         },
       ],
@@ -1903,21 +1906,7 @@ export class Session extends HeyApiClient {
             type: "before"
             messageID: string
           }
-      workspace?:
-        | {
-            mode: "current"
-          }
-        | {
-            mode: "existing"
-            target: string
-            force?: boolean
-          }
-        | {
-            mode: "create"
-            name?: string
-            baseRef?: "current" | "fresh"
-            baseRevision?: string
-          }
+      workspace?: SessionWorkspaceSelection
       title?: string
       controlProfile?: "guarded" | "autonomous" | "full_access"
     },

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2950,6 +2950,22 @@ export type SessionAgendaResponse = {
   hasMore: boolean
 }
 
+export type SessionWorkspaceSelection =
+  | {
+      mode: "current"
+    }
+  | {
+      mode: "existing"
+      target: string
+      force?: boolean
+    }
+  | {
+      mode: "create"
+      name?: string
+      baseRef?: "current" | "fresh"
+      baseRevision?: string
+    }
+
 export type SessionInboxItemSource = {
   type: string
   label?: string
@@ -7276,6 +7292,7 @@ export type SessionCreateData = {
     title?: string
     id?: string
     controlProfile?: "guarded" | "autonomous" | "full_access"
+    workspace?: SessionWorkspaceSelection
   }
   path?: never
   query?: {
@@ -7646,21 +7663,7 @@ export type SessionForkData = {
           type: "before"
           messageID: string
         }
-    workspace?:
-      | {
-          mode: "current"
-        }
-      | {
-          mode: "existing"
-          target: string
-          force?: boolean
-        }
-      | {
-          mode: "create"
-          name?: string
-          baseRef?: "current" | "fresh"
-          baseRevision?: string
-        }
+    workspace?: SessionWorkspaceSelection
     title?: string
     controlProfile?: "guarded" | "autonomous" | "full_access"
   }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3773,6 +3773,9 @@
                   "controlProfile": {
                     "type": "string",
                     "enum": ["guarded", "autonomous", "full_access"]
+                  },
+                  "workspace": {
+                    "$ref": "#/components/schemas/SessionWorkspaceSelection"
                   }
                 }
               }
@@ -4597,56 +4600,7 @@
                     ]
                   },
                   "workspace": {
-                    "anyOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "mode": {
-                            "type": "string",
-                            "const": "current"
-                          }
-                        },
-                        "required": ["mode"]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "mode": {
-                            "type": "string",
-                            "const": "existing"
-                          },
-                          "target": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "force": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": ["mode", "target"]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "mode": {
-                            "type": "string",
-                            "const": "create"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "baseRef": {
-                            "type": "string",
-                            "enum": ["current", "fresh"]
-                          },
-                          "baseRevision": {
-                            "type": "string",
-                            "minLength": 1
-                          }
-                        },
-                        "required": ["mode"]
-                      }
-                    ]
+                    "$ref": "#/components/schemas/SessionWorkspaceSelection"
                   },
                   "title": {
                     "type": "string"
@@ -22706,6 +22660,58 @@
           }
         },
         "required": ["sessionID", "count", "hasActiveAgenda", "items", "offset", "limit", "total", "hasMore"]
+      },
+      "SessionWorkspaceSelection": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "current"
+              }
+            },
+            "required": ["mode"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "existing"
+              },
+              "target": {
+                "type": "string",
+                "minLength": 1
+              },
+              "force": {
+                "type": "boolean"
+              }
+            },
+            "required": ["mode", "target"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "create"
+              },
+              "name": {
+                "type": "string"
+              },
+              "baseRef": {
+                "type": "string",
+                "enum": ["current", "fresh"]
+              },
+              "baseRevision": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": ["mode"]
+          }
+        ]
       },
       "SessionInboxItemSource": {
         "type": "object",

--- a/packages/synergy/src/project/worktree.ts
+++ b/packages/synergy/src/project/worktree.ts
@@ -119,6 +119,10 @@ export namespace Worktree {
   export const LockFailedError = NamedError.create("WorktreeLockFailedError", z.object({ message: z.string() }))
   export const NotFoundError = NamedError.create("WorktreeNotFoundError", z.object({ message: z.string() }))
   export const DirtyError = NamedError.create("WorktreeDirtyError", z.object({ message: z.string() }))
+  export const SessionBusyError = NamedError.create(
+    "WorktreeSessionBusyError",
+    z.object({ message: z.string(), sessionID: z.string() }),
+  )
 
   const ADJECTIVES = [
     "brave",
@@ -640,7 +644,12 @@ export namespace Worktree {
       )
     }
     const scope = session.scope as Scope
-    const mainWorkspace = { type: "main" as const, path: scope.directory, scopeID: scope.id }
+    const originalCheckout =
+      previous?.type === "git_worktree" && typeof previous.originalCheckout === "string"
+        ? previous.originalCheckout
+        : undefined
+    const mainPath = originalCheckout ?? scope.worktree ?? scope.directory
+    const mainWorkspace = { type: "main" as const, path: mainPath, scopeID: scope.id }
     const result = await Session.updateWorkspace(sessionID, mainWorkspace)
     ScopeContext.refreshWorkspace(mainWorkspace as import("../session/types").Workspace)
     return result

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -39,6 +39,7 @@ import { Installation } from "@/global/installation"
 import { MDNS } from "./mdns"
 import { Worktree } from "../project/worktree"
 import { Session } from "../session"
+import { SessionManager } from "../session/manager"
 import { SessionRoute } from "./session"
 import { PtyRoute } from "./pty"
 import { ProviderRoute } from "./provider"
@@ -224,6 +225,15 @@ export namespace Server {
     } catch {
       return scopeID
     }
+  }
+
+  function assertWorktreeSessionIdle(sessionID: string | undefined) {
+    if (!sessionID) return
+    if (!SessionManager.isRunning(sessionID)) return
+    throw new Worktree.SessionBusyError({
+      sessionID,
+      message: "Stop the session before changing worktree.",
+    })
   }
 
   async function resolveScopedRequestScope(
@@ -813,6 +823,7 @@ export namespace Server {
           validator("json", Worktree.PublicCreateInput),
           async (c) => {
             const body = c.req.valid("json")
+            if (body.bind !== false) assertWorktreeSessionIdle(body.sessionID)
             const worktree = await Worktree.create(body)
             return c.json(worktree)
           },
@@ -866,6 +877,7 @@ export namespace Server {
           ),
           async (c) => {
             const sessionID = c.req.valid("param").sessionID
+            assertWorktreeSessionIdle(sessionID)
             const session = await Worktree.leave(sessionID)
             return c.json(session)
           },

--- a/packages/synergy/src/server/session.ts
+++ b/packages/synergy/src/server/session.ts
@@ -346,12 +346,19 @@ export const SessionRoute = new Hono()
           title: z.string().optional(),
           id: z.string().optional(),
           controlProfile: ControlProfileId.optional(),
+          workspace: Session.WorkspaceSelection.optional(),
         })
         .optional(),
     ),
     async (c) => {
-      const body = c.req.valid("json") ?? {}
-      const session = await Session.create(body)
+      const { workspace, ...body } = c.req.valid("json") ?? {}
+      let session = await Session.create(body)
+      try {
+        session = await Session.applyWorkspaceSelection(session.id, workspace)
+      } catch (error) {
+        await Session.remove(session.id)
+        throw error
+      }
       return c.json(session)
     },
   )

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -105,6 +105,26 @@ export namespace Session {
   export type ChildCursor = z.infer<typeof ChildCursor>
   export type ChildrenPage = z.infer<typeof ChildrenPage>
 
+  export const WorkspaceSelection = z
+    .discriminatedUnion("mode", [
+      z.object({
+        mode: z.literal("current"),
+      }),
+      z.object({
+        mode: z.literal("existing"),
+        target: z.string().min(1),
+        force: z.boolean().optional(),
+      }),
+      z.object({
+        mode: z.literal("create"),
+        name: z.string().optional(),
+        baseRef: z.enum(["current", "fresh"]).optional(),
+        baseRevision: z.string().min(1).optional(),
+      }),
+    ])
+    .meta({ ref: "SessionWorkspaceSelection" })
+  export type WorkspaceSelection = z.infer<typeof WorkspaceSelection>
+
   export async function readPageIndex(scopeID: string): Promise<PageIndex> {
     return Storage.read<PageIndex>(StoragePath.sessionsPageIndex(asScopeID(scopeID))).catch(() => ({ entries: [] }))
   }
@@ -339,6 +359,32 @@ export namespace Session {
     return withRuntimeInfo(result)
   }
 
+  export async function applyWorkspaceSelection(
+    sessionID: string,
+    selection?: WorkspaceSelection,
+  ): Promise<Info & { working?: WorkingInfoType }> {
+    if (!selection || selection.mode === "current") return get(sessionID)
+
+    const { Worktree } = await import("../project/worktree")
+    if (selection.mode === "create") {
+      await Worktree.create({
+        sessionID,
+        name: selection.name,
+        baseRef: selection.baseRef ?? "current",
+        baseRevision: selection.baseRevision,
+        bind: true,
+      })
+      return get(sessionID)
+    }
+
+    await Worktree.enter({
+      sessionID,
+      target: selection.target,
+      force: selection.force ?? false,
+    })
+    return get(sessionID)
+  }
+
   export const fork = fn(
     z.object({
       sessionID: Identifier.schema("session"),
@@ -354,24 +400,7 @@ export namespace Session {
           }),
         ])
         .optional(),
-      workspace: z
-        .discriminatedUnion("mode", [
-          z.object({
-            mode: z.literal("current"),
-          }),
-          z.object({
-            mode: z.literal("existing"),
-            target: z.string().min(1),
-            force: z.boolean().optional(),
-          }),
-          z.object({
-            mode: z.literal("create"),
-            name: z.string().optional(),
-            baseRef: z.enum(["current", "fresh"]).optional(),
-            baseRevision: z.string().min(1).optional(),
-          }),
-        ])
-        .optional(),
+      workspace: WorkspaceSelection.optional(),
       title: z.string().optional(),
       controlProfile: z.enum(["guarded", "autonomous", "full_access"]).optional(),
     }),
@@ -415,26 +444,7 @@ export namespace Session {
       }
 
       try {
-        if (input.workspace?.mode === "create") {
-          const { Worktree } = await import("../project/worktree")
-          await Worktree.create({
-            sessionID: session.id,
-            name: input.workspace.name,
-            baseRef: input.workspace.baseRef ?? "current",
-            baseRevision: input.workspace.baseRevision,
-            bind: true,
-          })
-          session = await get(session.id)
-        }
-        if (input.workspace?.mode === "existing") {
-          const { Worktree } = await import("../project/worktree")
-          await Worktree.enter({
-            sessionID: session.id,
-            target: input.workspace.target,
-            force: input.workspace.force ?? false,
-          })
-          session = await get(session.id)
-        }
+        session = await applyWorkspaceSelection(session.id, input.workspace)
       } catch (error) {
         await remove(session.id)
         throw error

--- a/packages/synergy/src/session/migration.ts
+++ b/packages/synergy/src/session/migration.ts
@@ -32,6 +32,126 @@ function compact<T extends Record<string, unknown>>(value: T): T | undefined {
   return Object.fromEntries(entries) as T
 }
 
+function normalizePathForCompare(input: string) {
+  const resolved = path.resolve(input)
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved
+}
+
+function samePath(a: string, b: string) {
+  return normalizePathForCompare(a) === normalizePathForCompare(b)
+}
+
+async function findWorktreeRegistry(
+  mainCheckout: string,
+  worktreePath: string,
+): Promise<Record<string, unknown> | undefined> {
+  const root = path.join(mainCheckout, ".synergy", "worktrees", ".registry")
+  const entries = await fs.readdir(root).catch(() => [] as string[])
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue
+    const filepath = path.join(root, entry)
+    const text = await Bun.file(filepath)
+      .text()
+      .catch(() => undefined)
+    if (!text) continue
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      continue
+    }
+    const registeredPath = asString(parsed.path)
+    if (registeredPath && samePath(registeredPath, worktreePath)) return parsed
+  }
+  return undefined
+}
+
+async function migrateSessionWorktreeWorkspace(progress: (current: number, total: number) => void) {
+  const scopeIDs = await Storage.scan(["sessions"]).catch(() => [])
+  const tasks: Array<{ scopeID: string; sessionID: string; info: any }> = []
+
+  for (const scopeID of scopeIDs) {
+    const scope = Identifier.asScopeID(scopeID)
+    const sessionIDs = await Storage.scan(StoragePath.sessionsRoot(scope)).catch(() => [])
+    const sessions = await Storage.readMany<any>(
+      sessionIDs.map((sessionID) => StoragePath.sessionInfo(scope, Identifier.asSessionID(sessionID))),
+    )
+
+    for (const info of sessions) {
+      const scopeInfo = asRecord(info?.scope)
+      const directory = asString(scopeInfo?.directory)
+      const worktree = asString(scopeInfo?.worktree)
+      const workspace = asRecord(info?.workspace)
+      if (!info?.id || !directory || !worktree) continue
+      if (samePath(directory, worktree)) continue
+      if (workspace?.type && workspace.type !== "main") continue
+      tasks.push({ scopeID, sessionID: info.id, info })
+    }
+  }
+
+  if (tasks.length === 0) return
+
+  const changedScopes = new Set<string>()
+  let done = 0
+  let changed = 0
+  for (const { scopeID, sessionID, info } of tasks) {
+    const scope = Identifier.asScopeID(scopeID)
+    const sid = Identifier.asSessionID(sessionID)
+    const scopeInfo = asRecord(info.scope)!
+    const worktreePath = asString(scopeInfo.directory)!
+    const mainCheckout = asString(scopeInfo.worktree)!
+    const registry = await findWorktreeRegistry(mainCheckout, worktreePath)
+    const sandboxes = Array.isArray(scopeInfo.sandboxes)
+      ? scopeInfo.sandboxes.filter((item): item is string => typeof item === "string" && item.length > 0)
+      : []
+    const nextSandboxes = sandboxes.includes(worktreePath) ? sandboxes : [...sandboxes, worktreePath]
+    const workspace = compact({
+      type: "git_worktree",
+      path: worktreePath,
+      scopeID,
+      worktreeID: asString(registry?.id),
+      name: asString(registry?.name) ?? path.basename(worktreePath),
+      branch: asString(registry?.branch),
+      baseRef: asString(registry?.baseRef),
+      baseRevision: asString(registry?.baseRevision),
+      resolvedBaseCommit: asString(registry?.resolvedBaseCommit),
+      originalCheckout: mainCheckout,
+    })!
+    const nextInfo = {
+      ...info,
+      scope: {
+        ...scopeInfo,
+        directory: mainCheckout,
+        worktree: mainCheckout,
+        sandboxes: nextSandboxes,
+      },
+      workspace,
+    }
+
+    await Storage.write(StoragePath.sessionInfo(scope, sid), nextInfo)
+    await Storage.write(StoragePath.sessionIndex(sid), {
+      sessionID,
+      scopeID,
+      directory: mainCheckout,
+      parentID: nextInfo.parentID,
+      endpoint: nextInfo.endpoint,
+      endpointKey: nextInfo.endpoint ? SessionEndpoint.toKey(nextInfo.endpoint) : undefined,
+    })
+    changedScopes.add(scopeID)
+    changed++
+    done++
+    progress(done, tasks.length)
+  }
+
+  for (const scopeID of changedScopes) {
+    await SessionNav.buildNavIndex(scopeID).catch((error) => {
+      log.warn("failed to rebuild nav index after worktree workspace migration", { scopeID, error: String(error) })
+    })
+  }
+
+  log.info("session worktree workspace migration complete", { total: tasks.length, changed })
+}
+
 function normalizeLegacyHolosMetadata(metadata: Record<string, unknown>): {
   metadata: Record<string, unknown> | undefined
   changed: boolean
@@ -1403,6 +1523,13 @@ export const migrations: Migration[] = [
     description: "Build parent-to-child session indexes for paginated child session lookup",
     async up(progress) {
       await migrateSessionChildIndex(progress)
+    },
+  },
+  {
+    id: "20260703-session-worktree-workspace",
+    description: "Normalize legacy route-directory worktree sessions into session workspace metadata",
+    async up(progress) {
+      await migrateSessionWorktreeWorkspace(progress)
     },
   },
 ]

--- a/packages/synergy/test/project/worktree.test.ts
+++ b/packages/synergy/test/project/worktree.test.ts
@@ -8,6 +8,8 @@ import { Session } from "../../src/session"
 import { Worktree } from "../../src/project/worktree"
 import { Log } from "../../src/util/log"
 import { Identifier } from "../../src/id/id"
+import { Server } from "../../src/server/server"
+import { SessionManager } from "../../src/session/manager"
 
 Log.init({ print: false })
 
@@ -89,6 +91,131 @@ describe("git worktree integration", () => {
 
           await Worktree.remove({ sessionID: session.id, target: created.id, force: true })
           await Session.remove(session.id)
+        })(),
+    })
+  })
+
+  test("POST /session with workspace create returns a git worktree session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: () =>
+        using(async () => {
+          const app = Server.App()
+          const response = await app.request(`/session?directory=${encodeURIComponent(scope.worktree)}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              title: "Route Worktree",
+              workspace: { mode: "create", name: "route-worktree" },
+            }),
+          })
+
+          expect(response.status).toBe(200)
+          const session = await response.json()
+          expect(session.workspace?.type).toBe("git_worktree")
+          expect(session.workspace?.path).toStartWith(path.join(scope.worktree, ".synergy", "worktrees"))
+          expect(session.workspace?.originalCheckout).toBe(scope.worktree)
+          expect(session.scope.directory).toBe(scope.worktree)
+
+          await Worktree.remove({ sessionID: session.id, target: session.workspace.worktreeID, force: true })
+          await Session.remove(session.id)
+        })(),
+    })
+  })
+
+  test("POST /session cleans up the session if workspace creation fails", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: () =>
+        using(async () => {
+          const app = Server.App()
+          const sessionID = Identifier.descending("session")
+          const response = await app.request(`/session?directory=${encodeURIComponent(scope.worktree)}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              id: sessionID,
+              workspace: { mode: "create", baseRevision: "missing-revision-for-test" },
+            }),
+          })
+
+          expect(response.status).toBe(400)
+          expect(await SessionManager.getSession(sessionID)).toBeUndefined()
+        })(),
+    })
+  })
+
+  test("HTTP worktree create and leave reject running sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: () =>
+        using(async () => {
+          const app = Server.App()
+          const session = await Session.create({ title: "Busy Session" })
+          SessionManager.registerRuntime(session.id)
+          SessionManager.acquire(session.id)
+
+          try {
+            const create = await app.request(`/experimental/worktree?directory=${encodeURIComponent(scope.worktree)}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ sessionID: session.id, bind: true }),
+            })
+            expect(create.status).toBe(400)
+            expect((await create.json()).name).toBe("WorktreeSessionBusyError")
+
+            const leave = await app.request(
+              `/experimental/worktree/session/${session.id}/leave?directory=${encodeURIComponent(scope.worktree)}`,
+              { method: "POST" },
+            )
+            expect(leave.status).toBe(400)
+            expect((await leave.json()).name).toBe("WorktreeSessionBusyError")
+          } finally {
+            await SessionManager.release(session.id)
+            await Session.remove(session.id)
+          }
+        })(),
+    })
+  })
+
+  test("core worktree APIs still work while a session is running", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: () =>
+        using(async () => {
+          const session = await Session.create({ title: "Running Core Worktree" })
+          SessionManager.registerRuntime(session.id)
+          SessionManager.acquire(session.id)
+
+          let created: Worktree.Info | undefined
+          try {
+            created = await Worktree.create({
+              name: "running-core",
+              sessionID: session.id,
+              bind: true,
+              baseRef: "current",
+            })
+            expect((await Session.get(session.id)).workspace?.type).toBe("git_worktree")
+
+            await Worktree.leave(session.id)
+            expect((await Session.get(session.id)).workspace?.type).toBe("main")
+          } finally {
+            await SessionManager.release(session.id)
+            if (created) await Worktree.remove({ sessionID: session.id, target: created.id, force: true })
+            await Session.remove(session.id)
+          }
         })(),
     })
   })

--- a/packages/synergy/test/session/migration.test.ts
+++ b/packages/synergy/test/session/migration.test.ts
@@ -10,6 +10,7 @@ import { Storage } from "../../src/storage/storage"
 import { StoragePath } from "../../src/storage/path"
 import { SnapshotSchema } from "../../src/session/snapshot-schema"
 import { SessionBounds } from "../../src/session/bounds"
+import { Worktree } from "../../src/project/worktree"
 
 const projectRoot = path.join(__dirname, "../..")
 
@@ -69,6 +70,55 @@ describe("session migrations", () => {
         expect(index.entries.find((entry) => entry.id === childA.id)?.title).toBe("Child A")
 
         await Session.remove(parent.id)
+      },
+    })
+  })
+
+  test("migrates legacy route-directory worktree sessions to workspace metadata", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const tmpScope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope: tmpScope,
+      fn: async () => {
+        const session = await Session.create({ title: "Legacy Worktree Session" })
+        const worktree = await Worktree.create({ name: "legacy-migration", bind: false, baseRef: "current" })
+        const scope = Identifier.asScopeID(tmpScope.id)
+        const sid = Identifier.asSessionID(session.id)
+        const legacyScope = {
+          ...(session.scope as any),
+          directory: worktree.path,
+          worktree: tmpScope.worktree,
+          sandboxes: [worktree.path],
+        }
+        await Storage.write(StoragePath.sessionInfo(scope, sid), {
+          ...session,
+          scope: legacyScope,
+          workspace: { type: "main", path: worktree.path, scopeID: tmpScope.id },
+        })
+        await Storage.write(StoragePath.sessionIndex(sid), {
+          sessionID: session.id,
+          scopeID: tmpScope.id,
+          directory: worktree.path,
+        })
+
+        const migration = migrations.find((entry) => entry.id === "20260703-session-worktree-workspace")
+        expect(migration).toBeDefined()
+        await migration!.up(() => {})
+
+        const migrated = await Storage.read<any>(StoragePath.sessionInfo(scope, sid))
+        expect(migrated.scope.directory).toBe(tmpScope.worktree)
+        expect(migrated.workspace.type).toBe("git_worktree")
+        expect(migrated.workspace.path).toBe(worktree.path)
+        expect(migrated.workspace.worktreeID).toBe(worktree.id)
+        expect(migrated.workspace.name).toBe(worktree.name)
+        expect(migrated.workspace.originalCheckout).toBe(tmpScope.worktree)
+
+        const index = await Storage.read<any>(StoragePath.sessionIndex(sid))
+        expect(index.directory).toBe(tmpScope.worktree)
+
+        await Worktree.remove({ sessionID: session.id, target: worktree.id, force: true })
+        await Session.remove(session.id)
       },
     })
   })

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -6,6 +6,7 @@ export interface DialogProps extends ParentProps {
   title?: JSXElement
   description?: JSXElement
   action?: JSXElement
+  dismissible?: boolean
   class?: ComponentProps<"div">["class"]
   classList?: ComponentProps<"div">["classList"]
 }
@@ -16,6 +17,15 @@ export function Dialog(props: DialogProps) {
       <div data-slot="dialog-container">
         <Kobalte.Content
           data-slot="dialog-content"
+          onEscapeKeyDown={(e) => {
+            if (props.dismissible === false) e.preventDefault()
+          }}
+          onPointerDownOutside={(e) => {
+            if (props.dismissible === false) e.preventDefault()
+          }}
+          onInteractOutside={(e) => {
+            if (props.dismissible === false) e.preventDefault()
+          }}
           classList={{
             ...(props.classList ?? {}),
             [props.class ?? ""]: !!props.class,


### PR DESCRIPTION
## Summary
- unify new-session and existing-session worktree entry through real session workspace binding
- add blocking progress dialogs for new worktree session startup and existing-session enter/exit transitions
- guard HTTP worktree enter/leave while sessions are running, add migration for legacy route-directory worktree sessions, and regenerate SDK types

## Tests
- `bun test test/project/worktree.test.ts test/session/migration.test.ts` in `packages/synergy`
- `bun test src/components/session/worktree-session.test.ts` in `packages/app`
- `bun run typecheck` in `packages/app`
- `bun run typecheck` in `packages/synergy`
- `bun run typecheck` in `packages/ui`
- pre-push hook: full `bun turbo typecheck` and Prettier check