### PR TITLE
Show provider usage reset times

### DIFF
--- a/packages/app/PRODUCT.md
+++ b/packages/app/PRODUCT.md
@@ -61,7 +61,7 @@ Model settings should keep role routing and quick-switcher visibility together i
 
 Provider settings should behave like a connection workspace, not a config editor. Keep provider discovery, selected-provider detail, and login flows together in the Providers page; provider quota, billing, and account-health details belong in Usage. The provider list should scroll inside its own column so the selected detail remains anchored. Do not expose raw provider allow/deny text lists in the primary settings UI.
 
-Usage settings should read as compact account summaries, not a wide report. Keep refresh controls inside the content flow, label quota windows with user-facing durations such as a 5-hour window, and avoid stretching quota rows across the full modal width.
+Usage settings should read as compact account summaries, not a wide report. Keep refresh controls inside the content flow, label quota windows with user-facing durations such as a 5-hour window, show provider reset timing inline with each quota row when available, and avoid stretching quota rows across the full modal width.
 
 Integration settings such as MCP and Email should present connection management, not protocol debugging. Use compact status rows, plain task labels, and grouped connection fields that explain what Synergy will do with the connection. Keep local command, remote endpoint, SMTP, and IMAP details secondary to the user's intent: add tools, send mail, or read mail.
 

