### PR TITLE
Add semantic note edit results

### DIFF
--- a/packages/synergy/src/note/document.ts
+++ b/packages/synergy/src/note/document.ts
@@ -467,15 +467,15 @@ export namespace NoteDocument {
     return node
   }
 
-  export function replaceText(
+  export function replaceTextDetailed(
     doc: Node,
     block: BlockInfo,
     input: { find?: string; range?: { from: number; to: number }; replacement: string; occurrence?: number },
-  ): Node {
+  ): { doc: Node; from: number; to: number; matchedText: string; beforeText: string; afterText: string } {
     const next = normalize(doc)
     const target = parentContent(next, block.path)
     const node = target.content[target.index]
-    const text = nodeText(node)
+    const beforeText = nodeText(node)
     let from: number
     let to: number
 
@@ -483,11 +483,12 @@ export namespace NoteDocument {
       from = input.range.from
       to = input.range.to
     } else if (input.find !== undefined) {
+      if (input.find.length === 0) throw new Error("replaceText find must not be empty; use range for insertion.")
       const matches: number[] = []
-      let at = text.indexOf(input.find)
+      let at = beforeText.indexOf(input.find)
       while (at >= 0) {
         matches.push(at)
-        at = text.indexOf(input.find, at + input.find.length)
+        at = beforeText.indexOf(input.find, at + input.find.length)
       }
       if (matches.length === 0) throw new Error(`Text "${input.find}" was not found in block ${block.id}.`)
       if (matches.length > 1 && input.occurrence === undefined) {
@@ -502,15 +503,18 @@ export namespace NoteDocument {
       throw new Error("replaceText requires find or range.")
     }
 
-    if (from < 0 || to < from || to > text.length) throw new Error(`Invalid text range ${from}-${to}.`)
+    if (from < 0 || to < from || to > beforeText.length) throw new Error(`Invalid text range ${from}-${to}.`)
+    const matchedText = beforeText.slice(from, to)
     const allRefs = textRefs(node)
     const refs = allRefs.filter((ref) => ref.end > from && ref.start < to)
     if (from === to) {
       const insertionRef = allRefs.find((ref) => ref.start <= from && from <= ref.end)
       if (!insertionRef) {
-        if (text.length === 0) {
+        if (beforeText.length === 0) {
           node.content = [...(node.content ?? []), { type: "text", text: input.replacement }]
-          return normalize(next)
+          const updatedDoc = normalize(next)
+          const updated = parentContent(updatedDoc, block.path).content[target.index]
+          return { doc: updatedDoc, from, to, matchedText, beforeText, afterText: nodeText(updated) }
         }
         throw new Error("Text insertion point does not overlap editable text nodes.")
       }
@@ -519,7 +523,9 @@ export namespace NoteDocument {
       const local = from - insertionRef.start
       insertionRef.node.text = current.slice(0, local) + input.replacement + current.slice(local)
       target.content[target.index] = pruneEmptyText(node)
-      return normalize(next)
+      const updatedDoc = normalize(next)
+      const updated = parentContent(updatedDoc, block.path).content[target.index]
+      return { doc: updatedDoc, from, to, matchedText, beforeText, afterText: nodeText(updated) }
     }
 
     if (refs.length === 0) throw new Error("Text range does not overlap editable text nodes.")
@@ -537,7 +543,17 @@ export namespace NoteDocument {
     for (const ref of refs.slice(1, -1)) ref.node.text = ""
     if (last !== first) last.node.text = suffix
     target.content[target.index] = pruneEmptyText(node)
-    return normalize(next)
+    const updatedDoc = normalize(next)
+    const updated = parentContent(updatedDoc, block.path).content[target.index]
+    return { doc: updatedDoc, from, to, matchedText, beforeText, afterText: nodeText(updated) }
+  }
+
+  export function replaceText(
+    doc: Node,
+    block: BlockInfo,
+    input: { find?: string; range?: { from: number; to: number }; replacement: string; occurrence?: number },
+  ): Node {
+    return replaceTextDetailed(doc, block, input).doc
   }
 
   export function updateTableCell(

--- a/packages/synergy/src/note/document.ts
+++ b/packages/synergy/src/note/document.ts
@@ -130,6 +130,19 @@ export namespace NoteDocument {
     return typeof node.attrs?.synergyId === "string" ? node.attrs.synergyId : undefined
   }
 
+  function childTextSeparator(node: Node): string {
+    switch (node.type) {
+      case "paragraph":
+      case "heading":
+      case "codeBlock":
+        return ""
+      case "tableRow":
+        return " | "
+      default:
+        return "\n"
+    }
+  }
+
   function nodeText(node: Node): string {
     switch (node.type) {
       case "text":
@@ -147,7 +160,7 @@ export namespace NoteDocument {
       case "mermaidDiagram":
         return node.attrs?.content ?? ""
       default:
-        return (node.content ?? []).map(nodeText).join(node.type === "tableRow" ? " | " : "\n")
+        return (node.content ?? []).map(nodeText).join(childTextSeparator(node))
     }
   }
 
@@ -417,15 +430,33 @@ export namespace NoteDocument {
         offset += text.length
         return
       }
-      if (current.type === "hardBreak") {
-        offset += 1
+      if (
+        current.type === "hardBreak" ||
+        current.type === "inlineMath" ||
+        current.type === "mathInline" ||
+        current.type === "image" ||
+        current.type === "video" ||
+        current.type === "mermaid" ||
+        current.type === "mermaidDiagram"
+      ) {
+        offset += nodeText(current).length
         return
       }
-      for (const child of current.content ?? []) visit(child)
+
+      const children = current.content ?? []
+      const separator = childTextSeparator(current)
+      children.forEach((child, index) => {
+        if (index > 0) offset += separator.length
+        visit(child)
+      })
     }
 
     visit(node)
     return refs
+  }
+
+  function editableLength(refs: TextRef[], from: number, to: number): number {
+    return refs.reduce((sum, ref) => sum + Math.max(0, Math.min(to, ref.end) - Math.max(from, ref.start)), 0)
   }
 
   function pruneEmptyText(node: Node): Node {
@@ -472,11 +503,28 @@ export namespace NoteDocument {
     }
 
     if (from < 0 || to < from || to > text.length) throw new Error(`Invalid text range ${from}-${to}.`)
-    const refs = textRefs(node).filter((ref) => ref.end > from && ref.start < to)
-    if (refs.length === 0 && from !== to) throw new Error("Text range does not overlap editable text nodes.")
-    if (refs.length === 0) {
-      node.content = [...(node.content ?? []), { type: "text", text: input.replacement }]
+    const allRefs = textRefs(node)
+    const refs = allRefs.filter((ref) => ref.end > from && ref.start < to)
+    if (from === to) {
+      const insertionRef = allRefs.find((ref) => ref.start <= from && from <= ref.end)
+      if (!insertionRef) {
+        if (text.length === 0) {
+          node.content = [...(node.content ?? []), { type: "text", text: input.replacement }]
+          return normalize(next)
+        }
+        throw new Error("Text insertion point does not overlap editable text nodes.")
+      }
+
+      const current = insertionRef.node.text ?? ""
+      const local = from - insertionRef.start
+      insertionRef.node.text = current.slice(0, local) + input.replacement + current.slice(local)
+      target.content[target.index] = pruneEmptyText(node)
       return normalize(next)
+    }
+
+    if (refs.length === 0) throw new Error("Text range does not overlap editable text nodes.")
+    if (editableLength(refs, from, to) !== to - from) {
+      throw new Error("Text range includes non-editable content; replace a narrower text span or replace the block.")
     }
 
     const first = refs[0]

--- a/packages/synergy/src/tool/note-edit.ts
+++ b/packages/synergy/src/tool/note-edit.ts
@@ -95,6 +95,84 @@ const parameters = z.object({
 type Params = z.infer<typeof parameters>
 type Operation = z.infer<typeof operation>
 
+type BlockPreview = {
+  id: string
+  type: string
+  path: string
+  hash?: string
+  text?: string
+  summary: string
+  row?: number
+  col?: number
+  tableId?: string
+}
+
+type OperationSemanticResult = {
+  opIndex: number
+  action: Operation["action"]
+  status: "applied" | "noop"
+  targetBlocks: BlockPreview[]
+  directChangedBlocks: BlockPreview[]
+  ancestorChangedBlocks: BlockPreview[]
+  unexpectedChangedBlocks: BlockPreview[]
+  semantic: Record<string, unknown>
+  checks: Record<string, boolean | number | string | undefined>
+  warnings: string[]
+}
+
+type SemanticSeed = {
+  targetIds: string[]
+  directIds: string[]
+  semantic: Record<string, unknown>
+  checks?: Record<string, boolean | number | string | undefined>
+}
+
+type ApplyResult = { doc: NoteDocument.Node; touched: string[]; semanticSeed: SemanticSeed }
+
+const BLOCK_PREVIEW_LIMIT = 800
+const CONTEXT_RADIUS = 120
+
+function previewText(text: string, limit = BLOCK_PREVIEW_LIMIT) {
+  if (text.length <= limit) return text
+  const head = Math.floor((limit - 32) / 2)
+  const tail = Math.max(0, limit - 32 - head)
+  return `${text.slice(0, head)}…[${text.length} chars]…${text.slice(text.length - tail)}`
+}
+
+function contextText(text: string, from: number, to: number) {
+  const start = Math.max(0, from - CONTEXT_RADIUS)
+  const end = Math.min(text.length, to + CONTEXT_RADIUS)
+  const prefix = start > 0 ? "…" : ""
+  const suffix = end < text.length ? "…" : ""
+  return `${prefix}${text.slice(start, end)}${suffix}`
+}
+
+function countOccurrences(text: string, find: string) {
+  if (!find) return 0
+  let count = 0
+  let at = text.indexOf(find)
+  while (at >= 0) {
+    count++
+    at = text.indexOf(find, at + find.length)
+  }
+  return count
+}
+
+function blockPreview(block: NoteDocument.BlockInfo | undefined): BlockPreview | undefined {
+  if (!block) return undefined
+  return {
+    id: block.id,
+    type: block.type,
+    path: block.pathLabel,
+    hash: block.hash,
+    text: previewText(block.text),
+    summary: block.summary,
+    row: block.row,
+    col: block.col,
+    tableId: block.tableId,
+  }
+}
+
 function compactBlocks(content: unknown, ids?: string[]) {
   const blocks = NoteDocument.listBlocks(content)
   const filtered = ids?.length ? blocks.filter((block) => ids.includes(block.id)) : blocks.slice(0, 20)
@@ -116,6 +194,8 @@ function errorResult(input: {
   message: string
   note?: Awaited<ReturnType<typeof NoteStore.getAny>>
   blockIds?: string[]
+  failedOpIndex?: number
+  failedAction?: Operation["action"]
 }) {
   const doc = input.note ? NoteDocument.normalize(input.note.content) : undefined
   const docHash = doc ? NoteDocument.hash(doc) : undefined
@@ -125,22 +205,34 @@ function errorResult(input: {
       `Error: ${input.message}`,
       `Code: ${input.code}`,
       `ID: ${input.id}`,
+      input.failedOpIndex !== undefined
+        ? `Failed operation: ${input.failedOpIndex + 1} ${input.failedAction}`
+        : undefined,
+      input.failedOpIndex !== undefined ? "No write occurred." : undefined,
       ...(input.note ? [`Current version: ${input.note.version}`] : []),
       ...(docHash ? [`Current docHash: ${docHash}`] : []),
       ...(doc ? ["Current blocks:", JSON.stringify(compactBlocks(doc, input.blockIds), null, 2)] : []),
-    ].join("\n"),
+    ]
+      .filter((line): line is string => line !== undefined)
+      .join("\n"),
     metadata: {
       id: input.id,
       errorCode: input.code,
       currentVersion: input.note?.version,
       currentDocHash: docHash,
       blocks: doc ? compactBlocks(doc, input.blockIds) : undefined,
+      failedOpIndex: input.failedOpIndex,
+      failedAction: input.failedAction,
     } as Record<string, any>,
   }
 }
 
 function blockMap(doc: NoteDocument.Node) {
   return new Map(NoteDocument.listBlocks(doc, { includeJson: true }).map((block) => [block.id, block]))
+}
+
+function blocksMap(blocks: NoteDocument.BlockInfo[]) {
+  return new Map(blocks.map((block) => [block.id, block]))
 }
 
 function requireHash(block: NoteDocument.BlockInfo, expectedHash: string | undefined, context: string) {
@@ -155,6 +247,16 @@ function resolveById(doc: NoteDocument.Node, blockId: string, expectedHash: stri
   if (!block) throw new Error(`${context} target block ${blockId} was not found.`)
   if (expectedHash) requireHash(block, expectedHash, context)
   return block
+}
+
+function resolveTableCell(doc: NoteDocument.Node, op: z.infer<typeof updateTableCellOp>) {
+  const cell = NoteDocument.listBlocks(doc, { includeJson: true }).find((block) => {
+    if (block.type !== "tableCell" && block.type !== "tableHeader") return false
+    if (op.cellId) return block.id === op.cellId
+    return block.tableId === op.tableId && block.row === op.row && block.col === op.col
+  })
+  if (!cell) throw new Error("Target table cell was not found.")
+  return cell
 }
 
 function targetIds(op: Operation): string[] {
@@ -174,44 +276,149 @@ function targetIds(op: Operation): string[] {
   }
 }
 
-function applyOperation(doc: NoteDocument.Node, op: Operation): { doc: NoteDocument.Node; touched: string[] } {
+function contentText(nodes: NoteDocument.Node[]) {
+  const doc = NoteDocument.normalize({ type: "doc", content: nodes })
+  return NoteDocument.listBlocks(doc)
+    .map((block) => block.text.trim())
+    .filter(Boolean)
+    .join("\n")
+}
+
+function isSameParentPath(a: number[], b: number[]) {
+  return a.length === b.length && a.slice(0, -1).every((value, index) => value === b[index])
+}
+
+function isPathPrefix(parent: number[], child: number[]) {
+  return parent.every((value, index) => child[index] === value)
+}
+
+function rangeBlocks(doc: NoteDocument.Node, start: NoteDocument.BlockInfo, end: NoteDocument.BlockInfo) {
+  const from = Math.min(start.path[start.path.length - 1], end.path[end.path.length - 1])
+  const to = Math.max(start.path[start.path.length - 1], end.path[end.path.length - 1])
+  const parent = start.path.slice(0, -1)
+  return NoteDocument.listBlocks(doc).filter((block) => {
+    if (block.path.length < start.path.length) return false
+    if (!isPathPrefix(parent, block.path)) return false
+    const siblingIndex = block.path[parent.length]
+    return siblingIndex >= from && siblingIndex <= to
+  })
+}
+
+function applyOperation(doc: NoteDocument.Node, op: Operation): ApplyResult {
   switch (op.action) {
     case "replaceBlock": {
       const block = resolveById(doc, op.blockId, op.expectedHash, "replaceBlock")
       const nodes = NoteDocument.parseContent(op.content)
-      return { doc: NoteDocument.replaceBlock(doc, block, nodes), touched: [block.id] }
+      return {
+        doc: NoteDocument.replaceBlock(doc, block, nodes),
+        touched: [block.id],
+        semanticSeed: {
+          targetIds: [block.id],
+          directIds: [block.id],
+          semantic: {
+            removedBlocks: [blockPreview(block)].filter(Boolean),
+            replacementText: previewText(contentText(nodes)),
+          },
+        },
+      }
     }
     case "insertBefore": {
       const block = resolveById(doc, op.blockId, undefined, "insertBefore")
       const nodes = NoteDocument.parseContent(op.content)
-      return { doc: NoteDocument.insertNearBlock(doc, block, nodes, "before"), touched: [block.id] }
+      return {
+        doc: NoteDocument.insertNearBlock(doc, block, nodes, "before"),
+        touched: [block.id],
+        semanticSeed: {
+          targetIds: [block.id],
+          directIds: [block.id],
+          semantic: {
+            side: "before",
+            anchorText: previewText(block.text),
+            insertedText: previewText(contentText(nodes)),
+          },
+        },
+      }
     }
     case "insertAfter": {
       const block = resolveById(doc, op.blockId, undefined, "insertAfter")
       const nodes = NoteDocument.parseContent(op.content)
-      return { doc: NoteDocument.insertNearBlock(doc, block, nodes, "after"), touched: [block.id] }
+      return {
+        doc: NoteDocument.insertNearBlock(doc, block, nodes, "after"),
+        touched: [block.id],
+        semanticSeed: {
+          targetIds: [block.id],
+          directIds: [block.id],
+          semantic: {
+            side: "after",
+            anchorText: previewText(block.text),
+            insertedText: previewText(contentText(nodes)),
+          },
+        },
+      }
     }
     case "deleteBlock": {
       const block = resolveById(doc, op.blockId, op.expectedHash, "deleteBlock")
-      return { doc: NoteDocument.deleteBlock(doc, block), touched: [block.id] }
+      return {
+        doc: NoteDocument.deleteBlock(doc, block),
+        touched: [block.id],
+        semanticSeed: {
+          targetIds: [block.id],
+          directIds: [block.id],
+          semantic: { deletedBlocks: [blockPreview(block)].filter(Boolean), deletedText: previewText(block.text) },
+        },
+      }
     }
     case "setAttrs": {
       const block = resolveById(doc, op.blockId, op.expectedHash, "setAttrs")
-      return { doc: NoteDocument.setAttrs(doc, block, op.attrs), touched: [block.id] }
+      return {
+        doc: NoteDocument.setAttrs(doc, block, op.attrs),
+        touched: [block.id],
+        semanticSeed: {
+          targetIds: [block.id],
+          directIds: [block.id],
+          semantic: { beforeAttrs: block.attrs ?? {}, afterAttrs: op.attrs },
+        },
+      }
     }
     case "replaceText": {
       const block = resolveById(doc, op.blockId, op.expectedHash, "replaceText")
+      const result = NoteDocument.replaceTextDetailed(doc, block, {
+        find: op.find,
+        range: op.range,
+        replacement: op.replacement,
+        occurrence: op.occurrence,
+      })
+      const checks = {
+        matchedRequestedText: op.find === undefined || result.matchedText === op.find,
+        replacementPresentInTarget: result.afterText.includes(op.replacement),
+        oldTextRemainingInTargetCount: op.find === undefined ? undefined : countOccurrences(result.afterText, op.find),
+      }
       return {
-        doc: NoteDocument.replaceText(doc, block, {
-          find: op.find,
-          range: op.range,
-          replacement: op.replacement,
-          occurrence: op.occurrence,
-        }),
+        doc: result.doc,
         touched: [block.id],
+        semanticSeed: {
+          targetIds: [block.id],
+          directIds: [block.id],
+          semantic: {
+            find: op.find,
+            range: { from: result.from, to: result.to },
+            occurrence: op.occurrence ?? 1,
+            matchedText: result.matchedText,
+            replacement: op.replacement,
+            beforeContext: contextText(result.beforeText, result.from, result.to),
+            afterContext: contextText(result.afterText, result.from, result.from + op.replacement.length),
+            beforeText: previewText(result.beforeText),
+            afterText: previewText(result.afterText),
+          },
+          checks,
+        },
       }
     }
     case "updateTableCell": {
+      const current = resolveTableCell(doc, op)
+      if (op.expectedHash) {
+        requireHash(current, op.expectedHash, "updateTableCell")
+      }
       const nodes = NoteDocument.parseContent(op.content)
       const result = NoteDocument.updateTableCell(doc, {
         tableId: op.tableId,
@@ -220,16 +427,45 @@ function applyOperation(doc: NoteDocument.Node, op: Operation): { doc: NoteDocum
         col: op.col,
         content: nodes,
       })
-      if (op.expectedHash) {
-        requireHash(result.cell, op.expectedHash, "updateTableCell")
+      const requestedText = contentText(nodes)
+      return {
+        doc: result.doc,
+        touched: [result.cell.id],
+        semanticSeed: {
+          targetIds: [result.cell.id, result.cell.tableId].filter((id): id is string => !!id),
+          directIds: [result.cell.id],
+          semantic: {
+            cellId: result.cell.id,
+            tableId: result.cell.tableId,
+            row: result.cell.row,
+            col: result.cell.col,
+            beforeText: previewText(result.cell.text),
+            replacementText: previewText(requestedText),
+          },
+          checks: { replacementPresentInTarget: requestedText.length ? undefined : true },
+        },
       }
-      return { doc: result.doc, touched: [result.cell.id] }
     }
     case "replaceRange": {
       const start = resolveById(doc, op.startBlockId, op.expectedStartHash, "replaceRange start")
       const end = resolveById(doc, op.endBlockId, op.expectedEndHash, "replaceRange end")
+      if (!isSameParentPath(start.path, end.path)) {
+        throw new Error("replaceRange currently requires start and end blocks to share the same parent.")
+      }
+      const removedBlocks = rangeBlocks(doc, start, end)
       const nodes = NoteDocument.parseContent(op.content)
-      return { doc: NoteDocument.replaceRange(doc, start, end, nodes), touched: [start.id, end.id] }
+      return {
+        doc: NoteDocument.replaceRange(doc, start, end, nodes),
+        touched: [start.id, end.id],
+        semanticSeed: {
+          targetIds: [start.id, end.id],
+          directIds: removedBlocks.map((block) => block.id),
+          semantic: {
+            removedBlocks: removedBlocks.map(blockPreview).filter((block): block is BlockPreview => !!block),
+            replacementText: previewText(contentText(nodes)),
+          },
+        },
+      }
     }
   }
 }
@@ -239,6 +475,152 @@ function changedBlocks(before: NoteDocument.Node, after: NoteDocument.Node, touc
   return NoteDocument.listBlocks(after).filter(
     (block) => touched.has(block.id) || beforeHashes.get(block.id) !== block.hash,
   )
+}
+
+function changedIds(beforeBlocks: NoteDocument.BlockInfo[], afterBlocks: NoteDocument.BlockInfo[]) {
+  const before = blocksMap(beforeBlocks)
+  const after = blocksMap(afterBlocks)
+  const ids = new Set([...before.keys(), ...after.keys()])
+  return [...ids].filter((id) => before.get(id)?.hash !== after.get(id)?.hash)
+}
+
+function ancestorIds(
+  beforeBlocks: NoteDocument.BlockInfo[],
+  afterBlocks: NoteDocument.BlockInfo[],
+  directIds: Set<string>,
+  changed: Set<string>,
+) {
+  const before = blocksMap(beforeBlocks)
+  const after = blocksMap(afterBlocks)
+  const ancestors = new Set<string>()
+  for (const id of directIds) {
+    let current = after.get(id) ?? before.get(id)
+    while (current?.parentId) {
+      if (changed.has(current.parentId)) ancestors.add(current.parentId)
+      current = after.get(current.parentId) ?? before.get(current.parentId)
+    }
+  }
+  return ancestors
+}
+
+function previewForId(
+  id: string,
+  before: Map<string, NoteDocument.BlockInfo>,
+  after: Map<string, NoteDocument.BlockInfo>,
+) {
+  return blockPreview(after.get(id) ?? before.get(id))
+}
+
+function classifyChanges(
+  beforeBlocks: NoteDocument.BlockInfo[],
+  afterBlocks: NoteDocument.BlockInfo[],
+  directIds: string[],
+) {
+  const before = blocksMap(beforeBlocks)
+  const after = blocksMap(afterBlocks)
+  const changed = new Set(changedIds(beforeBlocks, afterBlocks))
+  const insertedIds = [...after.keys()].filter((id) => !before.has(id))
+  const allDirect = new Set(
+    [...directIds, ...insertedIds].filter((id) => changed.has(id) || !before.has(id) || !after.has(id)),
+  )
+  const ancestors = ancestorIds(beforeBlocks, afterBlocks, allDirect, changed)
+  const unexpected = [...changed].filter((id) => !allDirect.has(id) && !ancestors.has(id))
+  return {
+    directChangedBlocks: [...allDirect]
+      .map((id) => previewForId(id, before, after))
+      .filter((block): block is BlockPreview => !!block),
+    ancestorChangedBlocks: [...ancestors]
+      .map((id) => previewForId(id, before, after))
+      .filter((block): block is BlockPreview => !!block),
+    unexpectedChangedBlocks: unexpected
+      .map((id) => previewForId(id, before, after))
+      .filter((block): block is BlockPreview => !!block),
+  }
+}
+
+function buildOperationResult(input: {
+  opIndex: number
+  action: Operation["action"]
+  beforeDoc: NoteDocument.Node
+  afterDoc: NoteDocument.Node
+  beforeBlocks: NoteDocument.BlockInfo[]
+  afterBlocks: NoteDocument.BlockInfo[]
+  seed: SemanticSeed
+}): OperationSemanticResult {
+  const beforeHash = NoteDocument.hash(input.beforeDoc)
+  const afterHash = NoteDocument.hash(input.afterDoc)
+  const before = blocksMap(input.beforeBlocks)
+  const after = blocksMap(input.afterBlocks)
+  const classified = classifyChanges(input.beforeBlocks, input.afterBlocks, input.seed.directIds)
+  const noop = beforeHash === afterHash
+  const targetBlocks = input.seed.targetIds
+    .map((id) => previewForId(id, before, after))
+    .filter((block): block is BlockPreview => !!block)
+  const checks: Record<string, boolean | number | string | undefined> = { ...input.seed.checks, noop }
+  if (input.action === "updateTableCell" && checks.replacementPresentInTarget === undefined) {
+    const direct = classified.directChangedBlocks[0]
+    const replacement = input.seed.semantic.replacementText
+    checks.replacementPresentInTarget =
+      typeof replacement === "string" && replacement.length > 0 ? (direct?.text ?? "").includes(replacement) : true
+  }
+  const warnings: string[] = []
+  if (noop) warnings.push("Operation produced no document change.")
+  if (classified.unexpectedChangedBlocks.length > 0)
+    warnings.push("Operation changed blocks outside direct targets and ancestors.")
+  if (input.action === "replaceText" && checks.replacementPresentInTarget === false) {
+    warnings.push("Replacement text is not present in the target block after editing.")
+  }
+  return {
+    opIndex: input.opIndex,
+    action: input.action,
+    status: noop ? "noop" : "applied",
+    targetBlocks,
+    ...classified,
+    semantic: input.seed.semantic,
+    checks,
+    warnings,
+  }
+}
+
+function renderBlockTarget(block: BlockPreview) {
+  const rowCol = block.row !== undefined && block.col !== undefined ? ` row=${block.row} col=${block.col}` : ""
+  const table = block.tableId ? ` table=${block.tableId}` : ""
+  return `${block.type} path=${block.path} id=${block.id}${rowCol}${table} hash=${block.hash}`
+}
+
+function renderChecks(checks: OperationSemanticResult["checks"]) {
+  return Object.entries(checks)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ")
+}
+
+function renderOperationResult(result: OperationSemanticResult) {
+  const semantic = result.semantic
+  const lines = [`Operation ${result.opIndex + 1} ${result.action}: ${result.status}`]
+  for (const target of result.targetBlocks) lines.push(`Target: ${renderBlockTarget(target)}`)
+  if (typeof semantic.matchedText === "string") {
+    const range = semantic.range as { from?: number; to?: number } | undefined
+    lines.push(
+      `Matched: ${JSON.stringify(semantic.matchedText)} at ${range?.from ?? "?"}-${range?.to ?? "?"} occurrence=${semantic.occurrence ?? 1}`,
+    )
+  }
+  if (typeof semantic.beforeContext === "string") lines.push(`Before context: ${semantic.beforeContext}`)
+  if (typeof semantic.afterContext === "string") lines.push(`After context: ${semantic.afterContext}`)
+  if (typeof semantic.beforeText === "string") lines.push(`Before: ${semantic.beforeText}`)
+  if (typeof semantic.afterText === "string") lines.push(`After: ${semantic.afterText}`)
+  if (typeof semantic.deletedText === "string") lines.push(`Deleted: ${semantic.deletedText}`)
+  if (typeof semantic.insertedText === "string") lines.push(`Inserted: ${semantic.insertedText}`)
+  if (typeof semantic.replacementText === "string") lines.push(`Replacement: ${semantic.replacementText}`)
+  if (semantic.beforeAttrs || semantic.afterAttrs) {
+    lines.push(`Attrs: ${JSON.stringify(semantic.beforeAttrs ?? {})} -> ${JSON.stringify(semantic.afterAttrs ?? {})}`)
+  }
+  lines.push(`Checks: ${renderChecks(result.checks)}`)
+  lines.push(
+    `Changed: direct=${result.directChangedBlocks.length} ancestor=${result.ancestorChangedBlocks.length} unexpected=${result.unexpectedChangedBlocks.length}`,
+  )
+  if (result.warnings.length) lines.push(`Warnings: ${result.warnings.join("; ")}`)
+  return lines.join("\n")
 }
 
 export const NoteEditTool = Tool.define("note_edit", {
@@ -292,11 +674,26 @@ export const NoteEditTool = Tool.define("note_edit", {
 
     let nextDoc = beforeDoc
     const touched = new Set<string>()
+    const operationResults: OperationSemanticResult[] = []
 
     try {
-      for (const op of params.ops) {
-        const result = applyOperation(nextDoc, op)
+      for (const [opIndex, op] of params.ops.entries()) {
+        const stepBeforeDoc = nextDoc
+        const stepBeforeBlocks = NoteDocument.listBlocks(stepBeforeDoc)
+        const result = applyOperation(stepBeforeDoc, op)
         nextDoc = result.doc
+        const stepAfterBlocks = NoteDocument.listBlocks(nextDoc)
+        operationResults.push(
+          buildOperationResult({
+            opIndex,
+            action: op.action,
+            beforeDoc: stepBeforeDoc,
+            afterDoc: nextDoc,
+            beforeBlocks: stepBeforeBlocks,
+            afterBlocks: stepAfterBlocks,
+            seed: result.semanticSeed,
+          }),
+        )
         for (const id of result.touched) touched.add(id)
       }
 
@@ -312,17 +709,41 @@ export const NoteEditTool = Tool.define("note_edit", {
       }
       nextDoc = validation.doc
     } catch (error) {
+      const failedOpIndex = operationResults.length
+      const failedAction = params.ops[failedOpIndex]?.action
       return errorResult({
         id: params.id,
         code: "EDIT_PRECONDITION_FAILED",
         message: error instanceof Error ? error.message : String(error),
         note: existing,
         blockIds: [...new Set(params.ops.flatMap(targetIds))],
+        failedOpIndex,
+        failedAction,
       })
     }
 
     const changed = changedBlocks(beforeDoc, nextDoc, touched)
     const nextHash = NoteDocument.hash(nextDoc)
+    const warnings = operationResults.flatMap((result) =>
+      result.warnings.map((warning) => `Operation ${result.opIndex + 1}: ${warning}`),
+    )
+    const directChangedBlockIds = new Set(
+      operationResults.flatMap((result) => result.directChangedBlocks.map((block) => block.id)),
+    )
+    const ancestorChangedBlockIds = new Set(
+      operationResults.flatMap((result) => result.ancestorChangedBlocks.map((block) => block.id)),
+    )
+    const unexpectedChangedBlockIds = new Set(
+      operationResults.flatMap((result) => result.unexpectedChangedBlocks.map((block) => block.id)),
+    )
+    const changeSummary = {
+      operations: params.ops.length,
+      changedBlocks: changed.length,
+      directChangedBlocks: directChangedBlockIds.size,
+      ancestorChangedBlocks: ancestorChangedBlockIds.size,
+      unexpectedChangedBlocks: unexpectedChangedBlockIds.size,
+      noopOperations: operationResults.filter((result) => result.status === "noop").length,
+    }
 
     if (!params.dryRun) {
       try {
@@ -361,17 +782,13 @@ export const NoteEditTool = Tool.define("note_edit", {
         `DocHash: ${nextHash}`,
         `Operations applied: ${params.ops.length}`,
         `Changed blocks: ${changed.length}`,
+        `Warnings: ${warnings.length ? warnings.join("; ") : "none"}`,
+        "",
+        operationResults.map(renderOperationResult).join("\n\n"),
+        "",
+        "Changed blocks:",
         JSON.stringify(
-          changed.map((block) => ({
-            id: block.id,
-            type: block.type,
-            path: block.pathLabel,
-            hash: block.hash,
-            summary: block.summary,
-            row: block.row,
-            col: block.col,
-            tableId: block.tableId,
-          })),
+          changed.map(blockPreview).filter((block): block is BlockPreview => !!block),
           null,
           2,
         ),
@@ -385,6 +802,9 @@ export const NoteEditTool = Tool.define("note_edit", {
         opCount: params.ops.length,
         changedBlockIds: changed.map((block) => block.id),
         changedBlocks: changed,
+        operationResults,
+        changeSummary,
+        warnings,
       } as Record<string, any>,
     }
   },

--- a/packages/synergy/src/tool/note-edit.ts
+++ b/packages/synergy/src/tool/note-edit.ts
@@ -100,6 +100,8 @@ type BlockPreview = {
   type: string
   path: string
   hash?: string
+  beforeHash?: string
+  afterHash?: string
   text?: string
   summary: string
   row?: number
@@ -171,6 +173,19 @@ function blockPreview(block: NoteDocument.BlockInfo | undefined): BlockPreview |
     col: block.col,
     tableId: block.tableId,
   }
+}
+
+function targetBlockPreview(
+  id: string,
+  before: Map<string, NoteDocument.BlockInfo>,
+  after: Map<string, NoteDocument.BlockInfo>,
+) {
+  const block = after.get(id) ?? before.get(id)
+  const preview = blockPreview(block)
+  if (!preview) return undefined
+  preview.beforeHash = before.get(id)?.hash
+  preview.afterHash = after.get(id)?.hash
+  return preview
 }
 
 function compactBlocks(content: unknown, ids?: string[]) {
@@ -428,6 +443,7 @@ function applyOperation(doc: NoteDocument.Node, op: Operation): ApplyResult {
         content: nodes,
       })
       const requestedText = contentText(nodes)
+      const afterCell = NoteDocument.listBlocks(result.doc).find((block) => block.id === result.cell.id)
       return {
         doc: result.doc,
         touched: [result.cell.id],
@@ -439,7 +455,8 @@ function applyOperation(doc: NoteDocument.Node, op: Operation): ApplyResult {
             tableId: result.cell.tableId,
             row: result.cell.row,
             col: result.cell.col,
-            beforeText: previewText(result.cell.text),
+            beforeText: previewText(current.text),
+            afterText: previewText(afterCell?.text ?? ""),
             replacementText: previewText(requestedText),
           },
           checks: { replacementPresentInTarget: requestedText.length ? undefined : true },
@@ -554,7 +571,7 @@ function buildOperationResult(input: {
   const classified = classifyChanges(input.beforeBlocks, input.afterBlocks, input.seed.directIds)
   const noop = beforeHash === afterHash
   const targetBlocks = input.seed.targetIds
-    .map((id) => previewForId(id, before, after))
+    .map((id) => targetBlockPreview(id, before, after))
     .filter((block): block is BlockPreview => !!block)
   const checks: Record<string, boolean | number | string | undefined> = { ...input.seed.checks, noop }
   if (input.action === "updateTableCell" && checks.replacementPresentInTarget === undefined) {
@@ -582,10 +599,15 @@ function buildOperationResult(input: {
   }
 }
 
+function renderHashTransition(block: BlockPreview) {
+  if (!("beforeHash" in block) && !("afterHash" in block)) return block.hash ?? "unknown"
+  return `${block.beforeHash ?? "missing"} -> ${block.afterHash ?? "missing"}`
+}
+
 function renderBlockTarget(block: BlockPreview) {
   const rowCol = block.row !== undefined && block.col !== undefined ? ` row=${block.row} col=${block.col}` : ""
   const table = block.tableId ? ` table=${block.tableId}` : ""
-  return `${block.type} path=${block.path} id=${block.id}${rowCol}${table} hash=${block.hash}`
+  return `${block.type} path=${block.path} id=${block.id}${rowCol}${table} hash=${renderHashTransition(block)}`
 }
 
 function renderChecks(checks: OperationSemanticResult["checks"]) {

--- a/packages/synergy/src/tool/note-edit.ts
+++ b/packages/synergy/src/tool/note-edit.ts
@@ -242,11 +242,7 @@ function errorResult(input: {
   }
 }
 
-function blockMap(doc: NoteDocument.Node) {
-  return new Map(NoteDocument.listBlocks(doc, { includeJson: true }).map((block) => [block.id, block]))
-}
-
-function blocksMap(blocks: NoteDocument.BlockInfo[]) {
+function blockMap(blocks: NoteDocument.BlockInfo[]) {
   return new Map(blocks.map((block) => [block.id, block]))
 }
 
@@ -258,7 +254,7 @@ function requireHash(block: NoteDocument.BlockInfo, expectedHash: string | undef
 }
 
 function resolveById(doc: NoteDocument.Node, blockId: string, expectedHash: string | undefined, context: string) {
-  const block = blockMap(doc).get(blockId)
+  const block = blockMap(NoteDocument.listBlocks(doc, { includeJson: true })).get(blockId)
   if (!block) throw new Error(`${context} target block ${blockId} was not found.`)
   if (expectedHash) requireHash(block, expectedHash, context)
   return block
@@ -495,8 +491,8 @@ function changedBlocks(before: NoteDocument.Node, after: NoteDocument.Node, touc
 }
 
 function changedIds(beforeBlocks: NoteDocument.BlockInfo[], afterBlocks: NoteDocument.BlockInfo[]) {
-  const before = blocksMap(beforeBlocks)
-  const after = blocksMap(afterBlocks)
+  const before = blockMap(beforeBlocks)
+  const after = blockMap(afterBlocks)
   const ids = new Set([...before.keys(), ...after.keys()])
   return [...ids].filter((id) => before.get(id)?.hash !== after.get(id)?.hash)
 }
@@ -507,8 +503,8 @@ function ancestorIds(
   directIds: Set<string>,
   changed: Set<string>,
 ) {
-  const before = blocksMap(beforeBlocks)
-  const after = blocksMap(afterBlocks)
+  const before = blockMap(beforeBlocks)
+  const after = blockMap(afterBlocks)
   const ancestors = new Set<string>()
   for (const id of directIds) {
     let current = after.get(id) ?? before.get(id)
@@ -533,8 +529,8 @@ function classifyChanges(
   afterBlocks: NoteDocument.BlockInfo[],
   directIds: string[],
 ) {
-  const before = blocksMap(beforeBlocks)
-  const after = blocksMap(afterBlocks)
+  const before = blockMap(beforeBlocks)
+  const after = blockMap(afterBlocks)
   const changed = new Set(changedIds(beforeBlocks, afterBlocks))
   const insertedIds = [...after.keys()].filter((id) => !before.has(id))
   const allDirect = new Set(
@@ -566,8 +562,8 @@ function buildOperationResult(input: {
 }): OperationSemanticResult {
   const beforeHash = NoteDocument.hash(input.beforeDoc)
   const afterHash = NoteDocument.hash(input.afterDoc)
-  const before = blocksMap(input.beforeBlocks)
-  const after = blocksMap(input.afterBlocks)
+  const before = blockMap(input.beforeBlocks)
+  const after = blockMap(input.afterBlocks)
   const classified = classifyChanges(input.beforeBlocks, input.afterBlocks, input.seed.directIds)
   const noop = beforeHash === afterHash
   const targetBlocks = input.seed.targetIds

--- a/packages/synergy/src/tool/note-edit.txt
+++ b/packages/synergy/src/tool/note-edit.txt
@@ -22,5 +22,10 @@ Content inputs:
 
 Safety behavior:
 - Version mismatch, docHash mismatch, missing targets, hash mismatch, invalid JSON content, ambiguous text replacements, and replaceText ranges that include non-editable rendered content fail without writing.
-- On failure, the tool returns current version, current docHash, and current block summaries so you can re-read/retry deliberately.
-- dryRun:true validates and reports changed blocks without writing.
+- On failure, the tool returns current version, current docHash, failed operation index/action when applicable, and current block summaries so you can re-read/retry deliberately. A failed operation means no write occurred.
+- dryRun:true validates and returns the same semantic operation preview without writing.
+
+Result interpretation:
+- Success output includes one section per operation. Inspect matched text, before/after context, checks, warnings, and changed-block classification before assuming the edit is correct.
+- `directChangedBlocks` are the operation's target, inserted, or deleted blocks; `ancestorChangedBlocks` are parent list/table/blockquote/container hashes changed by descendants; `unexpectedChangedBlocks` are changes outside that direct/ancestor set.
+- Warnings are not fatal, but they indicate a possible no-op, unexpected extra change, or semantic mismatch and should usually be followed by re-reading or correcting the note.

--- a/packages/synergy/src/tool/note-edit.txt
+++ b/packages/synergy/src/tool/note-edit.txt
@@ -11,7 +11,7 @@ Preferred operations:
 - insertBefore / insertAfter: Insert content adjacent to a stable blockId.
 - deleteBlock: Delete one block by stable blockId.
 - setAttrs: Update a block's attributes while preserving its blockId.
-- replaceText: Replace text inside one block using find or range. If find appears more than once, specify occurrence.
+- replaceText: Replace editable text inside one block using find or range. If find appears more than once, specify occurrence. Ranges use the exact block text shown by note_read, but spans that cross non-editable rendered content such as hard breaks, inline math, images, or generated separators fail without writing; use replaceBlock for those cases.
 - updateTableCell: Replace the content of one table cell by cellId or by tableId,row,col.
 - replaceRange: Replace a contiguous sibling range.
 
@@ -21,6 +21,6 @@ Content inputs:
 - { format:"json", json:{...} } inserts exact ProseMirror/Tiptap JSON. Use this for rich structures.
 
 Safety behavior:
-- Version mismatch, docHash mismatch, missing targets, hash mismatch, invalid JSON content, and ambiguous text replacements fail without writing.
+- Version mismatch, docHash mismatch, missing targets, hash mismatch, invalid JSON content, ambiguous text replacements, and replaceText ranges that include non-editable rendered content fail without writing.
 - On failure, the tool returns current version, current docHash, and current block summaries so you can re-read/retry deliberately.
 - dryRun:true validates and reports changed blocks without writing.

--- a/packages/synergy/test/tool/note-edit.test.ts
+++ b/packages/synergy/test/tool/note-edit.test.ts
@@ -727,6 +727,152 @@ describe("note_edit anchored operations", () => {
     })
   })
 
+  test("setAttrs semantic result reports beforeAttrs and afterAttrs", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic setAttrs",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Title" }],
+              },
+            ],
+          },
+        })
+        const block = NoteDocument.listBlocks(note.content)[0]
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "setAttrs",
+              blockId: block.id,
+              expectedHash: block.hash,
+              attrs: { level: 2 },
+            },
+          ],
+        })
+
+        const op = result.metadata.operationResults[0]
+        expect(op.semantic.beforeAttrs).toEqual({ level: 1 })
+        expect(op.semantic.afterAttrs).toEqual({ level: 2 })
+        expect(op.directChangedBlocks[0].id).toBe(block.id)
+        expect(op.warnings).toHaveLength(0)
+        expect(result.output).toContain("level")
+        expect(result.output).toContain("Attrs:")
+      },
+    })
+  })
+
+  test("replaceRange semantic result reports removedBlocks and replacementText", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic replaceRange",
+          content: {
+            type: "doc",
+            content: [paragraph("A"), paragraph("B"), paragraph("C"), paragraph("D")],
+          },
+        })
+        const blocks = NoteDocument.listBlocks(note.content)
+        const b = blocks.find((block) => block.text.trim() === "B")!
+        const c = blocks.find((block) => block.text.trim() === "C")!
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceRange",
+              startBlockId: b.id,
+              endBlockId: c.id,
+              expectedStartHash: b.hash,
+              expectedEndHash: c.hash,
+              content: { format: "text", text: "BC replaced" },
+            },
+          ],
+        })
+
+        const op = result.metadata.operationResults[0]
+        expect(op.targetBlocks).toHaveLength(2)
+        expect(op.directChangedBlocks).toHaveLength(3)
+        expect(op.semantic.replacementText).toBe("BC replaced")
+        expect(result.output).toContain("Replacement: BC replaced")
+        expect(result.output).toContain("Changed: direct=3")
+      },
+    })
+  })
+
+  test("updateTableCell via cellId produces the same semantic result fields", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic cellId",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "table",
+                content: [
+                  {
+                    type: "tableRow",
+                    content: [
+                      { type: "tableHeader", content: [paragraph("Header")] },
+                      { type: "tableCell", content: [paragraph("Data")] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        const cell = NoteDocument.listBlocks(note.content).find((block) => block.type === "tableCell")!
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "updateTableCell",
+              cellId: cell.id,
+              expectedHash: cell.hash,
+              content: { format: "text", text: "Updated via cellId" },
+            },
+          ],
+        })
+
+        const op = result.metadata.operationResults[0]
+        expect(op.semantic.cellId).toBe(cell.id)
+        expect(op.semantic.row).toBe(0)
+        expect(op.semantic.col).toBe(1)
+        expect(op.semantic.beforeText).toBe("Data")
+        expect(op.semantic.afterText).toBe("Updated via cellId")
+        expect(op.checks.replacementPresentInTarget).toBe(true)
+        expect(result.output).toContain("row=0 col=1")
+      },
+    })
+  })
+
   test("dryRun validates edits without updating version or content", async () => {
     await using tmp = await tmpdir()
     const scope = (await Scope.fromDirectory(tmp.path)).scope

--- a/packages/synergy/test/tool/note-edit.test.ts
+++ b/packages/synergy/test/tool/note-edit.test.ts
@@ -471,6 +471,9 @@ describe("note_edit anchored operations", () => {
         expect(op.checks.replacementPresentInTarget).toBe(true)
         expect(op.checks.oldTextRemainingInTargetCount).toBe(0)
         expect(op.checks.noop).toBe(false)
+        expect(op.targetBlocks[0].beforeHash).toBe(block.hash)
+        expect(op.targetBlocks[0].afterHash).not.toBe(block.hash)
+        expect(result.output).toContain(`${block.hash} ->`)
         expect(result.output).toContain('Matched: "TARGET"')
         expect(result.output).toContain("After context:")
       },
@@ -564,9 +567,11 @@ describe("note_edit anchored operations", () => {
         expect(op.semantic.row).toBe(0)
         expect(op.semantic.col).toBe(0)
         expect(op.semantic.beforeText).toBe("old cell")
+        expect(op.semantic.afterText).toBe("new cell")
         expect(op.directChangedBlocks[0].text).toBe("new cell")
         expect(op.checks.replacementPresentInTarget).toBe(true)
         expect(result.output).toContain("row=0 col=0")
+        expect(result.output).toContain("After: new cell")
       },
     })
   })

--- a/packages/synergy/test/tool/note-edit.test.ts
+++ b/packages/synergy/test/tool/note-edit.test.ts
@@ -425,6 +425,303 @@ describe("note_edit anchored operations", () => {
     })
   })
 
+  test("replaceText semantic result reports match context and checks", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic replaceText",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "prefix " },
+                  { type: "text", text: "CODE", marks: [{ type: "code" }] },
+                  { type: "text", text: " before TARGET after" },
+                ],
+              },
+            ],
+          },
+        })
+        const block = NoteDocument.listBlocks(note.content)[0]
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: block.id,
+              expectedHash: block.hash,
+              find: "TARGET",
+              replacement: "DONE",
+            },
+          ],
+        })
+
+        const op = result.metadata.operationResults[0]
+        expect(op.semantic.matchedText).toBe("TARGET")
+        expect(op.semantic.afterContext).toContain("DONE")
+        expect(op.checks.replacementPresentInTarget).toBe(true)
+        expect(op.checks.oldTextRemainingInTargetCount).toBe(0)
+        expect(op.checks.noop).toBe(false)
+        expect(result.output).toContain('Matched: "TARGET"')
+        expect(result.output).toContain("After context:")
+      },
+    })
+  })
+
+  test("classifies parent container changes as ancestors", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic ancestors",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "blockquote",
+                content: [paragraph("child TARGET")],
+              },
+            ],
+          },
+        })
+        const blocks = NoteDocument.listBlocks(note.content)
+        const blockquote = blocks.find((block) => block.type === "blockquote")!
+        const child = blocks.find((block) => block.parentId === blockquote.id && block.type === "paragraph")!
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: child.id,
+              expectedHash: child.hash,
+              find: "TARGET",
+              replacement: "done",
+            },
+          ],
+        })
+
+        const op = result.metadata.operationResults[0]
+        expect(op.directChangedBlocks.map((block: any) => block.id)).toContain(child.id)
+        expect(op.ancestorChangedBlocks.map((block: any) => block.id)).toContain(blockquote.id)
+        expect(op.unexpectedChangedBlocks).toHaveLength(0)
+      },
+    })
+  })
+
+  test("table cell semantic result includes coordinates and before after text", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic table",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "table",
+                content: [{ type: "tableRow", content: [{ type: "tableCell", content: [paragraph("old cell")] }] }],
+              },
+            ],
+          },
+        })
+        const cell = NoteDocument.listBlocks(note.content).find((block) => block.type === "tableCell")!
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "updateTableCell",
+              tableId: cell.tableId,
+              row: cell.row,
+              col: cell.col,
+              expectedHash: cell.hash,
+              content: { format: "text", text: "new cell" },
+            },
+          ],
+        })
+
+        const op = result.metadata.operationResults[0]
+        expect(op.semantic.row).toBe(0)
+        expect(op.semantic.col).toBe(0)
+        expect(op.semantic.beforeText).toBe("old cell")
+        expect(op.directChangedBlocks[0].text).toBe("new cell")
+        expect(op.checks.replacementPresentInTarget).toBe(true)
+        expect(result.output).toContain("row=0 col=0")
+      },
+    })
+  })
+
+  test("insert and delete semantic results report inserted and deleted previews", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic insert delete",
+          content: { type: "doc", content: [paragraph("anchor"), paragraph("remove me")] },
+        })
+        const [anchor, removed] = NoteDocument.listBlocks(note.content)
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            { action: "insertAfter", blockId: anchor.id, content: { format: "text", text: "inserted block" } },
+            { action: "deleteBlock", blockId: removed.id, expectedHash: removed.hash },
+          ],
+        })
+
+        const insertOp = result.metadata.operationResults[0]
+        const deleteOp = result.metadata.operationResults[1]
+        expect(insertOp.semantic.insertedText).toBe("inserted block")
+        expect(insertOp.directChangedBlocks.some((block: any) => block.text === "inserted block")).toBe(true)
+        expect(deleteOp.semantic.deletedText).toBe("remove me")
+        expect(deleteOp.directChangedBlocks.some((block: any) => block.text === "remove me")).toBe(true)
+      },
+    })
+  })
+
+  test("failed operation reports failed index and action without writing", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic failure",
+          content: { type: "doc", content: [paragraph("target and target")] },
+        })
+        const block = NoteDocument.listBlocks(note.content)[0]
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: block.id,
+              expectedHash: block.hash,
+              find: "target",
+              replacement: "done",
+            },
+          ],
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(result.metadata.errorCode).toBe("EDIT_PRECONDITION_FAILED")
+        expect(result.metadata.failedOpIndex).toBe(0)
+        expect(result.metadata.failedAction).toBe("replaceText")
+        expect(result.output).toContain("No write occurred.")
+        expect(noteText(current.content)).toContain("target and target")
+      },
+    })
+  })
+
+  test("failed second operation leaves earlier operation unwritten", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Semantic partial failure",
+          content: { type: "doc", content: [paragraph("first"), paragraph("target and target")] },
+        })
+        const [first, second] = NoteDocument.listBlocks(note.content)
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: first.id,
+              expectedHash: first.hash,
+              find: "first",
+              replacement: "changed",
+            },
+            {
+              action: "replaceText",
+              blockId: second.id,
+              expectedHash: second.hash,
+              find: "target",
+              replacement: "done",
+            },
+          ],
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(result.metadata.errorCode).toBe("EDIT_PRECONDITION_FAILED")
+        expect(result.metadata.failedOpIndex).toBe(1)
+        expect(result.metadata.failedAction).toBe("replaceText")
+        expect(current.version).toBe(note.version)
+        expect(noteText(current.content)).toContain("first")
+        expect(noteText(current.content)).not.toContain("changed")
+      },
+    })
+  })
+
+  test("replaceText rejects empty find instead of hanging", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Empty find",
+          content: { type: "doc", content: [paragraph("target")] },
+        })
+        const block = NoteDocument.listBlocks(note.content)[0]
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: block.id,
+              expectedHash: block.hash,
+              find: "",
+              replacement: "bad",
+            },
+          ],
+        })
+
+        expect(result.metadata.errorCode).toBe("EDIT_PRECONDITION_FAILED")
+        expect(result.output).toContain("find must not be empty")
+      },
+    })
+  })
+
   test("dryRun validates edits without updating version or content", async () => {
     await using tmp = await tmpdir()
     const scope = (await Scope.fromDirectory(tmp.path)).scope
@@ -456,6 +753,10 @@ describe("note_edit anchored operations", () => {
         const current = await NoteStore.get(scope.id, note.id)
         expect(result.metadata.dryRun).toBe(true)
         expect(current.version).toBe(note.version)
+        expect(result.metadata.operationResults[0].status).toBe("applied")
+        expect(result.metadata.operationResults[0].semantic.replacementText).toBe("new")
+        expect(result.metadata.operationResults[0].checks.noop).toBe(false)
+        expect(result.output).toContain("Operation 1 replaceBlock: applied")
         expect(noteText(current.content)).toContain("old")
       },
     })

--- a/packages/synergy/test/tool/note-edit.test.ts
+++ b/packages/synergy/test/tool/note-edit.test.ts
@@ -215,6 +215,163 @@ describe("note_edit anchored operations", () => {
     })
   })
 
