### PR TITLE
fix: use peek-then-commit for inbox drain to prevent message loss (#193)

### DIFF
--- a/packages/synergy/src/session/inbox.ts
+++ b/packages/synergy/src/session/inbox.ts
@@ -313,4 +313,28 @@ export namespace SessionInbox {
       (item) => item.kind === "queued_user" || item.kind === "guiding" || item.kind === "agent_update",
     )
   }
+
+  /**
+   * Peek ready inbox items without deleting them from storage.
+   * Used by the session loop's after-turn boundary so items are only
+   * committed after the full reply cycle succeeds.
+   */
+  export async function peekReady(sessionID: string, excludeIDs?: Set<string>): Promise<StoredItem[]> {
+    const items = await listStored(sessionID)
+    const ready = items.filter(
+      (item) =>
+        (item.kind === "queued_user" || item.kind === "guiding" || item.kind === "agent_update") &&
+        (!excludeIDs || !excludeIDs.has(item.id)),
+    )
+    return sortItems(ready)
+  }
+
+  /**
+   * Commit (delete) inbox items after they have been successfully
+   * materialized into the session and the reply cycle has completed.
+   */
+  export async function commitReady(sessionID: string, itemIDs: Iterable<string>): Promise<void> {
+    const ids = Array.from(itemIDs)
+    await removeItems(sessionID, ids)
+  }
 }

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -854,15 +854,31 @@ export namespace SessionInvoke {
         continue
       }
 
-      // Inner loop finished — drain queued user input and agent updates in the
-      // same visible Inbox order. If any item requires a reply, re-enter the loop.
-      const readyItems = await SessionInbox.drainReady(sessionID)
+      // Inner loop finished — use peek-then-commit pattern for inbox items
+      // so items are never deleted before they are successfully materialized
+      // and the reply cycle completes. If needsReply, commit now (they're
+      // already in the session as user messages) and re-enter the loop.
+      // Otherwise, commit after the full loop exits with a final race check.
+      const readyItems = await SessionInbox.peekReady(sessionID)
       const readyResult = await materializeInboxItems(sessionID, readyItems)
-      if (readyResult.needsReply) continue outer
+      const committedIDs = new Set(readyItems.map((item) => item.id))
+
+      if (readyResult.needsReply) {
+        await SessionInbox.commitReady(sessionID, committedIDs)
+        continue outer
+      }
 
       const legacyMails = SessionManager.drainAllMails(sessionID).filter((mail) => !mail.inboxItemID)
       const legacyResult = await materializeLegacyMails(sessionID, legacyMails)
-      if (legacyResult.needsReply) continue outer
+      if (legacyResult.needsReply) {
+        await SessionInbox.commitReady(sessionID, committedIDs)
+        continue outer
+      }
+
+      // Commit to remove materialized items from the inbox, then do a
+      // final check for late-arriving items before clearing pendingReply.
+      await SessionInbox.commitReady(sessionID, committedIDs)
+      if (await hasLateArrivingInbox(sessionID)) continue outer
       break
     }
 
@@ -971,6 +987,22 @@ export namespace SessionInvoke {
     await Session.update(sessionID, (draft) => {
       draft.pendingReply = undefined
     })
+  }
+
+  /**
+   * Check for inbox items that arrived after the after-turn boundary closed.
+   * Returns true if any ready items exist and should trigger a loop re-entry.
+   */
+  async function hasLateArrivingInbox(sessionID: string): Promise<boolean> {
+    const lateItems = await SessionInbox.peekReady(sessionID)
+    if (lateItems.length > 0) {
+      log.info("late-arriving inbox items detected, re-entering loop", {
+        sessionID,
+        count: lateItems.length,
+      })
+      return true
+    }
+    return false
   }
 
   async function writeAbortedAssistantMessage(sessionID: string, scopeID: string): Promise<MessageV2.WithParts> {

--- a/packages/synergy/test/session/inbox.test.ts
+++ b/packages/synergy/test/session/inbox.test.ts
@@ -153,3 +153,163 @@ describe("SessionInbox", () => {
     })
   })
 })
