### PR TITLE
Fix managed desktop dev parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ bun dev server                # server only, fixed development port
 bun dev app --open            # Vite web app against an existing server
 bun dev web                   # server + Vite web app
 bun dev desktop               # server + Vite web app + Electron desktop shell
-bun dev desktop --managed     # Electron desktop shell with managed server mode
+bun dev desktop --managed     # rebuild Web app dist + Electron desktop shell with managed server mode
 ```
 
 One-off CLI execution from source:
@@ -117,7 +117,7 @@ bun dev build app
 bun dev build desktop
 ```
 
-`packages/desktop` production builds use `electron-builder`, app id `io.holosai.synergy`, protocol `synergy://`, and managed server mode by default. Daily desktop development should use `bun dev desktop`, which defaults to external mode against the Vite app and local server.
+`packages/desktop` production builds use `electron-builder`, app id `io.holosai.synergy`, protocol `synergy://`, and managed server mode by default. Daily desktop development should use `bun dev desktop`, which defaults to external mode against the Vite app and local server. Use `bun dev desktop --managed` when validating the production-style managed server path; it rebuilds the Web app dist before launching Electron so stale frontend assets do not mix with current desktop/server code.
 
 ### Type checking and formatting
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ bun dev server            # server only, fixed development port
 bun dev app --open        # Vite web app against an existing server
 bun dev web               # server + Vite web app
 bun dev desktop           # server + Vite web app + Electron desktop shell
+bun dev desktop --managed # rebuild Web app dist + Electron managed server mode
 ```
 
 After editing code:
@@ -632,6 +633,12 @@ Run the desktop shell in the default external development mode:
 
 ```bash
 bun dev desktop
