### PR TITLE
Resolve channel control profiles from session source

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,9 @@ Control profiles are configured in the permissions domain (`80-permissions.jsonc
 }
 ```
 
-**Precedence:** agent config `controlProfile` > top-level config `controlProfile` > default `guarded`.
+**Precedence:** explicit session control profile resolved from the session parent chain > agent config `controlProfile` > top-level config `controlProfile` > source default. Channel-backed and agenda automation root sessions default to `autonomous`; ordinary interactive/manual sessions default to `guarded`.
+
+Explicit configuration is always honored. For example, a top-level `controlProfile: "full_access"` remains `full_access` for Feishu/channel sessions instead of being downgraded by unattended metadata.
 
 Blueprint runs started from the Notes side panel use the current session's control profile when running in the current session. New-session and worktree Blueprint runs create an execution session with at least `autonomous`; a top-level `full_access` profile remains `full_access`.
 
@@ -426,13 +428,11 @@ Risk levels follow the operation's effect. Ordinary reads, including non-protect
 
 Built-in profiles:
 
-| Config value  | UI label    | Behavior                                                                                                                                                                               |
-| ------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `guarded`     | Guarded     | Default protected mode. Auto-allows ordinary reads, workspace-local edits, and ordinary network lookups; asks before shell, external writes, identity, platform, or extension actions. |
-| `autonomous`  | Autonomous  | Unattended mode. Includes Guarded's automatic approvals, allows medium-risk development work, and denies high-risk asks instead of prompting.                                          |
-| `full_access` | Full Access | Allows all tool requests without approval prompts or workspace sandboxing.                                                                                                             |
-
-`full_access` is blocked in unattended execution mode. It is only available in attended sessions.
+| Config value  | UI label    | Behavior                                                                                                                                                                                           |
+| ------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `guarded`     | Guarded     | Protected mode for manual sessions. Auto-allows ordinary reads, workspace-local edits, and ordinary network lookups; asks before shell, external writes, identity, platform, or extension actions. |
+| `autonomous`  | Autonomous  | Automation-oriented profile. Includes Guarded's automatic approvals, allows medium-risk development work, and denies high-risk asks instead of prompting.                                          |
+| `full_access` | Full Access | Allows all tool requests without approval prompts or workspace sandboxing. Explicit `full_access` remains valid for channel and automation sessions.                                               |
 
 ### Sandbox
 

--- a/bun.lock
+++ b/bun.lock
@@ -338,6 +338,7 @@
         "virtua": "catalog:",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.11",
         "@tailwindcss/vite": "catalog:",
         "@tsconfig/node22": "catalog:",
         "@types/bun": "catalog:",

--- a/packages/synergy/src/control-profile/profiles.ts
+++ b/packages/synergy/src/control-profile/profiles.ts
@@ -225,7 +225,7 @@ export async function resolveEffectiveSandbox(profileId: ProfileId): Promise<Pro
 
 export async function buildProfile(idInput: ProfileIdInput | string, ctx: ResolutionContext): Promise<ResolvedProfile> {
   const id = normalizeProfileId(idInput)
-  const { workspace, interactionMode } = ctx
+  const { workspace } = ctx
   const effectiveSandbox = await resolveEffectiveSandbox(id)
 
   switch (id) {
@@ -263,19 +263,6 @@ export async function buildProfile(idInput: ProfileIdInput | string, ctx: Resolu
     }
 
     case "full_access": {
-      if (interactionMode === "unattended") {
-        return {
-          valid: false,
-          reason: "full_access profile is forbidden in unattended mode",
-          label: "Full Access",
-          description: "Unrestricted local access. Disabled for unattended sessions.",
-          ruleset: [],
-          filesystem: { readRoots: [], writeRoots: [], protectedPaths: [] },
-          network: { mode: "disabled" },
-          sandbox: { mode: "read_only", fallback: "deny" },
-          approval: approval("full_access"),
-        }
-      }
       const policy = fullAccessPolicy()
       const profile = {
         valid: true,

--- a/packages/synergy/src/control-profile/types.ts
+++ b/packages/synergy/src/control-profile/types.ts
@@ -46,7 +46,6 @@ export interface ControlProfile {
 export interface ResolutionContext {
   workspace: string
   workspaceType: string
-  interactionMode?: string
 }
 
 export interface ProfileSummary {

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -94,7 +94,6 @@ export interface GateOptions {
   activeWorkspace: string
   workspaceType: string
   profileId?: ProfileIdInput
-  interactionMode?: "attended" | "unattended"
   registeredMcpTools?: Set<string>
   registeredPluginTools?: Set<string>
   /** Map from plugin tool full ID (e.g. plugin__x__y) to resolved capabilities */
@@ -430,7 +429,6 @@ export namespace EnforcementGate {
       activeWorkspace,
       workspaceType,
       profileId: rawProfileId = "guarded",
-      interactionMode = "attended",
       registeredMcpTools = new Set<string>(),
       registeredPluginTools = new Set<string>(),
       pluginToolCapabilities = {},
@@ -444,7 +442,6 @@ export namespace EnforcementGate {
     const resolved = await ControlProfileCompiler.resolve(profileId, {
       workspace: activeWorkspace,
       workspaceType,
-      interactionMode,
     })
 
     if (!resolved.valid) {

--- a/packages/synergy/src/permission/next.ts
+++ b/packages/synergy/src/permission/next.ts
@@ -1,10 +1,9 @@
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { Config } from "@/config/config"
-import { Identifier } from "@/id/id"
 import { isNonBypassableMetadata } from "@/enforcement/capability"
+import { Identifier } from "@/id/id"
 import { PermissionRules } from "@/permission/rules"
-import { ScopeContext } from "@/scope/context"
 import { ScopedState } from "@/scope/scoped-state"
 import { SessionInteraction } from "@/session/interaction"
 import { fn } from "@/util/fn"
@@ -102,7 +101,6 @@ export namespace PermissionNext {
       }),
     ),
   }
-
   function isNonBypassable(request: { metadata?: Record<string, any> }): boolean {
     return isNonBypassableMetadata(request.metadata)
   }
@@ -176,16 +174,6 @@ export namespace PermissionNext {
           })
           s.pending[id] = { info, resolve: resolvePending!, reject: rejectPending!, cleanup }
 
-          if (request.metadata?.sessionInteractionMode === "unattended" && !isNonBypassable(request)) {
-            log.info("unattended auto-approve", {
-              sessionID: request.sessionID,
-              permission: request.permission,
-              pattern,
-            })
-            delete s.pending[id]
-            resolvePending!()
-            continue
-          }
           Bus.publish(Event.Asked, info)
           return pendingPromise
         }
@@ -314,14 +302,6 @@ export namespace PermissionNext {
         })
         pending.reject(new DOMException("Session was cancelled", "AbortError"))
       }
-    }
-  }
-
-  export function requestMetadata(input?: { interaction?: SessionInteraction.Info }) {
-    if (!input?.interaction) return {}
-    return {
-      sessionInteractionMode: input.interaction.mode,
-      sessionInteractionSource: input.interaction.source,
     }
   }
 

--- a/packages/synergy/src/plugin/host-services.ts
+++ b/packages/synergy/src/plugin/host-services.ts
@@ -246,20 +246,16 @@ export async function requestPluginPermission(
 
   const agent = await Agent.get(context.agent)
   const session = await Session.get(context.sessionID)
-  const topLevelProfile = await topLevelControlProfile()
-  const sessionProfile = session?.id ? await Session.resolveSessionControlProfile(session.id) : undefined
-  const profileId = ControlProfileCompiler.normalize(sessionProfile ?? agent?.controlProfile ?? topLevelProfile)
+  const profileId = await Session.resolveEffectiveControlProfile({
+    sessionID: session?.id,
+    agentControlProfile: agent?.controlProfile,
+  })
   const workspaceInfo = ScopeContext.current.workspace
-  const interaction = session?.interaction
   const profile = await ControlProfileCompiler.resolve(profileId, {
     workspace: context.directory ?? ScopeContext.current.directory,
     workspaceType: workspaceInfo?.type === "git_worktree" ? "worktree" : "main",
-    interactionMode: interaction?.mode === "unattended" ? "unattended" : "attended",
   })
-  const metadata = {
-    ...request.metadata,
-    ...PermissionNext.requestMetadata(session),
-  }
+  const metadata = request.metadata ?? {}
   const decision = ApprovalPolicy.decidePermission(profile, request.permission, metadata)
   if (decision.action === "deny") {
     throw new EnforcementError.PolicyDenied(
@@ -279,14 +275,6 @@ export async function requestPluginPermission(
     ruleset: PermissionNext.merge(agent?.permission ?? [], PermissionNext.sessionRuleset(session)),
     signal: context.abort,
   })
-}
-
-async function topLevelControlProfile(): Promise<string | undefined> {
-  try {
-    return (await Config.current()).controlProfile
-  } catch {
-    return undefined
-  }
 }
 
 async function parentModel(context: RuntimeContext) {

--- a/packages/synergy/src/server/control-profile-route.ts
+++ b/packages/synergy/src/server/control-profile-route.ts
@@ -61,7 +61,6 @@ export const ControlProfileRoute = new Hono()
             ControlProfileCompiler.resolve(id, {
               workspace: "/",
               workspaceType: "main",
-              interactionMode: "attended",
             }),
           ])
           return { id, label: label.label, description: resolved.description }

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -17,6 +17,8 @@ import { Snapshot } from "@/session/snapshot"
 import { SnapshotSchema } from "@/session/snapshot-schema"
 import { SessionHistory } from "./history"
 import { Config } from "@/config/config"
+import { ControlProfileCompiler } from "@/control-profile/compiler"
+import type { ProfileId } from "@/control-profile/types"
 
 import type { Provider } from "@/provider/provider"
 import { PermissionNext } from "@/permission/next"
@@ -481,23 +483,52 @@ export namespace Session {
     return updated
   }
 
-  export async function resolveSessionControlProfile(sessionID: string): Promise<Info["controlProfile"] | undefined> {
+  async function sessionControlProfileState(
+    sessionID: string,
+  ): Promise<{ controlProfile?: Info["controlProfile"]; root: Info }> {
     let currentID = sessionID
     while (true) {
       const session = await SessionManager.requireSession(currentID)
       const scope = session.scope as Scope
-      const info = await Storage.read<Info>(StoragePath.sessionInfo(asScopeID(scope.id), asSessionID(currentID)))
-      if (info?.controlProfile) return info.controlProfile
-      if (!info?.parentID) return undefined
+      const info =
+        (await Storage.read<Info>(StoragePath.sessionInfo(asScopeID(scope.id), asSessionID(currentID)))) ?? session
+      if (info.controlProfile) return { controlProfile: info.controlProfile, root: info }
+      if (!info.parentID) return { root: info }
       currentID = info.parentID
     }
   }
 
+  export function defaultControlProfileForSessionSource(session?: Pick<Info, "endpoint" | "agenda">): ProfileId {
+    if (session?.endpoint?.kind === "channel") return "autonomous"
+    if (session?.agenda) return "autonomous"
+    return "guarded"
+  }
+
+  export async function resolveSessionControlProfile(sessionID: string): Promise<Info["controlProfile"] | undefined> {
+    return (await sessionControlProfileState(sessionID)).controlProfile
+  }
+
+  export async function resolveEffectiveControlProfile(input: {
+    sessionID?: string
+    agentControlProfile?: string
+    topLevelControlProfile?: string
+  }): Promise<ProfileId> {
+    const sessionState = input.sessionID ? await sessionControlProfileState(input.sessionID) : undefined
+    if (sessionState?.controlProfile) return ControlProfileCompiler.normalize(sessionState.controlProfile)
+    if (input.agentControlProfile) return ControlProfileCompiler.normalize(input.agentControlProfile)
+
+    const topLevelProfile =
+      input.topLevelControlProfile ??
+      (await Config.current()
+        .then((cfg) => cfg.controlProfile)
+        .catch(() => undefined))
+    if (topLevelProfile) return ControlProfileCompiler.normalize(topLevelProfile)
+
+    return defaultControlProfileForSessionSource(sessionState?.root)
+  }
+
   export async function resolveControlProfile(sessionID: string): Promise<NonNullable<Info["controlProfile"]>> {
-    const sessionProfile = await resolveSessionControlProfile(sessionID)
-    if (sessionProfile) return sessionProfile
-    const cfg = await Config.current().catch(() => undefined)
-    return cfg?.controlProfile ?? "guarded"
+    return resolveEffectiveControlProfile({ sessionID })
   }
 
   export const get = fn(Identifier.schema("session"), async (id) => {

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -398,11 +398,10 @@ export namespace SessionInvoke {
         })
 
         if (agent.external) {
-          const topLevelProfile = await Config.current()
-            .then((c) => c.controlProfile)
-            .catch(() => undefined)
-          const sessionProfile = session?.id ? await Session.resolveSessionControlProfile(session.id) : undefined
-          const profileId = ControlProfileCompiler.normalize(sessionProfile ?? agent.controlProfile ?? topLevelProfile)
+          const profileId = await Session.resolveEffectiveControlProfile({
+            sessionID: session?.id,
+            agentControlProfile: agent.controlProfile,
+          })
           const adapter = ExternalAgent.getAdapter(agent.external.adapter, sessionID)
           if (!adapter) {
             log.error("external adapter not found", { adapter: agent.external.adapter, sessionID })
@@ -579,17 +578,13 @@ export namespace SessionInvoke {
         try {
           const workspace = ScopeContext.current.directory
           const workspaceInfo = ScopeContext.current.workspace
-          const interaction = session?.interaction
-          const interactionMode = interaction?.mode === "unattended" ? "unattended" : "attended"
-          const topLevelProfile = await Config.current()
-            .then((c) => c.controlProfile)
-            .catch(() => undefined)
-          const sessionProfile = session?.id ? await Session.resolveSessionControlProfile(session.id) : undefined
-          const profileId = ControlProfileCompiler.normalize(sessionProfile ?? agent.controlProfile ?? topLevelProfile)
+          const profileId = await Session.resolveEffectiveControlProfile({
+            sessionID: session?.id,
+            agentControlProfile: agent.controlProfile,
+          })
           const resolved = await ControlProfileCompiler.resolve(profileId, {
             workspace,
             workspaceType: workspaceInfo?.type === "git_worktree" ? "worktree" : "main",
-            interactionMode,
           })
           if (resolved.valid) {
             const ctx = buildPermissionContext(resolved, workspace)

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -393,9 +393,7 @@ export namespace SessionProcessor {
                       metadata: {
                         tool: value.toolName,
                         input: toolInput,
-                        ...PermissionNext.requestMetadata(session),
                       },
-
                       ruleset: PermissionNext.merge(agent.permission, PermissionNext.sessionRuleset(session)),
                       signal: input.abort,
                     })

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -28,7 +28,7 @@ import { ScopeContext } from "@/scope/context"
 import { EnforcementGate, type Capability } from "@/enforcement/gate"
 import { SandboxBackend } from "@/sandbox/backend"
 import type { SandboxExecutionWrapper } from "@/sandbox/backend"
-import type { ProfileId, ResolvedProfile } from "@/control-profile/types"
+import type { ResolvedProfile } from "@/control-profile/types"
 import { EnforcementError } from "@/enforcement/errors"
 import { Config } from "@/config/config"
 import { ControlProfileCompiler } from "@/control-profile/compiler"
@@ -83,25 +83,6 @@ export namespace ToolResolver {
   export interface ResolvedTools {
     tools: Record<string, AITool>
     activeToolIDs: string[]
-  }
-
-  /**
-   * Resolve the effective control profile id using precedence:
-   *   1. session controlProfile (resolved from parent chain)
-   *   2. agent config controlProfile
-   *   3. top-level config controlProfile
-   *   4. default 'guarded'
-   */
-  function resolveEffectiveProfile(agent: Agent.Info, topLevelProfile?: string, sessionProfile?: string): ProfileId {
-    return ControlProfileCompiler.normalize(sessionProfile ?? agent.controlProfile ?? topLevelProfile)
-  }
-
-  async function currentTopLevelProfile(): Promise<string | undefined> {
-    try {
-      return (await Config.current()).controlProfile
-    } catch {
-      return undefined
-    }
   }
 
   interface PluginGateData {
@@ -655,18 +636,14 @@ export namespace ToolResolver {
       const resolvedProfile = async (): Promise<ResolvedProfile> => {
         if (!profilePromise) {
           profilePromise = (async () => {
-            const topLevelProfile = await currentTopLevelProfile()
-            const sessionProfile = input.session?.id
-              ? await Session.resolveSessionControlProfile(input.session.id)
-              : undefined
-            const profileId = resolveEffectiveProfile(input.agent, topLevelProfile, sessionProfile)
+            const profileId = await Session.resolveEffectiveControlProfile({
+              sessionID: input.session?.id,
+              agentControlProfile: input.agent.controlProfile,
+            })
             const workspaceInfo = ScopeContext.current.workspace
-            const interaction = input.session?.interaction
-            const interactionMode = interaction?.mode === "unattended" ? "unattended" : "attended"
             return ControlProfileCompiler.resolve(profileId, {
               workspace: ScopeContext.current.directory,
               workspaceType: workspaceInfo?.type === "git_worktree" ? "worktree" : "main",
-              interactionMode,
             })
           })()
         }
@@ -697,10 +674,7 @@ export namespace ToolResolver {
         },
         async ask(req) {
           const profile = await resolvedProfile()
-          const requestMetadata = {
-            ...req.metadata,
-            ...PermissionNext.requestMetadata(input.session),
-          }
+          const requestMetadata = req.metadata ?? {}
           const decision = ApprovalPolicy.decidePermission(profile, req.permission, requestMetadata)
           if (decision.action === "deny") {
             const approval = ApprovalPolicy.metadata(profile.approval, decision, "auto_denied")
@@ -1004,20 +978,16 @@ export namespace ToolResolver {
                 toolTrace = await startToolTrace(runtimeInput, ctx, item.id, args as Record<string, unknown>)
                 const workspace = ScopeContext.current.directory
                 const workspaceInfo = ScopeContext.current.workspace
-                const interaction = runtimeInput.session?.interaction
-                const interactionMode = interaction?.mode === "unattended" ? "unattended" : "attended"
-                const topLevelProfile = await currentTopLevelProfile()
-                const sessionProfile = runtimeInput.session?.id
-                  ? await Session.resolveSessionControlProfile(runtimeInput.session.id)
-                  : undefined
-                const profileId = resolveEffectiveProfile(runtimeInput.agent, topLevelProfile, sessionProfile)
+                const profileId = await Session.resolveEffectiveControlProfile({
+                  sessionID: runtimeInput.session?.id,
+                  agentControlProfile: runtimeInput.agent.controlProfile,
+                })
                 const synergyRoot = Global.Path.root
                 const pluginToolIds = await currentPluginToolIds()
                 const pluginGateData = await currentPluginGateData()
                 const gate = await EnforcementGate.create({
                   activeWorkspace: workspace,
                   workspaceType: workspaceInfo?.type === "git_worktree" ? "worktree" : "main",
-                  interactionMode,
                   originalCheckout: (workspaceInfo as any)?.originalCheckout,
                   registeredPluginTools: pluginToolIds,
                   pluginToolCapabilities: pluginGateData.toolCapabilities,
@@ -1234,19 +1204,15 @@ export namespace ToolResolver {
                   toolTrace = await startToolTrace(runtimeInput, ctx, key, args as Record<string, unknown>)
                   const workspace = ScopeContext.current.directory
                   const workspaceInfo = ScopeContext.current.workspace
-                  const interaction = runtimeInput.session?.interaction
-                  const interactionMode = interaction?.mode === "unattended" ? "unattended" : "attended"
-                  const topLevelProfile = await currentTopLevelProfile()
-                  const sessionProfile = runtimeInput.session?.id
-                    ? await Session.resolveSessionControlProfile(runtimeInput.session.id)
-                    : undefined
-                  const profileId = resolveEffectiveProfile(runtimeInput.agent, topLevelProfile, sessionProfile)
+                  const profileId = await Session.resolveEffectiveControlProfile({
+                    sessionID: runtimeInput.session?.id,
+                    agentControlProfile: runtimeInput.agent.controlProfile,
+                  })
                   const pluginToolIds = await currentPluginToolIds()
                   const pluginGateData = await currentPluginGateData()
                   const gate = await EnforcementGate.create({
                     activeWorkspace: workspace,
                     workspaceType: workspaceInfo?.type === "git_worktree" ? "worktree" : "main",
-                    interactionMode,
                     originalCheckout: (workspaceInfo as any)?.originalCheckout,
                     registeredMcpTools: mcpToolNames,
                     registeredPluginTools: pluginToolIds,

--- a/packages/synergy/test/control-profile/compiler.test.ts
+++ b/packages/synergy/test/control-profile/compiler.test.ts
@@ -87,13 +87,10 @@ describe("full_access profile policy", () => {
     expect(rule(profile, "identity_act")?.action).toBe("allow")
   })
 
-  test("is forbidden in unattended interaction mode", async () => {
-    const result = await ControlProfileCompiler.resolve("full_access", {
-      ...context,
-      interactionMode: "unattended",
-    })
-    expect(result.valid).toBe(false)
-    expect(result.reason).toContain("unattended")
+  test("is valid in non-interactive channel contexts when explicitly selected", async () => {
+    const result = await ControlProfileCompiler.resolve("full_access", context)
+    expect(result.valid).toBe(true)
+    expect(result.summary?.approval.mode).toBe("full_access")
   })
 })
 

--- a/packages/synergy/test/control-profile/resolve-profile.test.ts
+++ b/packages/synergy/test/control-profile/resolve-profile.test.ts
@@ -1,46 +1,93 @@
 import { describe, expect, test } from "bun:test"
-import { ControlProfileCompiler } from "../../src/control-profile/compiler"
-import type { ProfileId } from "../../src/control-profile/types"
+import { Session } from "../../src/session"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
 
-// Minimal inline mock of resolveEffectiveProfile for direct unit testing
-// This mirrors the logic in tool-resolver.ts
-function resolveEffectiveProfile(
-  sessionProfile: string | undefined,
-  agentProfile: string | undefined,
-  topLevelProfile: string | undefined,
-): ProfileId {
-  return ControlProfileCompiler.normalize(sessionProfile ?? agentProfile ?? topLevelProfile)
-}
+describe("Session.resolveEffectiveControlProfile", () => {
+  test("uses guarded for ordinary sessions when nothing is configured", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
 
-describe("resolveEffectiveProfile", () => {
-  test("default is guarded when nothing is configured", () => {
-    expect(resolveEffectiveProfile(undefined, undefined, undefined)).toBe("guarded")
+        expect(await Session.resolveEffectiveControlProfile({ sessionID: session.id })).toBe("guarded")
+
+        await Session.remove(session.id)
+      },
+    })
   })
 
-  test("top-level config overrides default", () => {
-    expect(resolveEffectiveProfile(undefined, undefined, "full_access")).toBe("full_access")
+  test("honors top-level config before source fallback", async () => {
+    await using tmp = await tmpdir({ git: true, config: { controlProfile: "full_access" } })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        expect(await Session.resolveEffectiveControlProfile({ sessionID: session.id })).toBe("full_access")
+
+        await Session.remove(session.id)
+      },
+    })
   })
 
-  test("agent config overrides top-level", () => {
-    expect(resolveEffectiveProfile(undefined, "full_access", "guarded")).toBe("full_access")
+  test("honors agent config before top-level config", async () => {
+    await using tmp = await tmpdir({ git: true, config: { controlProfile: "guarded" } })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        expect(
+          await Session.resolveEffectiveControlProfile({
+            sessionID: session.id,
+            agentControlProfile: "full_access",
+          }),
+        ).toBe("full_access")
+
+        await Session.remove(session.id)
+      },
+    })
   })
 
-  test("session config has highest precedence", () => {
-    expect(resolveEffectiveProfile("autonomous", "full_access", "guarded")).toBe("autonomous")
+  test("honors explicit session config before agent and top-level config", async () => {
+    await using tmp = await tmpdir({ git: true, config: { controlProfile: "guarded" } })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({
+          controlProfile: "autonomous",
+        })
+
+        expect(
+          await Session.resolveEffectiveControlProfile({
+            sessionID: session.id,
+            agentControlProfile: "full_access",
+          }),
+        ).toBe("autonomous")
+
+        await Session.remove(session.id)
+      },
+    })
   })
 
-  test("invalid top-level falls back to guarded", () => {
-    expect(resolveEffectiveProfile(undefined, undefined, "bogus")).toBe("guarded")
-  })
+  test("normalizes invalid configured profile values", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
 
-  test("both absent falls back to guarded", () => {
-    expect(resolveEffectiveProfile(undefined, undefined, undefined)).toBe("guarded")
-  })
+        expect(
+          await Session.resolveEffectiveControlProfile({
+            sessionID: session.id,
+            topLevelControlProfile: "bogus",
+          }),
+        ).toBe("guarded")
 
-  test("all valid profiles are accepted", () => {
-    const ids: ProfileId[] = ["guarded", "autonomous", "full_access"]
-    for (const id of ids) {
-      expect(resolveEffectiveProfile(id, undefined, undefined)).toBe(id)
-    }
+        await Session.remove(session.id)
+      },
+    })
   })
 })

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -618,7 +618,6 @@ describe("EnforcementGate profile integration", () => {
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
       profileId: "full_access",
-      interactionMode: "attended",
     })
 
     const envelope = gate.evaluate("read", {
@@ -629,16 +628,18 @@ describe("EnforcementGate profile integration", () => {
     expect(envelope.decision).toBe("allow")
   })
 
-  test("gate rejects full_access in unattended mode", async () => {
-    // Creating a gate with full_access + unattended must fail
-    expect(() =>
-      EnforcementGate.create({
-        activeWorkspace: "/Users/test/synergy-control-profile",
-        workspaceType: "worktree",
-        profileId: "full_access",
-        interactionMode: "unattended",
-      }),
-    ).toThrow()
+  test("gate allows full_access without interaction-mode restrictions", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "full_access",
+    })
+
+    const envelope = gate.evaluate("read", {
+      filePath: "/private/channel-context.txt",
+    })
+
+    expect(envelope.decision).toBe("allow")
   })
 
   test("autonomous denies git push as shell_destructive", async () => {

--- a/packages/synergy/test/enforcement/mcp-plugin.test.ts
+++ b/packages/synergy/test/enforcement/mcp-plugin.test.ts
@@ -5,9 +5,8 @@ const { EnforcementGate } = await import("../../src/enforcement/gate")
 // enforcement/mcp-plugin.test.ts
 //
 // Tests for the EnforcementGate MCP and plugin opaque strategy — unknown
-// external tools must trigger ask/deny and never be auto-approved in
-// unattended mode.
-//
+// external tools must trigger ask/deny according to the active profile.
+
 // These tests encode the MCP/plugin external I/O boundary contract.
 // ---------------------------------------------------------------------------
 
@@ -58,12 +57,11 @@ describe("EnforcementGate MCP opaque strategy", () => {
     expect(mcpCap.opaque).toBe(true)
   })
 
-  test("unattended mode does not auto-approve unknown MCP tool", async () => {
+  test("guarded profile asks for unknown MCP tools", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
       profileId: "guarded",
-      interactionMode: "unattended",
     })
 
     const envelope = gate.evaluate("mcp__any_service__do_work", {
@@ -71,7 +69,7 @@ describe("EnforcementGate MCP opaque strategy", () => {
       toolName: "do_work",
     })
 
-    // Unattended mode must NOT auto-approve MCP opaque externalIO
+    // Guarded profile must ask for opaque MCP externalIO.
     expect(envelope.decision).toBe("ask")
   })
 
@@ -152,12 +150,11 @@ describe("EnforcementGate plugin opaque strategy", () => {
     expect(pluginCap.opaque).toBe(true)
   })
 
-  test("unattended mode does not auto-approve unknown plugin tool", async () => {
+  test("guarded profile asks for unknown plugin tools", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
       profileId: "guarded",
-      interactionMode: "unattended",
     })
 
     const envelope = gate.evaluate("plugin__remote_plugin__fetch", {
@@ -165,7 +162,7 @@ describe("EnforcementGate plugin opaque strategy", () => {
       actionName: "fetch",
     })
 
-    // Unattended mode must NOT auto-approve plugin opaque externalIO
+    // Guarded profile must ask for opaque plugin externalIO.
     expect(envelope.decision).toBe("ask")
   })
 

--- a/packages/synergy/test/permission/agent-blanket-allow.test.ts
+++ b/packages/synergy/test/permission/agent-blanket-allow.test.ts
@@ -84,7 +84,7 @@ describe("nonBypassable defeats blanket external_directory allow", () => {
     })
   })
 
-  test("nonBypassable defeats unattended auto-approve with blanket allow rule", async () => {
+  test("nonBypassable metadata defeats blanket allow rules", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
       scope: await tmp.scope(),
@@ -103,7 +103,7 @@ describe("nonBypassable defeats blanket external_directory allow", () => {
           ruleset: [{ permission: "external_directory", pattern: "*", action: "allow" }],
         })
 
-        // Unattended must NOT auto-approve nonBypassable
+        // nonBypassable boundaries must remain pending even with blanket allow rules.
         expect(promise).toBeInstanceOf(Promise)
 
         const pending = await PermissionNext.list()

--- a/packages/synergy/test/permission/identity-boundary.test.ts
+++ b/packages/synergy/test/permission/identity-boundary.test.ts
@@ -42,7 +42,7 @@ describe("session_send identity boundary", () => {
     })
   })
 
-  test("identity_act with nonBypassable metadata prevents unattended auto-approve", async () => {
+  test("identity_act with unattended metadata stays pending", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
       scope: await tmp.scope(),
@@ -136,7 +136,7 @@ describe("email_send communication boundary", () => {
     })
   })
 
-  test("communication_email with nonBypassable metadata prevents unattended auto-approve", async () => {
+  test("communication_email with unattended metadata stays pending", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
       scope: await tmp.scope(),

--- a/packages/synergy/test/permission/next.test.ts
+++ b/packages/synergy/test/permission/next.test.ts
@@ -602,20 +602,26 @@ test("ask - allows all patterns when all match allow rules", async () => {
   })
 })
 
-test("ask - unattended metadata auto-approves ask actions", async () => {
+test("ask - unattended metadata does not auto-approve ask actions", async () => {
   await using tmp = await tmpdir({ git: true })
   await ScopeContext.provide({
     scope: await tmp.scope(),
     fn: async () => {
-      await expect(
-        PermissionNext.ask({
-          sessionID: "session_test",
-          permission: "bash",
-          patterns: ["ls"],
-          metadata: { sessionInteractionMode: "unattended" },
-          ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
-        }),
-      ).resolves.toBeUndefined()
+      const promise = PermissionNext.ask({
+        id: "permission_unattended_ask",
+        sessionID: "session_test",
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: { sessionInteractionMode: "unattended" },
+        ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
+      })
+
+      const pending = await PermissionNext.list()
+      const request = pending.find((r) => r.id === "permission_unattended_ask")
+      expect(request).toBeDefined()
+
+      await PermissionNext.reply({ requestID: "permission_unattended_ask", reply: "once" })
+      await expect(promise).resolves.toBeUndefined()
     },
   })
 })
@@ -690,12 +696,13 @@ test("ask - nonBypassable metadata stays pending for ask rules", async () => {
   })
 })
 
-test("ask - workspaceBoundary context does not block unattended auto-approve", async () => {
+test("ask - workspaceBoundary metadata stays pending for unattended ask rules", async () => {
   await using tmp = await tmpdir({ git: true })
   await ScopeContext.provide({
     scope: await tmp.scope(),
     fn: async () => {
-      const result = await PermissionNext.ask({
+      const promise = PermissionNext.ask({
+        id: "permission_workspace_boundary_unattended",
         sessionID: "session_test_workspace_boundary",
         permission: "bash",
         patterns: ["rm /outside/file"],
@@ -707,9 +714,12 @@ test("ask - workspaceBoundary context does not block unattended auto-approve", a
         ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
       })
 
-      expect(result).toBeUndefined()
-      const request = await PermissionNext.list()
-      expect(request.find((r) => r.sessionID === "session_test_workspace_boundary")).toBeUndefined()
+      const pending = await PermissionNext.list()
+      const request = pending.find((r) => r.id === "permission_workspace_boundary_unattended")
+      expect(request).toBeDefined()
+
+      await PermissionNext.reply({ requestID: "permission_workspace_boundary_unattended", reply: "once" })
+      await expect(promise).resolves.toBeUndefined()
     },
   })
 })

--- a/packages/synergy/test/session/session.test.ts
+++ b/packages/synergy/test/session/session.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "../fixture/fixture"
 import { Session } from "../../src/session"
 import { SessionInteraction } from "../../src/session/interaction"
 import { AppChannel } from "../../src/channel/app"
+import { SessionEndpoint } from "../../src/session/endpoint"
 import { SessionEvent } from "../../src/session/event"
 import { MessageV2 } from "../../src/session/message-v2"
 import { Bus } from "../../src/bus"
@@ -161,6 +162,99 @@ describe("session lifecycle events", () => {
 
         expect(await Session.resolveSessionControlProfile(session.id)).toBeUndefined()
         expect(await Session.resolveControlProfile(session.id)).toBe("full_access")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+  test("resolveControlProfile falls back to guarded for ordinary root sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        expect(await Session.resolveSessionControlProfile(session.id)).toBeUndefined()
+        expect(await Session.resolveControlProfile(session.id)).toBe("guarded")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("resolveControlProfile falls back to autonomous for channel roots", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const root = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type: "feishu",
+            accountId: "acct_1",
+            chatId: "chat_1",
+          }),
+        })
+        const child = await Session.create({ parentID: root.id })
+
+        expect(await Session.resolveControlProfile(root.id)).toBe("autonomous")
+        expect(await Session.resolveControlProfile(child.id)).toBe("autonomous")
+
+        await Session.remove(root.id)
+      },
+    })
+  })
+
+  test("resolveControlProfile honors top-level full_access for channel roots", async () => {
+    await using tmp = await tmpdir({ git: true, config: { controlProfile: "full_access" } })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type: "feishu",
+            accountId: "acct_1",
+            chatId: "chat_1",
+          }),
+        })
+
+        expect(await Session.resolveControlProfile(session.id)).toBe("full_access")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("resolveControlProfile honors explicit guarded profile for channel roots", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({
+          controlProfile: "guarded",
+          endpoint: SessionEndpoint.fromChannel({
+            type: "feishu",
+            accountId: "acct_1",
+            chatId: "chat_1",
+          }),
+        })
+
+        expect(await Session.resolveControlProfile(session.id)).toBe("guarded")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("resolveControlProfile falls back to autonomous for agenda roots", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({
+          agenda: { itemID: "agenda_item_1" },
+        })
+
+        expect(await Session.resolveControlProfile(session.id)).toBe("autonomous")
 
         await Session.remove(session.id)
       },

--- a/packages/synergy/test/session/unattended.test.ts
+++ b/packages/synergy/test/session/unattended.test.ts
@@ -33,25 +33,30 @@ test("sessionRuleset denies question for unattended sessions", async () => {
   expect(PermissionNext.evaluate("question", "*", ruleset).action).toBe("deny")
 })
 
-test("unattended permission ask auto-approves ask actions", async () => {
+test("unattended permission ask remains pending for ask actions", async () => {
   await using tmp = await tmpdir({ git: true })
   await ScopeContext.provide({
     scope: await tmp.scope(),
     fn: async () => {
-      await expect(
-        PermissionNext.ask({
-          sessionID: "ses_unattended",
-          permission: "bash",
-          patterns: ["ls"],
-          metadata: { sessionInteractionMode: "unattended" },
-          ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
-        }),
-      ).resolves.toBeUndefined()
+      const promise = PermissionNext.ask({
+        id: "permission_unattended_session_ask",
+        sessionID: "ses_unattended",
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: { sessionInteractionMode: "unattended" },
+        ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
+      })
+
+      const pending = await PermissionNext.list()
+      expect(pending.find((r) => r.id === "permission_unattended_session_ask")).toBeDefined()
+
+      await PermissionNext.reply({ requestID: "permission_unattended_session_ask", reply: "once" })
+      await expect(promise).resolves.toBeUndefined()
     },
   })
 })
 
-test("unattended permission ask still rejects explicit deny", async () => {
+test("unattended permission ask still rejects explicit deny rules", async () => {
   await using tmp = await tmpdir({ git: true })
   await ScopeContext.provide({
     scope: await tmp.scope(),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
     "generate:tailwind": "bun run script/tailwind.ts"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "20.0.11",
     "@tailwindcss/vite": "catalog:",
     "@tsconfig/node22": "catalog:",
     "@types/bun": "catalog:",


### PR DESCRIPTION
## Summary

This PR removes the legacy unattended permission auto-approval path and makes channel/automation permissions resolve through the same control-profile authority used by ordinary tool enforcement.

The intended final behavior is:

- Explicit session control profiles win through the parent chain.
- Agent `controlProfile` wins next.
- Top-level config `controlProfile` wins next.
- If nothing explicit is configured, the session source decides the default:
  - channel-backed root sessions default to `autonomous`;
  - agenda automation root sessions default to `autonomous`;
  - ordinary interactive/manual root sessions default to `guarded`.
- `SessionInteraction.unattended(...)` remains useful metadata for source labels, diagnostics, stats, and question rejection, but it no longer silently changes permission decisions.
- Explicit `full_access` is respected in channel/unattended contexts instead of being rejected just because the session is non-interactive.

## 1. 问题是什么

Before this cleanup, channel and automation permissions were controlled by two different models at the same time.

### Legacy unattended metadata silently changed permission asks

`PermissionNext.ask()` had a special branch that looked at request metadata:

- if `metadata.sessionInteractionMode === "unattended"`, and
- the request was not marked non-bypassable,
- then an `ask` decision was silently resolved as approved.

That meant `unattended` was not just session/source metadata. It was also an implicit permission override. A guarded channel session could therefore behave unlike an ordinary guarded session even when the resolved control profile said the action should ask.

This was especially confusing for Feishu/channel sessions because the channel entry point creates sessions with `SessionInteraction.unattended("channel:feishu")`. The intent was “this surface cannot answer live questions”, but the implementation also treated that metadata as “approve ordinary asks”.

### Effective control-profile resolution was duplicated

The same precedence logic was scattered across runtime paths:

- session resolution;
- tool resolver profile promises;
- local tool gate creation;
- MCP tool gate creation;
- plugin permission checks;
- external-agent setup;
- permission context prompt generation;
- control-profile route helpers.

Those copies generally ended at `guarded`, so prompt text, tool enforcement, and plugin decisions could drift as the rules changed. A future fix in one path could easily leave another path enforcing a different profile.

### Channel and agenda sessions had the wrong default shape

Without explicit configuration, Feishu/channel and agenda automation sessions need to be non-interactive by default. The right default is not hidden ask auto-approval; it is an explicit `autonomous` source fallback.

The old design achieved some automation convenience by inspecting `unattended` metadata at permission-request time. That made the default behavior hard to reason about and tightly coupled to a specific metadata field instead of a profile.

### `full_access` was artificially blocked for unattended contexts

The old control-profile compiler rejected `full_access` when the resolution context said the interaction mode was unattended. That contradicted explicit user configuration. If a user deliberately chooses top-level or session/agent `full_access`, the resolver should honor that configuration regardless of whether the session is backed by Feishu, agenda, or an interactive UI.

## 2. 为什么要这么做

### Control profiles should be the single source of permission truth

The permission model is much easier to audit when one layer owns each decision:

- Session/source context chooses an effective profile only when no explicit profile exists.
- Control profiles define allow / ask / deny rules.
- The enforcement gate and permission system apply those rules.
- Session interaction metadata stays metadata.

This PR removes the hidden rule where `unattended` could override `ask`. If a resolved profile says a request should ask, it now goes through the normal permission request path. If a channel or agenda session should avoid routine asks, that should happen because it resolved to `autonomous`, not because a metadata branch silently approved it.

### Explicit configuration must remain explicit

A user-selected profile is a stronger signal than source defaults. That matters for both directions:

- If a channel session has no explicit profile, it gets `autonomous` because the source is non-interactive.
- If the user explicitly configures `guarded`, asks can surface normally.
- If the user explicitly configures `full_access`, Synergy should not downgrade or reject it just because the source is unattended.

This makes behavior predictable: source defaults only fill the blank; they do not override user configuration.

### Feishu should not need a provider-specific permission knob

Feishu is currently the channel provider, but the behavior belongs to the generic channel endpoint model. Adding a Feishu-specific `controlProfile` field would create another policy path and would not help future channel providers.

By using `endpoint.kind === "channel"` at the session/source layer, future channel providers inherit the same default without adding special-case config.

### Deleting the old path is cleaner than wrapping it

The old unattended auto-approval path was not a boundary that needed compatibility. It was the behavior being replaced. Keeping it behind another condition or adapter would preserve the same confusing model with more layers.

This PR intentionally deletes the obsolete branch, deletes request metadata plumbing that existed to feed it, and removes `interactionMode` from control-profile resolution rather than passing it around unused.

## 3. 你怎么做的

### Centralized effective profile resolution

Added a single owner-level resolver in `packages/synergy/src/session/index.ts`:

- `Session.resolveEffectiveControlProfile(...)`
- `Session.defaultControlProfileForSessionSource(...)`

The resolver now applies the required precedence:

1. Explicit session `controlProfile`, walking the session parent chain.
2. Agent `controlProfile`.
3. Top-level config `controlProfile`.
4. Source fallback:
   - channel roots -> `autonomous`;
   - agenda roots -> `autonomous`;
   - ordinary/manual roots -> `guarded`.

It uses `ControlProfileCompiler.normalize(...)` to validate explicit string values, while keeping source fallback logic in the session/source boundary.

### Replaced duplicated runtime resolution

Updated the runtime paths that previously rebuilt their own fallback chains:

- `packages/synergy/src/session/invoke.ts`
  - external-agent setup now uses the central resolver;
  - permission context prompt generation now uses the central resolver.
- `packages/synergy/src/session/tool-resolver.ts`
  - deleted the local `resolveEffectiveProfile(...)` helper;
  - local tools, MCP tools, and profile promise setup all use the central resolver.
- `packages/synergy/src/plugin/host-services.ts`
  - plugin permission checks use the central resolver before profile policy decisions.
- `packages/synergy/src/server/control-profile-route.ts`
  - removed obsolete interaction-mode context from profile resolution.

The important invariant is that the prompt context and all enforcement paths now ask the same resolver for the same effective profile.

### Deleted unattended auto-approval

In `packages/synergy/src/permission/next.ts`:

- removed the `unattended auto-approve` branch;
- removed `PermissionNext.requestMetadata(...)`;
- removed call-site spreads of session interaction metadata from permission requests.

`SessionInteraction.unattended(...)` still exists and still matters for non-permission behavior such as question rejection and session diagnostics, but it no longer auto-approves normal permission asks.

### Removed `full_access` unattended prohibition

In the control-profile/enforcement boundary:

- removed the `full_access` invalid-profile branch for unattended contexts;
- removed `interactionMode` from `ResolutionContext`;
- removed `interactionMode` from `EnforcementGate` options;
- removed `interactionMode` call-site plumbing.

`full_access` is now resolved like any other explicit profile. It is never an implicit fallback for channels or agenda sessions, but it is respected when explicitly configured.

### Updated tests around the new invariants

Updated and added tests for:

- ordinary root sessions defaulting to `guarded`;
- channel roots defaulting to `autonomous`;
- children of channel roots inheriting the channel root source fallback;
- channel roots honoring top-level `full_access`;
- channel roots honoring explicit session `guarded`;
- agenda roots defaulting to `autonomous`;
- unattended metadata no longer auto-approving `ask` rules;
- explicit deny rules still rejecting;
- `full_access` being valid without interaction-mode restrictions;
- enforcement gate behavior without `interactionMode`;
- MCP/plugin guarded asks without relying on unattended mode;
- stale resolver test coverage now calling the real `Session.resolveEffectiveControlProfile` instead of reimplementing deleted fallback logic.

### Updated documentation

Updated the README control-profile section to describe the final behavior directly:

- full precedence order;
- channel/agenda source defaults;
- ordinary interactive default;
- explicit `full_access` remaining valid for channel sessions;
- removed stale wording that said `full_access` is blocked in unattended execution.

### Kept quality gates reproducible

During repository-level typecheck, `packages/ui` failed because `packages/ui/src/components/special-user-message.test.tsx` imports `@happy-dom/global-registrator` but `packages/ui/package.json` did not declare it. The dependency already existed in the lockfile through the app package, but package-local typecheck needs package-local declaration.

This PR adds `@happy-dom/global-registrator` to `packages/ui` devDependencies so `bun run typecheck` is reproducible from this worktree.

## Verification

Commands run:

```bash
cd packages/synergy
bun test test/session/session.test.ts test/session/unattended.test.ts test/permission/next.test.ts test/control-profile/compiler.test.ts test/control-profile/resolve-profile.test.ts
bun test test/permission/identity-boundary.test.ts test/permission/agent-blanket-allow.test.ts
bun test test/session test/permission test/control-profile
bun test test/session/prompt-budgeter.test.ts test/session/invoke-compaction.test.ts
bun test test/permission/identity-boundary.test.ts test/permission/agent-blanket-allow.test.ts test/enforcement/gate.test.ts test/enforcement/mcp-plugin.test.ts
bun run typecheck
./script/format.ts
bun run typecheck && ./script/format.ts
```

Results:

- Targeted session/permission/control-profile tests passed.
- Boundary tests passed.
- Final changed-file test set passed: 332 tests.
- `bun run typecheck` passed.
- `./script/format.ts` passed.
- Pre-push hook reran typecheck and formatting successfully before pushing the branch.

Note: the broad `bun test test/session test/permission test/control-profile` slice produced 615 passing tests and 4 transient failures in session prompt-budgeter/compaction tests during the combined run. The failed files were immediately rerun directly and passed, so no code change was made for that transient combined-run timing issue.

## Review

Maintainability review was run before PR creation.

- Initial review found one blocker: `resolve-profile.test.ts` still had an inline mock of deleted resolver logic.
- The test was replaced with real `Session.resolveEffectiveControlProfile` coverage.
- Re-review passed with no blockers.

## SDK / migration impact

- No config schema change.
- No persisted schema migration.
- No SDK regeneration required; server route schemas/OpenAPI contracts were not changed.
