### PR TITLE
fix: exclude .synergy/worktrees/ from protected-path matching

### DIFF
--- a/packages/synergy/src/enforcement/classify.ts
+++ b/packages/synergy/src/enforcement/classify.ts
@@ -70,6 +70,15 @@ export function checkProtectedPath(path: string, mode: "read" | "write"): Protec
     for (const prefix of PROTECTED_WRITE_PATHS) {
       const trimmed = prefix.endsWith("/") ? prefix : prefix + "/"
       if (lower === prefix || lower.startsWith(trimmed) || lower.includes("/" + trimmed)) {
+        // .synergy/worktrees/ is a workspace, not Synergy config data.
+        // Paths inside worktrees should not trigger the .synergy/ protected
+        // write check. Must handle both relative (startsWith) and absolute
+        // (includes "/.synergy/worktrees/") paths.
+        if (
+          prefix === ".synergy/" &&
+          (lower.startsWith(".synergy/worktrees/") || lower.includes("/.synergy/worktrees/"))
+        )
+          continue
         const category: ProtectedMatch["category"] = prefix.startsWith(".git")
           ? "vcs"
           : prefix.startsWith(".env")

--- a/packages/synergy/test/enforcement/protected-paths.test.ts
+++ b/packages/synergy/test/enforcement/protected-paths.test.ts
@@ -135,3 +135,31 @@ describe("checkProtectedPath - secrets always protected (both modes)", () => {
     expect(checkProtectedPath("id_rsa", "write").matched).toBe(true)
   })
 })
+
+describe("checkProtectedPath - worktree exclusion", () => {
+  test("worktree paths are NOT flagged (absolute)", () => {
+    const worktreePath = "/home/user/project/.synergy/worktrees/fix-123/src/index.ts"
+    expect(checkProtectedPath(worktreePath, "write").matched).toBe(false)
+  })
+
+  test("worktree paths are NOT flagged (relative)", () => {
+    const worktreePath = ".synergy/worktrees/fix-123/packages/synergy/src/index.ts"
+    expect(checkProtectedPath(worktreePath, "write").matched).toBe(false)
+  })
+
+  test("worktree paths are NOT flagged (read mode)", () => {
+    expect(checkProtectedPath(".synergy/worktrees/fix-123/src/main.ts", "read").matched).toBe(false)
+  })
+
+  test("non-worktree .synergy/ paths are STILL flagged", () => {
+    expect(checkProtectedPath(".synergy/config", "write").matched).toBe(true)
+    expect(checkProtectedPath(".synergy/synergy.d/00-general.jsonc", "write").matched).toBe(true)
+    expect(checkProtectedPath("subdir/.synergy/data/profile.json", "write").matched).toBe(true)
+  })
+
+  test("worktree paths with config-like content are safe", () => {
+    // A path like .synergy/worktrees/X/.synergy/config should NOT be flagged
+    // because the worktree prefix takes priority
+    expect(checkProtectedPath(".synergy/worktrees/fix-123/.synergy/config", "write").matched).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes #200: worktree paths (`.synergy/worktrees/*`) no longer trigger `protected_op → ask` on every file operation
- Adds an early exit in `checkProtectedPath()` for paths starting with or containing `.synergy/worktrees/`
- Non-worktree `.synergy/` paths (config, data) remain protected as before

## Root Cause

`checkProtectedPath()` in `enforcement/classify.ts` unconditionally matched any path containing `/.synergy/` as a protected write path. Since worktrees live at `<repo>/.synergy/worktrees/<name>`, every file read/write in a worktree session was classified as `protected_op`, forcing an `ask` even under `full_access` profiles.

## Fix

A single `continue` guard in the `.synergy/` matching loop: if the matched prefix is `.synergy/` and the path starts with or contains `.synergy/worktrees/`, skip the protected-path classification.

## Tests

- **69 tests pass** (35 protected-paths + 34 classify)
- 5 new test cases covering absolute/relative/read-mode/config-nested worktree paths
- Existing `.synergy/config` protection tests continue to pass

## Changed Files

| File | Change |
|---|---|
| `packages/synergy/src/enforcement/classify.ts` | +9 lines: worktree exclusion in `checkProtectedPath()` |
| `packages/synergy/test/enforcement/protected-paths.test.ts` | +28 lines: 5 new worktree exclusion tests |