### PR TITLE
Refine question prompt decision surface

### DIFF
--- a/packages/app/src/components/session/question-prompt.css
+++ b/packages/app/src/components/session/question-prompt.css
@@ -17,7 +17,7 @@
   color: var(--text-base);
   background: var(--question-shell-bg);
   border: 1px solid var(--question-border);
-  border-radius: 22px;
+  border-radius: var(--radius-2xl);
   box-shadow: none;
 }
 
@@ -78,26 +78,26 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
   padding: 16px;
 }
 
 .question-prompt-header {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
-  gap: 10px;
+  gap: 12px;
 }
 
 .question-prompt-collapse-button {
-  width: 30px;
-  height: 30px;
+  width: 24px;
+  height: 24px;
   display: grid;
   place-items: center;
   color: var(--text-muted);
   background: transparent;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -124,7 +124,7 @@
   line-height: 1.35;
 }
 
-.question-prompt-header-meta {
+.question-prompt-header-actions {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -133,10 +133,19 @@
   font-variant-numeric: tabular-nums;
 }
 
-.question-prompt-header-meta [data-component="countdown"] {
+.question-prompt-step-count,
+.question-prompt-header-actions [data-component="countdown"] {
   padding: 3px 8px;
   background: var(--question-control-bg);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
+}
+
+.question-prompt-skip {
+  height: 24px;
+  min-width: auto;
+  padding-inline: 8px;
+  color: var(--text-muted);
+  border-radius: var(--radius-md);
 }
 
 .question-prompt-steps {
@@ -180,7 +189,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 13px;
+  gap: 12px;
   overflow: auto;
   padding-right: 2px;
 }
@@ -191,6 +200,10 @@
   font-size: 14px;
   font-weight: 600;
   line-height: 1.6;
+}
+
+.question-prompt-question strong {
+  font-weight: 700;
 }
 
 .question-prompt-question > * {
@@ -214,8 +227,12 @@
   color: var(--text-base);
   background: var(--question-content-bg);
   border: 1px solid transparent;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
+  transition:
+    background-color 150ms ease-out,
+    border-color 150ms ease-out,
+    color 150ms ease-out;
 }
 
 .question-prompt-option:hover {
@@ -236,7 +253,7 @@
   margin-top: 1px;
   color: var(--text-muted);
   background: var(--question-control-bg);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
 }
 
 .question-prompt-option.is-picked .question-prompt-option-mark {
@@ -246,9 +263,13 @@
 
 .question-prompt-option-copy {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .question-prompt-option-label {
+  display: block;
   color: var(--text-strong);
   font-size: 14px;
   font-weight: 650;
@@ -256,7 +277,7 @@
 }
 
 .question-prompt-option-description {
-  margin-top: 3px;
+  display: block;
   color: var(--text-muted);
   font-size: 13px;
   font-weight: 500;
@@ -264,17 +285,15 @@
 }
 
 .question-prompt-other-trigger {
-  width: fit-content;
-  padding: 4px 0;
-  color: var(--text-muted);
-  background: transparent;
-  border: 0;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
+  color: var(--text-base);
 }
 
-.question-prompt-other-trigger:hover {
+.question-prompt-other-trigger:hover,
+.question-prompt-other-trigger:focus-visible {
+  color: var(--text-strong);
+}
+
+.question-prompt-other-mark {
   color: var(--text-strong);
 }
 
@@ -284,10 +303,15 @@
   gap: 8px;
   padding: 10px;
   background: var(--question-content-bg);
-  border-radius: 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-xl);
 }
 
 .question-prompt-other-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   color: var(--text-muted);
   font-size: 12px;
   font-weight: 600;
@@ -339,7 +363,7 @@
   color: var(--text-base);
   background: var(--question-content-bg);
   border: 0;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
 }
 
@@ -376,14 +400,10 @@
 .question-prompt-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
   padding-top: 12px;
   border-top: 1px solid var(--question-border-soft);
-}
-
-.question-prompt-dismiss {
-  flex: none;
 }
 
 .question-prompt-footer-actions {
@@ -395,7 +415,7 @@
 .question-prompt-footer [data-component="button"] {
   min-width: 78px;
   height: 34px;
-  border-radius: 999px;
+  border-radius: var(--radius-md);
 }
 
 @media (max-width: 680px) {
@@ -404,11 +424,12 @@
   }
 
   .question-prompt-header {
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .question-prompt-header-meta {
-    grid-column: 2;
+  .question-prompt-header-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .question-prompt-other-row,

--- a/packages/app/src/components/session/question-prompt.tsx
+++ b/packages/app/src/components/session/question-prompt.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { TextField } from "@ericsanchezok/synergy-ui/text-field"
 import { Markdown } from "@ericsanchezok/synergy-ui/markdown"
 import { Countdown } from "@ericsanchezok/synergy-ui/countdown"
+import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { useSDK } from "@/context/sdk"
 import "./question-prompt.css"
 
@@ -124,11 +125,11 @@ export function QuestionPrompt(props: QuestionPromptProps) {
   }
 
   return (
-    <section class="question-prompt-shell">
+    <section class="question-prompt-shell" aria-label="Question awaiting your input">
       <Show when={collapsed()}>
         <button type="button" class="question-prompt-collapsed" onClick={() => setCollapsed(false)}>
           <span class="question-prompt-collapsed-main">
-            <Icon name="chevron-right" size="small" class="question-prompt-muted-icon" />
+            <Icon name={getSemanticIcon("navigation.expand")} size="small" class="question-prompt-muted-icon" />
             <span class="question-prompt-collapsed-title">{currentStepLabel()}</span>
           </span>
           <span class="question-prompt-collapsed-meta">
@@ -143,27 +144,30 @@ export function QuestionPrompt(props: QuestionPromptProps) {
       <Show when={!collapsed()}>
         <div class="question-prompt-expanded">
           <header class="question-prompt-header">
-            <button
-              type="button"
-              class="question-prompt-collapse-button"
-              onClick={() => setCollapsed(true)}
-              title="Collapse"
-            >
-              <Icon name="chevron-down" size="small" />
-            </button>
             <div class="question-prompt-heading">
               <div class="question-prompt-kicker">Needs your input</div>
               <div class="question-prompt-title">{currentStepLabel()}</div>
             </div>
-            <div class="question-prompt-header-meta">
+            <div class="question-prompt-header-actions">
               <Show when={!single()}>
-                <span>
+                <span class="question-prompt-step-count">
                   {Math.min(store.tab + 1, questions().length)} / {questions().length}
                 </span>
               </Show>
               <Show when={countdownSeconds() != null}>
                 <Countdown seconds={countdownSeconds()!} active={true} />
               </Show>
+              <Button variant="ghost" size="small" onClick={reject} class="question-prompt-skip" title="Skip question">
+                Skip
+              </Button>
+              <button
+                type="button"
+                class="question-prompt-collapse-button"
+                onClick={() => setCollapsed(true)}
+                title="Collapse"
+              >
+                <Icon name={getSemanticIcon("navigation.collapse")} size="small" />
+              </button>
             </div>
           </header>
 
@@ -185,7 +189,7 @@ export function QuestionPrompt(props: QuestionPromptProps) {
                     >
                       <span>{q.header}</span>
                       <Show when={isAnswered()}>
-                        <Icon name="check" size="small" />
+                        <Icon name={getSemanticIcon("state.success")} size="small" />
                       </Show>
                     </button>
                   )
@@ -226,7 +230,7 @@ export function QuestionPrompt(props: QuestionPromptProps) {
                       >
                         <span class="question-prompt-option-mark">
                           <Show when={picked()}>
-                            <Icon name="check" size="small" />
+                            <Icon name={getSemanticIcon("state.success")} size="small" />
                           </Show>
                         </span>
                         <span class="question-prompt-option-copy">
@@ -243,10 +247,16 @@ export function QuestionPrompt(props: QuestionPromptProps) {
                   fallback={
                     <button
                       type="button"
-                      class="question-prompt-other-trigger"
+                      class="question-prompt-option question-prompt-other-trigger"
                       onClick={() => setStore("otherOpen", true)}
                     >
-                      Other answer...
+                      <span class="question-prompt-option-mark question-prompt-other-mark">
+                        <Icon name={getSemanticIcon("action.add")} size="small" />
+                      </span>
+                      <span class="question-prompt-option-copy">
+                        <span class="question-prompt-option-label">Other answer</span>
+                        <span class="question-prompt-option-description">Type a different answer</span>
+                      </span>
                     </button>
                   }
                 >
@@ -254,7 +264,7 @@ export function QuestionPrompt(props: QuestionPromptProps) {
                     <div class="question-prompt-other-label">
                       <span>Other answer</span>
                       <Show when={customPicked()}>
-                        <Icon name="check" size="small" />
+                        <Icon name={getSemanticIcon("state.success")} size="small" />
                       </Show>
                     </div>
                     <div class="question-prompt-other-row">
@@ -318,11 +328,8 @@ export function QuestionPrompt(props: QuestionPromptProps) {
             </Show>
           </div>
 
-          <footer class="question-prompt-footer">
-            <Button variant="ghost" size="large" onClick={reject} class="question-prompt-dismiss">
-              Dismiss
-            </Button>
-            <Show when={!single()}>
+          <Show when={!single()}>
+            <footer class="question-prompt-footer">
               <div class="question-prompt-footer-actions">
                 <Show when={store.tab > 0}>
                   <Button variant="ghost" size="large" onClick={() => goToTab(store.tab - 1)}>
@@ -345,8 +352,8 @@ export function QuestionPrompt(props: QuestionPromptProps) {
                   </Button>
                 </Show>
               </div>
-            </Show>
-          </footer>
+            </footer>
+          </Show>
         </div>
       </Show>
     </section>

--- a/packages/app/src/workbench-surface.test.ts
+++ b/packages/app/src/workbench-surface.test.ts
@@ -198,17 +198,22 @@ describe("workbench surface polarity", () => {
   })
 
   test("question prompts use a dedicated decision surface instead of a generic tool card", () => {
-    expect(questionPrompt).toContain('<section class="question-prompt-shell">')
+    expect(questionPrompt).toContain('<section class="question-prompt-shell"')
     expect(questionPrompt).toContain("question-prompt-option")
+    expect(questionPrompt).toContain('class="question-prompt-option question-prompt-other-trigger"')
+    expect(questionPrompt).toContain("question-prompt-skip")
     expect(questionPrompt).toContain("disabled={!currentAnswered()}")
     expect(questionPrompt).toContain("disabled={!allAnswered()}")
+    expect(questionPrompt).not.toContain("Dismiss")
     expect(questionPrompt).not.toContain('Card variant="info"')
     expect(questionPrompt).not.toContain("workbench-card-surface workbench-card-surface-hover")
 
     expect(questionPromptCss).toContain("--question-shell-bg")
     expect(questionPromptCss).toContain("--question-content-bg")
     expect(questionPromptCss).toContain("--question-selected-bg")
+    expect(questionPromptCss).toContain("border-radius: var(--radius-2xl);")
     expect(questionPromptCss).toContain(".question-prompt-option.is-picked")
+    expect(questionPromptCss).toContain(".question-prompt-option-copy")
     expect(questionPromptCss).toContain(".question-prompt-footer")
   })
 


### PR DESCRIPTION
## Summary
- Move the question skip action into the header so single-question prompts no longer show a confusing full-width Dismiss row
- Make the custom answer affordance render as a filled option row with existing workbench tokens
- Tighten question prompt styling around existing radius, surface, semantic icon, and option text patterns

## Testing
- bun test src/workbench-surface.test.ts (from packages/app)
- bun run --cwd packages/app typecheck
- node /Users/eric/.codex/skills/impeccable/scripts/detect.mjs --json packages/app/src/components/session/question-prompt.tsx
- pre-push hook: bun turbo typecheck; Prettier check