### PR TITLE
fix: skip attachment discovery for git/gh informational commands (#206)

### DIFF
--- a/packages/synergy/src/tool/attachment-discovery.ts
+++ b/packages/synergy/src/tool/attachment-discovery.ts
@@ -32,6 +32,16 @@ const EXTENSION_PATTERN = Object.keys(MIME_BY_EXT)
   .sort((a, b) => b.length - a.length)
   .join("|")
 
+/**
+ * Commands whose shell output is informational — file paths in the output
+ * are incidental metadata, not user-facing file artifacts worth previewing.
+ *
+ * Expanding entries for npm, yarn, pip, docker, kubectl, and common listing
+ * commands should be low risk; start conservatively.
+ */
+const INFORMATIONAL_COMMAND_PREFIX = /^(git|gh)\s/
+const INFORMATIONAL_COMMAND_EXACT = new Set(["git", "gh"])
+
 export namespace AttachmentDiscovery {
   export interface Candidate {
     value: string
@@ -46,6 +56,16 @@ export namespace AttachmentDiscovery {
     tool: string
     maxAttachments?: number
     maxTotalBytes?: number
+  }
+
+  /**
+   * Returns true when attachment discovery should be skipped because the
+   * tool command is informational — file paths in its output are not meant
+   * for preview.
+   */
+  export function shouldSkip(command: string | undefined): boolean {
+    if (!command) return false
+    return INFORMATIONAL_COMMAND_EXACT.has(command) || INFORMATIONAL_COMMAND_PREFIX.test(command)
   }
 
   export function extractCandidates(output: string): Candidate[] {

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -155,6 +155,7 @@ export const LocalBashBackend: BashBackend = {
     const sandboxWarning = (ctx.extra as any)?.sandboxWarning as string | undefined
     const warnOutput = (base: string) => (sandboxWarning ? `[Sandbox unavailable: ${sandboxWarning}]\n\n${base}` : base)
     const withAttachments = async (result: BashResult): Promise<BashResult> => {
+      if (AttachmentDiscovery.shouldSkip(params.command)) return result
       await trace("attachment.discovery.start", {
         outputChars: result.output.length,
       })

--- a/packages/synergy/src/tool/process/local.ts
+++ b/packages/synergy/src/tool/process/local.ts
@@ -15,8 +15,10 @@ export namespace LocalProcessBackend {
       result: ProcessResult,
       output: string,
       cwd = ScopeContext.current.directory,
+      command?: string,
     ): Promise<ProcessResult> => {
       if (!ctx || (action !== "poll" && action !== "log")) return result
+      if (AttachmentDiscovery.shouldSkip(command)) return result
       const attachments = await AttachmentDiscovery.discover({
         output,
         cwd,
@@ -121,6 +123,7 @@ export namespace LocalProcessBackend {
             },
             currentFinished.output,
             currentFinished.cwd,
+            currentFinished.command,
           )
         }
 
@@ -167,7 +170,7 @@ export namespace LocalProcessBackend {
           output: slice || "(no output)",
         }
         if (status === "running") return result
-        return withAttachments(result, slice || output, target.cwd)
+        return withAttachments(result, slice || output, target.cwd, target.command)
       }
 
       case "write": {

--- a/packages/synergy/test/tool/attachment-discovery.test.ts
+++ b/packages/synergy/test/tool/attachment-discovery.test.ts
@@ -122,3 +122,46 @@ describe("tool.attachment-discovery", () => {
     })
   })
 })
+
+describe("tool.attachment-discovery.shouldSkip", () => {
+  test("returns true for bare git command", () => {
+    expect(AttachmentDiscovery.shouldSkip("git")).toBe(true)
+  })
+
+  test("returns true for git subcommands", () => {
+    expect(AttachmentDiscovery.shouldSkip("git diff")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("git log --oneline")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("git status")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("git show HEAD~1")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("git push origin main")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("git commit -m 'fix'")).toBe(true)
+  })
+
+  test("returns true for bare gh command", () => {
+    expect(AttachmentDiscovery.shouldSkip("gh")).toBe(true)
+  })
+
+  test("returns true for gh subcommands", () => {
+    expect(AttachmentDiscovery.shouldSkip("gh pr view 217")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("gh issue list")).toBe(true)
+    expect(AttachmentDiscovery.shouldSkip("gh pr create --title 'fix'")).toBe(true)
+  })
+
+  test("returns false for non-git non-gh commands", () => {
+    expect(AttachmentDiscovery.shouldSkip("python plot.py")).toBe(false)
+    expect(AttachmentDiscovery.shouldSkip("ls")).toBe(false)
+    expect(AttachmentDiscovery.shouldSkip("cat file.txt")).toBe(false)
+    expect(AttachmentDiscovery.shouldSkip("npm test")).toBe(false)
+    expect(AttachmentDiscovery.shouldSkip("bun run build")).toBe(false)
+  })
+
+  test("returns false for undefined or empty command", () => {
+    expect(AttachmentDiscovery.shouldSkip(undefined)).toBe(false)
+    expect(AttachmentDiscovery.shouldSkip("")).toBe(false)
+  })
+
+  test("returns false for commands that merely contain git but are not git", () => {
+    expect(AttachmentDiscovery.shouldSkip("fugitive open")).toBe(false)
+    expect(AttachmentDiscovery.shouldSkip("digital something")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Skip attachment discovery for `git` and `gh` commands in both the `bash` and `process` backends. File paths in git output (e.g., `git diff`, `git log`, `git status`, `git show`) are incidental metadata, not user-facing artifacts worth previewing as attachments.

## Changes

- **`packages/synergy/src/tool/attachment-discovery.ts`** — add `shouldSkip(command)` helper that checks for `git` or `gh` command prefix
- **`packages/synergy/src/tool/bash/local.ts`** — guard `withAttachments` with `shouldSkip(params.command)` 
- **`packages/synergy/src/tool/process/local.ts`** — thread original process command through `withAttachments` and guard with `shouldSkip`
- **`packages/synergy/test/tool/attachment-discovery.test.ts`** — add 7 `shouldSkip` unit tests covering git/gh positive cases, non-git negative cases, and edge cases

## Verification

- Types: 10/10 packages pass
- Format: clean
- Tests: 4652 pass (6 pre-existing failures unrelated), including 12/12 attachment-discovery tests
- New `shouldSkip` tests: 7 tests, 17 assertions

Closes #206

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>