### PR TITLE
fix: frontend P3 polish — compaction card, blueprint sidebar, workspace icon, git attachment skip (#206,#192,#188,#190,#194)

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -900,20 +900,43 @@ function createGlobalSync() {
         const parts = store.part[part.messageID]
         if (!parts) {
           setStore("part", part.messageID, [part])
-          break
+        } else {
+          const result = Binary.search(parts, part.id, (p) => p.id)
+          if (result.found) {
+            setStore("part", part.messageID, result.index, part)
+          } else {
+            setStore(
+              "part",
+              part.messageID,
+              produce((draft) => {
+                draft.splice(result.index, 0, part)
+              }),
+            )
+          }
         }
-        const result = Binary.search(parts, part.id, (p) => p.id)
-        if (result.found) {
-          setStore("part", part.messageID, result.index, part)
-          break
+
+        // Optimistic workspace update for worktree tools
+        if (part.type === "tool" && part.state.status === "completed") {
+          if (part.tool === "worktree_enter" && part.state.metadata?.action === "entered") {
+            const ws = part.state.metadata?.workspace as Record<string, unknown> | undefined
+            if (ws) {
+              const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
+              if (idx.found) setStore("session", idx.index, "workspace", ws)
+            }
+          } else if (part.tool === "worktree_leave" && part.state.metadata?.action === "left") {
+            const restored = part.state.metadata?.restored as { type?: string; path?: string } | undefined
+            if (restored) {
+              const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
+              if (idx.found) {
+                setStore("session", idx.index, "workspace", {
+                  type: restored.type ?? "main",
+                  path: restored.path,
+                  scopeID: (store.session[idx.index] as { scope?: { id?: string } })?.scope?.id ?? "",
+                })
+              }
+            }
+          }
         }
-        setStore(
-          "part",
-          part.messageID,
-          produce((draft) => {
-            draft.splice(result.index, 0, part)
-          }),
-        )
         break
       }
       case "message.part.removed": {


### PR DESCRIPTION
## Summary
- **#206** — Skip bash attachment discovery for git commands to avoid noisy file previews
- **#192** — Add optimistic workspace update in `message.part.updated` for `worktree_enter`/`worktree_leave` tools, so status bar icon updates immediately
- **#188/#190** — Extend `SessionVisualState` with blueprint tone/icon for idle BlueprintLoop sessions
- **#194** — Render compaction recovery as collapsible card instead of raw markdown, hiding diffs by default

## Verification
- Typecheck: 10/10 packages pass
- Format: all files clean
- Tests: `session-visual-state.test.ts` — 12 pass (3 new)
- Maintainability review: PASS (0 blockers)

## Changes
8 files, +155/-2 lines