### PR TITLE
fix: register supervisor agent visibility for synergy BlueprintLoop (#218)

### DIFF
--- a/packages/synergy/src/agent/prompt/supervisor/builder.ts
+++ b/packages/synergy/src/agent/prompt/supervisor/builder.ts
@@ -17,6 +17,6 @@ export function createSupervisorAgent(ctx: BuiltinAgentContext) {
     prompt: buildSupervisorPrompt([]),
     model: "thinking",
     permission: "supervisor",
-    visibleTo: [],
+    visibleTo: ["synergy", "synergy-max", "supervisor"],
   })
 }


### PR DESCRIPTION
## Summary

- `supervisor` agent was registered with `visibleTo: []`, making it invisible in `synergy`'s prompt agent table
- `synergy`'s LLM could not correctly invoke the supervisor during BlueprintLoop audit phases

## Root Cause

The `supervisor` agent is a BlueprintLoop audit agent. When `synergy` runs a BlueprintLoop, `blueprint_loop_finish({ status: "auditing" })` internally calls `Cortex.launch({ agent: "supervisor" })` — this path bypasses `visibleTo` and works correctly for both `synergy` and `synergy-max`.

However, `synergy`'s LLM prompt agent table (built by `getDelegatableAgents()`) filters agents by `visibleTo`. With `visibleTo: []`, `supervisor` was absent from `synergy`'s agent table. When `synergy`'s LLM needed to handle the audit workflow, it could not reference `supervisor` and would fall back to using `inspector` or other agents incorrectly. Additionally, if the LLM ever attempted `task({ subagent_type: "supervisor" })`, the tool's `visibleTo` check would reject it.

`synergy-max` was not affected because its highly structured engineering prompt explicitly follows the `blueprint_loop_finish → Cortex.launch` code path, never attempting to delegate supervisor through the `task` tool or agent table.

## Fix

Added `"synergy"` and `"synergy-max"` to `supervisor`'s `visibleTo` array, plus `"supervisor"` for self-delegation.

## Verification

- All 4 `max-subagents.test.ts` tests pass
- All 61 Blueprint-related tests pass
- Formatter check passes (no changes)