+```
+
+Validate the production-style managed server path with a fresh Web app dist:
+
+```bash
+bun dev desktop --managed
 ```
 
 Build, test, and package the desktop app:

--- a/packages/app/src/app-build-css-contract.test.ts
+++ b/packages/app/src/app-build-css-contract.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const appDir = fileURLToPath(new URL("..", import.meta.url))
+
+type CssRuleContract = {
+  selector: string
+  declarations: string[]
+}
+
+const rootRuleContracts: CssRuleContract[] = [
+  {
+    selector: "[data-component=markdown]",
+    declarations: [
+      "width:100%",
+      "min-width:0",
+      "max-width:100%",
+      "overflow-wrap:break-word",
+      "color:var(--text-base)",
+      "font-family:var(--font-family-sans)",
+      "font-size:var(--font-size-base)",
+      "line-height:1.68",
+    ],
+  },
+  {
+    selector: "[data-component=button]",
+    declarations: [
+      "display:inline-flex",
+      "align-items:center",
+      "justify-content:center",
+      "border-style:solid",
+      "border-width:1px",
+      "border-radius:var(--radius-md)",
+      "text-decoration:none",
+      "user-select:none",
+    ],
+  },
+  {
+    selector: "[data-component=icon]",
+    declarations: [
+      "display:inline-flex",
+      "align-items:center",
+      "justify-content:center",
+      "flex-shrink:0",
+      "aspect-ratio:1",
+      "color:var(--icon-base)",
+    ],
+  },
+  {
+    selector: "[data-component=countdown]",
+    declarations: [
+      "font-family:var(--font-family-sans)",
+      "font-size:var(--font-size-small)",
+      "font-variant-numeric:tabular-nums",
+      "font-weight:var(--font-weight-medium)",
+      "line-height:var(--line-height-large)",
+      "color:var(--text-weak)",
+      "flex-shrink:0",
+    ],
+  },
+  {
+    selector: "[data-component=file-icon]",
+    declarations: ["flex-shrink:0", "width:16px", "height:16px"],
+  },
+  {
+    selector: "[data-component=popover-content]",
+    declarations: [
+      "z-index:50",
+      "min-width:200px",
+      "max-width:320px",
+      "border-radius:var(--radius-xl)",
+      "background-color:var(--workbench-popover-bg",
+      "transform-origin:var(--kb-popover-content-transform-origin)",
+    ],
+  },
+  {
+    selector: "[data-component=session-turn]",
+    declarations: [
+      "height:100%",
+      "min-height:0",
+      "min-width:0",
+      "display:flex",
+      "align-items:flex-start",
+      "justify-content:flex-start",
+    ],
+  },
+  {
+    selector: "[data-component=dialog]",
+    declarations: [
+      "position:fixed",
+      "inset:0",
+      "margin-left:var(--dialog-left-margin)",
+      "z-index:50",
+      "display:flex",
+      "align-items:center",
+      "justify-content:center",
+    ],
+  },
+]
+
+function collectRootRuleBodies(css: string, selector: string): string[] {
+  const bodies: string[] = []
+  let searchIndex = 0
+
+  while (searchIndex < css.length) {
+    const selectorIndex = css.indexOf(selector, searchIndex)
+    if (selectorIndex === -1) break
+    searchIndex = selectorIndex + selector.length
+
+    const blockStart = css.indexOf("{", selectorIndex)
+    if (blockStart === -1) break
+    const ruleStart = Math.max(css.lastIndexOf("}", selectorIndex), css.lastIndexOf("{", selectorIndex)) + 1
+    const prelude = css.slice(ruleStart, blockStart).trim()
+    const selectors = prelude.split(",").map((item) => item.trim())
+    if (!selectors.includes(selector)) continue
+
+    let depth = 0
+    for (let index = blockStart; index < css.length; index++) {
+      const char = css[index]
+      if (char === "{") {
+        depth++
+        continue
+      }
+      if (char !== "}") continue
+      depth--
+      if (depth === 0) {
+        bodies.push(css.slice(blockStart + 1, index))
+        searchIndex = index + 1
+        break
+      }
+    }
+  }
+
+  return bodies
+}
+
+function expectRootRule(css: string, contract: CssRuleContract) {
+  const bodies = collectRootRuleBodies(css, contract.selector)
+  expect(bodies.length, `Missing root CSS rule for ${contract.selector}`).toBeGreaterThan(0)
+
+  const combinedBody = bodies.join(";")
+  if (contract.declarations.every((declaration) => combinedBody.includes(declaration))) return
+
+  throw new Error(
+    `Missing declarations for ${contract.selector} in built CSS:\n` +
+      contract.declarations.map((declaration) => `  ${declaration}`).join("\n") +
+      `\nFound root bodies:\n` +
+      bodies.map((body) => `  ${body.slice(0, 240)}`).join("\n"),
+  )
+}
+
+async function readBuiltCss(outDir: string) {
+  const assetsDir = path.join(outDir, "assets")
+  const assets = await readdir(assetsDir)
+  const cssFiles = assets.filter((file) => file.endsWith(".css"))
+  expect(cssFiles.length).toBeGreaterThan(0)
+
+  const chunks = await Promise.all(cssFiles.map((file) => readFile(path.join(assetsDir, file), "utf8")))
+  return chunks.join("\n")
+}
+
+async function runAppBuild(outDir: string) {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, "run", "build", "--outDir", outDir, "--emptyOutDir"],
+    cwd: appDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1" },
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode === 0) return
+
+  throw new Error(`App build failed with exit code ${exitCode}\n${stdout}\n${stderr}`)
+}
+
+describe("app production CSS contract", () => {
+  test("preserves core component root declarations in the production build", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "synergy-app-dist-"))
+    try {
+      await runAppBuild(outDir)
+      const css = await readBuiltCss(outDir)
+
+      for (const contract of rootRuleContracts) {
+        expectRootRule(css, contract)
+      }
+    } finally {
+      await rm(outDir, { recursive: true, force: true })
+    }
+  }, 60_000)
+})

--- a/packages/synergy/test/script/dev.test.ts
+++ b/packages/synergy/test/script/dev.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import { createDevPlan } from "../../../../script/dev"
 
 const options = { repoRoot: "/repo", cwd: "/workspace", bunPath: "/bun" }
@@ -44,7 +47,7 @@ describe("dev orchestrator planner", () => {
     })
   })
 
-  test("plans managed desktop with build when app/dist is missing", () => {
+  test("plans managed desktop with install and app build when dependencies are missing", () => {
     const plan = createDevPlan(["desktop", "--managed"], options)
 
     expect(plan.kind).toBe("run")
@@ -55,6 +58,30 @@ describe("dev orchestrator planner", () => {
       SYNERGY_DESKTOP_SERVER_MODE: "managed",
     })
     expect(plan.processes[2]?.env).not.toHaveProperty("SYNERGY_DESKTOP_APP_URL")
+  })
+
+  test("plans managed desktop with app build even when app/dist already exists", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "synergy-dev-plan-"))
+    try {
+      await mkdir(path.join(repoRoot, "node_modules"), { recursive: true })
+      await mkdir(path.join(repoRoot, "packages", "app", "dist"), { recursive: true })
+      await writeFile(path.join(repoRoot, "packages", "app", "dist", "index.html"), "<!doctype html>")
+
+      const plan = createDevPlan(["desktop", "--managed"], { ...options, repoRoot })
+
+      expect(plan.kind).toBe("run")
+      expect(plan.mode).toBe("serial")
+      expect(plan.processes.map((process) => process.label)).toEqual(["build", "desktop"])
+      expect(plan.processes[0]?.command).toEqual(["/bun", "run", "build"])
+      expect(plan.processes[0]?.cwd).toBe(path.join(repoRoot, "packages", "app"))
+      expect(plan.processes[1]?.env).toMatchObject({
+        SYNERGY_DESKTOP_CHANNEL: "dev",
+        SYNERGY_DESKTOP_SERVER_MODE: "managed",
+      })
+      expect(plan.processes[1]?.env).not.toHaveProperty("SYNERGY_DESKTOP_APP_URL")
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true })
+    }
   })
 
   test("requires an explicit build target", () => {

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -7,376 +7,372 @@
   font-family: var(--font-family-sans);
   font-size: var(--font-size-base);
   line-height: 1.68;
+}
 
-  > *:first-child {
-    margin-top: 0;
+[data-component="markdown"] > *:first-child {
+  margin-top: 0;
+}
+
+[data-component="markdown"] > *:last-child {
+  margin-bottom: 0;
+}
+
+[data-component="markdown"] h1,
+[data-component="markdown"] h2,
+[data-component="markdown"] h3,
+[data-component="markdown"] h4,
+[data-component="markdown"] h5,
+[data-component="markdown"] h6 {
+  color: var(--markdown-heading);
+  font-weight: var(--font-weight-medium);
+  margin-top: 1.125rem;
+  margin-bottom: 0.5rem;
+  padding-left: 12px;
+  border-left: 3px solid var(--markdown-heading);
+  line-height: var(--line-height-large);
+}
+
+[data-component="markdown"] h1 {
+  font-size: 1.25em;
+}
+
+[data-component="markdown"] h2 {
+  font-size: 1.125em;
+}
+
+[data-component="markdown"] h3,
+[data-component="markdown"] h4,
+[data-component="markdown"] h5,
+[data-component="markdown"] h6 {
+  font-size: 1em;
+}
+
+[data-component="markdown"] strong,
+[data-component="markdown"] b {
+  color: var(--text-strong);
+  font-weight: var(--font-weight-medium);
+}
+
+[data-component="markdown"] p {
+  margin-bottom: 1rem;
+}
+
+[data-component="markdown"] a {
+  color: var(--text-interactive-base);
+  text-decoration: none;
+  font-weight: inherit;
+  text-underline-offset: 2px;
+}
+
+[data-component="markdown"] a:hover {
+  text-decoration: underline;
+}
+
+[data-component="markdown"] ul,
+[data-component="markdown"] ol {
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+[data-component="markdown"] ul {
+  list-style-type: disc;
+}
+
+[data-component="markdown"] ol {
+  list-style-type: decimal;
+}
+
+[data-component="markdown"] li {
+  margin-bottom: 0.5rem;
+}
+
+[data-component="markdown"] li > p {
+  display: inline;
+}
+
+[data-component="markdown"] li > p + p {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+[data-component="markdown"] li::marker {
+  color: var(--text-weak);
+}
+
+[data-component="markdown"] li > ul,
+[data-component="markdown"] li > ol {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+[data-component="markdown"] blockquote {
+  margin: 1rem 0;
+  padding: 0.5rem 0.75rem 0.5rem 0.875rem;
+  border-left: 3px solid var(--markdown-block-quote);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--text-weak);
+  background-color: var(--workbench-control-bg, var(--surface-inset-base));
+}
+
+[data-component="markdown"] blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+[data-component="markdown"] hr {
+  display: block;
+  margin: 1.25rem 0;
+  border: 0;
+  border-top: 1px solid var(--border-weaker-base);
+}
+
+[data-component="markdown"] [data-slot="markdown-code-block"] {
+  box-sizing: border-box;
+  width: 100%;
+  margin: 1rem 0;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border-weaker-base) 78%, transparent);
+  border-radius: var(--radius-lg);
+  background-color: var(--workbench-control-bg, var(--surface-inset-base));
+}
+
+[data-component="markdown"] [data-slot="markdown-code-header"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.3125rem 0.5rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-weaker-base) 54%, transparent);
+  background-color: transparent;
+}
+
+[data-component="markdown"] [data-slot="markdown-code-header"][data-has-label="false"] {
+  justify-content: flex-end;
+}
+
+[data-component="markdown"] [data-slot="markdown-code-language"] {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-weaker);
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.01em;
+}
+
+[data-component="markdown"] [data-slot="markdown-code-copy"] {
+  appearance: none;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-weak);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0.1875rem 0.375rem;
+  font: inherit;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    color var(--motion-duration-fast) var(--motion-ease-standard),
+    box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+[data-component="markdown"] [data-slot="markdown-code-copy"]:hover {
+  background-color: color-mix(in srgb, var(--surface-focus) 64%, transparent);
+  color: var(--text-base);
+}
+
+[data-component="markdown"] [data-slot="markdown-code-copy"]:focus-visible {
+  outline: none;
+  background-color: color-mix(in srgb, var(--surface-focus) 72%, transparent);
+  color: var(--text-strong);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-weaker-focus) 34%, transparent);
+}
+
+[data-component="markdown"] [data-slot="markdown-code-copy"][data-copy-state="copied"] {
+  background-color: var(--workbench-selected-bg, var(--surface-interactive-selected));
+  color: var(--text-strong);
+}
+
+[data-component="markdown"] [data-slot="markdown-code-copy"][data-copy-state="failed"] {
+  background-color: color-mix(in srgb, var(--surface-critical-base) 32%, transparent);
+  color: var(--text-on-critical-base);
+}
+
+[data-component="markdown"] .shiki {
+  margin: 0;
+  padding: 0.75rem 0.875rem;
+  background-color: transparent !important;
+  color: inherit;
+  font-size: var(--font-size-small);
+  border: 0;
+  border-radius: 0;
+}
+
+[data-component="markdown"] pre {
+  box-sizing: border-box;
+  width: 100%;
+  margin: 1rem 0;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: clip;
+  overflow-y: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+[data-component="markdown"] [data-slot="markdown-code-block"] pre {
+  margin: 0;
+}
+
+[data-component="markdown"] pre code {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+  font-family: var(--font-family-mono);
+  font-feature-settings: var(--font-family-mono--font-feature-settings);
+}
+
+[data-component="markdown"] pre code span {
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+}
+
+[data-component="markdown"] :not(pre) > code {
+  display: inline;
+  border: 1px solid color-mix(in srgb, var(--border-weaker-base) 58%, transparent);
+  border-radius: calc(var(--radius-sm) - 1px);
+  background-color: color-mix(in srgb, var(--surface-inset-base) 88%, transparent);
+  padding: 0.0625rem 0.3125rem;
+  font-family: var(--font-family-mono);
+  font-feature-settings: var(--font-family-mono--font-feature-settings);
+  color: color-mix(in srgb, var(--text-strong) 92%, var(--text-base));
+  font-size: 0.9em;
+  font-weight: var(--font-weight-medium);
+  overflow-wrap: anywhere;
+}
+
+[data-component="markdown"] [data-slot="markdown-table-scroll"] {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  margin: 1rem 0;
+  overflow-x: clip;
+  overflow-y: hidden;
+}
+
+[data-component="markdown"] [data-slot="markdown-table-scroll"] > table {
+  margin: 0;
+}
+
+[data-component="markdown"] table {
+  width: 100%;
+  min-width: 0;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: var(--font-size-base);
+  border: 1px solid var(--border-weaker-base);
+  border-radius: var(--radius-md);
+  background-color: var(--workbench-control-bg, var(--surface-inset-base));
+  overflow: hidden;
+}
+
+[data-component="markdown"] th,
+[data-component="markdown"] td {
+  padding: 0.75rem 0.875rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--border-weaker-base);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+[data-component="markdown"] th + th,
+[data-component="markdown"] td + td {
+  border-left: 1px solid var(--border-weaker-base);
+}
+
+[data-component="markdown"] th {
+  color: var(--text-strong);
+  font-weight: var(--font-weight-medium);
+  background-color: color-mix(in srgb, var(--workbench-selected-bg, var(--surface-raised-base-hover)) 76%, transparent);
+}
+
+[data-component="markdown"] tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+[data-component="markdown"] img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 1rem 0;
+  border-radius: var(--radius-sm);
+}
+
+/* KaTeX formula click-to-copy */
+[data-component="markdown"] .katex[data-katex-copy="true"],
+[data-component="markdown"] .katex-display[data-katex-copy="true"] {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.15s ease;
+}
+
+[data-component="markdown"] .katex[data-katex-copy="true"]:hover,
+[data-component="markdown"] .katex-display[data-katex-copy="true"]:hover {
+  background-color: color-mix(in srgb, var(--text-base) 8%, transparent);
+}
+
+[data-component="markdown"] .katex[data-katex-copy="true"]:active,
+[data-component="markdown"] .katex-display[data-katex-copy="true"]:active {
+  background-color: color-mix(in srgb, var(--text-base) 14%, transparent);
+}
+
+[data-component="markdown"] [data-slot="katex-copy-tooltip"] {
+  position: absolute;
+  top: -1.75em;
+  right: 0;
+  z-index: 1;
+  padding: 0.15rem 0.4rem;
+  border-radius: var(--radius-sm);
+  background-color: var(--surface-raised-stronger-non-alpha);
+  color: var(--text-strong);
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.3;
+  white-space: nowrap;
+  pointer-events: none;
+  animation: katex-tooltip-appear 0.12s ease;
+}
+
+@keyframes katex-tooltip-appear {
+  from {
+    opacity: 0;
+    transform: translateY(0.125rem);
   }
-
-  > *:last-child {
-    margin-bottom: 0;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    color: var(--markdown-heading);
-    font-weight: var(--font-weight-medium);
-    margin-top: 1.125rem;
-    margin-bottom: 0.5rem;
-    padding-left: 12px;
-    border-left: 3px solid var(--markdown-heading);
-    line-height: var(--line-height-large);
-  }
-
-  h1 {
-    font-size: 1.25em;
-  }
-
-  h2 {
-    font-size: 1.125em;
-  }
-
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: 1em;
-  }
-
-  strong,
-  b {
-    color: var(--text-strong);
-    font-weight: var(--font-weight-medium);
-  }
-
-  p {
-    margin-bottom: 1rem;
-  }
-
-  a {
-    color: var(--text-interactive-base);
-    text-decoration: none;
-    font-weight: inherit;
-    text-underline-offset: 2px;
-  }
-
-  a:hover {
-    text-decoration: underline;
-  }
-
-  ul,
-  ol {
-    margin-top: 0.5rem;
-    margin-bottom: 1rem;
-    padding-left: 1.5rem;
-  }
-
-  ul {
-    list-style-type: disc;
-  }
-
-  ol {
-    list-style-type: decimal;
-  }
-
-  li {
-    margin-bottom: 0.5rem;
-  }
-
-  li > p {
-    display: inline;
-  }
-
-  li > p + p {
-    display: block;
-    margin-top: 0.25rem;
-  }
-
-  li::marker {
-    color: var(--text-weak);
-  }
-
-  li > ul,
-  li > ol {
-    margin-top: 0.25rem;
-    margin-bottom: 0.25rem;
-  }
-
-  blockquote {
-    margin: 1rem 0;
-    padding: 0.5rem 0.75rem 0.5rem 0.875rem;
-    border-left: 3px solid var(--markdown-block-quote);
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-    color: var(--text-weak);
-    background-color: var(--workbench-control-bg, var(--surface-inset-base));
-  }
-
-  blockquote > :last-child {
-    margin-bottom: 0;
-  }
-
-  hr {
-    display: block;
-    margin: 1.25rem 0;
-    border: 0;
-    border-top: 1px solid var(--border-weaker-base);
-  }
-
-  [data-slot="markdown-code-block"] {
-    box-sizing: border-box;
-    width: 100%;
-    margin: 1rem 0;
-    min-width: 0;
-    max-width: 100%;
-    overflow: hidden;
-    border: 1px solid color-mix(in srgb, var(--border-weaker-base) 78%, transparent);
-    border-radius: var(--radius-lg);
-    background-color: var(--workbench-control-bg, var(--surface-inset-base));
-  }
-
-  [data-slot="markdown-code-header"] {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    min-width: 0;
-    padding: 0.3125rem 0.5rem;
-    border-bottom: 1px solid color-mix(in srgb, var(--border-weaker-base) 54%, transparent);
-    background-color: transparent;
-  }
-
-  [data-slot="markdown-code-header"][data-has-label="false"] {
-    justify-content: flex-end;
-  }
-
-  [data-slot="markdown-code-language"] {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--text-weaker);
-    font-size: 0.6875rem;
-    font-weight: var(--font-weight-medium);
-    letter-spacing: 0.01em;
-  }
-
-  [data-slot="markdown-code-copy"] {
-    appearance: none;
-    border: 0;
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--text-weak);
-    cursor: pointer;
-    flex-shrink: 0;
-    padding: 0.1875rem 0.375rem;
-    font: inherit;
-    font-size: 0.75rem;
-    line-height: 1.2;
-    transition:
-      background-color var(--motion-duration-fast) var(--motion-ease-standard),
-      color var(--motion-duration-fast) var(--motion-ease-standard),
-      box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
-  }
-
-  [data-slot="markdown-code-copy"]:hover {
-    background-color: color-mix(in srgb, var(--surface-focus) 64%, transparent);
-    color: var(--text-base);
-  }
-
-  [data-slot="markdown-code-copy"]:focus-visible {
-    outline: none;
-    background-color: color-mix(in srgb, var(--surface-focus) 72%, transparent);
-    color: var(--text-strong);
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-weaker-focus) 34%, transparent);
-  }
-
-  [data-slot="markdown-code-copy"][data-copy-state="copied"] {
-    background-color: var(--workbench-selected-bg, var(--surface-interactive-selected));
-    color: var(--text-strong);
-  }
-
-  [data-slot="markdown-code-copy"][data-copy-state="failed"] {
-    background-color: color-mix(in srgb, var(--surface-critical-base) 32%, transparent);
-    color: var(--text-on-critical-base);
-  }
-
-  .shiki {
-    margin: 0;
-    padding: 0.75rem 0.875rem;
-    background-color: transparent !important;
-    color: inherit;
-    font-size: var(--font-size-small);
-    border: 0;
-    border-radius: 0;
-  }
-
-  pre {
-    box-sizing: border-box;
-    width: 100%;
-    margin: 1rem 0;
-    min-width: 0;
-    max-width: 100%;
-    overflow-x: clip;
-    overflow-y: hidden;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
-
-  [data-slot="markdown-code-block"] pre {
-    margin: 0;
-  }
-
-  pre code {
-    display: block;
-    min-width: 0;
-    max-width: 100%;
-    white-space: inherit;
-    overflow-wrap: inherit;
-    word-break: inherit;
-    font-family: var(--font-family-mono);
-    font-feature-settings: var(--font-family-mono--font-feature-settings);
-  }
-
-  pre code span {
-    white-space: inherit;
-    overflow-wrap: inherit;
-    word-break: inherit;
-  }
-
-  :not(pre) > code {
-    display: inline;
-    border: 1px solid color-mix(in srgb, var(--border-weaker-base) 58%, transparent);
-    border-radius: calc(var(--radius-sm) - 1px);
-    background-color: color-mix(in srgb, var(--surface-inset-base) 88%, transparent);
-    padding: 0.0625rem 0.3125rem;
-    font-family: var(--font-family-mono);
-    font-feature-settings: var(--font-family-mono--font-feature-settings);
-    color: color-mix(in srgb, var(--text-strong) 92%, var(--text-base));
-    font-size: 0.9em;
-    font-weight: var(--font-weight-medium);
-    overflow-wrap: anywhere;
-  }
-
-  [data-slot="markdown-table-scroll"] {
-    box-sizing: border-box;
-    width: 100%;
-    min-width: 0;
-    max-width: 100%;
-    margin: 1rem 0;
-    overflow-x: clip;
-    overflow-y: hidden;
-  }
-
-  [data-slot="markdown-table-scroll"] > table {
-    margin: 0;
-  }
-
-  table {
-    width: 100%;
-    min-width: 0;
-    table-layout: fixed;
-    border-collapse: separate;
-    border-spacing: 0;
-    font-size: var(--font-size-base);
-    border: 1px solid var(--border-weaker-base);
-    border-radius: var(--radius-md);
-    background-color: var(--workbench-control-bg, var(--surface-inset-base));
-    overflow: hidden;
-  }
-
-  th,
-  td {
-    padding: 0.75rem 0.875rem;
-    text-align: left;
-    vertical-align: top;
-    border-bottom: 1px solid var(--border-weaker-base);
-    min-width: 0;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-  }
-
-  th + th,
-  td + td {
-    border-left: 1px solid var(--border-weaker-base);
-  }
-
-  th {
-    color: var(--text-strong);
-    font-weight: var(--font-weight-medium);
-    background-color: color-mix(
-      in srgb,
-      var(--workbench-selected-bg, var(--surface-raised-base-hover)) 76%,
-      transparent
-    );
-  }
-
-  tbody tr:last-child td {
-    border-bottom: 0;
-  }
-
-  img {
-    display: block;
-    max-width: 100%;
-    height: auto;
-    margin: 1rem 0;
-    border-radius: var(--radius-sm);
-  }
-
-  /* KaTeX formula click-to-copy */
-  .katex[data-katex-copy="true"],
-  .katex-display[data-katex-copy="true"] {
-    cursor: pointer;
-    border-radius: var(--radius-sm);
-    transition: background-color 0.15s ease;
-
-    &:hover {
-      background-color: color-mix(in srgb, var(--text-base) 8%, transparent);
-    }
-
-    &:active {
-      background-color: color-mix(in srgb, var(--text-base) 14%, transparent);
-    }
-  }
-
-  [data-slot="katex-copy-tooltip"] {
-    position: absolute;
-    top: -1.75em;
-    right: 0;
-    z-index: 1;
-    padding: 0.15rem 0.4rem;
-    border-radius: var(--radius-sm);
-    background-color: var(--surface-raised-stronger-non-alpha);
-    color: var(--text-strong);
-    font-size: 0.6875rem;
-    font-weight: var(--font-weight-medium);
-    line-height: 1.3;
-    white-space: nowrap;
-    pointer-events: none;
-    animation: katex-tooltip-appear 0.12s ease;
-  }
-
-  @keyframes katex-tooltip-appear {
-    from {
-      opacity: 0;
-      transform: translateY(0.125rem);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
-:root[data-color-scheme="light"] [data-component="markdown"] {
-  [data-slot="markdown-code-block"] {
-    background-color: color-mix(in srgb, var(--surface-base) 92%, var(--surface-inset-base));
-  }
+:root[data-color-scheme="light"] [data-component="markdown"] [data-slot="markdown-code-block"] {
+  background-color: color-mix(in srgb, var(--surface-base) 92%, var(--surface-inset-base));
+}
 
-  :not(pre) > code {
-    background-color: color-mix(in srgb, var(--surface-base) 78%, var(--surface-inset-base));
-  }
+:root[data-color-scheme="light"] [data-component="markdown"] :not(pre) > code {
+  background-color: color-mix(in srgb, var(--surface-base) 78%, var(--surface-inset-base));
 }

--- a/packages/ui/test/css-token-integrity.test.ts
+++ b/packages/ui/test/css-token-integrity.test.ts
@@ -300,9 +300,17 @@ describe("CSS Token Integrity", () => {
     const codeBlock = extractRuleBlock(css, '[data-slot="markdown-code-block"]')
     expect(codeBlock).toContain("background-color: var(--workbench-control-bg")
 
-    const lightOverride = extractRuleBlock(css, ':root[data-color-scheme="light"] [data-component="markdown"]')
-    expect(lightOverride).toContain("var(--surface-base) 92%")
-    expect(lightOverride).toContain("var(--surface-base) 78%")
+    const lightCodeBlock = extractRuleBlock(
+      css,
+      ':root[data-color-scheme="light"] [data-component="markdown"] [data-slot="markdown-code-block"]',
+    )
+    expect(lightCodeBlock).toContain("var(--surface-base) 92%")
+
+    const lightInlineCode = extractRuleBlock(
+      css,
+      ':root[data-color-scheme="light"] [data-component="markdown"] :not(pre) > code',
+    )
+    expect(lightInlineCode).toContain("var(--surface-base) 78%")
 
     const header = extractRuleBlock(css, '[data-slot="markdown-code-header"]')
     expect(header).toContain("background-color: transparent")

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -152,7 +152,7 @@ Options:
   --attach <url>          Reuse an existing server instead of starting one
   --open                  Open the browser for bun dev app
   --no-open               Do not open the browser for bun dev web
-  --managed               Start desktop in managed-server mode
+  --managed               Start desktop in managed-server mode after rebuilding the app
   --print-logs            Print server logs to stderr
 `
 }