+  test("replaceText uses the same text coordinates it shows for marked inline text", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Inline mark coordinates",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "prefix " },
+                  { type: "text", text: "CODE", marks: [{ type: "code" }] },
+                  { type: "text", text: " before TARGET after" },
+                ],
+              },
+            ],
+          },
+        })
+        const block = NoteDocument.listBlocks(note.content)[0]
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: block.id,
+              expectedHash: block.hash,
+              find: "TARGET",
+              replacement: "DONE",
+            },
+          ],
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        const [currentBlock] = NoteDocument.listBlocks(current.content, { includeJson: true })
+        expect(result.metadata.errorCode).toBeUndefined()
+        expect(currentBlock.text).toBe("prefix CODE before DONE after")
+        expect(currentBlock.json?.content?.[1]?.marks).toEqual([{ type: "code" }])
+      },
+    })
+  })
+
+  test("replaceText accounts for hardBreak offsets and rejects spans through hardBreaks", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const content = {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "before" }, { type: "hardBreak" }, { type: "text", text: "after" }],
+            },
+          ],
+        }
+        const editableNote = await NoteStore.create({ title: "Hard break offset", content })
+        const editableBlock = NoteDocument.listBlocks(editableNote.content)[0]
+
+        const editResult = await execute({
+          id: editableNote.id,
+          baseVersion: editableNote.version,
+          baseDocHash: NoteDocument.hash(editableNote.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: editableBlock.id,
+              expectedHash: editableBlock.hash,
+              find: "after",
+              replacement: "done",
+            },
+          ],
+        })
+
+        const edited = await NoteStore.get(scope.id, editableNote.id)
+        const [editedBlock] = NoteDocument.listBlocks(edited.content)
+        expect(editResult.metadata.errorCode).toBeUndefined()
+        expect(editedBlock.text).toBe("before\ndone")
+
+        const guardedNote = await NoteStore.create({ title: "Hard break guard", content })
+        const guardedBlock = NoteDocument.listBlocks(guardedNote.content)[0]
+        const guardResult = await execute({
+          id: guardedNote.id,
+          baseVersion: guardedNote.version,
+          baseDocHash: NoteDocument.hash(guardedNote.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: guardedBlock.id,
+              expectedHash: guardedBlock.hash,
+              find: "before\nafter",
+              replacement: "bad",
+            },
+          ],
+        })
+
+        const guarded = await NoteStore.get(scope.id, guardedNote.id)
+        const [currentGuardedBlock] = NoteDocument.listBlocks(guarded.content)
+        expect(guardResult.metadata.errorCode).toBe("EDIT_PRECONDITION_FAILED")
+        expect(currentGuardedBlock.text).toBe("before\nafter")
+      },
+    })
+  })
+
+  test("replaceText accounts for nested block separators", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Nested separators",
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "blockquote",
+                content: [paragraph("first"), paragraph("second TARGET")],
+              },
+            ],
+          },
+        })
+        const blockquote = NoteDocument.listBlocks(note.content).find((block) => block.type === "blockquote")!
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: blockquote.id,
+              expectedHash: blockquote.hash,
+              find: "TARGET",
+              replacement: "done",
+            },
+          ],
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        const currentBlockquote = NoteDocument.listBlocks(current.content).find((block) => block.type === "blockquote")!
+        expect(result.metadata.errorCode).toBeUndefined()
+        expect(currentBlockquote.text).toBe("first\nsecond done")
+      },
+    })
+  })
+
   test("updates a table cell without changing adjacent cells", async () => {
     await using tmp = await tmpdir()
     const scope = (await Scope.fromDirectory(tmp.path)).scope


### PR DESCRIPTION
## Summary
- Add per-operation semantic reporting to `note_edit` success output and metadata so agents can inspect matched text, contexts, checks, and warnings.
- Classify changed blocks as direct, ancestor, or unexpected, and report failed operation index/action without writing on apply failures.
- Expose detailed `replaceText` match facts from `NoteDocument` while preserving the existing `replaceText` wrapper.

## Tests
- `cd packages/synergy && bun test test/tool/note-edit.test.ts`
- `cd packages/synergy && bun run typecheck`
- `git diff --check -- packages/synergy/src/tool/note-edit.ts packages/synergy/src/tool/note-edit.txt packages/synergy/src/note/document.ts packages/synergy/test/tool/note-edit.test.ts`