+
+describe("inbox peek / commit", () => {
+  test("peekReady returns queued items without deleting them", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "first" }],
+        })
+        await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "second" }],
+        })
+
+        // First peek — should return both items
+        const firstPeek = await SessionInbox.peekReady(session.id)
+        expect(firstPeek).toHaveLength(2)
+
+        // Items should still be in the inbox (peek is non-destructive)
+        const items = await SessionInbox.list(session.id)
+        expect(items).toHaveLength(2)
+
+        // Second peek should return the same items
+        const secondPeek = await SessionInbox.peekReady(session.id)
+        expect(secondPeek).toHaveLength(2)
+        expect(secondPeek.map((i) => i.id).sort()).toEqual(firstPeek.map((i) => i.id).sort())
+
+        SessionManager.unregisterRuntime(session.id)
+      },
+    })
+  })
+
+  test("commitReady deletes specified items and leaves others intact", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        const first = await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "keep" }],
+        })
+        const second = await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "delete" }],
+        })
+
+        await SessionInbox.commitReady(session.id, [second.id])
+
+        const items = await SessionInbox.list(session.id)
+        expect(items).toHaveLength(1)
+        expect(items[0].id).toBe(first.id)
+
+        SessionManager.unregisterRuntime(session.id)
+      },
+    })
+  })
+
+  test("peek-then-commit pattern preserves items when commit is skipped", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        const item = await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "do not lose me" }],
+        })
+
+        // Peek — but simulate processing failure: never call commit
+        const peeked = await SessionInbox.peekReady(session.id)
+        expect(peeked).toHaveLength(1)
+        expect(peeked[0].id).toBe(item.id)
+
+        // Still in the inbox because commit was never called
+        const items = await SessionInbox.list(session.id)
+        expect(items).toHaveLength(1)
+
+        // Can be re-peeked (survives failed processing cycles)
+        const rePeeked = await SessionInbox.peekReady(session.id)
+        expect(rePeeked).toHaveLength(1)
+        expect(rePeeked[0].id).toBe(item.id)
+
+        SessionManager.unregisterRuntime(session.id)
+      },
+    })
+  })
+
+  test("drainReady deletes items (existing destructive behaviour)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "gone" }],
+        })
+
+        const drained = await SessionInbox.drainReady(session.id)
+        expect(drained).toHaveLength(1)
+
+        // drainReady is destructive — items should be gone
+        const items = await SessionInbox.list(session.id)
+        expect(items).toHaveLength(0)
+
+        SessionManager.unregisterRuntime(session.id)
+      },
+    })
+  })
+
+  test("peekReady with excludeIDs skips already-committed items", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+
+        const first = await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "first" }],
+        })
+        const second = await SessionInbox.enqueueUser({
+          sessionID: session.id,
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "second" }],
+        })
+
+        // Committed items excluded, still-queued returned
+        const peeked = await SessionInbox.peekReady(session.id, new Set([first.id]))
+        expect(peeked).toHaveLength(1)
+        expect(peeked[0].id).toBe(second.id)
+
+        SessionManager.unregisterRuntime(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Added `peekReady()` and `commitReady()` to `inbox.ts`: peek without deleting, commit only after successful materialization and reply cycle
- Replaced `drainReady` with `peekReady` at the after-turn boundary in the session loop so items are never deleted from storage before they are successfully turned into assistant replies
- Added `hasLateArrivingInbox()` guard to catch inbox items that arrive between the drain boundary and the `pendingReply` clear — re-enters the loop instead of leaving them orphaned in storage
- Kept existing `drainReady()` for `processMailbox` (mailbox delivery path) where destructive semantics are correct

## What
Closes #193

## Test
1. Start a session with an active agent run
2. While the agent is working, send another message — it should appear in the inbox
3. Wait for the current run to complete — the queued message should be processed as the next turn
4. If the session is aborted mid-run, inbox items should remain visible and not silently disappear
5. Late-arriving messages (sent during the commit/pendingReply boundary) should trigger a loop re-entry

## Files Changed
- `packages/synergy/src/session/inbox.ts` — `peekReady`, `commitReady`
- `packages/synergy/src/session/invoke.ts` — peek-then-commit at after-turn boundary, `hasLateArrivingInbox` guard