--- a/packages/app/src/components/settings/panels/UsagePanel.model.ts
+++ b/packages/app/src/components/settings/panels/UsagePanel.model.ts
@@ -1,0 +1,112 @@
+import type { AccountUsageSnapshot, AccountUsageWindow } from "@ericsanchezok/synergy-sdk/client"
+
+type UsageResetCopy = {
+  value: string
+  title: string
+}
+
+function validTimestamp(value: number) {
+  return Number.isFinite(value) && value > 0
+}
+
+function sameCalendarDay(left: Date, right: Date) {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  )
+}
+
+function resetDayLabel(date: Date, now: Date) {
+  if (sameCalendarDay(date, now)) return "today"
+  const tomorrow = new Date(now)
+  tomorrow.setDate(now.getDate() + 1)
+  if (sameCalendarDay(date, tomorrow)) return "tomorrow"
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: date.getFullYear() === now.getFullYear() ? undefined : "numeric",
+  })
+}
+
+function resetTimeLabel(date: Date) {
+  return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
+}
+
+function sentenceCase(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+export function parseUsageResetAt(value: string | undefined) {
+  if (!value) return undefined
+  const timestamp = new Date(value).getTime()
+  return validTimestamp(timestamp) ? timestamp : undefined
+}
+
+export function formatUsageResetCompact(resetAt: string | undefined, now = Date.now()): UsageResetCopy | undefined {
+  const timestamp = parseUsageResetAt(resetAt)
+  if (!timestamp) return undefined
+
+  const resetDate = new Date(timestamp)
+  const nowDate = new Date(now)
+  const day = resetDayLabel(resetDate, nowDate)
+  const time = resetTimeLabel(resetDate)
+  const value = `${sentenceCase(day)} at ${time}`
+  return {
+    value,
+    title: `Resets ${day} at ${time}`,
+  }
+}
+
+export function formatUsageResetSentence(resetAt: string | undefined, now = Date.now()) {
+  const reset = formatUsageResetCompact(resetAt, now)
+  return reset ? { value: reset.title, title: reset.title } : undefined
+}
+
+export function nextUsageReset(
+  snapshots: Array<AccountUsageSnapshot | undefined>,
+  now = Date.now(),
+): UsageResetCopy | undefined {
+  const next = snapshots
+    .flatMap((snapshot) => snapshot?.windows ?? [])
+    .map((window) => parseUsageResetAt(window.resetAt))
+    .filter((timestamp): timestamp is number => timestamp !== undefined && timestamp >= now)
+    .sort((left, right) => left - right)[0]
+  return next ? formatUsageResetCompact(new Date(next).toISOString(), now) : undefined
+}
+
+export function formatPercent(value: number | undefined) {
+  if (value === undefined) return "n/a"
+  return `${Math.round(value)}%`
+}
+
+export function formatUsageWindowLabel(label: string) {
+  const normalized = label.trim().toLowerCase()
+  if (normalized === "session") return "5-hour window"
+  if (normalized === "current session") return "5-hour window"
+  if (normalized === "weekly") return "Weekly window"
+  if (normalized === "current week") return "Weekly window"
+  if (normalized === "monthly") return "Monthly window"
+  return label
+}
+
+export function formatUsageWindowValue(window: AccountUsageWindow) {
+  if (window.remainingPercent !== undefined) return `${formatPercent(window.remainingPercent)} remaining`
+  if (window.usedPercent !== undefined) return `${formatPercent(window.usedPercent)} used`
+  return "n/a"
+}
+
+export function formatUsageWindowDetail(window: AccountUsageWindow) {
+  const detail = window.detail?.trim()
+  return detail || undefined
+}
+
+export function usageWindowMeterPercent(window: AccountUsageWindow) {
+  const value =
+    window.remainingPercent !== undefined
+      ? window.remainingPercent
+      : window.usedPercent !== undefined
+        ? 100 - window.usedPercent
+        : 0
+  return Math.max(0, Math.min(100, Math.round(value)))
+}

--- a/packages/app/src/components/settings/panels/UsagePanel.test.ts
+++ b/packages/app/src/components/settings/panels/UsagePanel.test.ts
@@ -1,27 +1,81 @@
 import { describe, expect, test } from "bun:test"
+import {
+  formatUsageResetCompact,
+  formatUsageResetSentence,
+  formatUsageWindowDetail,
+  formatUsageWindowLabel,
+  formatUsageWindowValue,
+  nextUsageReset,
+  usageWindowMeterPercent,
+} from "./UsagePanel.model"
 
-const usagePanel = await Bun.file(new URL("./UsagePanel.tsx", import.meta.url)).text()
-const settingsCss = await Bun.file(new URL("../settings-panel.css", import.meta.url)).text()
-
-describe("Usage panel UI contract", () => {
-  test("keeps refresh inside the content flow instead of the page header", () => {
-    expect(usagePanel).toContain("usage-overview")
-    expect(usagePanel).toContain("usage-page-shell")
-    expect(usagePanel).not.toContain("actions={")
-  })
+describe("Usage panel model", () => {
+  const now = Date.UTC(2026, 6, 3, 12, 0, 0)
 
   test("uses human-facing quota window labels and values", () => {
-    expect(usagePanel).toContain("formatUsageWindowLabel(window.label)")
-    expect(usagePanel).toContain('"5-hour window"')
-    expect(usagePanel).toContain("formatPercent(window.remainingPercent)")
-    expect(usagePanel).toContain("remaining")
-    expect(usagePanel).not.toContain('<div class="usage-window-label">{window.label}</div>')
+    expect(formatUsageWindowLabel("Session")).toBe("5-hour window")
+    expect(formatUsageWindowLabel("Current session")).toBe("5-hour window")
+    expect(formatUsageWindowLabel("Weekly")).toBe("Weekly window")
+    expect(formatUsageWindowLabel("Current week")).toBe("Weekly window")
+    expect(formatUsageWindowValue({ label: "Session", remainingPercent: 94 })).toBe("94% remaining")
+    expect(formatUsageWindowValue({ label: "Session", usedPercent: 54 })).toBe("54% used")
+    expect(usageWindowMeterPercent({ label: "Session", remainingPercent: 94.4 })).toBe(94)
   })
 
-  test("renders compact usage rows with a meter instead of distant label-value pairs", () => {
-    expect(usagePanel).toContain("usage-window-meter")
-    expect(settingsCss).toContain(".ds-content-inner:has(> .usage-page-shell)")
-    expect(settingsCss).toContain("grid-template-columns: minmax(150px, 1fr) minmax(120px, 170px)")
-    expect(settingsCss).toContain(".usage-window-meter span")
+  test("keeps provider details separate from reset timing", () => {
+    const resetAt = new Date(now + 90 * 60 * 1000).toISOString()
+    expect(
+      formatUsageWindowDetail({
+        label: "API key quota",
+        remainingPercent: 24,
+        resetAt,
+        detail: "$12.00 of $50.00 remaining",
+      }),
+    ).toBe("$12.00 of $50.00 remaining")
+  })
+
+  test("formats reset timing as product copy", () => {
+    const resetAt = new Date(now + 90 * 60 * 1000).toISOString()
+    const sentence = formatUsageResetSentence(resetAt, now)
+    const compact = formatUsageResetCompact(resetAt, now)
+
+    expect(sentence?.value).toMatch(/^Resets today at /)
+    expect(sentence?.title).toBe(sentence?.value)
+    expect(compact?.value).toMatch(/^Today at /)
+    expect(compact?.title).toBe(sentence?.value)
+    expect(formatUsageResetSentence(undefined, now)).toBeUndefined()
+    expect(formatUsageResetSentence("not-a-date", now)).toBeUndefined()
+  })
+
+  test("finds the next future reset across connected snapshots", () => {
+    const earliest = new Date(now + 2 * 60 * 60 * 1000).toISOString()
+    const later = new Date(now + 8 * 60 * 60 * 1000).toISOString()
+    const past = new Date(now - 60 * 1000).toISOString()
+
+    const reset = nextUsageReset(
+      [
+        {
+          providerID: "openai-codex",
+          status: "available",
+          fetchedAt: new Date(now).toISOString(),
+          windows: [
+            { label: "Session", remainingPercent: 94, resetAt: later },
+            { label: "Weekly", remainingPercent: 46, resetAt: earliest },
+          ],
+          details: [],
+        },
+        {
+          providerID: "anthropic",
+          status: "available",
+          fetchedAt: new Date(now).toISOString(),
+          windows: [{ label: "Current session", remainingPercent: 80, resetAt: past }],
+          details: [],
+        },
+      ],
+      now,
+    )
+
+    expect(reset?.value).toMatch(/^Today at /)
+    expect(reset?.title).toMatch(/^Resets today at /)
   })
 })

--- a/packages/app/src/components/settings/panels/UsagePanel.tsx
+++ b/packages/app/src/components/settings/panels/UsagePanel.tsx
@@ -1,4 +1,4 @@
-import type { AccountUsageSnapshot, AccountUsageWindow } from "@ericsanchezok/synergy-sdk/client"
+import type { AccountUsageSnapshot } from "@ericsanchezok/synergy-sdk/client"
 import { Button } from "@ericsanchezok/synergy-ui/button"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { ProviderIcon } from "@ericsanchezok/synergy-ui/provider-icon"
@@ -9,6 +9,14 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { compareProviderIDs, providerConnectCopy } from "@/components/provider/provider-recommendation"
 import { SettingsEntityList, SettingsPage, SettingsSection } from "../components/SettingsPrimitives"
+import {
+  formatUsageResetSentence,
+  formatUsageWindowDetail,
+  formatUsageWindowLabel,
+  formatUsageWindowValue,
+  nextUsageReset,
+  usageWindowMeterPercent,
+} from "./UsagePanel.model"
 
 const USAGE_FIRST_PROVIDER_IDS = ["openai-codex", "anthropic", "github-copilot", "openrouter", "openai"]
 
@@ -48,6 +56,7 @@ export function UsagePanel(props: { onConnectProvider: (providerID?: string) => 
     if (times.length === 0) return undefined
     return formatDate(new Date(Math.max(...times)).toISOString())
   })
+  const nextReset = createMemo(() => nextUsageReset(connectedUsage().map((item) => item.snapshot)))
 
   function providerName(providerID: string) {
     return providers().find((provider) => provider.id === providerID)?.name ?? providerID
@@ -66,6 +75,14 @@ export function UsagePanel(props: { onConnectProvider: (providerID?: string) => 
               <span class="usage-overview-value">{unconnected().length}</span>
               <span class="usage-overview-label">Available to connect</span>
             </div>
+            <Show when={nextReset()}>
+              {(reset) => (
+                <div class="usage-overview-metric" title={reset().title}>
+                  <span class="usage-overview-value usage-overview-date">{reset().value}</span>
+                  <span class="usage-overview-label">Next reset</span>
+                </div>
+              )}
+            </Show>
             <Show when={lastFetched()}>
               {(value) => (
                 <div class="usage-overview-metric">
@@ -222,7 +239,16 @@ function UsageProviderPanel(props: {
                   <div class="usage-window-meter" aria-hidden="true">
                     <span style={{ width: `${usageWindowMeterPercent(window)}%` }} />
                   </div>
-                  <div class="usage-window-value">{formatUsageWindowValue(window)}</div>
+                  <div class="usage-window-reading">
+                    <div class="usage-window-value">{formatUsageWindowValue(window)}</div>
+                    <Show when={formatUsageResetSentence(window.resetAt)}>
+                      {(reset) => (
+                        <div class="usage-window-reset" title={reset().title}>
+                          {reset().value}
+                        </div>
+                      )}
+                    </Show>
+                  </div>
                 </div>
               )}
             </For>
@@ -231,14 +257,16 @@ function UsageProviderPanel(props: {
                 <div class="usage-window-row">
                   <div class="usage-window-label">Credits</div>
                   <div class="usage-window-meter usage-window-meter-empty" aria-hidden="true" />
-                  <div class="usage-window-value">
-                    {credits().unlimited
-                      ? "unlimited"
-                      : credits().balance !== undefined
-                        ? `${credits().balance}${credits().currency ? ` ${credits().currency}` : ""}`
-                        : credits().hasCredits === false
-                          ? "none"
-                          : "available"}
+                  <div class="usage-window-reading">
+                    <div class="usage-window-value">
+                      {credits().unlimited
+                        ? "unlimited"
+                        : credits().balance !== undefined
+                          ? `${credits().balance}${credits().currency ? ` ${credits().currency}` : ""}`
+                          : credits().hasCredits === false
+                            ? "none"
+                            : "available"}
+                    </div>
                   </div>
                 </div>
               )}
@@ -249,42 +277,6 @@ function UsageProviderPanel(props: {
       </Show>
     </div>
   )
-}
-
-function formatPercent(value: number | undefined) {
-  if (value === undefined) return "n/a"
-  return `${Math.round(value)}%`
-}
-
-function formatUsageWindowLabel(label: string) {
-  const normalized = label.trim().toLowerCase()
-  if (normalized === "session") return "5-hour window"
-  if (normalized === "weekly") return "Weekly window"
-  if (normalized === "monthly") return "Monthly window"
-  return label
-}
-
-function formatUsageWindowValue(window: AccountUsageWindow) {
-  if (window.remainingPercent !== undefined) return `${formatPercent(window.remainingPercent)} remaining`
-  if (window.usedPercent !== undefined) return `${formatPercent(window.usedPercent)} used`
-  return "n/a"
-}
-
-function formatUsageWindowDetail(window: AccountUsageWindow) {
-  const detail = window.detail?.trim()
-  const renews = window.resetAt ? `Renews ${formatDate(window.resetAt)}` : undefined
-  if (detail && renews) return `${detail} · ${renews}`
-  return detail || renews
-}
-
-function usageWindowMeterPercent(window: AccountUsageWindow) {
-  const value =
-    window.remainingPercent !== undefined
-      ? window.remainingPercent
-      : window.usedPercent !== undefined
-        ? 100 - window.usedPercent
-        : 0
-  return Math.max(0, Math.min(100, Math.round(value)))
 }
 
 function formatDate(value: string) {

--- a/packages/app/src/components/settings/settings-panel.css
+++ b/packages/app/src/components/settings/settings-panel.css
@@ -2499,6 +2499,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 16px;
   padding: 12px 14px;
   border-radius: 12px;
@@ -2510,6 +2511,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 22px;
 }
 
@@ -2580,7 +2582,7 @@
 
 .usage-window-row {
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) minmax(120px, 170px) minmax(92px, auto);
+  grid-template-columns: minmax(150px, 1fr) minmax(120px, 170px) minmax(142px, auto);
   align-items: center;
   gap: 12px;
   margin-top: 8px;
@@ -2618,12 +2620,28 @@
   opacity: 0;
 }
 
-.usage-window-value {
+.usage-window-reading {
+  min-width: 0;
   justify-self: end;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  text-align: right;
+}
+
+.usage-window-value {
   color: var(--text-weak);
   font-size: var(--settings-type-caption-size);
   line-height: var(--settings-type-caption-line-height);
-  text-align: right;
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.usage-window-reset {
+  color: var(--text-weaker);
+  font-size: var(--settings-type-caption-size);
+  line-height: var(--settings-type-caption-line-height);
   white-space: nowrap;
 }
 
@@ -2686,8 +2704,9 @@
     flex-direction: column;
   }
 
-  .usage-window-value {
+  .usage-window-reading {
     justify-self: start;
+    align-items: flex-start;
     text-align: left;
   }
 }


### PR DESCRIPTION
## Summary
- show the next provider usage reset in the Usage overview
- display per-window reset timing inline with quota rows
- move usage formatting into a tested model helper and update the Usage product contract

## Tests
- bun test src/components/settings/panels/UsagePanel.test.ts (from packages/app)
- bun run typecheck
- git diff --check
- pre-push typecheck and Prettier during git push