### PR TITLE
Allow subagents to use MCP tools

### DIFF
--- a/packages/synergy/src/agent/builtin-context.ts
+++ b/packages/synergy/src/agent/builtin-context.ts
@@ -89,6 +89,7 @@ function anchoredWriteTools(): PermissionNext.Ruleset {
 function baseToolPermissions(profile: SubagentPermissionProfile): PermissionNext.Ruleset {
   const common = PermissionNext.fromConfig({
     "*": "deny",
+    "mcp__*": "allow",
     question: "deny",
     dagwrite: "deny",
     dagread: "deny",

--- a/packages/synergy/test/agent/agent.test.ts
+++ b/packages/synergy/test/agent/agent.test.ts
@@ -46,6 +46,7 @@ test("developer agent has correct default properties", async () => {
       expect(developer?.native).toBe(true)
       expect(evalPerm(developer, "edit")).toBe("ask")
       expect(evalPerm(developer, "bash")).toBe("allow")
+      expect(evalPerm(developer, "mcp__any_server__any_tool")).toBe("allow")
     },
   })
 })

--- a/packages/synergy/test/agent/max-subagents.test.ts
+++ b/packages/synergy/test/agent/max-subagents.test.ts
@@ -35,6 +35,7 @@ describe("synergy-max subagents", () => {
         expect(action(agent, permission)).toBe("allow")
       }
       expect(action(agent, "arxiv_download")).toBe("ask")
+      expect(action(agent, "mcp__any_server__any_tool")).toBe("allow")
     }
   })
 


### PR DESCRIPTION
## Summary
- Allow built-in subagents to see dynamic MCP tools by default via the shared `mcp__*` permission rule.
- Cover both classic and synergy-max subagent paths so future MCP servers do not need per-tool permission wiring.

## Why
MCP tools are registered dynamically as `mcp__<server>__<tool>`. Built-in subagents start from `* deny`, so newly configured MCP servers were available to the primary agent but hidden from subagents unless each server/tool was explicitly allowlisted. This makes MCP configuration brittle as more MCP servers are added.

The new shared rule keeps unknown non-MCP tools denied while allowing MCP tool IDs through the existing permission mechanism. More specific user or project permission overrides can still deny individual MCP servers or tools later.

## Tests
- `cd packages/synergy && bun test test/agent/max-subagents.test.ts test/agent/agent.test.ts`
- pre-push hook: `bun turbo typecheck`
- pre-push hook: formatting check