### PR TITLE
Fix plugin marketplace compatibility metadata

### DIFF
--- a/docs/plugin/marketplace.md
+++ b/docs/plugin/marketplace.md
@@ -159,7 +159,7 @@ An official detail entry points to real release artifacts:
 ```
 
 The plugin id, detail filename, `plugin.json.name`, signature `pluginId`, approval id, and registry id must all be the same canonical plugin id.
-Synergy version requirements live only in the packaged `plugin.json` under `engines.synergy`; registry entries do not duplicate that contract.
+Synergy version requirements originate in the packaged `plugin.json` under `engines.synergy`. Marketplace entries record that range as `compatibility.synergy` so remote detail and version views can display and validate the reviewed package contract without downloading the artifact.
 
 Third-party plugins are signed by the plugin author. The registry entry records the author signer public key for each version, CI verifies the release signature with that key, and Synergy clients trust the signer only because it was reviewed through the official registry PR.
 

--- a/docs/plugin/toolchain.md
+++ b/docs/plugin/toolchain.md
@@ -227,7 +227,7 @@ synergy-plugin entry <tarball> \
   --write-entry ../synergy-plugins/plugins/<name>.json
 ```
 
-`entry` does not upload assets or mutate the remote registry. Use `--download-url` and `--signature-url` when the release asset URLs cannot be inferred from `--repo` and `v<version>`. The generated entry includes the Ed25519 signer public key from `<tarball>.sig`; the official registry CI verifies that signer before the plugin is installable from the Official source. Synergy version requirements stay in packaged `plugin.json` as `engines.synergy`.
+`entry` does not upload assets or mutate the remote registry. Use `--download-url` and `--signature-url` when the release asset URLs cannot be inferred from `--repo` and `v<version>`. The generated entry includes the Ed25519 signer public key from `<tarball>.sig` and copies `plugin.json` `engines.synergy` into `compatibility.synergy`; the official registry CI verifies the signer before the plugin is installable from the Official source.
 
 ## local publish
 

