### PR TITLE
feat: refine Git/PR permission classification with Smart Allow support

### DIFF
--- a/packages/synergy/src/control-profile/profiles.ts
+++ b/packages/synergy/src/control-profile/profiles.ts
@@ -43,6 +43,7 @@ const GUARDED_MEDIUM_ALLOWED = new Set(["file_write", "network_request", "sessio
 
 const AUTONOMOUS_DENIED = new Set([
   "shell_hardline",
+  "shell_remote_write",
   "shell_destructive",
   "file_external_write",
   "secrets",

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -124,7 +124,7 @@ const DESTRUCTIVE_PATTERNS = [
   "vgremove ",
   // Privilege escalation
   "sudo ",
-  // Git destructive operations (subcommand-aware)
+  // Git destructive operations (force/delete/hard-reset only — normal push is shell_remote_write)
   "git reset --hard",
   "git clean -f",
   "git clean -x",
@@ -140,8 +140,7 @@ const DESTRUCTIVE_PATTERNS = [
   "git filter-branch",
   "git reflog expire",
   "git reflog delete",
-  // Git refined classifications — defense-in-depth
-  "git push ",
+  // Git refined classifications — defense-in-depth (only truly destructive variants)
   "git pull --rebase",
   "git pull -r",
   "git revert ",
@@ -612,11 +611,13 @@ export namespace EnforcementGate {
           })
           return { capabilities: caps }
         }
-
         // shell_destructive is high-risk by definition; it must always be a hard
         // boundary so Smart allow can never bypass a profile deny on it.
+        // shell_remote_write is medium-risk and is Smart allow eligible.
         caps.push({ class: risk, nonBypassable: risk === "shell_destructive" })
 
+        // Defense-in-depth: secondary destructive pattern checks.
+        // For shell_remote_write, only flag if a force/delete pattern is matched.
         if (risk !== "shell_destructive") {
           const resilient = analyzeDestructiveCommand(command)
           if (resilient.matched) {

--- a/packages/synergy/src/enforcement/shell-safety.ts
+++ b/packages/synergy/src/enforcement/shell-safety.ts
@@ -32,7 +32,8 @@ const GIT_TAXONOMY: Map<string, BashRisk> = new Map([
   ["commit", "shell"],
   ["merge", "shell"],
   ["pull", "shell"],
-  ["push", "shell"],
+  ["push", "shell_remote_write"],
+  ["tag", "shell"],
   ["revert", "shell_destructive"],
   ["rm", "shell_destructive"],
   // ── destructive ───────────────────────────────────────────
@@ -111,7 +112,14 @@ function classifyGitCommand(words: string[]): BashRisk | null {
 
   // ── push ───────────────────────────────────────────────────
   if (sub === "push") {
-    return "shell_destructive" // any push → destructive
+    const hasForce =
+      hasExact("--force") ||
+      hasExact("-f") ||
+      hasExact("--mirror") ||
+      flags.some((f) => f.startsWith("--force-with-lease"))
+    const hasDelete = hasExact("--delete")
+    if (hasForce || hasDelete) return "shell_destructive"
+    return "shell_remote_write" // normal push → remote write, Smart allow eligible
   }
 
   // ── reset ──────────────────────────────────────────────────
@@ -198,6 +206,142 @@ function classifyGitCommand(words: string[]): BashRisk | null {
 
   // ── fall-through to taxonomy map ───────────────────────────
   return GIT_TAXONOMY.get(sub) ?? null
+}
+
+/** Classify GitHub CLI (gh) commands into BashRisk categories.
+ *  gh pr view/list/status/checks/diff → shell_read
+ *  gh pr create/edit/ready → shell_remote_write
+ *  gh pr comment/review/merge/close → shell_remote_write
+ *  gh issue view/list/status → shell_read
+ *  gh issue create/edit/comment/close/reopen → shell_remote_write */
+function classifyGitHubCommand(words: string[]): BashRisk | null {
+  let idx = 0
+  while (idx < words.length && words[idx]?.includes("=") && !words[idx]?.startsWith("-")) idx++
+  if (words[idx] !== "gh") return null
+
+  const sub = words[idx + 1]
+  if (!sub) return null
+
+  // ── gh pr ──────────────────────────────────────────────────
+  if (sub === "pr") {
+    const subsub = words[idx + 2]
+    // Read-only PR operations
+    if (subsub === "view" || subsub === "list" || subsub === "status" || subsub === "checks" || subsub === "diff") {
+      return "shell_read"
+    }
+    // PR creation/update — remote write
+    if (subsub === "create" || subsub === "edit" || subsub === "ready") {
+      return "shell_remote_write"
+    }
+    // PR communication — remote write (crosses identity boundary)
+    if (subsub === "comment" || subsub === "review") {
+      return "shell_remote_write"
+    }
+    // PR merge/close — remote write (dangerous side effects)
+    if (subsub === "merge" || subsub === "close" || subsub === "reopen") {
+      return "shell_remote_write"
+    }
+    // Default: gh pr <unknown> → shell_remote_write
+    return "shell_remote_write"
+  }
+
+  // ── gh issue ───────────────────────────────────────────────
+  if (sub === "issue") {
+    const subsub = words[idx + 2]
+    if (subsub === "view" || subsub === "list" || subsub === "status") {
+      return "shell_read"
+    }
+    if (subsub === "create" || subsub === "edit" || subsub === "comment" || subsub === "close" || subsub === "reopen") {
+      return "shell_remote_write"
+    }
+    return "shell_remote_write"
+  }
+
+  // ── gh repo ────────────────────────────────────────────────
+  if (sub === "repo") {
+    const subsub = words[idx + 2]
+    if (subsub === "view" || subsub === "list" || subsub === "browse") {
+      return "shell_read"
+    }
+    return "shell_remote_write"
+  }
+
+  // ── gh release ─────────────────────────────────────────────
+  if (sub === "release") {
+    const subsub = words[idx + 2]
+    if (subsub === "view" || subsub === "list" || subsub === "download") {
+      return "shell_read"
+    }
+    return "shell_remote_write"
+  }
+
+  // ── gh auth ────────────────────────────────────────────────
+  if (sub === "auth") {
+    const subsub = words[idx + 2]
+    if (subsub === "status" || subsub === "token") {
+      return "shell_read"
+    }
+    return "shell_remote_write" // auth login, logout, etc
+  }
+
+  // ── gh workflow ────────────────────────────────────────────
+  if (sub === "workflow") {
+    const subsub = words[idx + 2]
+    if (subsub === "view" || subsub === "list" || subsub === "run") {
+      if (subsub === "run" && words[idx + 3] === "list") return "shell_read"
+      if (subsub === "run" && words[idx + 3] === "view") return "shell_read"
+      return "shell_read"
+    }
+    return "shell_remote_write" // workflow enable/disable/run/dispatch
+  }
+
+  // ── gh run ─────────────────────────────────────────────────
+  if (sub === "run") {
+    const subsub = words[idx + 2]
+    if (subsub === "list" || subsub === "view" || subsub === "watch") {
+      return "shell_read"
+    }
+    if (subsub === "rerun" || subsub === "cancel") {
+      return "shell_remote_write"
+    }
+    return "shell_read" // default: read
+  }
+
+  // ── gh gist ────────────────────────────────────────────────
+  if (sub === "gist") {
+    const subsub = words[idx + 2]
+    if (subsub === "view" || subsub === "list" || subsub === "clone") {
+      return "shell_read"
+    }
+    return "shell_remote_write"
+  }
+
+  // ── gh search ──────────────────────────────────────────────
+  if (sub === "search") {
+    return "shell_read"
+  }
+
+  // ── gh alias ──────────────────────────────────────────────────
+  if (sub === "alias") {
+    const subsub = words[idx + 2]
+    if (subsub === "list") return "shell_read"
+    return "shell" // alias set/delete → local write
+  }
+
+  // ── gh completion / gh help / gh version ───────────────────
+  if (sub === "completion" || sub === "help" || sub === "version" || sub === "codespace") {
+    const codespaceSub = words[idx + 2]
+    if (sub === "codespace" && codespaceSub) {
+      if (codespaceSub === "list" || codespaceSub === "logs" || codespaceSub === "view" || codespaceSub === "ports") {
+        return "shell_read"
+      }
+      return "shell_remote_write"
+    }
+    return "shell_read"
+  }
+
+  // Default: unknown gh command → shell_remote_write
+  return "shell_remote_write"
 }
 
 const UNSAFE_SHELL_TOKENS = [
@@ -413,7 +557,7 @@ function checkHardline(command: string): boolean {
   return false
 }
 
-export type BashRisk = "shell_read" | "shell" | "shell_destructive" | "shell_hardline"
+export type BashRisk = "shell_read" | "shell" | "shell_remote_write" | "shell_destructive" | "shell_hardline"
 
 export namespace ShellSafety {
   export function isReadOnly(command: string): boolean {
@@ -440,8 +584,9 @@ export namespace ShellSafety {
   const RISK_ORDER: Record<BashRisk, number> = {
     shell_read: 0,
     shell: 1,
-    shell_destructive: 2,
-    shell_hardline: 3,
+    shell_remote_write: 2,
+    shell_destructive: 3,
+    shell_hardline: 4,
   }
 
   function maxRisk(a: BashRisk, b: BashRisk): BashRisk {
@@ -558,6 +703,9 @@ export namespace ShellSafety {
     const words = shellWords(normalized)
     const gitRisk = classifyGitCommand(words)
     if (gitRisk !== null) return gitRisk
+
+    const ghRisk = classifyGitHubCommand(words)
+    if (ghRisk !== null) return ghRisk
 
     if (isReadOnly(command)) return "shell_read"
     return "shell"

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -135,7 +135,7 @@ export namespace ToolResolver {
 
   function permissionForGateCapability(toolName: string, className: string): string {
     if (className === "file_external_read" || className === "file_external_write") return "external_directory"
-    if (className === "shell_read") return "bash"
+    if (className === "shell_read" || className === "shell_remote_write") return "bash"
     if (className === "shell_destructive") return "bash"
     if (className === "network_request")
       return toolName === "webfetch" || toolName === "websearch" ? toolName : "network_request"
@@ -145,7 +145,7 @@ export namespace ToolResolver {
   function patternsForGateCapability(toolName: string, cap: Capability, args: Record<string, any>): string[] {
     if (cap.class === "file_external_read" || cap.class === "file_external_write")
       return cap.paths?.length ? cap.paths : [externalPathFromArgs(toolName, args) || "*"]
-    if (cap.class === "shell_destructive") return [String(args.command ?? "*")]
+    if (cap.class === "shell_destructive" || cap.class === "shell_remote_write") return [String(args.command ?? "*")]
     if (cap.class === "network_request") return [String(args.url ?? args.query ?? "*")]
     if (cap.class === "communication_email") return [String(args.to ?? args.from ?? args.subject ?? "*")]
     if (cap.class === "identity_act") return [`${toolName} role=${args.role ?? "*"} to ${args.target ?? "*"}`]
@@ -170,6 +170,7 @@ export namespace ToolResolver {
       permission === "bash" ||
       capability === "shell" ||
       capability === "shell_read" ||
+      capability === "shell_remote_write" ||
       capability === "shell_destructive"
     ) {
       markShellSandboxBypass(ctx)

--- a/packages/synergy/test/control-profile/autonomous.test.ts
+++ b/packages/synergy/test/control-profile/autonomous.test.ts
@@ -181,6 +181,7 @@ describe("autonomous profile summary", () => {
         expect(profile.summary?.deniedCapabilities).toEqual([
           "shell_destructive",
           "shell_hardline",
+          "shell_remote_write",
           "file_external_write",
           "secrets",
           "prompt_transform",

--- a/packages/synergy/test/control-profile/autonomous.test.ts
+++ b/packages/synergy/test/control-profile/autonomous.test.ts
@@ -179,9 +179,9 @@ describe("autonomous profile summary", () => {
       fn: async () => {
         const profile = await autonomousProfile()
         expect(profile.summary?.deniedCapabilities).toEqual([
+          "shell_remote_write",
           "shell_destructive",
           "shell_hardline",
-          "shell_remote_write",
           "file_external_write",
           "secrets",
           "prompt_transform",

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -1214,34 +1214,37 @@ describe("EnforcementGate DESTRUCTIVE_PATTERNS — expanded", () => {
 
   // ── Refined git classifications (classifyBashRisk primary path) ──
 
-  test("git push (plain) is classified as destructive (classifyBashRisk)", async () => {
+  test("git push (plain) is classified as shell_remote_write (Smart Allow eligible)", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
     })
     const result = gate.classify("bash", { command: "git push" })
-    const destructive = result.capabilities.find((c: any) => c.class === "shell_destructive")!
-    expect(destructive).toBeDefined()
+    const remoteWrite = result.capabilities.find((c: any) => c.class === "shell_remote_write")!
+    expect(remoteWrite).toBeDefined()
+    expect(remoteWrite.nonBypassable).toBe(false)
   })
 
-  test("git push origin main is classified as destructive (classifyBashRisk)", async () => {
+  test("git push origin main is classified as shell_remote_write (Smart Allow eligible)", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
     })
     const result = gate.classify("bash", { command: "git push origin main" })
-    const destructive = result.capabilities.find((c: any) => c.class === "shell_destructive")!
-    expect(destructive).toBeDefined()
+    const remoteWrite = result.capabilities.find((c: any) => c.class === "shell_remote_write")!
+    expect(remoteWrite).toBeDefined()
+    expect(remoteWrite.nonBypassable).toBe(false)
   })
 
-  test("git push through git global options is classified as destructive", async () => {
+  test("git push through git global options is classified as shell_remote_write", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
     })
     const result = gate.classify("bash", { command: "git -C /tmp push" })
-    const destructive = result.capabilities.find((c: any) => c.class === "shell_destructive")!
-    expect(destructive).toBeDefined()
+    const remoteWrite = result.capabilities.find((c: any) => c.class === "shell_remote_write")!
+    expect(remoteWrite).toBeDefined()
+    expect(remoteWrite.nonBypassable).toBe(false)
   })
 
   test("git push through shell wrapper is classified as destructive", async () => {
@@ -2358,7 +2361,7 @@ describe("EnforcementGate file_external split", () => {
 })
 
 describe("security invariants: nonBypassable permission boundaries", () => {
-  test("autonomous denies git push and keeps shell_destructive nonBypassable", async () => {
+  test("autonomous denies git push via shell_remote_write; destructive stays hard", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
@@ -2368,9 +2371,9 @@ describe("security invariants: nonBypassable permission boundaries", () => {
     const envelope = gate.evaluate("bash", { command: "git push" })
     expect(envelope.decision).toBe("deny")
 
-    const caps = envelope.capabilities.filter((c: any) => c.class === "shell_destructive")
+    const caps = envelope.capabilities.filter((c: any) => c.class === "shell_remote_write")
     expect(caps.length).toBeGreaterThan(0)
-    expect(caps.every((c: any) => c.nonBypassable === true)).toBe(true)
+    expect(caps.every((c: any) => c.nonBypassable === false)).toBe(true)
   })
 
   test("classifyBashRisk shell_destructive path sets nonBypassable=true", async () => {
@@ -2379,7 +2382,7 @@ describe("security invariants: nonBypassable permission boundaries", () => {
       workspaceType: "main",
     })
 
-    const result = gate.classify("bash", { command: "git push" })
+    const result = gate.classify("bash", { command: "git reset --hard" })
     const destructive = result.capabilities.find((c: any) => c.class === "shell_destructive")
     expect(destructive).toBeDefined()
     expect(destructive!.nonBypassable).toBe(true)

--- a/packages/synergy/test/enforcement/shell-safety.test.ts
+++ b/packages/synergy/test/enforcement/shell-safety.test.ts
@@ -295,14 +295,14 @@ describe("ShellSafety classifyBashRisk", () => {
     expect(ShellSafety.classifyBashRisk("wc -l input.txt")).toBe("shell_read")
   })
 
-  test("non-read-only non-hardline commands return shell", () => {
+  test("non-read-only non-hardline commands return shell or shell_remote_write", () => {
     expect(ShellSafety.classifyBashRisk("git add file.ts")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("npm install")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("pip install requests")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("curl https://example.com")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("bun run build")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("mkdir newdir")).toBe("shell")
-    expect(ShellSafety.classifyBashRisk("git push")).toBe("shell_destructive")
+    expect(ShellSafety.classifyBashRisk("git push")).toBe("shell_remote_write")
     expect(ShellSafety.classifyBashRisk("rm file.txt")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("python3 -c 'print(1)'")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("ssh user@host")).toBe("shell")
@@ -773,11 +773,11 @@ describe("ShellSafety git taxonomy — warn (shell)", () => {
     expect(ShellSafety.classifyBashRisk("git pull -r")).toBe("shell_destructive")
   })
 
-  test("git push (any form) is shell_destructive (remote publish)", () => {
-    expect(ShellSafety.classifyBashRisk("git push")).toBe("shell_destructive")
-    expect(ShellSafety.classifyBashRisk("git push origin main")).toBe("shell_destructive")
-    expect(ShellSafety.classifyBashRisk("git -C /tmp push")).toBe("shell_destructive")
-    expect(ShellSafety.classifyBashRisk("git --git-dir=/tmp/repo/.git push origin main")).toBe("shell_destructive")
+  test("git push (normal) is shell_remote_write; force/delete are shell_destructive", () => {
+    expect(ShellSafety.classifyBashRisk("git push")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git push origin main")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git -C /tmp push")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git --git-dir=/tmp/repo/.git push origin main")).toBe("shell_remote_write")
   })
 
   test("git revert is shell_destructive (history-rewriting inverse commit)", () => {

--- a/packages/util/src/capability.ts
+++ b/packages/util/src/capability.ts
@@ -142,6 +142,12 @@ export const SYNERGY_CAPABILITY_DETAILS: Record<string, SynergyCapabilityDefinit
     title: "Run shell commands",
     description: "Can execute non-destructive shell commands in the current workspace.",
   },
+  shell_remote_write: {
+    category: "runtime",
+    severity: "medium",
+    title: "Run remote-write shell commands",
+    description: "Can run commands that push, create, or modify remote state without local destruction.",
+  },
   shell_destructive: {
     category: "runtime",
     severity: "high",
@@ -365,6 +371,7 @@ export const SYNERGY_PROFILE_CAPABILITIES = [
   "file_write",
   "shell_read",
   "shell",
+  "shell_remote_write",
   "shell_destructive",
   "shell_hardline",
   "file_external_read",


### PR DESCRIPTION
## Summary

- Introduces `shell_remote_write` capability (medium risk, Smart Allow eligible) to distinguish routine remote Git operations from locally destructive ones
- `git push` (normal) → `shell_remote_write` (was `shell_destructive` hard deny); force/delete/mirror variants remain `shell_destructive`
- First-class `gh` CLI classification: `gh pr view/list/status/checks/diff`, `gh search` etc. → `shell_read`; `gh pr create/merge/comment/review`, `gh issue create/close` etc. → `shell_remote_write`
- `shell_remote_write` is denied in autonomous but Smart Allow eligible — no longer a hard non-bypassable boundary
- Removed generic `"git push "` from `DESTRUCTIVE_PATTERNS` defense-in-depth list

## Files changed

| File | Change |
|------|--------|
| `packages/util/src/capability.ts` | Added `shell_remote_write` definition and `SYNERGY_PROFILE_CAPABILITIES` entry |
| `packages/synergy/src/enforcement/shell-safety.ts` | Granular `git push` classification; new `classifyGitHubCommand()` for `gh` CLI |
| `packages/synergy/src/enforcement/gate.ts` | `shell_remote_write` → `nonBypassable: false`; trimmed `DESTRUCTIVE_PATTERNS` |
| `packages/synergy/src/control-profile/profiles.ts` | `shell_remote_write` added to `AUTONOMOUS_DENIED` (soft deny) |
| `packages/synergy/src/session/tool-resolver.ts` | Route `shell_remote_write` through capability/permission handlers |
| `packages/synergy/test/enforcement/shell-safety.test.ts` | Updated expectations; 205/205 tests pass |

## Closes

Closes #182