@@ -337,15 +337,12 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
   if (command === "desktop") {
     const managed = boolFlag(parsed.flags, "managed")
     if (managed) {
-      const dirs = directories(repoRoot)
-      const appDistExists = fs.existsSync(path.join(dirs.app, "dist", "index.html"))
-      const processes: DevProcessSpec[] = appDistExists
-        ? [desktopProcess({ repoRoot, bunPath, mode: "managed" })]
-        : [
-            { label: "install", command: [bunPath, "install"], cwd: repoRoot },
-            { label: "build", command: [bunPath, "run", "build"], cwd: dirs.app },
-            desktopProcess({ repoRoot, bunPath, mode: "managed" }),
-          ]
+      const dependenciesInstalled = fs.existsSync(path.join(repoRoot, "node_modules"))
+      const processes: DevProcessSpec[] = [
+        ...(dependenciesInstalled ? [] : [{ label: "install" as const, command: [bunPath, "install"], cwd: repoRoot }]),
+        { label: "build", command: [bunPath, "run", "build"], cwd: dirs.app },
+        desktopProcess({ repoRoot, bunPath, mode: "managed" }),
+      ]
       return {
         kind: "run",
         mode: "serial",


### PR DESCRIPTION
## Summary
- Flatten Markdown component CSS so production builds preserve the root text contract used by message rendering.
- Make `bun dev desktop --managed` always rebuild the Web app before launching managed Electron, only installing dependencies when `node_modules` is missing.
- Add production CSS contract coverage for core component root declarations and update docs for the managed workflow.

## Tests
- bun test test/script/dev.test.ts (packages/synergy)
- bun test test/css-token-integrity.test.ts (packages/ui)
- bun test src/app-build-css-contract.test.ts (packages/app)
- bun run typecheck
- bun dev build app

Note: push hook also reran typecheck and Prettier.