### PR TITLE
Fix running session input queue ordering

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -870,12 +870,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const agent = currentAgent.name
     const model = { modelID: currentModel.id, providerID: currentModel.provider.id }
     const variant = local.model.variant.current()
-    const messageID = Identifier.ascending("message")
+    const queueing = working()
+    const messageID = queueing ? undefined : Identifier.ascending("message")
     const textPart = { id: Identifier.ascending("part"), type: "text" as const, text }
 
-    const optimistic: Message = { id: messageID, sessionID, role: "user", time: { created: Date.now() }, agent, model }
+    const optimistic: Message | undefined = messageID
+      ? { id: messageID, sessionID, role: "user", time: { created: Date.now() }, agent, model }
+      : undefined
     let optimisticAdded = false
     const addOptimisticMessage = () => {
+      if (!messageID || !optimistic) return
       sync.set(
         produce((draft) => {
           const messages = draft.message[sessionID]
@@ -891,6 +895,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       optimisticAdded = true
     }
     const removeOptimisticMessage = () => {
+      if (!messageID) return
       sync.set(
         produce((draft) => {
           const messages = draft.message[sessionID]
@@ -904,10 +909,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       optimisticAdded = false
     }
 
-    if (!working()) addOptimisticMessage()
+    if (!queueing) addOptimisticMessage()
 
     sdk.client.session
-      .input({ sessionID, agent, model, messageID, parts: [textPart], variant })
+      .input({ sessionID, agent, model, ...(messageID ? { messageID } : {}), parts: [textPart], variant })
       .then((result) => {
         if (result.data?.status === "queued" && optimisticAdded) removeOptimisticMessage()
       })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -610,7 +610,8 @@ export function usePromptSubmit(input: PromptSubmitInput) {
       },
     }))
 
-    const messageID = Identifier.ascending("message")
+    const queueing = input.working()
+    const messageID = queueing ? undefined : Identifier.ascending("message")
     const textPart = {
       id: Identifier.ascending("part"),
       type: "text" as const,
@@ -625,26 +626,31 @@ export function usePromptSubmit(input: PromptSubmitInput) {
       ...sessionAttachmentParts,
     ]
 
-    const optimisticParts = requestParts.map((part) => ({
-      ...part,
-      sessionID: activeSession.id,
-      messageID,
-    })) as unknown as Part[]
+    const optimisticParts = messageID
+      ? (requestParts.map((part) => ({
+          ...part,
+          sessionID: activeSession.id,
+          messageID,
+        })) as unknown as Part[])
+      : []
 
-    const optimisticMessage: Message = {
-      id: messageID,
-      sessionID: activeSession.id,
-      role: "user",
-      time: { created: Date.now() },
-      agent,
-      model,
-      ...(optimisticPlanModeMetadata ? { metadata: optimisticPlanModeMetadata } : {}),
-    }
+    const optimisticMessage: Message | undefined = messageID
+      ? {
+          id: messageID,
+          sessionID: activeSession.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent,
+          model,
+          ...(optimisticPlanModeMetadata ? { metadata: optimisticPlanModeMetadata } : {}),
+        }
+      : undefined
 
     const setSyncStore =
       sessionScopeKey === currentScopeKey ? sync.set : globalSync.ensureScopeState(sessionScopeKey)[1]
 
     const addOptimisticMessage = () => {
+      if (!messageID || !optimisticMessage) return
       setSyncStore(
         produce((draft) => {
           const messages = draft.message[activeSession.id]
@@ -663,6 +669,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
     }
 
     const removeOptimisticMessage = () => {
+      if (!messageID) return
       setSyncStore(
         produce((draft) => {
           const messages = draft.message[activeSession.id]
@@ -677,7 +684,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
 
     clearInput()
     let optimisticAdded = false
-    if (!input.working()) {
+    if (!queueing) {
       addOptimisticMessage()
       optimisticAdded = true
     }
@@ -689,7 +696,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
         sessionID: activeSession.id,
         agent,
         model,
-        messageID,
+        ...(messageID ? { messageID } : {}),
         parts: requestParts,
         variant,
       })

--- a/packages/synergy/src/server/session.ts
+++ b/packages/synergy/src/server/session.ts
@@ -30,12 +30,13 @@ const booleanQuery = z.preprocess((value) => {
 }, z.boolean())
 
 async function submitInput(input: InvokeInput): Promise<SessionInbox.InputResult> {
-  const messageID = input.messageID ?? Identifier.ascending("message")
-  const next = { ...input, messageID }
   if (SessionManager.isRunning(input.sessionID)) {
-    const item = await SessionInbox.enqueueUser(next)
+    const { messageID: _queuedMessageID, ...queuedInput } = input
+    const item = await SessionInbox.enqueueUser(queuedInput)
     return { status: "queued", item }
   }
+  const messageID = input.messageID ?? Identifier.ascending("message")
+  const next = { ...input, messageID }
   SessionInvoke.invoke(next).catch((error) => {
     log.error("failed to execute async input", { sessionID: input.sessionID, error })
   })

--- a/packages/synergy/src/session/inbox.ts
+++ b/packages/synergy/src/session/inbox.ts
@@ -218,7 +218,7 @@ export namespace SessionInbox {
 
   export async function enqueueUser(input: InvokeInput): Promise<Item> {
     const itemID = Identifier.ascending("inbox")
-    const messageID = input.messageID ?? Identifier.ascending("message")
+    const { messageID: _queuedMessageID, ...queuedInput } = input
     const summarized = summarizeParts(input.parts)
     const item: StoredItem = {
       id: itemID,
@@ -234,8 +234,7 @@ export namespace SessionInbox {
       source: { type: "user", label: "You" },
       time: { created: Date.now() },
       orderKey: itemID,
-      messageID,
-      input: { ...input, messageID },
+      input: queuedInput,
     }
     return publicItem(await writeItem(item))
   }

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -174,14 +174,15 @@ export namespace SessionInvoke {
 
     for (const item of items) {
       if (item.input) {
+        const { messageID: _queuedMessageID, ...queuedInput } = item.input
         const noReply = options?.guiding ? true : item.input.noReply
         const created = await createUserMessage({
-          ...item.input,
+          ...queuedInput,
           sessionID,
           noReply,
           metadata: {
             ...(noReply === true ? { guided: item.kind === "guiding" } : {}),
-            ...item.input.metadata,
+            ...queuedInput.metadata,
           },
         })
         userMessages.push(created)
@@ -338,7 +339,7 @@ export namespace SessionInvoke {
         if (!lastUser) {
           break
         }
-        if (lastFinished && lastUser.id < lastFinished.id) {
+        if (SessionProgress.hasTerminalReply({ messages: msgs, userID: lastUser.id })) {
           break
         }
 
@@ -931,14 +932,8 @@ export namespace SessionInvoke {
     }
 
     if (lastReplyRequiredUser) {
-      for (let index = messages.length - 1; index >= 0; index--) {
-        const msg = messages[index]
-        if (msg.info.role !== "assistant") continue
-        const assistant = msg.info as MessageV2.Assistant
-        if (assistant.parentID === lastReplyRequiredUser.id) {
-          return msg
-        }
-      }
+      const reply = SessionProgress.findTerminalReply(messages, lastReplyRequiredUser.id)
+      if (reply) return reply
     }
 
     for (let index = messages.length - 1; index >= 0; index--) {

--- a/packages/synergy/src/session/migration.ts
+++ b/packages/synergy/src/session/migration.ts
@@ -961,6 +961,52 @@ async function repairPendingReplyFlags(progress: (current: number, total: number
   log.info("pendingReply repair complete", { checked: tasks.length, cleared })
 }
 
+async function recomputePendingReplyFlags(progress: (current: number, total: number) => void) {
+  const scopeIDs = await Storage.scan(["sessions"]).catch(() => [])
+  const tasks: Array<{ scopeID: string; sessionID: string; info: Info }> = []
+
+  for (const scopeID of scopeIDs) {
+    const scope = Identifier.asScopeID(scopeID)
+    const sessionIDs = await Storage.scan(StoragePath.sessionsRoot(scope)).catch(() => [])
+    const sessions = await Storage.readMany<Info>(
+      sessionIDs.map((sessionID) => StoragePath.sessionInfo(scope, Identifier.asSessionID(sessionID))),
+    )
+
+    for (const info of sessions) {
+      if (!info || info.time?.archived) continue
+      tasks.push({ scopeID, sessionID: info.id, info })
+    }
+  }
+
+  if (tasks.length === 0) return
+
+  let done = 0
+  let updated = 0
+  for (const { scopeID, sessionID, info } of tasks) {
+    const scope = Identifier.asScopeID(scopeID)
+    const sid = Identifier.asSessionID(sessionID)
+    try {
+      const messages = await MessageV2.filterCompacted(MessageV2.stream({ scopeID, sessionID }))
+      const pendingReply = SessionProgress.pendingReply(messages)
+      const nextPendingReply = pendingReply || undefined
+      if (info.pendingReply !== nextPendingReply) {
+        await Storage.write(StoragePath.sessionInfo(scope, sid), {
+          ...info,
+          pendingReply: nextPendingReply,
+        })
+        updated++
+      }
+    } catch (error) {
+      log.warn("failed to recompute pendingReply flag", { scopeID, sessionID, error: String(error) })
+    }
+
+    done++
+    progress(done, tasks.length)
+  }
+
+  log.info("pendingReply recompute complete", { checked: tasks.length, updated })
+}
+
 async function migrateActiveRevertState(progress: (current: number, total: number) => void) {
   const scopeIDs = await Storage.scan(["sessions"]).catch(() => [])
   const tasks: Array<{ scopeID: string; sessionID: string; info: any }> = []
@@ -1530,6 +1576,13 @@ export const migrations: Migration[] = [
     description: "Normalize legacy route-directory worktree sessions into session workspace metadata",
     async up(progress) {
       await migrateSessionWorktreeWorkspace(progress)
+    },
+  },
+  {
+    id: "20260703-session-parent-pending-reply",
+    description: "Recompute session pendingReply using assistant parent links",
+    async up(progress) {
+      await recomputePendingReplyFlags(progress)
     },
   },
 ]

--- a/packages/synergy/src/session/progress.ts
+++ b/packages/synergy/src/session/progress.ts
@@ -9,9 +9,21 @@ export namespace SessionProgress {
     return !!assistant.finish && !["tool-calls", "unknown"].includes(assistant.finish)
   }
 
+  export function findTerminalReply(messages: MessageV2.WithParts[], userID: string) {
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const msg = messages[index]
+      if (msg.info.role !== "assistant") continue
+      const assistant = msg.info as MessageV2.Assistant
+      if (assistant.parentID === userID && isTerminalAssistant(assistant)) return msg
+    }
+  }
+
+  export function hasTerminalReply(input: { messages: MessageV2.WithParts[]; userID: string }) {
+    return !!findTerminalReply(input.messages, input.userID)
+  }
+
   export function pendingReply(messages: MessageV2.WithParts[]) {
     let lastReplyRequiredUser: MessageV2.User | undefined
-    let lastTerminalAssistant: MessageV2.Assistant | undefined
 
     for (let index = messages.length - 1; index >= 0; index--) {
       const msg = messages[index]
@@ -21,15 +33,9 @@ export namespace SessionProgress {
           lastReplyRequiredUser = user
         }
       }
-      if (!lastTerminalAssistant && msg.info.role === "assistant") {
-        const assistant = msg.info as MessageV2.Assistant
-        if (isTerminalAssistant(assistant)) {
-          lastTerminalAssistant = assistant
-        }
-      }
-      if (lastReplyRequiredUser && lastTerminalAssistant) break
+      if (lastReplyRequiredUser) break
     }
 
-    return !!lastReplyRequiredUser && (!lastTerminalAssistant || lastTerminalAssistant.id < lastReplyRequiredUser.id)
+    return !!lastReplyRequiredUser && !hasTerminalReply({ messages, userID: lastReplyRequiredUser.id })
   }
 }

--- a/packages/synergy/test/session/inbox.test.ts
+++ b/packages/synergy/test/session/inbox.test.ts
@@ -25,6 +25,7 @@ describe("SessionInbox", () => {
 
         expect(item.kind).toBe("queued_user")
         expect(item.deliveryTarget).toBe("after_turn")
+        expect(item.messageID).toBeUndefined()
         expect(item.summary.preview).toContain("please adjust")
         expect(await Session.messages({ sessionID: session.id })).toEqual([])
 
@@ -51,9 +52,11 @@ describe("SessionInbox", () => {
 
         expect(guided.kind).toBe("guiding")
         expect(guided.deliveryTarget).toBe("next_model_call")
+        expect(guided.messageID).toBeUndefined()
         expect(items).toHaveLength(1)
         expect(items[0].id).toBe(queued.id)
         expect(items[0].kind).toBe("guiding")
+        expect(items[0].messageID).toBeUndefined()
 
         SessionManager.unregisterRuntime(session.id)
       },

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test, mock } from "bun:test"
 import { SessionManager } from "../../src/session/manager"
 import { SessionInvoke } from "../../src/session/invoke"
 import { MessageV2 } from "../../src/session/message-v2"
+import { SessionInbox } from "../../src/session/inbox"
+import { SessionProgress } from "../../src/session/progress"
 import { PermissionNext } from "../../src/permission/next"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
@@ -68,6 +70,104 @@ function assistantMessage(id: string, parentID: string, text: string): MessageV2
   }
 }
 
+function installBasicLoopMocks(options?: {
+  onBuildPlan?: (input: any) => void
+  onProcess?: (input: any, assistant: MessageV2.Assistant, callIndex: number) => Promise<void> | void
+}) {
+  const originalGetModel = Provider.getModel
+  const originalGetAgent = Agent.get
+  const originalConfigCurrent = Config.current
+  const originalDefinitions = ToolResolver.definitions
+  const originalResolveWithAvailability = ToolResolver.resolveWithAvailability
+  const originalBuildPlan = PromptBudgeter.buildPlan
+  const originalDecide = PromptBudgeter.decide
+  const originalProcessorCreate = SessionProcessor.create
+  const originalCortexList = Cortex.list
+  const originalCortexGetRunningTasks = Cortex.getRunningTasks
+  const originalEmbeddingGenerate = Embedding.generate
+
+  let callIndex = 0
+
+  ;(Provider.getModel as any) = mock(async () => ({
+    id: "test-model",
+    providerID: "test-provider",
+    name: "Test Model",
+    limit: { context: 100_000, output: 8_192 },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      input: { text: true, image: false, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+    },
+    api: { npm: "@ai-sdk/openai" },
+    options: {},
+  }))
+  ;(Agent.get as any) = mock(async (name: string) => ({
+    name,
+    mode: "primary",
+    permission: PermissionNext.fromConfig({ "*": "allow" }),
+    options: {},
+  }))
+  ;(Config.current as any) = mock(async () => ({
+    ...(await originalConfigCurrent()),
+    compaction: { auto: true, maxHistoryImages: 8 },
+    library: { memory: { enabled: false }, experience: { retrieve: false } },
+  }))
+  ;(ToolResolver.definitions as any) = mock(async () => [])
+  ;(ToolResolver.resolveWithAvailability as any) = mock(async () => ({ tools: {}, activeToolIDs: [] }))
+  ;(PromptBudgeter.buildPlan as any) = mock(async (input: Parameters<typeof PromptBudgeter.buildPlan>[0]) => {
+    options?.onBuildPlan?.(input)
+    return {
+      system: input.system,
+      systemCacheBreakpoint: input.systemCacheBreakpoint,
+      messages: input.messages,
+      toolDefinitions: input.toolDefinitions,
+    }
+  })
+  ;(PromptBudgeter.decide as any) = mock(async () => ({
+    budget: { context: 100_000, usable: 100_000, threshold: 0.85, soft: 85_000 },
+    measure: { system: 10, messages: 10, tools: 0, total: 20 },
+    shouldCompact: false,
+  }))
+  ;(SessionProcessor.create as any) = mock((input: Parameters<typeof SessionProcessor.create>[0]) => ({
+    message: input.assistantMessage,
+    partFromToolCall: () => undefined,
+    trackExecution: () => {},
+    process: mock(async (processInput: any) => {
+      callIndex++
+      await options?.onProcess?.(processInput, input.assistantMessage, callIndex)
+      input.assistantMessage.finish = "stop"
+      input.assistantMessage.time.completed = Date.now()
+      await Session.updateMessage(input.assistantMessage)
+      return "stop" as const
+    }),
+  }))
+  ;(Cortex.list as any) = mock(() => [])
+  ;(Cortex.getRunningTasks as any) = mock(() => [])
+  ;(Embedding.generate as any) = mock(async (input: Parameters<typeof Embedding.generate>[0]) => ({
+    id: input.id,
+    vector: [],
+    model: "test-embedding",
+  }))
+
+  return () => {
+    ;(Provider.getModel as any) = originalGetModel
+    ;(Agent.get as any) = originalGetAgent
+    ;(Config.current as any) = originalConfigCurrent
+    ;(ToolResolver.definitions as any) = originalDefinitions
+    ;(ToolResolver.resolveWithAvailability as any) = originalResolveWithAvailability
+    ;(PromptBudgeter.buildPlan as any) = originalBuildPlan
+    ;(PromptBudgeter.decide as any) = originalDecide
+    ;(SessionProcessor.create as any) = originalProcessorCreate
+    ;(Cortex.list as any) = originalCortexList
+    ;(Cortex.getRunningTasks as any) = originalCortexGetRunningTasks
+    ;(Embedding.generate as any) = originalEmbeddingGenerate
+  }
+}
+
 describe("SessionInvoke.selectResultMessage", () => {
   test("selects the last assistant for the latest reply-required user turn", () => {
     const user = userMessage("msg_user")
@@ -97,6 +197,16 @@ describe("SessionInvoke.selectResultMessage", () => {
     const result = SessionInvoke.selectResultMessage([user, assistant])
 
     expect(result?.info.id).toBe("msg_assistant")
+  })
+})
+
+describe("SessionProgress.pendingReply", () => {
+  test("uses assistant parent links instead of message id ordering", () => {
+    const oldUser = userMessage("msg_user_1")
+    const queuedUser = userMessage("msg_user_2")
+    const unrelatedLaterAssistant = assistantMessage("msg_user_3", "msg_user_1", "old reply")
+
+    expect(SessionProgress.pendingReply([oldUser, queuedUser, unrelatedLaterAssistant])).toBe(true)
   })
 })
 
@@ -227,6 +337,150 @@ describe("SessionInvoke system prompt assembly", () => {
       ;(Cortex.list as any) = originalCortexList
       ;(Cortex.getRunningTasks as any) = originalCortexGetRunningTasks
       ;(Embedding.generate as any) = originalEmbeddingGenerate
+    }
+  })
+})
+
+describe("SessionInvoke inbox boundaries", () => {
+  test("queued user input waits for after-turn and receives a materialization-time message id", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    let activeSessionID = ""
+    let staleMessageID = ""
+    const processedUsers: string[] = []
+    const promptPayloads: string[] = []
+
+    const restore = installBasicLoopMocks({
+      onProcess: async (input, _assistant, callIndex) => {
+        processedUsers.push(input.user.id)
+        promptPayloads.push(JSON.stringify(input.messages))
+        if (callIndex !== 1) return
+        await SessionInbox.enqueueUser({
+          sessionID: activeSessionID,
+          agent: "synergy",
+          model: { providerID: "test-provider", modelID: "test-model" },
+          messageID: staleMessageID,
+          parts: [{ type: "text", text: "queued while running" }],
+        })
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          activeSessionID = session.id
+          const user = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "user",
+            sessionID: session.id,
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: user.id,
+            sessionID: session.id,
+            type: "text",
+            text: "initial prompt",
+          })
+          staleMessageID = Identifier.ascending("message")
+
+          await SessionInvoke.loop.force(session.id)
+
+          const messages = await Session.messages({ sessionID: session.id })
+          const queued = messages.find(
+            (msg): msg is MessageV2.WithParts & { info: MessageV2.User } =>
+              msg.info.role === "user" && MessageV2.extractText(msg.parts).includes("queued while running"),
+          )
+          const firstReply = messages.find(
+            (msg): msg is MessageV2.WithParts & { info: MessageV2.Assistant } =>
+              msg.info.role === "assistant" && (msg.info as MessageV2.Assistant).parentID === user.id,
+          )
+
+          expect(processedUsers).toHaveLength(2)
+          expect(processedUsers[0]).toBe(user.id)
+          expect(queued).toBeDefined()
+          expect(firstReply).toBeDefined()
+          expect(processedUsers[1]).toBe(queued!.info.id)
+          expect(queued!.info.id).not.toBe(staleMessageID)
+          expect(queued!.info.id > firstReply!.info.id).toBe(true)
+          expect(promptPayloads[0]).not.toContain("queued while running")
+          expect(promptPayloads[1]).toContain("queued while running")
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
+  test("guided inbox input steers the next model call without scheduling another turn", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    let activeSessionID = ""
+    const processedUsers: string[] = []
+    const promptPayloads: string[] = []
+
+    const restore = installBasicLoopMocks({
+      onProcess: (input) => {
+        processedUsers.push(input.user.id)
+        promptPayloads.push(JSON.stringify(input.messages))
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          activeSessionID = session.id
+          const user = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "user",
+            sessionID: session.id,
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: user.id,
+            sessionID: session.id,
+            type: "text",
+            text: "initial prompt",
+          })
+          const staleMessageID = Identifier.ascending("message")
+          const queued = await SessionInbox.enqueueUser({
+            sessionID: session.id,
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            messageID: staleMessageID,
+            parts: [{ type: "text", text: "steer sooner" }],
+          })
+          await SessionInbox.guide({ sessionID: session.id, itemID: queued.id })
+
+          await SessionInvoke.loop.force(session.id)
+
+          const messages = await Session.messages({ sessionID: session.id })
+          const guided = messages.find(
+            (msg): msg is MessageV2.WithParts & { info: MessageV2.User } =>
+              msg.info.role === "user" && MessageV2.extractText(msg.parts).includes("steer sooner"),
+          )
+
+          expect(processedUsers).toEqual([user.id])
+          expect(promptPayloads[0]).toContain("steer sooner")
+          expect(guided).toBeDefined()
+          expect(guided!.info.id).not.toBe(staleMessageID)
+          expect(guided!.info.metadata?.noReply).toBe(true)
+          expect(guided!.info.metadata?.guided).toBe(true)
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
     }
   })
 })

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -206,7 +206,34 @@ describe("SessionProgress.pendingReply", () => {
     const queuedUser = userMessage("msg_user_2")
     const unrelatedLaterAssistant = assistantMessage("msg_user_3", "msg_user_1", "old reply")
 
+    // Key scenario: the reverse scan finds msg_user_3 (assistant, parentID=msg_user_1),
+    // then msg_user_2 (user, no reply). Old id < id logic would see
+    // lastTerminalAssistant.id (msg_user_3) > lastReplyRequiredUser.id (msg_user_2)
+    // and incorrectly conclude a reply exists. ParentID check correctly returns true.
     expect(SessionProgress.pendingReply([oldUser, queuedUser, unrelatedLaterAssistant])).toBe(true)
+  })
+
+  test("materialized user with larger messageID than old assistant has no false reply", () => {
+    // After queued input is materialized, its messageID is generated later and
+    // is therefore alphabetically larger than the old assistant's messageID.
+    // Old code using id < id ordering would see oldAssistant.id < queuedUser.id
+    // and incorrectly conclude a reply exists (return false).
+    //
+    // Messages in reverse scan order:
+    //   msg_3 (queuedUser) → lastReplyRequiredUser
+    //   msg_2 (oldAssistant, parentID=msg_1) → lastTerminalAssistant
+    //   msg_1 (oldUser)
+    //
+    // Old logic: lastTerminalAssistant.id (msg_2) < lastReplyRequiredUser.id (msg_3)
+    // → returns false (no pending reply) ← WRONG
+    //
+    // New logic: hasTerminalReply(userID=msg_3) → no assistant with parentID=msg_3
+    // → returns true (has pending reply) ← CORRECT
+    const oldUser = userMessage("msg_1")
+    const oldAssistant = assistantMessage("msg_2", "msg_1", "reply to old user")
+    const queuedUser = userMessage("msg_3")
+
+    expect(SessionProgress.pendingReply([oldUser, oldAssistant, queuedUser])).toBe(true)
   })
 })
 

--- a/packages/synergy/test/session/migration.test.ts
+++ b/packages/synergy/test/session/migration.test.ts
@@ -154,6 +154,46 @@ describe("session migrations", () => {
     })
   })
 
+  test("recomputes pendingReply from assistant parent links and skips archived sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const swallowed = await Session.create({})
+        const swallowedFirstUser = await addUserMessage(swallowed.id)
+        await addTerminalAssistantMessage(swallowed.id, swallowedFirstUser.id)
+        await addUserMessage(swallowed.id)
+        await addTerminalAssistantMessage(swallowed.id, swallowedFirstUser.id)
+
+        const completed = await Session.create({})
+        const completedUser = await addUserMessage(completed.id)
+        await addTerminalAssistantMessage(completed.id, completedUser.id)
+        await Session.update(completed.id, (draft) => {
+          draft.pendingReply = true
+        })
+
+        const archived = await Session.create({})
+        await addUserMessage(archived.id)
+        await Session.update(archived.id, (draft) => {
+          draft.pendingReply = undefined
+          draft.time.archived = Date.now()
+        })
+
+        const migration = migrations.find((entry) => entry.id === "20260703-session-parent-pending-reply")
+        expect(migration).toBeDefined()
+        await migration!.up(() => {})
+
+        const swallowedAfter = await SessionManager.getSession(swallowed.id)
+        const completedAfter = await SessionManager.getSession(completed.id)
+        const archivedAfter = await SessionManager.getSession(archived.id)
+
+        expect(swallowedAfter?.pendingReply).toBe(true)
+        expect(completedAfter?.pendingReply).toBeUndefined()
+        expect(archivedAfter?.pendingReply).toBeUndefined()
+      },
+    })
+  })
+
   test("migrates legacy file parts and artifact-only tool metadata to attachments", async () => {
     await using tmp = await tmpdir({ git: true })
     const tmpScope = await tmp.scope()


### PR DESCRIPTION
## Summary

Fixes the running-session input queue semantics so queued user input and guided user input obey two explicit invariants:

- A normal `queued_user` / `after_turn` input submitted while a session is running stays in the inbox until the current turn completes. It is only materialized into the transcript when the next turn is started.
- The final transcript `messageID` for queued or guided input is generated at materialization time, not at enqueue time and not from a frontend optimistic id.

This also removes the fragile message-id-order based reply detection and replaces it with assistant `parentID` ownership checks.

## Problem

The stuck session showed two related failures in the running input path:

1. A message sent while the agent was already running could enter the active session turn even though the user did not manually guide it with the lightning action. Under the intended model, that input should wait in the inbox until the current turn finishes, then trigger the next turn.
2. Queued/guided inputs could carry a preselected `messageID` from enqueue time or frontend optimistic state. That made transcript order depend on an id allocated before the message actually existed in the transcript.

There was also a third contributing issue: parts of the loop used message id lexical ordering to decide whether the latest user message had already received an assistant reply. That is not a valid ownership signal once messages can be materialized later or have unrelated ids. The durable relationship is `assistant.parentID === user.id`.

## Solution

Backend input queue:

- `/session/:sessionID/input` now checks whether the session is running before allocating or preserving a final message id.
- If the session is running, the route enqueues the raw user input and explicitly drops any request `messageID`.
- If the session is idle, the existing optimistic-id behavior is preserved so immediate-start submissions can still reconcile with the frontend optimistic message.
- `SessionInbox.enqueueUser()` no longer generates or stores a final transcript `messageID`; the inbox item's stable identity is only `item.id`.
- `materializeInboxItems()` is the single place where queued/guided inbox items become transcript messages, and it strips stale/client-supplied ids before calling `createUserMessage()`.

Reply detection:

- Added parent-link helpers in `SessionProgress`:
  - find terminal assistant replies whose `parentID` points to the user message
  - check whether a user message has a terminal assistant reply
- Replaced the old `lastUser.id < lastFinished.id` loop condition with the parent-link helper.
- Updated `pendingReply()` to compute pending state from the latest reply-required user and terminal assistant parent links.
- Kept `selectResultMessage()` aligned with the same parentID semantics.

Frontend submit behavior:

- Normal submit and quick action submit now detect `working()` before creating a final message id.
- While working, the frontend sends only prompt parts and does not create/send a `messageID`.
- Idle/new-session submit still creates an optimistic id so existing immediate-start UI reconciliation is unchanged.
- Inbox UI continues to rely on `item.id`, not `item.messageID`.

Data repair:

- Added a one-time session migration that scans non-archived sessions and recomputes `pendingReply` with the new parentID-based logic.
- This identifies old swallowed queued user messages as still pending when no assistant terminal reply points to them.
- The migration does not rewrite historical message ids, does not auto-call a provider, and does not add runtime fallback behavior.

## Why This Shape

This keeps one clean model instead of preserving conflicting legacy paths:

- Inbox identity and transcript identity are separate. `item.id` identifies queued work; transcript `messageID` is created only when the message is actually inserted into transcript order.
- Queue timing is explicit. Normal running input waits for the current turn to finish; guided input is the separate path that can steer the active turn.
- Reply ownership is explicit. Parent links describe which assistant message answered which user message; id ordering only describes allocation timing and is not reliable for conversation semantics.
- Data repair is isolated in migration. Existing bad session state is fixed once without adding permanent compatibility branches to runtime logic.

## Tests

Added and updated coverage for:

- queued inbox items not writing transcript messages early
- queued/guided inbox items not exposing a final `messageID`
- normal running input waiting until after the current processor call before materialization
- queued materialization creating a new user id after the previous assistant reply
- guided input entering the current model call with `noReply/guided` metadata and without triggering an extra turn
- legacy bad data where user id ordering would incorrectly imply a reply exists
- migration recomputing `pendingReply` for bad, completed, and archived sessions

Verification run:

```bash
cd packages/synergy && bun test test/session/inbox.test.ts test/session/invoke.test.ts test/session/migration.test.ts
bun run typecheck
git diff --check
```

The push hook also ran typecheck and Prettier verification successfully. Turbo emitted a lockfile transitive-closure warning for an optional dependency entry, but all typecheck tasks completed successfully.