--- a/docs/plugins/02-manifest-reference.md
+++ b/docs/plugins/02-manifest-reference.md
@@ -16,7 +16,7 @@
 ```
 
 `name` is the canonical plugin id and must match `PluginDescriptor.id`.
-`engines.synergy` is the only Synergy version contract. Synergy rejects installation when the current runtime does not satisfy the declared range.
+`engines.synergy` is the package's Synergy version contract. Synergy rejects installation when the current runtime does not satisfy the declared range, and official marketplace entries copy the same range into `compatibility.synergy`.
 The plugin kit scaffold uses `PLUGIN_PROTOCOL_MIN_SYNERGY_RANGE` from `@ericsanchezok/synergy-plugin` for this field.
 
 ## Runtime Entry

--- a/packages/plugin-kit/src/lib/market-entry.ts
+++ b/packages/plugin-kit/src/lib/market-entry.ts
@@ -35,6 +35,7 @@ export interface RegistryEntry {
   verified: boolean
   official: boolean
   keywords: string[]
+  compatibility: { synergy: string }
   versions: Array<{
     version: string
     downloadUrl: string
@@ -166,6 +167,12 @@ function iconForManifest(manifest: PluginManifestType, extractedDir: string): Re
   return { type: "registry-svg", path: registryIconPath(manifest.name) }
 }
 
+function compatibilityForManifest(manifest: PluginManifestType): RegistryEntry["compatibility"] {
+  const synergy = manifest.engines?.synergy?.trim()
+  if (!synergy) throw new Error("Marketplace registry entry requires plugin.json engines.synergy")
+  return { synergy }
+}
+
 export function uiSurfaces(manifest: PluginManifestType): string[] {
   const ui = manifest.contributes?.ui
   if (!ui) return []
@@ -254,6 +261,7 @@ export function registryEntry(input: {
     verified: false,
     official: false,
     keywords: [...new Set([...(manifest.keywords ?? []), "synergy-plugin"])].sort(),
+    compatibility: compatibilityForManifest(manifest),
     versions: [
       {
         version: manifest.version,

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -299,7 +299,7 @@ Worker and process plugins are started through Synergy's plugin runner. The runn
 - `dist/permissions.summary.json`
 - `dist/integrity.json`
 
-`synergy-plugin pack` archives `dist/` into `<name>-<version>.synergy-plugin.tgz`. `synergy-plugin sign` writes `<tarball>.sig`. `synergy-plugin publish-market` prepares the official marketplace submission by uploading or checking GitHub Release assets, writing a `SII-Holos/synergy-plugins` entry with the signer public key, regenerating the registry index, running registry validation, and opening a PR when `gh` is available.
+`synergy-plugin pack` archives `dist/` into `<name>-<version>.synergy-plugin.tgz`. `synergy-plugin sign` writes `<tarball>.sig`. `synergy-plugin publish-market` prepares the official marketplace submission by uploading or checking GitHub Release assets, writing a `SII-Holos/synergy-plugins` entry with the signer public key and `compatibility.synergy` from `plugin.json` `engines.synergy`, regenerating the registry index, running registry validation, and opening a PR when `gh` is available.
 
 For local marketplace UX testing, the Synergy runtime still provides `synergy plugin publish <tarball>` to publish into the local development registry.
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -4653,6 +4653,10 @@ export type RegistryPluginSummary = {
   source: "official" | "local"
 }
 
+export type RegistryPluginCompatibility = {
+  synergy: string
+}
+
 export type RegistryPluginSignature = {
   algorithm: "ed25519"
   signer: string
@@ -4707,6 +4711,7 @@ export type RegistryPluginEntry = {
   verified: boolean
   official: boolean
   keywords: Array<string>
+  compatibility?: RegistryPluginCompatibility
   versions: Array<RegistryPluginVersion>
   createdAt: number
   updatedAt: number
@@ -4740,6 +4745,7 @@ export type RegistryPublishInput = {
   verified: boolean
   official: boolean
   keywords: Array<string>
+  compatibility?: RegistryPluginCompatibility
   versions: Array<RegistryPluginVersion>
   risk: "low" | "medium" | "high"
   trustTier: "declarative" | "trusted-import" | "sandbox"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -27901,6 +27901,17 @@
           "source"
         ]
       },
+      "RegistryPluginCompatibility": {
+        "type": "object",
+        "properties": {
+          "synergy": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["synergy"],
+        "additionalProperties": false
+      },
       "RegistryPluginSignature": {
         "type": "object",
         "properties": {
@@ -28070,6 +28081,9 @@
               "type": "string"
             }
           },
+          "compatibility": {
+            "$ref": "#/components/schemas/RegistryPluginCompatibility"
+          },
           "versions": {
             "type": "array",
             "items": {
@@ -28206,6 +28220,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "compatibility": {
+            "$ref": "#/components/schemas/RegistryPluginCompatibility"
           },
           "versions": {
             "type": "array",

--- a/packages/synergy/src/cli/cmd/plugin-publish.ts
+++ b/packages/synergy/src/cli/cmd/plugin-publish.ts
@@ -37,6 +37,7 @@ interface PublishInput {
   verified: boolean
   official: boolean
   keywords: string[]
+  compatibility?: { synergy: string }
   versions: RegistryPluginVersion[]
   risk: "low" | "medium" | "high"
   trustTier: "declarative" | "trusted-import" | "sandbox"
@@ -153,6 +154,7 @@ export const PluginPublishCommand = cmd({
         verified: false,
         official: false,
         keywords: [...new Set([...(manifest.keywords ?? []), "synergy-plugin"])],
+        ...(manifest.engines?.synergy ? { compatibility: { synergy: manifest.engines.synergy } } : {}),
         risk,
         trustTier: policy.trust.tier,
         runtimeMode: policy.runtimeMode,

--- a/packages/synergy/src/plugin/marketplace-registry.ts
+++ b/packages/synergy/src/plugin/marketplace-registry.ts
@@ -35,6 +35,11 @@ export namespace PluginMarketplaceRegistry {
     email: z.string().optional(),
     url: z.string().optional(),
   })
+  const Compatibility = z
+    .object({
+      synergy: z.string().min(1),
+    })
+    .strict()
   const RemotePermission = z.object({
     key: z.string(),
     description: z.string(),
@@ -80,6 +85,7 @@ export namespace PluginMarketplaceRegistry {
       verified: z.boolean(),
       official: z.boolean(),
       keywords: z.array(z.string()),
+      compatibility: Compatibility.optional(),
       versions: z.array(RemoteVersion),
       yankedVersions: z.array(z.string()).optional().default([]),
     })
@@ -143,6 +149,7 @@ export namespace PluginMarketplaceRegistry {
     verified: boolean
     official: boolean
     keywords: string[]
+    compatibility?: { synergy: string }
     versions: NormalizedVersion[]
     createdAt: number
     updatedAt: number
@@ -302,6 +309,7 @@ export namespace PluginMarketplaceRegistry {
       verified: entry.verified,
       official: entry.official,
       keywords: entry.keywords,
+      ...(entry.compatibility ? { compatibility: entry.compatibility } : {}),
       versions,
       createdAt: versions.length ? Math.min(...versions.map((version) => version.publishedAt)) : 0,
       updatedAt: latest?.publishedAt ?? 0,

--- a/packages/synergy/src/server/plugin-registry-routes.ts
+++ b/packages/synergy/src/server/plugin-registry-routes.ts
@@ -30,6 +30,13 @@ const RegistryPermissionSummary = z
   })
   .meta({ ref: "RegistryPermissionSummary" })
 
+const RegistryPluginCompatibility = z
+  .object({
+    synergy: z.string().min(1),
+  })
+  .strict()
+  .meta({ ref: "RegistryPluginCompatibility" })
+
 const PluginSignature = z
   .object({
     algorithm: z.literal("ed25519"),
@@ -89,6 +96,7 @@ const RegistryPluginEntry = z
     verified: z.boolean(),
     official: z.boolean(),
     keywords: z.array(z.string()),
+    compatibility: RegistryPluginCompatibility.optional(),
     versions: z.array(RegistryPluginVersion),
     createdAt: z.number(),
     updatedAt: z.number(),

--- a/packages/synergy/test/plugin/scaffold-toolchain.test.ts
+++ b/packages/synergy/test/plugin/scaffold-toolchain.test.ts
@@ -79,6 +79,9 @@ describe("plugin scaffold toolchain", () => {
           name: "asset-fixture",
           version: "0.1.0",
           description: "Fixture plugin with declared contribution assets",
+          engines: {
+            synergy: PLUGIN_PROTOCOL_MIN_SYNERGY_RANGE,
+          },
           icon: "./icons/market.svg",
           main: "./src/index.ts",
           contributes: {
@@ -233,7 +236,7 @@ export default plugin
       publishedAt: "2026-06-27T00:00:00.000Z",
     })
     expect(entry.icon).toEqual({ type: "registry-svg", path: "icons/asset-fixture.svg" })
-    expect("compatibility" in entry).toBe(false)
+    expect(entry.compatibility).toEqual({ synergy: PLUGIN_PROTOCOL_MIN_SYNERGY_RANGE })
 
     const registryEntryPath = path.join(tmp.path, "registry", "plugins", "asset-fixture.json")
     writeRegistryEntry(registryEntryPath, entry)

--- a/packages/synergy/test/server/plugin-registry-routes.test.ts
+++ b/packages/synergy/test/server/plugin-registry-routes.test.ts
@@ -34,6 +34,7 @@ function buildEntry(overrides: Record<string, any> = {}): Record<string, any> {
     verified: false,
     official: false,
     keywords: ["test", "v2"],
+    compatibility: { synergy: ">=1.0.0" },
     versions: [
       {
         version: "1.0.0",
@@ -130,6 +131,7 @@ async function writeOfficialRegistryCache(registryUrl = PluginMarketplaceRegistr
         verified: true,
         official: true,
         keywords: ["synergy-plugin", "official"],
+        compatibility: { synergy: ">=2.4.3" },
         versions: [
           {
             version: "1.0.0",
@@ -236,11 +238,11 @@ describe("plugin registry routes v2", () => {
     })
   })
 
-  test("publish rejects removed compatibility field", async () => {
+  test("publish preserves compatibility metadata", async () => {
     await using tmp = await tmpdir({ git: true })
     cleanRegistry()
 
-    const entry = buildEntry({ compatibility: { synergy: ">=1.0.0" } })
+    const entry = buildEntry({ compatibility: { synergy: ">=2.4.3" } })
 
     await ScopeContext.provide({
       scope: await tmp.scope(),
@@ -251,7 +253,9 @@ describe("plugin registry routes v2", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(entry),
         })
-        expect(res.status).toBe(400)
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        expect(body.compatibility).toEqual({ synergy: ">=2.4.3" })
       },
     })
   })
@@ -438,6 +442,48 @@ describe("plugin registry routes v2", () => {
       const aggregate = await aggregateRes.json()
       expect(aggregate.total).toBe(2)
       expect(new Set(aggregate.plugins.map((plugin: any) => plugin.source))).toEqual(new Set(["official", "local"]))
+    } finally {
+      await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
+      await Config.reload("global")
+    }
+  })
+
+  test("official detail and versions accept compatibility metadata", async () => {
+    const registryUrl = "https://registry.test/synergy/plugins/registry.json"
+    const previousDomain = await Config.domainGet("plugins")
+    cleanRegistry()
+    await writeOfficialRegistryCache(registryUrl)
+
+    try {
+      await Config.domainUpdate(
+        "plugins",
+        {
+          ...previousDomain,
+          pluginMarketplace: {
+            ...PLUGIN_MARKETPLACE_DEFAULTS,
+            enabled: true,
+            registryUrl,
+          },
+        },
+        { mode: "replace-domain" },
+      )
+      await Config.reload("global")
+
+      await ScopeContext.provide({
+        scope: Scope.home(),
+        fn: async () => {
+          const app = Server.App()
+          const detailRes = await app.request("/api/registry/official-test-plugin?source=official")
+          expect(detailRes.status).toBe(200)
+          const detail = await detailRes.json()
+          expect(detail.compatibility).toEqual({ synergy: ">=2.4.3" })
+
+          const versionsRes = await app.request("/api/registry/official-test-plugin/versions?source=official")
+          expect(versionsRes.status).toBe(200)
+          const versions = await versionsRes.json()
+          expect(versions[0].version).toBe("1.0.0")
+        },
+      })
     } finally {
       await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
       await Config.reload("global")


### PR DESCRIPTION
## Summary
- accept and return registry compatibility metadata in plugin marketplace APIs
- include compatibility.synergy in Plugin Kit and local publish-generated entries
- add regression coverage for official plugin detail/version routes and regenerate SDK types

## Tests
- bun test test/server/plugin-registry-routes.test.ts test/plugin/scaffold-toolchain.test.ts
- bun run typecheck