### PR TITLE
Add desktop-managed CLI installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           - os: macos-latest
             platform: darwin
             runtime_targets: darwin-x64,darwin-arm64
-            builder_args: --mac dmg zip --x64 --arm64
+            builder_args: --mac pkg dmg zip --x64 --arm64
           - os: windows-latest
             platform: win32
             runtime_targets: win32-x64,win32-arm64
@@ -168,6 +168,7 @@ jobs:
             packages/desktop/release/*.blockmap
             packages/desktop/release/*.deb
             packages/desktop/release/*.dmg
+            packages/desktop/release/*.pkg
             packages/desktop/release/*.exe
             packages/desktop/release/*.tar.gz
             packages/desktop/release/*.yml

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Large browser diagnostics such as console, network, snapshots, assets, and downl
 
 ### Desktop Application
 
-`packages/desktop` is the Electron desktop product for Synergy. Its production identity is `io.holosai.synergy`, product name `Synergy`, executable name `synergy`, and URL protocol `synergy://`.
+`packages/desktop` is the Electron desktop product for Synergy. Its production identity is `io.holosai.synergy`, product name `Synergy`, desktop shell executable name `synergy-desktop`, public runtime CLI name `synergy`, and URL protocol `synergy://`.
 
 Production desktop builds default to managed server mode: the app starts a packaged local Synergy server runtime, waits for `/global/health`, then loads the Web UI from the local server origin. Managed server failures show a desktop error page. Source-checkout desktop development uses `bun dev desktop`, which defaults to external mode against the local Vite app and Synergy server.
 
@@ -70,11 +70,11 @@ In managed desktop mode, Add/Open Project uses the operating system's native fol
 
 On Windows and Linux, closing the desktop window hides it to the Synergy system tray icon so the local server and session shell remain reopenable. Use the tray menu to reopen Synergy or quit the desktop process. macOS keeps the standard Dock activation behavior.
 
-Desktop release artifacts are produced with `electron-builder` for macOS, Windows, and Linux and published through GitHub Releases. Stable builds use GitHub Releases update metadata through `electron-updater`; dev builds show product updates as disabled and never check the release feed.
+Desktop release artifacts are produced with `electron-builder` for macOS, Windows, and Linux and published through GitHub Releases. Recommended Desktop installers are macOS `.pkg`, Windows NSIS `.exe`, and Linux `.deb`; they install the Desktop app and expose the packaged runtime as the public `synergy` CLI. Portable artifacts such as `.dmg`, `.zip`, `.AppImage`, and `.tar.gz` remain available for updater, app-bundle, or debug workflows and do not modify PATH.
 
-Stable desktop users can update without a terminal. The desktop shell checks for updates in the background, downloads according to the local desktop update mode, then offers `Restart to Update` in Settings and in the persistent sidebar update prompt; that action stops the managed server process, installs the Electron update, restarts the app, and starts the new bundled server runtime.
+Stable desktop users can update without a terminal. The desktop shell checks for updates in the background, downloads according to the local desktop update mode, then offers `Restart to Update` in Settings and in the persistent sidebar update prompt; that action stops the managed server process, installs the Electron update, restarts the app, and starts the new bundled server runtime. Desktop-managed CLI updates follow the same Desktop updater path.
 
-Web clients update frontend assets by refreshing the browser page when the loaded app version differs from `/global/health`; the sidebar prompt offers `Refresh` when that state is detected. Server replacement from Web is available only for a localhost Synergy managed daemon installed through a supported package manager. A normal terminal-run `synergy server` remains owned by the terminal or deployment system and is not replaced from the browser.
+Web clients update frontend assets by refreshing the browser page when the loaded app version differs from `/global/health`; the sidebar prompt offers `Refresh` when that state is detected. Server replacement from Web is available only for a localhost Synergy managed daemon installed through a supported package manager. A normal terminal-run `synergy server` and a Desktop-managed runtime remain owned by their launch surface and are not replaced from the browser.
 
 ### Session History, File Restore, And Forking
 
@@ -88,19 +88,34 @@ Forking copies the current effective history by default, so rolled-back turns ar
 
 ### Install
 
-Install the latest bundled release:
+Recommended Desktop install:
+
+Download the platform installer from GitHub Releases: macOS `.pkg`, Windows `.exe`, or Linux `.deb`. After installation, a new terminal can run both the Desktop-managed CLI and the app-managed runtime:
+
+```bash
+synergy --version
+synergy start
+synergy web
+synergy send "summarize this repo"
+synergy status
+synergy doctor
+```
+
+The Desktop installer does not run the CLI installer, does not copy a second runtime, and does not edit shell rc files. It exposes the runtime already bundled inside the Desktop app. Portable Desktop artifacts do not modify PATH; use the recommended installer when you want the Desktop app and CLI together.
+
+CLI + Web install:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SII-Holos/synergy/main/install | bash
 ```
 
-Install a specific version:
+Install a specific CLI + Web version:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SII-Holos/synergy/main/install | bash -s -- --version 2.4.3
 ```
 
-The installer places the runtime binary together with the bundled Web UI and schema assets under `~/.synergy/`, so `synergy web` works without requiring a local source checkout.
+The CLI + Web installer places the runtime binary together with the bundled Web UI and schema assets under `~/.synergy/`, so `synergy web` works without requiring a local source checkout. It does not install the Electron Desktop app.
 
 ### Develop Plugins
 

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -104,7 +104,7 @@ Product release keeps the existing candidate/finalize model:
 
 - `bun run --cwd packages/desktop desktop:test`
 - `bun run --cwd packages/desktop desktop:build`
-- `electron-builder --dir --publish=never` with `SYNERGY_DESKTOP_ALLOW_MISSING_RUNTIME=1` for config-only CI validation
+- `cd packages/desktop && SYNERGY_DESKTOP_ALLOW_MISSING_RUNTIME=1 bunx electron-builder --dir --publish=never --config electron-builder.json` for config-only CI validation
 - Install `.pkg`, `.exe`, and `.deb` in platform runners or VMs and check `synergy --version` plus `synergy doctor`
 - Confirm Windows does not expose internal runtime helper binaries through PATH
 - Confirm Linux provides both `/usr/bin/synergy-desktop` for the desktop shell and `/usr/bin/synergy` for the runtime CLI

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -1,13 +1,13 @@
 # Synergy Desktop Release Runbook
 
-`packages/desktop` is the production Electron application for Synergy. It uses `electron-builder`, app id `io.holosai.synergy`, product name `Synergy`, executable name `synergy`, and protocol `synergy://`.
+`packages/desktop` is the production Electron application for Synergy. It uses `electron-builder`, app id `io.holosai.synergy`, product name `Synergy`, desktop shell executable name `synergy-desktop`, public runtime CLI name `synergy`, and protocol `synergy://`.
 
 ## Channels
 
 - `stable`: packaged release channel, GitHub Releases update metadata enabled.
 - `dev`: development channel, automatic updates disabled.
 
-Stable desktop updates use `electron-updater` against the GitHub Release metadata files below. The app stores its desktop update preference under Electron `userData`; `auto` downloads in the background, `notify` reports availability, `manual` waits for an explicit check, and `none` disables checks. Settings and the bottom sidebar update prompt show availability, download progress, install readiness, and errors. Installing an already downloaded update stops the managed local server before calling Electron's installer restart path.
+Stable desktop updates use `electron-updater` against the GitHub Release metadata files below. The app stores its desktop update preference under Electron `userData`; `auto` downloads in the background, `notify` reports availability, `manual` waits for an explicit check, and `none` disables checks. Settings and the bottom sidebar update prompt show availability, download progress, install readiness, and errors. Installing an already downloaded update stops the managed local server before calling Electron's updater install action.
 
 Runtime environment:
 
@@ -29,21 +29,37 @@ bun run desktop:dist
 
 ## Release Artifacts
 
-Primary artifact naming contract:
+Recommended Desktop installer artifacts:
 
-- `Synergy-darwin-x64-${version}.dmg`
-- `Synergy-darwin-arm64-${version}.dmg`
+- `Synergy-darwin-x64-${version}.pkg`
+- `Synergy-darwin-arm64-${version}.pkg`
 - `Synergy-win32-x64-${version}.exe`
 - `Synergy-win32-arm64-${version}.exe`
-- `Synergy-linux-x86_64-${version}.AppImage`
-- `Synergy-linux-arm64-${version}.AppImage`
+- `Synergy-linux-x86_64-${version}.deb`
+- `Synergy-linux-arm64-${version}.deb`
 - `Synergy-${version}-checksums.txt`
+
+Portable and updater artifacts are still published but are not the full Desktop + CLI install entry:
+
+- macOS `.zip` is required by updater metadata.
+- macOS `.dmg` is an app-bundle artifact and does not install the CLI link.
+- Linux `.AppImage` and `.tar.gz` are portable/debug artifacts and do not install global commands.
 
 Updater metadata expected on stable releases:
 
 - `latest-mac.yml`
 - `latest.yml`
 - `latest-linux.yml`
+
+## CLI Exposure
+
+Desktop installers expose the same packaged runtime used by managed server mode:
+
+- macOS `.pkg` creates `/usr/local/bin/synergy` as a symlink to `/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy`.
+- Windows NSIS creates `$INSTDIR\bin\synergy.cmd`, adds `$INSTDIR\bin` to the current user PATH, and forwards to `$INSTDIR\resources\synergy\bin\synergy.exe`.
+- Linux `.deb` installs `synergy-desktop` for the Electron shell and `synergy` for `/opt/Synergy/resources/synergy/bin/synergy` through package lifecycle scripts.
+
+Installers do not run the CLI installer, do not start the runtime, do not write shell rc files, and do not publish internal runtime helper binaries such as `ast-grep` to PATH. Desktop-managed CLI updates are handled by the Desktop updater; `synergy upgrade` reports that update path instead of running package-manager commands.
 
 ## Required Secrets
 
@@ -74,7 +90,7 @@ Product release keeps the existing candidate/finalize model:
 2. `stable_desktop_package` runs a three-way desktop matrix for macOS, Windows, and Linux. Each platform job builds both `x64` and `arm64` artifacts in one `electron-builder` invocation and generates updater metadata per platform.
 3. Each desktop matrix job rewrites package versions to the candidate version, builds the matching Synergy runtimes via `SYNERGY_BUILD_TARGETS`, then packages the platform artifact set with `electron-builder`.
 4. `stable_desktop_publish` downloads all desktop artifacts, generates `Synergy-${version}-checksums.txt`, and uploads the desktop assets to the draft GitHub Release.
-5. `stable_finalize` verifies npm candidates, runtime assets, desktop artifacts, checksum, and updater metadata by reading the draft GitHub Release assets, then promotes npm tags and publishes the GitHub Release.
+5. `stable_finalize` verifies npm candidates, runtime assets, recommended Desktop installer artifacts, portable artifacts, checksum, and updater metadata by reading the draft GitHub Release assets, then promotes npm tags and publishes the GitHub Release.
 
 ## Failure Recovery
 
@@ -89,5 +105,7 @@ Product release keeps the existing candidate/finalize model:
 - `bun run --cwd packages/desktop desktop:test`
 - `bun run --cwd packages/desktop desktop:build`
 - `electron-builder --dir --publish=never` with `SYNERGY_DESKTOP_ALLOW_MISSING_RUNTIME=1` for config-only CI validation
-- Linux CI runtime smoke under `xvfb`
-- Draft GitHub Release contains all expected primary artifacts, checksum, and updater metadata before finalize
+- Install `.pkg`, `.exe`, and `.deb` in platform runners or VMs and check `synergy --version` plus `synergy doctor`
+- Confirm Windows does not expose internal runtime helper binaries through PATH
+- Confirm Linux provides both `/usr/bin/synergy-desktop` for the desktop shell and `/usr/bin/synergy` for the runtime CLI
+- Draft GitHub Release contains all expected recommended installer artifacts, portable artifacts, checksum, and updater metadata before finalize

--- a/packages/desktop/build/installer.nsh
+++ b/packages/desktop/build/installer.nsh
@@ -9,9 +9,9 @@
   StrCpy $1 "$INSTDIR\bin"
   Push $0
   Push $1
-  Call StrStr
+  Call PathHasEntry
   Pop $2
-  ${If} $2 == ""
+  ${If} $2 != "1"
     ${If} $0 == ""
       WriteRegExpandStr HKCU "Environment" "Path" "$1"
     ${Else}
@@ -34,32 +34,42 @@
   SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
 !macroend
 
-Function StrStr
+Function PathHasEntry
   Exch $R1
   Exch
   Exch $R2
   Push $R3
   Push $R4
   Push $R5
-  StrLen $R3 $R1
-  StrCpy $R4 0
+  Push $R6
+  StrCpy $R3 "0"
   loop:
-    StrCpy $R5 $R2 $R3 $R4
-    StrCmp $R5 $R1 done
-    StrCmp $R5 "" notfound
-    IntOp $R4 $R4 + 1
+    StrCpy $R4 $R2 1
+    StrCmp $R4 "" done
+    StrCpy $R5 0
+  entry:
+    StrCpy $R4 $R2 1 $R5
+    StrCmp $R4 ";" entry_done
+    StrCmp $R4 "" entry_done
+    IntOp $R5 $R5 + 1
+    Goto entry
+  entry_done:
+    StrCpy $R6 $R2 $R5
+    IntOp $R5 $R5 + 1
+    StrCpy $R2 $R2 "" $R5
+    StrCmp $R6 $R1 found
     Goto loop
+  found:
+    StrCpy $R3 "1"
   done:
-    StrCpy $R1 $R2 "" $R4
-    Goto end
-  notfound:
-    StrCpy $R1 ""
-  end:
+    Pop $R6
     Pop $R5
     Pop $R4
-    Pop $R3
+    Exch $R3
+    Exch 3
     Pop $R2
-    Exch $R1
+    Pop $R1
+    Pop $R3
 FunctionEnd
 
 Function un.RemovePathEntry

--- a/packages/desktop/build/installer.nsh
+++ b/packages/desktop/build/installer.nsh
@@ -1,0 +1,106 @@
+!macro customInstall
+  CreateDirectory "$INSTDIR\bin"
+  FileOpen $0 "$INSTDIR\bin\synergy.cmd" w
+  FileWrite $0 "@echo off$\r$\n"
+  FileWrite $0 "\"$INSTDIR\resources\synergy\bin\synergy.exe\" %*$\r$\n"
+  FileClose $0
+
+  ReadRegStr $0 HKCU "Environment" "Path"
+  StrCpy $1 "$INSTDIR\bin"
+  Push $0
+  Push $1
+  Call StrStr
+  Pop $2
+  ${If} $2 == ""
+    ${If} $0 == ""
+      WriteRegExpandStr HKCU "Environment" "Path" "$1"
+    ${Else}
+      WriteRegExpandStr HKCU "Environment" "Path" "$0;$1"
+    ${EndIf}
+  ${EndIf}
+  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+!macroend
+
+!macro customUnInstall
+  ReadRegStr $0 HKCU "Environment" "Path"
+  StrCpy $1 "$INSTDIR\bin"
+  Push $0
+  Push $1
+  Call un.RemovePathEntry
+  Pop $2
+  WriteRegExpandStr HKCU "Environment" "Path" "$2"
+  Delete "$INSTDIR\bin\synergy.cmd"
+  RMDir "$INSTDIR\bin"
+  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+!macroend
+
+Function StrStr
+  Exch $R1
+  Exch
+  Exch $R2
+  Push $R3
+  Push $R4
+  Push $R5
+  StrLen $R3 $R1
+  StrCpy $R4 0
+  loop:
+    StrCpy $R5 $R2 $R3 $R4
+    StrCmp $R5 $R1 done
+    StrCmp $R5 "" notfound
+    IntOp $R4 $R4 + 1
+    Goto loop
+  done:
+    StrCpy $R1 $R2 "" $R4
+    Goto end
+  notfound:
+    StrCpy $R1 ""
+  end:
+    Pop $R5
+    Pop $R4
+    Pop $R3
+    Pop $R2
+    Exch $R1
+FunctionEnd
+
+Function un.RemovePathEntry
+  Exch $R1
+  Exch
+  Exch $R2
+  Push $R3
+  Push $R4
+  Push $R5
+  Push $R6
+  StrCpy $R3 ""
+  loop:
+    StrCpy $R4 $R2 1
+    StrCmp $R4 "" done
+    StrCpy $R5 0
+  entry:
+    StrCpy $R4 $R2 1 $R5
+    StrCmp $R4 ";" entry_done
+    StrCmp $R4 "" entry_done
+    IntOp $R5 $R5 + 1
+    Goto entry
+  entry_done:
+    StrCpy $R6 $R2 $R5
+    IntOp $R5 $R5 + 1
+    StrCpy $R2 $R2 "" $R5
+    StrCmp $R6 $R1 loop
+    StrCmp $R6 "" loop
+    StrCmp $R3 "" first append
+  first:
+    StrCpy $R3 $R6
+    Goto loop
+  append:
+    StrCpy $R3 "$R3;$R6"
+    Goto loop
+  done:
+    Pop $R6
+    Pop $R5
+    Pop $R4
+    Exch $R3
+    Exch 3
+    Pop $R2
+    Pop $R1
+    Pop $R3
+FunctionEnd

--- a/packages/desktop/build/linux/deb-after-install.sh
+++ b/packages/desktop/build/linux/deb-after-install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+DESKTOP_TARGET="/opt/Synergy/synergy-desktop"
+CLI_TARGET="/opt/Synergy/resources/synergy/bin/synergy"
+SANDBOX="/opt/Synergy/chrome-sandbox"
+APPARMOR_SOURCE="/opt/Synergy/io.holosai.synergy"
+APPARMOR_TARGET="/etc/apparmor.d/io.holosai.synergy"
+
+if [ -f "$SANDBOX" ] && [ ! -L "$SANDBOX" ]; then
+  chown root:root "$SANDBOX"
+  chmod 4755 "$SANDBOX"
+fi
+
+if command -v update-alternatives >/dev/null 2>&1; then
+  update-alternatives --remove synergy /opt/Synergy/synergy >/dev/null 2>&1 || true
+  if [ -e "$DESKTOP_TARGET" ]; then
+    update-alternatives --install /usr/bin/synergy-desktop synergy-desktop "$DESKTOP_TARGET" 100
+  fi
+  if [ -e "$CLI_TARGET" ]; then
+    update-alternatives --install /usr/bin/synergy synergy "$CLI_TARGET" 100
+  fi
+else
+  if [ -L /usr/bin/synergy ] && [ "$(readlink /usr/bin/synergy)" = "/opt/Synergy/synergy" ]; then
+    rm -f /usr/bin/synergy
+  fi
+  [ -e "$DESKTOP_TARGET" ] && ln -sfn "$DESKTOP_TARGET" /usr/bin/synergy-desktop
+  [ -e "$CLI_TARGET" ] && ln -sfn "$CLI_TARGET" /usr/bin/synergy
+fi
+
+if command -v update-mime-database >/dev/null 2>&1; then
+  update-mime-database /usr/share/mime || true
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database /usr/share/applications || true
+fi
+
+if [ -d /etc/apparmor.d ] && [ -f "$APPARMOR_SOURCE" ]; then
+  cp -f "$APPARMOR_SOURCE" "$APPARMOR_TARGET" || true
+  if command -v apparmor_parser >/dev/null 2>&1; then
+    apparmor_parser -r "$APPARMOR_TARGET" || true
+  fi
+fi
+
+exit 0

--- a/packages/desktop/build/linux/deb-after-remove.sh
+++ b/packages/desktop/build/linux/deb-after-remove.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+if command -v update-alternatives >/dev/null 2>&1; then
+  update-alternatives --remove synergy /opt/Synergy/resources/synergy/bin/synergy >/dev/null 2>&1 || true
+  update-alternatives --remove synergy-desktop /opt/Synergy/synergy-desktop >/dev/null 2>&1 || true
+else
+  if [ -L /usr/bin/synergy ] && [ "$(readlink /usr/bin/synergy)" = "/opt/Synergy/resources/synergy/bin/synergy" ]; then
+    rm -f /usr/bin/synergy
+  fi
+  if [ -L /usr/bin/synergy-desktop ] && [ "$(readlink /usr/bin/synergy-desktop)" = "/opt/Synergy/synergy-desktop" ]; then
+    rm -f /usr/bin/synergy-desktop
+  fi
+fi
+
+if command -v update-mime-database >/dev/null 2>&1; then
+  update-mime-database /usr/share/mime || true
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database /usr/share/applications || true
+fi
+
+APPARMOR_TARGET="/etc/apparmor.d/io.holosai.synergy"
+if [ -f "$APPARMOR_TARGET" ]; then
+  if command -v apparmor_parser >/dev/null 2>&1; then
+    apparmor_parser -R "$APPARMOR_TARGET" || true
+  fi
+  rm -f "$APPARMOR_TARGET" || true
+fi
+
+exit 0

--- a/packages/desktop/build/pkg-scripts/postinstall
+++ b/packages/desktop/build/pkg-scripts/postinstall
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -u
+
+CLI_LINK="/usr/local/bin/synergy"
+CLI_TARGET="/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy"
+
+mkdir -p "/usr/local/bin"
+
+if [ -e "$CLI_LINK" ] || [ -L "$CLI_LINK" ]; then
+  if [ -L "$CLI_LINK" ]; then
+    EXISTING_TARGET="$(readlink "$CLI_LINK")"
+    case "$EXISTING_TARGET" in
+      /Applications/Synergy.app/Contents/Resources/synergy/bin/synergy|*/Synergy.app/Contents/Resources/synergy/bin/synergy)
+        rm -f "$CLI_LINK"
+        ;;
+      *)
+        echo "Synergy Desktop warning: $CLI_LINK points to $EXISTING_TARGET. Leaving it unchanged." >&2
+        exit 0
+        ;;
+    esac
+  else
+    echo "Synergy Desktop warning: $CLI_LINK exists and is not a symlink. Leaving it unchanged." >&2
+    exit 0
+  fi
+fi
+
+ln -s "$CLI_TARGET" "$CLI_LINK"
+exit 0

--- a/packages/desktop/electron-builder.json
+++ b/packages/desktop/electron-builder.json
@@ -45,6 +45,10 @@
     "icon": "build/icon.icns",
     "target": [
       {
+        "target": "pkg",
+        "arch": ["x64", "arm64"]
+      },
+      {
         "target": "dmg",
         "arch": ["x64", "arm64"]
       },
@@ -82,9 +86,14 @@
       }
     ]
   },
+  "pkg": {
+    "scripts": "build/pkg-scripts",
+    "installLocation": "/Applications",
+    "mustClose": ["io.holosai.synergy"]
+  },
   "win": {
     "artifactName": "Synergy-win32-${arch}-${version}.${ext}",
-    "executableName": "synergy",
+    "executableName": "synergy-desktop",
     "icon": "build/icon.ico",
     "target": [
       {
@@ -104,7 +113,8 @@
     "createStartMenuShortcut": true,
     "oneClick": false,
     "perMachine": false,
-    "shortcutName": "Synergy"
+    "shortcutName": "Synergy",
+    "include": "build/installer.nsh"
   },
   "linux": {
     "artifactName": "Synergy-linux-${arch}-${version}.${ext}",
@@ -116,7 +126,7 @@
         "StartupWMClass": "synergy"
       }
     },
-    "executableName": "synergy",
+    "executableName": "synergy-desktop",
     "icon": "build/icons",
     "target": [
       {
@@ -132,6 +142,10 @@
         "arch": ["x64", "arm64"]
       }
     ]
+  },
+  "deb": {
+    "afterInstall": "build/linux/deb-after-install.sh",
+    "afterRemove": "build/linux/deb-after-remove.sh"
   },
   "electronFuses": {
     "runAsNode": false,

--- a/packages/desktop/script/after-pack.cjs
+++ b/packages/desktop/script/after-pack.cjs
@@ -15,6 +15,7 @@ exports.default = async function afterPack(context) {
   const destination = path.join(resourcesPath(context), "synergy")
   fs.rmSync(destination, { recursive: true, force: true })
   copyDirectory(source, destination)
+  writeDesktopPackageMetadata(destination, context)
 }
 
 function runtimePackageName(platform, arch) {
@@ -34,6 +35,16 @@ function resourcesPath(context) {
     return path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, "Contents", "Resources")
   }
   return path.join(context.appOutDir, "resources")
+}
+
+function writeDesktopPackageMetadata(destination, context) {
+  const version = context.packager?.appInfo?.version || packageVersion()
+  fs.writeFileSync(path.join(destination, "desktop-package.json"), `${JSON.stringify({ version }, null, 2)}\n`)
+}
+
+function packageVersion() {
+  const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf8"))
+  return packageJson.version
 }
 
 function copyDirectory(source, destination) {

--- a/packages/desktop/src/identity.ts
+++ b/packages/desktop/src/identity.ts
@@ -1,6 +1,6 @@
 export const DESKTOP_APP_ID = "io.holosai.synergy"
 export const DESKTOP_PRODUCT_NAME = "Synergy"
-export const DESKTOP_EXECUTABLE_NAME = "synergy"
+export const DESKTOP_EXECUTABLE_NAME = "synergy-desktop"
 export const DESKTOP_PROTOCOL = "synergy"
 
 export type DesktopChannel = "dev" | "stable"

--- a/packages/desktop/src/release-assets.ts
+++ b/packages/desktop/src/release-assets.ts
@@ -9,9 +9,20 @@ export function desktopPrimaryArtifactName(
   platform: DesktopReleasePlatform,
   arch: DesktopReleaseArch,
 ): string {
-  const extension = platform === "darwin" ? "dmg" : platform === "win32" ? "exe" : "AppImage"
+  const extension = platform === "darwin" ? "pkg" : platform === "win32" ? "exe" : "deb"
   const artifactArch = platform === "linux" && arch === "x64" ? "x86_64" : arch
   return `Synergy-${platform}-${artifactArch}-${version}.${extension}`
+}
+
+export function desktopPortableArtifactNames(version: string): string[] {
+  return DESKTOP_RELEASE_PLATFORMS.flatMap((platform) =>
+    DESKTOP_RELEASE_ARCHES.flatMap((arch) => {
+      const artifactArch = platform === "linux" && arch === "x64" ? "x86_64" : arch
+      const extensions =
+        platform === "darwin" ? ["dmg", "zip"] : platform === "win32" ? ["zip"] : ["AppImage", "tar.gz"]
+      return extensions.map((extension) => `Synergy-${platform}-${artifactArch}-${version}.${extension}`)
+    }),
+  )
 }
 
 export function expectedDesktopPrimaryArtifacts(version: string): string[] {

--- a/packages/desktop/test/identity.test.ts
+++ b/packages/desktop/test/identity.test.ts
@@ -12,7 +12,7 @@ import {
 describe("desktop identity", () => {
   test("uses the production app identity", () => {
     expect(DESKTOP_APP_ID).toBe("io.holosai.synergy")
-    expect(DESKTOP_EXECUTABLE_NAME).toBe("synergy")
+    expect(DESKTOP_EXECUTABLE_NAME).toBe("synergy-desktop")
     expect(DESKTOP_PROTOCOL).toBe("synergy")
   })
 

--- a/packages/desktop/test/packaging.test.ts
+++ b/packages/desktop/test/packaging.test.ts
@@ -81,6 +81,14 @@ describe("desktop packaging", () => {
     expect(nsisScript).not.toContain("$INSTDIR\\resources\\synergy\\bin;")
   })
 
+  test("Windows installer de-dupes PATH by exact entry rather than prefix substring", async () => {
+    const nsisScript = await Bun.file(new URL("../build/installer.nsh", import.meta.url)).text()
+
+    expect(nsisScript).toContain("Call PathHasEntry")
+    expect(nsisScript).toContain("StrCmp $R6 $R1 found")
+    expect(nsisScript).not.toContain("Call StrStr")
+  })
+
   test("writes Desktop package version metadata beside the embedded runtime", async () => {
     const afterPackScript = await Bun.file(new URL("../script/after-pack.cjs", import.meta.url)).text()
 

--- a/packages/desktop/test/packaging.test.ts
+++ b/packages/desktop/test/packaging.test.ts
@@ -80,4 +80,11 @@ describe("desktop packaging", () => {
     expect(nsisScript).not.toContain("WriteRegExpandStr HKLM")
     expect(nsisScript).not.toContain("$INSTDIR\\resources\\synergy\\bin;")
   })
+
+  test("writes Desktop package version metadata beside the embedded runtime", async () => {
+    const afterPackScript = await Bun.file(new URL("../script/after-pack.cjs", import.meta.url)).text()
+
+    expect(afterPackScript).toContain("desktop-package.json")
+    expect(afterPackScript).toContain("appInfo?.version")
+  })
 })

--- a/packages/desktop/test/packaging.test.ts
+++ b/packages/desktop/test/packaging.test.ts
@@ -1,6 +1,28 @@
 import { describe, expect, test } from "bun:test"
 
 interface ElectronBuilderConfig {
+  mac?: {
+    target?: Array<{ target?: string; arch?: string[] }>
+  }
+  pkg?: {
+    scripts?: string
+    installLocation?: string
+  }
+  win?: {
+    executableName?: string
+  }
+  nsis?: {
+    include?: string
+    shortcutName?: string
+  }
+  linux?: {
+    executableName?: string
+    desktop?: { entry?: { Name?: string; StartupWMClass?: string } }
+  }
+  deb?: {
+    afterInstall?: string
+    afterRemove?: string
+  }
   extraResources?: Array<{
     from?: string
     to?: string
@@ -21,5 +43,41 @@ describe("desktop packaging", () => {
       from: "build/icon.png",
       to: "icons/icon.png",
     })
+  })
+
+  test("keeps desktop shell executables separate from the public runtime CLI", async () => {
+    const config = (await Bun.file(
+      new URL("../electron-builder.json", import.meta.url),
+    ).json()) as ElectronBuilderConfig
+
+    expect(config.win?.executableName).toBe("synergy-desktop")
+    expect(config.linux?.executableName).toBe("synergy-desktop")
+    expect(config.nsis?.shortcutName).toBe("Synergy")
+    expect(config.linux?.desktop?.entry?.Name).toBe("Synergy")
+    expect(config.linux?.desktop?.entry?.StartupWMClass).toBe("synergy")
+  })
+
+  test("configures installer hooks that expose the embedded runtime as synergy", async () => {
+    const config = (await Bun.file(
+      new URL("../electron-builder.json", import.meta.url),
+    ).json()) as ElectronBuilderConfig
+
+    expect(config.mac?.target?.map((target) => target.target)).toContain("pkg")
+    expect(config.pkg?.scripts).toBe("build/pkg-scripts")
+    expect(config.pkg?.installLocation).toBe("/Applications")
+    expect(config.nsis?.include).toBe("build/installer.nsh")
+    expect(config.deb?.afterInstall).toBe("build/linux/deb-after-install.sh")
+    expect(config.deb?.afterRemove).toBe("build/linux/deb-after-remove.sh")
+  })
+
+  test("Windows installer publishes only the launcher directory, not runtime internals", async () => {
+    const nsisScript = await Bun.file(new URL("../build/installer.nsh", import.meta.url)).text()
+
+    expect(nsisScript).toContain("$INSTDIR\\bin\\synergy.cmd")
+    expect(nsisScript).toContain("$INSTDIR\\resources\\synergy\\bin\\synergy.exe")
+    expect(nsisScript).toContain("WriteRegExpandStr HKCU")
+    expect(nsisScript).toContain("$INSTDIR\\bin")
+    expect(nsisScript).not.toContain("WriteRegExpandStr HKLM")
+    expect(nsisScript).not.toContain("$INSTDIR\\resources\\synergy\\bin;")
   })
 })

--- a/packages/desktop/test/release-assets.test.ts
+++ b/packages/desktop/test/release-assets.test.ts
@@ -1,24 +1,32 @@
 import { describe, expect, test } from "bun:test"
 import {
   desktopChecksumsName,
+  desktopPortableArtifactNames,
   desktopPrimaryArtifactName,
   expectedDesktopPrimaryArtifacts,
   isDesktopUpdateMetadata,
 } from "../src/release-assets.js"
 
 describe("desktop release asset names", () => {
-  test("matches the public primary artifact naming contract", () => {
-    expect(desktopPrimaryArtifactName("1.2.3", "darwin", "arm64")).toBe("Synergy-darwin-arm64-1.2.3.dmg")
+  test("matches the public installer artifact naming contract", () => {
+    expect(desktopPrimaryArtifactName("1.2.3", "darwin", "arm64")).toBe("Synergy-darwin-arm64-1.2.3.pkg")
     expect(desktopPrimaryArtifactName("1.2.3", "win32", "x64")).toBe("Synergy-win32-x64-1.2.3.exe")
-    expect(desktopPrimaryArtifactName("1.2.3", "linux", "x64")).toBe("Synergy-linux-x86_64-1.2.3.AppImage")
-    expect(desktopPrimaryArtifactName("1.2.3", "linux", "arm64")).toBe("Synergy-linux-arm64-1.2.3.AppImage")
+    expect(desktopPrimaryArtifactName("1.2.3", "linux", "x64")).toBe("Synergy-linux-x86_64-1.2.3.deb")
+    expect(desktopPrimaryArtifactName("1.2.3", "linux", "arm64")).toBe("Synergy-linux-arm64-1.2.3.deb")
   })
 
-  test("lists all expected primary artifacts", () => {
+  test("lists all expected primary installer artifacts", () => {
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toHaveLength(6)
-    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-darwin-x64-1.2.3.dmg")
-    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.AppImage")
-    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.AppImage")
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-darwin-x64-1.2.3.pkg")
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.deb")
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.deb")
+  })
+
+  test("lists portable desktop artifacts separately from installer artifacts", () => {
+    expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-darwin-arm64-1.2.3.dmg")
+    expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-darwin-arm64-1.2.3.zip")
+    expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.AppImage")
+    expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.tar.gz")
   })
 
   test("names checksum and updater metadata predictably", () => {

--- a/packages/synergy/src/cli/cmd/doctor.ts
+++ b/packages/synergy/src/cli/cmd/doctor.ts
@@ -1,6 +1,9 @@
 import { cmd } from "./cmd"
 import { detectPlatform } from "../../sandbox/detect"
 import { getSandboxReadiness } from "../../sandbox/readiness"
+import fs from "fs/promises"
+import { Installation } from "../../global/installation"
+import { DesktopInstallation } from "../../global/desktop-installation"
 
 export const DoctorCommand = cmd({
   command: "doctor",
@@ -13,6 +16,7 @@ export const DoctorCommand = cmd({
     const platform = detectPlatform()
     console.log(`\nPlatform: ${platform}`)
 
+    await printInstallationChecks()
     // Readiness checks
     try {
       const readiness = await getSandboxReadiness()
@@ -44,3 +48,50 @@ export const DoctorCommand = cmd({
     console.log(`  SHELL: ${process.env.SHELL ?? "not set"}`)
   },
 })
+
+async function printInstallationChecks() {
+  const method = await Installation.method()
+  const realExecPath = await fs.realpath(process.execPath).catch(() => process.execPath)
+  const context = { platform: process.platform, execPath: process.execPath, realExecPath, env: process.env }
+
+  console.log(`\nInstallation:`)
+  console.log(`  Method: ${method}`)
+  console.log(`  Executable: ${process.execPath}`)
+  console.log(`  Real executable: ${realExecPath}`)
+
+  if (method === "desktop") {
+    console.log(`  Updates: Desktop updates are managed from the Synergy app.`)
+    const link = await DesktopInstallation.inspectCliLink(context)
+    const icon = link.status === "healthy" ? "✅" : link.status === "not-applicable" ? "ℹ️" : "⚠️"
+    console.log(`  ${icon} Desktop CLI link: ${link.message}`)
+    if (link.path) console.log(`     Path: ${link.path}`)
+    if (link.target) console.log(`     Target: ${link.target}`)
+
+    const expectedRuntime = DesktopInstallation.expectedRuntimePath(process.platform)
+    if (expectedRuntime) {
+      const consistent = DesktopInstallation.samePath(realExecPath, expectedRuntime, process.platform)
+      console.log(
+        `  ${consistent ? "✅" : "⚠️"} Version source: ${Installation.VERSION} from ${consistent ? "expected" : "unexpected"} Desktop runtime path`,
+      )
+    } else {
+      console.log(`  ℹ️ Version source: ${Installation.VERSION}`)
+    }
+  }
+
+  const candidates = await DesktopInstallation.pathCandidates(context)
+  if (candidates.length === 0) {
+    console.log(`  ⚠️ PATH: no synergy command found on PATH`)
+    return
+  }
+
+  console.log(`  PATH candidates:`)
+  candidates.forEach((candidate, index) => {
+    const first = index === 0
+    const icon = candidate.isCurrent ? "✅" : first ? "⚠️" : "•"
+    console.log(`    ${icon} ${candidate.path}${candidate.isCurrent ? " (current)" : ""}`)
+  })
+
+  if (method === "desktop" && !candidates[0]?.isCurrent) {
+    console.log(`  ⚠️ PATH conflict: the first synergy command is not this Desktop-managed CLI.`)
+  }
+}

--- a/packages/synergy/src/cli/cmd/doctor.ts
+++ b/packages/synergy/src/cli/cmd/doctor.ts
@@ -67,15 +67,11 @@ async function printInstallationChecks() {
     if (link.path) console.log(`     Path: ${link.path}`)
     if (link.target) console.log(`     Target: ${link.target}`)
 
-    const expectedRuntime = DesktopInstallation.expectedRuntimePath(process.platform)
-    if (expectedRuntime) {
-      const consistent = DesktopInstallation.samePath(realExecPath, expectedRuntime, process.platform)
-      console.log(
-        `  ${consistent ? "✅" : "⚠️"} Version source: ${Installation.VERSION} from ${consistent ? "expected" : "unexpected"} Desktop runtime path`,
-      )
-    } else {
-      console.log(`  ℹ️ Version source: ${Installation.VERSION}`)
-    }
+    const versionStatus = await DesktopInstallation.packageVersionStatus(context, Installation.VERSION)
+    const versionIcon =
+      versionStatus.status === "matching" ? "✅" : versionStatus.status === "not-applicable" ? "ℹ️" : "⚠️"
+    console.log(`  ${versionIcon} Desktop package version: ${versionStatus.message}`)
+    if (versionStatus.metadataPath) console.log(`     Metadata: ${versionStatus.metadataPath}`)
   }
 
   const candidates = await DesktopInstallation.pathCandidates(context)

--- a/packages/synergy/src/cli/cmd/uninstall.ts
+++ b/packages/synergy/src/cli/cmd/uninstall.ts
@@ -2,6 +2,7 @@ import type { Argv } from "yargs"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
 import { Installation } from "../../global/installation"
+import { DesktopInstallation } from "../../global/desktop-installation"
 import { Global } from "../../global"
 import { $ } from "bun"
 import fs from "fs/promises"
@@ -19,6 +20,8 @@ interface RemovalTargets {
   directories: Array<{ path: string; label: string; keep: boolean }>
   shellConfig: string | null
   binary: string | null
+  desktopCliLink: string | null
+  desktopPathEntry: string | null
 }
 
 export const UninstallCommand = {
@@ -96,8 +99,20 @@ async function collectRemovalTargets(args: UninstallArgs, method: Installation.M
 
   const shellConfig = null
   const binary = null
+  let desktopCliLink: string | null = null
+  let desktopPathEntry: string | null = null
 
-  return { directories, shellConfig, binary }
+  if (method === "desktop") {
+    const realExecPath = await fs.realpath(process.execPath).catch(() => process.execPath)
+    const context = { platform: process.platform, execPath: process.execPath, realExecPath, env: process.env }
+    const cliLink = await DesktopInstallation.inspectCliLink(context)
+    if (cliLink.path && (cliLink.status === "healthy" || cliLink.status === "broken")) {
+      desktopCliLink = cliLink.path
+    }
+    desktopPathEntry = DesktopInstallation.launcherDirectory(context)
+  }
+
+  return { directories, shellConfig, binary, desktopCliLink, desktopPathEntry }
 }
 
 async function showRemovalSummary(targets: RemovalTargets, method: Installation.Method) {
@@ -124,6 +139,19 @@ async function showRemovalSummary(targets: RemovalTargets, method: Installation.
 
   if (targets.shellConfig) {
     prompts.log.info(`  ✓ Shell PATH in ${shortenPath(targets.shellConfig)}`)
+  }
+
+  if (targets.desktopCliLink) {
+    prompts.log.info(`  ✓ Desktop CLI link: ${shortenPath(targets.desktopCliLink)}`)
+  }
+
+  if (targets.desktopPathEntry) {
+    prompts.log.info(`  ✓ Desktop CLI PATH entry: ${shortenPath(targets.desktopPathEntry)}`)
+  }
+
+  if (method === "desktop") {
+    prompts.log.info(`  ○ Desktop app: ${DesktopInstallation.desktopRemovalHint(process.platform)}`)
+    return
   }
 
   if (method !== "unknown") {
@@ -175,7 +203,24 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
     }
   }
 
-  if (method !== "unknown") {
+  if (targets.desktopCliLink) {
+    spinner.start("Removing Desktop CLI link...")
+    const err = await fs.rm(targets.desktopCliLink, { force: true }).catch((e) => e)
+    if (err) {
+      spinner.stop("Failed to remove Desktop CLI link", 1)
+      errors.push(`Desktop CLI link: ${err.message}`)
+    } else {
+      spinner.stop("Removed Desktop CLI link")
+    }
+  }
+
+  if (method === "desktop" && targets.desktopPathEntry && process.platform === "win32") {
+    prompts.log.warn(
+      `Remove ${targets.desktopPathEntry} from your user PATH if the Desktop uninstaller has not already done so.`,
+    )
+  }
+
+  if (method !== "unknown" && method !== "desktop") {
     const cmds: Record<string, string[]> = {
       npm: ["npm", "uninstall", "-g", "@ericsanchezok/synergy"],
       pnpm: ["pnpm", "uninstall", "-g", "@ericsanchezok/synergy"],

--- a/packages/synergy/src/cli/cmd/uninstall.ts
+++ b/packages/synergy/src/cli/cmd/uninstall.ts
@@ -215,9 +215,16 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
   }
 
   if (method === "desktop" && targets.desktopPathEntry && process.platform === "win32") {
-    prompts.log.warn(
-      `Remove ${targets.desktopPathEntry} from your user PATH if the Desktop uninstaller has not already done so.`,
-    )
+    spinner.start("Removing Desktop CLI PATH entry...")
+    const result = await DesktopInstallation.removeWindowsUserPathEntry(targets.desktopPathEntry).catch((e) => e)
+    if (result instanceof Error) {
+      spinner.stop("Failed to remove Desktop CLI PATH entry", 1)
+      errors.push(`Desktop CLI PATH entry: ${result.message}`)
+    } else if (result.removed) {
+      spinner.stop("Removed Desktop CLI PATH entry")
+    } else {
+      spinner.stop("Desktop CLI PATH entry was already absent")
+    }
   }
 
   if (method !== "unknown" && method !== "desktop") {

--- a/packages/synergy/src/cli/cmd/upgrade.ts
+++ b/packages/synergy/src/cli/cmd/upgrade.ts
@@ -16,7 +16,7 @@ export const UpgradeCommand = {
         alias: "m",
         describe: "installation method to use",
         type: "string",
-        choices: ["npm", "yarn", "pnpm", "bun", "brew"],
+        choices: ["npm", "yarn", "pnpm", "bun", "brew", "desktop"],
       })
   },
   handler: async (args: { target?: string; method?: string }) => {
@@ -42,6 +42,16 @@ export const UpgradeCommand = {
       }
     }
     prompts.log.info("Using method: " + method)
+    if (method === "desktop") {
+      const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest("desktop")
+      if (Installation.VERSION === target) {
+        prompts.log.warn(`synergy upgrade skipped: ${target} is already installed`)
+      }
+      prompts.log.info("Synergy is installed with the Desktop app.")
+      prompts.log.info("Desktop updates are managed from the Synergy app. Open Synergy and use Settings → Updates.")
+      prompts.outro("Done")
+      return
+    }
     const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest()
 
     if (Installation.VERSION === target) {

--- a/packages/synergy/src/global/desktop-installation.ts
+++ b/packages/synergy/src/global/desktop-installation.ts
@@ -21,6 +21,26 @@ export namespace DesktopInstallation {
     isCurrent: boolean
   }
 
+  export interface DesktopPackageVersionStatus {
+    status: "matching" | "mismatch" | "unavailable" | "not-applicable"
+    runtimeVersion: string
+    packageVersion: string | null
+    metadataPath: string | null
+    message: string
+  }
+
+  export interface WindowsUserPathStore {
+    read(): Promise<string | null>
+    write(value: string): Promise<void>
+    broadcast?(): Promise<void>
+  }
+
+  export interface WindowsUserPathRemovalResult {
+    removed: boolean
+    previousValue: string
+    nextValue: string
+  }
+
   export function normalizePath(value: string) {
     return value.replace(/\\/g, "/").toLowerCase()
   }
@@ -48,6 +68,88 @@ export namespace DesktopInstallation {
     const normalized = context.realExecPath.replace(/\\/g, path.win32.sep)
     const installRoot = path.win32.resolve(normalized, "..", "..", "..", "..")
     return path.win32.join(installRoot, "bin")
+  }
+
+  export function runtimeRoot(realExecPath: string, platform: NodeJS.Platform) {
+    const pathModule = platform === "win32" ? path.win32 : path
+    return pathModule.resolve(realExecPath, "..", "..")
+  }
+
+  export function packageVersionMetadataPath(realExecPath: string, platform: NodeJS.Platform) {
+    if (!isRuntimePath(platform, realExecPath)) return null
+    const pathModule = platform === "win32" ? path.win32 : path
+    return pathModule.join(runtimeRoot(realExecPath, platform), "desktop-package.json")
+  }
+
+  export async function packageVersionStatus(
+    context: Context,
+    runtimeVersion: string,
+  ): Promise<DesktopPackageVersionStatus> {
+    if (!detectDesktopInstall(context)) {
+      return {
+        status: "not-applicable",
+        runtimeVersion,
+        packageVersion: null,
+        metadataPath: null,
+        message: "Desktop package version is only checked for Desktop-managed runtimes.",
+      }
+    }
+
+    const metadataPath = packageVersionMetadataPath(context.realExecPath, context.platform)
+    if (!metadataPath) {
+      return {
+        status: "unavailable",
+        runtimeVersion,
+        packageVersion: null,
+        metadataPath: null,
+        message: "Desktop package version metadata is unavailable.",
+      }
+    }
+
+    const metadata = await readPackageVersionMetadata(metadataPath)
+    if (!metadata) {
+      return {
+        status: "unavailable",
+        runtimeVersion,
+        packageVersion: null,
+        metadataPath,
+        message: "Desktop package version metadata could not be read.",
+      }
+    }
+
+    if (metadata.version !== runtimeVersion) {
+      return {
+        status: "mismatch",
+        runtimeVersion,
+        packageVersion: metadata.version,
+        metadataPath,
+        message: `Desktop package version ${metadata.version} does not match runtime version ${runtimeVersion}.`,
+      }
+    }
+
+    return {
+      status: "matching",
+      runtimeVersion,
+      packageVersion: metadata.version,
+      metadataPath,
+      message: `Desktop package version ${metadata.version} matches runtime version ${runtimeVersion}.`,
+    }
+  }
+
+  async function readPackageVersionMetadata(metadataPath: string) {
+    const text = await fs.readFile(metadataPath, "utf8").catch(() => null)
+    if (!text) return null
+    const parsed = parseJsonObject(text)
+    if (!parsed || typeof parsed.version !== "string" || parsed.version.length === 0) return null
+    return { version: parsed.version }
+  }
+
+  function parseJsonObject(text: string) {
+    try {
+      return JSON.parse(text) as { version?: unknown }
+    } catch {
+      return null
+    }
   }
 
   export function linkPath(context: Context) {
@@ -150,6 +252,65 @@ export namespace DesktopInstallation {
   export function userPathEntries(env: NodeJS.ProcessEnv = process.env, platform: NodeJS.Platform = process.platform) {
     const delimiter = platform === "win32" ? ";" : path.delimiter
     return (env.Path ?? env.PATH ?? "").split(delimiter).filter(Boolean)
+  }
+
+  export function removePathEntry(pathValue: string, entryToRemove: string, platform: NodeJS.Platform) {
+    const delimiter = platform === "win32" ? ";" : path.delimiter
+    return pathValue
+      .split(delimiter)
+      .filter((entry) => entry.length > 0 && !samePath(entry, entryToRemove, platform))
+      .join(delimiter)
+  }
+
+  export async function removeWindowsUserPathEntry(
+    entryToRemove: string,
+    store: WindowsUserPathStore = windowsUserPathStore(),
+  ): Promise<WindowsUserPathRemovalResult> {
+    const previousValue = (await store.read()) ?? ""
+    const nextValue = removePathEntry(previousValue, entryToRemove, "win32")
+    if (nextValue === previousValue) return { removed: false, previousValue, nextValue }
+    await store.write(nextValue)
+    await store.broadcast?.()
+    return { removed: true, previousValue, nextValue }
+  }
+
+  function windowsUserPathStore(): WindowsUserPathStore {
+    return {
+      async read() {
+        const proc = Bun.spawn(["reg.exe", "query", "HKCU\\Environment", "/v", "Path"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+        const [exitCode, output] = await Promise.all([proc.exited, new Response(proc.stdout).text()])
+        if (exitCode !== 0) return ""
+        const line = output
+          .split(/\r?\n/)
+          .map((item) => item.trim())
+          .find((item) => item.toLowerCase().startsWith("path"))
+        if (!line) return ""
+        const parts = line.split(/\s{2,}/)
+        return parts.at(-1) ?? ""
+      },
+      async write(value) {
+        await Bun.spawn(
+          ["reg.exe", "add", "HKCU\\Environment", "/v", "Path", "/t", "REG_EXPAND_SZ", "/d", value, "/f"],
+          {
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        ).exited
+      },
+      async broadcast() {
+        await Bun.spawn([
+          "powershell.exe",
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          '[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", "User"), "User")',
+        ]).exited
+      },
+    }
   }
 
   export async function pathCandidates(context: Context): Promise<PathCandidate[]> {

--- a/packages/synergy/src/global/desktop-installation.ts
+++ b/packages/synergy/src/global/desktop-installation.ts
@@ -21,6 +21,11 @@ export namespace DesktopInstallation {
     isCurrent: boolean
   }
 
+  export interface PathCandidateFilesystem {
+    access(path: string): Promise<void>
+    realpath(path: string): Promise<string>
+  }
+
   export interface DesktopPackageVersionStatus {
     status: "matching" | "mismatch" | "unavailable" | "not-applicable"
     runtimeVersion: string
@@ -313,7 +318,10 @@ export namespace DesktopInstallation {
     }
   }
 
-  export async function pathCandidates(context: Context): Promise<PathCandidate[]> {
+  export async function pathCandidates(
+    context: Context,
+    filesystem: PathCandidateFilesystem = fs,
+  ): Promise<PathCandidate[]> {
     const commandNames = context.platform === "win32" ? ["synergy.cmd", "synergy.exe", "synergy.bat"] : ["synergy"]
     const candidates: PathCandidate[] = []
     const seen = new Set<string>()
@@ -323,16 +331,30 @@ export namespace DesktopInstallation {
         const key = normalizePath(candidate)
         if (seen.has(key)) continue
         seen.add(key)
-        const exists = await fs
+        const exists = await filesystem
           .access(candidate)
           .then(() => true)
           .catch(() => false)
         if (!exists) continue
-        const realCandidate = await fs.realpath(candidate).catch(() => candidate)
-        candidates.push({ path: candidate, isCurrent: samePath(realCandidate, context.realExecPath, context.platform) })
+        const isCurrent = await isCurrentPathCandidate(context, candidate, filesystem)
+        candidates.push({ path: candidate, isCurrent })
       }
     }
     return candidates
+  }
+
+  async function isCurrentPathCandidate(context: Context, candidate: string, filesystem: PathCandidateFilesystem) {
+    if (isDesktopWindowsLauncherCandidate(context, candidate)) return true
+    const realCandidate = await filesystem.realpath(candidate).catch(() => candidate)
+    return samePath(realCandidate, context.realExecPath, context.platform)
+  }
+
+  function isDesktopWindowsLauncherCandidate(context: Context, candidate: string) {
+    if (context.platform !== "win32") return false
+    if (!detectDesktopInstall(context)) return false
+    const expectedLink = linkPath(context)
+    if (!expectedLink) return false
+    return samePath(candidate, expectedLink, "win32")
   }
 
   export function samePath(a: string, b: string, platform: NodeJS.Platform) {

--- a/packages/synergy/src/global/desktop-installation.ts
+++ b/packages/synergy/src/global/desktop-installation.ts
@@ -1,0 +1,190 @@
+import fs from "fs/promises"
+import path from "path"
+
+export namespace DesktopInstallation {
+  export interface Context {
+    platform: NodeJS.Platform
+    execPath: string
+    realExecPath: string
+    env?: NodeJS.ProcessEnv
+  }
+
+  export interface CliLinkStatus {
+    path: string | null
+    status: "healthy" | "missing" | "broken" | "conflict" | "not-applicable"
+    target: string | null
+    message: string
+  }
+
+  export interface PathCandidate {
+    path: string
+    isCurrent: boolean
+  }
+
+  export function normalizePath(value: string) {
+    return value.replace(/\\/g, "/").toLowerCase()
+  }
+
+  export function isRuntimePath(platform: NodeJS.Platform, realExecPath: string) {
+    const normalized = normalizePath(realExecPath)
+    if (platform === "darwin") return normalized.endsWith(".app/contents/resources/synergy/bin/synergy")
+    if (platform === "win32") return normalized.endsWith("/resources/synergy/bin/synergy.exe")
+    if (platform === "linux") return normalized === "/opt/synergy/resources/synergy/bin/synergy"
+    return false
+  }
+
+  export function detectDesktopInstall(input: Context) {
+    return isRuntimePath(input.platform, input.realExecPath)
+  }
+
+  export function expectedRuntimePath(platform: NodeJS.Platform) {
+    if (platform === "darwin") return "/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy"
+    if (platform === "linux") return "/opt/Synergy/resources/synergy/bin/synergy"
+    return null
+  }
+
+  export function launcherDirectory(context: Context) {
+    if (context.platform !== "win32") return null
+    const normalized = context.realExecPath.replace(/\\/g, path.win32.sep)
+    const installRoot = path.win32.resolve(normalized, "..", "..", "..", "..")
+    return path.win32.join(installRoot, "bin")
+  }
+
+  export function linkPath(context: Context) {
+    if (context.platform === "darwin") return "/usr/local/bin/synergy"
+    if (context.platform === "linux") return "/usr/bin/synergy"
+    if (context.platform === "win32") {
+      const launcherDir = launcherDirectory(context)
+      return launcherDir ? path.win32.join(launcherDir, "synergy.cmd") : null
+    }
+    return null
+  }
+
+  export async function inspectCliLink(context: Context): Promise<CliLinkStatus> {
+    const publicPath = linkPath(context)
+    if (!publicPath) {
+      return {
+        path: null,
+        status: "not-applicable",
+        target: null,
+        message: "Desktop CLI links are not configured on this platform.",
+      }
+    }
+
+    if (context.platform === "win32") return inspectWindowsLauncher(context, publicPath)
+    return inspectSymlink(context, publicPath)
+  }
+
+  async function inspectSymlink(context: Context, publicPath: string): Promise<CliLinkStatus> {
+    const stat = await fs.lstat(publicPath).catch(() => null)
+    if (!stat)
+      return { path: publicPath, status: "missing", target: null, message: "Desktop CLI link is not installed." }
+    if (!stat.isSymbolicLink()) {
+      return {
+        path: publicPath,
+        status: "conflict",
+        target: null,
+        message: "Desktop CLI link path exists but is not a symlink.",
+      }
+    }
+
+    const target = await fs.readlink(publicPath).catch(() => null)
+    const realTarget = await fs.realpath(publicPath).catch(() => null)
+    if (!realTarget) return { path: publicPath, status: "broken", target, message: "Desktop CLI link is broken." }
+    if (!isRuntimePath(context.platform, realTarget)) {
+      return {
+        path: publicPath,
+        status: "conflict",
+        target: realTarget,
+        message: "Desktop CLI link points to a different command.",
+      }
+    }
+
+    const executable = await fs
+      .access(realTarget, fs.constants.X_OK)
+      .then(() => true)
+      .catch(() => false)
+    if (!executable) {
+      return {
+        path: publicPath,
+        status: "broken",
+        target: realTarget,
+        message: "Desktop CLI target is not executable.",
+      }
+    }
+    return {
+      path: publicPath,
+      status: "healthy",
+      target: realTarget,
+      message: "Desktop CLI link points to the embedded runtime.",
+    }
+  }
+
+  async function inspectWindowsLauncher(context: Context, publicPath: string): Promise<CliLinkStatus> {
+    const exists = await fs
+      .access(publicPath)
+      .then(() => true)
+      .catch(() => false)
+    const launcherDir = launcherDirectory(context)
+    const pathContainsLauncher = launcherDir
+      ? userPathEntries(context.env, context.platform).some((entry) => samePath(entry, launcherDir, "win32"))
+      : false
+    if (!exists)
+      return { path: publicPath, status: "missing", target: null, message: "Desktop CLI launcher is not installed." }
+    if (!pathContainsLauncher) {
+      return {
+        path: publicPath,
+        status: "broken",
+        target: context.realExecPath,
+        message: "Desktop CLI launcher directory is not in the user PATH.",
+      }
+    }
+    return {
+      path: publicPath,
+      status: "healthy",
+      target: context.realExecPath,
+      message: "Desktop CLI launcher forwards to the embedded runtime.",
+    }
+  }
+
+  export function userPathEntries(env: NodeJS.ProcessEnv = process.env, platform: NodeJS.Platform = process.platform) {
+    const delimiter = platform === "win32" ? ";" : path.delimiter
+    return (env.Path ?? env.PATH ?? "").split(delimiter).filter(Boolean)
+  }
+
+  export async function pathCandidates(context: Context): Promise<PathCandidate[]> {
+    const commandNames = context.platform === "win32" ? ["synergy.cmd", "synergy.exe", "synergy.bat"] : ["synergy"]
+    const candidates: PathCandidate[] = []
+    const seen = new Set<string>()
+    for (const dir of userPathEntries(context.env, context.platform)) {
+      for (const commandName of commandNames) {
+        const candidate = context.platform === "win32" ? path.win32.join(dir, commandName) : path.join(dir, commandName)
+        const key = normalizePath(candidate)
+        if (seen.has(key)) continue
+        seen.add(key)
+        const exists = await fs
+          .access(candidate)
+          .then(() => true)
+          .catch(() => false)
+        if (!exists) continue
+        const realCandidate = await fs.realpath(candidate).catch(() => candidate)
+        candidates.push({ path: candidate, isCurrent: samePath(realCandidate, context.realExecPath, context.platform) })
+      }
+    }
+    return candidates
+  }
+
+  export function samePath(a: string, b: string, platform: NodeJS.Platform) {
+    if (platform === "win32" || platform === "darwin") return normalizePath(a) === normalizePath(b)
+    return a === b
+  }
+
+  export function desktopRemovalHint(platform: NodeJS.Platform) {
+    if (platform === "darwin")
+      return "To remove the Desktop app, move Synergy.app to Trash or rerun the Desktop installer."
+    if (platform === "win32") return "To remove the Desktop app, uninstall Synergy from Windows Apps & Features."
+    if (platform === "linux")
+      return "To remove the Desktop app, run apt remove or your Linux package manager for Synergy."
+    return "Remove the Desktop app with your platform package manager."
+  }
+}

--- a/packages/synergy/src/global/installation.ts
+++ b/packages/synergy/src/global/installation.ts
@@ -2,6 +2,8 @@ import { BusEvent } from "@/bus/bus-event"
 import { $ } from "bun"
 import z from "zod"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
+import fs from "fs/promises"
+import { DesktopInstallation } from "./desktop-installation"
 import { Log } from "../util/log"
 import { Flag } from "../flag/flag"
 
@@ -14,7 +16,7 @@ export namespace Installation {
   const log = Log.create({ service: "installation" })
   const NPM_REGISTRY = "https://registry.npmjs.org"
 
-  export type Method = Awaited<ReturnType<typeof method>>
+  export type Method = "npm" | "yarn" | "pnpm" | "bun" | "brew" | "desktop" | "unknown"
 
   export const Event = {
     Updated: BusEvent.define(
@@ -56,9 +58,16 @@ export namespace Installation {
     return CHANNEL === "local"
   }
 
-  export async function method() {
-    const exec = process.execPath.toLowerCase()
+  export const detectDesktopInstall = DesktopInstallation.detectDesktopInstall
 
+  export async function method(): Promise<Method> {
+    const execPath = process.execPath
+    const realExecPath = await fs.realpath(execPath).catch(() => execPath)
+    if (DesktopInstallation.isRuntimePath(process.platform, realExecPath)) {
+      return "desktop"
+    }
+
+    const exec = execPath.toLowerCase()
     const checks = [
       {
         name: "npm" as const,
@@ -107,6 +116,13 @@ export namespace Installation {
     }),
   )
 
+  export const DesktopManagedUpdateError = NamedError.create(
+    "DesktopManagedUpdateError",
+    z.object({
+      message: z.string(),
+    }),
+  )
+
   async function getBrewFormula() {
     // Homebrew not supported for private repo
     return "synergy"
@@ -135,6 +151,11 @@ export namespace Installation {
         })
         break
       }
+      case "desktop":
+        throw new DesktopManagedUpdateError({
+          message:
+            "Synergy is installed with the Desktop app. Desktop updates are managed from the Synergy app. Open Synergy and use Settings → Updates.",
+        })
       default:
         throw new Error(`Unknown method: ${method}`)
     }

--- a/packages/synergy/src/server/update-route.ts
+++ b/packages/synergy/src/server/update-route.ts
@@ -9,6 +9,7 @@ import { Installation } from "../global/installation"
 
 const NPM_PACKAGE = "@ericsanchezok/synergy"
 const NPM_REGISTRY = "https://registry.npmjs.org"
+const DESKTOP_UPDATE_MESSAGE = "This service uses the Synergy Desktop runtime. Update it from the Desktop app."
 
 const ServerUpdateCapability = z.enum(["managed", "not-managed", "remote"])
 const ServerUpdatePhase = z.enum(["idle", "checking", "available", "updating", "restarting", "error"])
@@ -165,10 +166,13 @@ async function statusForRequest(url: string, host: string | undefined, check: bo
   try {
     const latest = await workerControls.latestVersion()
     const updateAvailable = isNewerVersion(latest, Installation.VERSION)
-    const unsupportedInstallMethod =
-      updateAvailable && !updateInstallCommand(await workerControls.installMethod(), latest)
+    const installMethod = await workerControls.installMethod()
+    const unsupportedInstallMethod = updateAvailable && !updateInstallCommand(installMethod, latest)
     if (unsupportedInstallMethod) {
-      const error = "Managed service install method cannot be updated from Web."
+      const error =
+        installMethod === "desktop"
+          ? DESKTOP_UPDATE_MESSAGE
+          : "Managed service install method cannot be updated from Web."
       return {
         ...managedStatus("error", latest, error, null),
         updateAvailable: true,
@@ -254,9 +258,16 @@ async function startWorker(
   if (!controlCommand) {
     return { ok: false, error: "Managed service command cannot be safely updated from Web." }
   }
-  const installCommand = updateInstallCommand(await workerControls.installMethod(), version)
+  const installMethod = await workerControls.installMethod()
+  const installCommand = updateInstallCommand(installMethod, version)
   if (!installCommand) {
-    return { ok: false, error: "Managed service install method cannot be updated from Web." }
+    return {
+      ok: false,
+      error:
+        installMethod === "desktop"
+          ? DESKTOP_UPDATE_MESSAGE
+          : "Managed service install method cannot be updated from Web.",
+    }
   }
 
   await writePersistedStatus({

--- a/packages/synergy/test/cli/doctor-desktop.test.ts
+++ b/packages/synergy/test/cli/doctor-desktop.test.ts
@@ -28,6 +28,29 @@ describe("desktop doctor helpers", () => {
     expect(Array.isArray(candidates)).toBe(true)
   })
 
+  test("marks the Windows Desktop launcher as current without resolving it to the runtime exe", async () => {
+    const installRoot = "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy"
+    const launcherDir = path.win32.join(installRoot, "bin")
+    const launcherPath = path.win32.join(launcherDir, "synergy.cmd")
+    const context = {
+      platform: "win32" as const,
+      execPath: launcherPath,
+      realExecPath: path.win32.join(installRoot, "resources", "synergy", "bin", "synergy.exe"),
+      env: { Path: `${launcherDir};C:\\Tools` },
+    }
+    const existing = new Set([DesktopInstallation.normalizePath(launcherPath)])
+    const candidates = await DesktopInstallation.pathCandidates(context, {
+      async access(candidate) {
+        if (!existing.has(DesktopInstallation.normalizePath(candidate))) throw new Error("missing")
+      },
+      async realpath(candidate) {
+        return candidate
+      },
+    })
+
+    expect(candidates[0]).toEqual({ path: launcherPath, isCurrent: true })
+  })
+
   test("reports matching Desktop package version metadata", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-doctor-version-"))
     const realExecPath = path.join(root, "Synergy.app", "Contents", "Resources", "synergy", "bin", "synergy")

--- a/packages/synergy/test/cli/doctor-desktop.test.ts
+++ b/packages/synergy/test/cli/doctor-desktop.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { DesktopInstallation } from "../../src/global/desktop-installation"
+
+describe("desktop doctor helpers", () => {
+  test("reports healthy Desktop CLI links", async () => {
+    const status = await DesktopInstallation.inspectCliLink({
+      platform: "darwin",
+      execPath: "/usr/local/bin/synergy",
+      realExecPath: "/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy",
+      env: {},
+    })
+
+    expect(status.path).toBe("/usr/local/bin/synergy")
+    expect(["healthy", "missing", "broken", "conflict"]).toContain(status.status)
+  })
+
+  test("detects multiple PATH candidates without executing them", async () => {
+    const candidates = await DesktopInstallation.pathCandidates({
+      platform: process.platform,
+      execPath: process.execPath,
+      realExecPath: process.execPath,
+      env: { PATH: process.env.PATH ?? "" },
+    })
+
+    expect(Array.isArray(candidates)).toBe(true)
+  })
+})

--- a/packages/synergy/test/cli/doctor-desktop.test.ts
+++ b/packages/synergy/test/cli/doctor-desktop.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
 import { DesktopInstallation } from "../../src/global/desktop-installation"
 
 describe("desktop doctor helpers", () => {
@@ -23,5 +26,53 @@ describe("desktop doctor helpers", () => {
     })
 
     expect(Array.isArray(candidates)).toBe(true)
+  })
+
+  test("reports matching Desktop package version metadata", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-doctor-version-"))
+    const realExecPath = path.join(root, "Synergy.app", "Contents", "Resources", "synergy", "bin", "synergy")
+    await fs.mkdir(path.dirname(realExecPath), { recursive: true })
+    await fs.writeFile(
+      path.join(root, "Synergy.app", "Contents", "Resources", "synergy", "desktop-package.json"),
+      '{"version":"1.2.3"}',
+    )
+
+    const status = await DesktopInstallation.packageVersionStatus(
+      { platform: "darwin", execPath: "/usr/local/bin/synergy", realExecPath, env: {} },
+      "1.2.3",
+    )
+
+    expect(status.status).toBe("matching")
+    expect(status.packageVersion).toBe("1.2.3")
+  })
+
+  test("reports mismatching Desktop package version metadata", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-doctor-version-"))
+    const realExecPath = path.join(root, "Synergy.app", "Contents", "Resources", "synergy", "bin", "synergy")
+    await fs.mkdir(path.dirname(realExecPath), { recursive: true })
+    await fs.writeFile(
+      path.join(root, "Synergy.app", "Contents", "Resources", "synergy", "desktop-package.json"),
+      '{"version":"1.2.4"}',
+    )
+
+    const status = await DesktopInstallation.packageVersionStatus(
+      { platform: "darwin", execPath: "/usr/local/bin/synergy", realExecPath, env: {} },
+      "1.2.3",
+    )
+
+    expect(status.status).toBe("mismatch")
+    expect(status.message).toContain("does not match")
+  })
+
+  test("reports unavailable Desktop package version metadata", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-doctor-version-"))
+    const realExecPath = path.join(root, "Synergy.app", "Contents", "Resources", "synergy", "bin", "synergy")
+
+    const status = await DesktopInstallation.packageVersionStatus(
+      { platform: "darwin", execPath: "/usr/local/bin/synergy", realExecPath, env: {} },
+      "1.2.3",
+    )
+
+    expect(status.status).toBe("unavailable")
   })
 })

--- a/packages/synergy/test/cli/uninstall-desktop.test.ts
+++ b/packages/synergy/test/cli/uninstall-desktop.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { DesktopInstallation } from "../../src/global/desktop-installation"
+
+describe("desktop-managed uninstall helpers", () => {
+  test("collects platform CLI link paths without app bundle removal targets", () => {
+    expect(
+      DesktopInstallation.linkPath({
+        platform: "darwin",
+        execPath: "/usr/local/bin/synergy",
+        realExecPath: "/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy",
+        env: {},
+      }),
+    ).toBe("/usr/local/bin/synergy")
+
+    expect(
+      DesktopInstallation.linkPath({
+        platform: "linux",
+        execPath: "/usr/bin/synergy",
+        realExecPath: "/opt/Synergy/resources/synergy/bin/synergy",
+        env: {},
+      }),
+    ).toBe("/usr/bin/synergy")
+  })
+
+  test("keeps Windows launcher directory separate from runtime internals", () => {
+    const context = {
+      platform: "win32" as const,
+      execPath: "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin\\synergy.cmd",
+      realExecPath: "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\resources\\synergy\\bin\\synergy.exe",
+      env: {},
+    }
+
+    expect(DesktopInstallation.launcherDirectory(context)).toBe(
+      "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin",
+    )
+    expect(DesktopInstallation.linkPath(context)).toBe(
+      "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin\\synergy.cmd",
+    )
+    expect(DesktopInstallation.launcherDirectory(context)).not.toContain("resources\\synergy\\bin")
+  })
+})

--- a/packages/synergy/test/cli/uninstall-desktop.test.ts
+++ b/packages/synergy/test/cli/uninstall-desktop.test.ts
@@ -38,4 +38,53 @@ describe("desktop-managed uninstall helpers", () => {
     )
     expect(DesktopInstallation.launcherDirectory(context)).not.toContain("resources\\synergy\\bin")
   })
+
+  test("removes only the exact Windows Desktop launcher directory from User PATH", async () => {
+    const launcherDir = "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin"
+    const pathValue = [
+      "C:\\Windows\\System32",
+      launcherDir,
+      "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin-extra",
+      "C:\\Tools",
+    ].join(";")
+
+    expect(DesktopInstallation.removePathEntry(pathValue, launcherDir.toLowerCase(), "win32")).toBe(
+      "C:\\Windows\\System32;C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin-extra;C:\\Tools",
+    )
+  })
+
+  test("updates Windows User PATH store and broadcasts when launcher entry is removed", async () => {
+    const writes: string[] = []
+    let broadcastCount = 0
+    const result = await DesktopInstallation.removeWindowsUserPathEntry("C:\\Synergy\\bin", {
+      async read() {
+        return "C:\\Windows;C:\\Synergy\\bin;C:\\Synergy\\bin-extra"
+      },
+      async write(value) {
+        writes.push(value)
+      },
+      async broadcast() {
+        broadcastCount++
+      },
+    })
+
+    expect(result.removed).toBe(true)
+    expect(writes).toEqual(["C:\\Windows;C:\\Synergy\\bin-extra"])
+    expect(broadcastCount).toBe(1)
+  })
+
+  test("does not write Windows User PATH when the launcher entry is absent", async () => {
+    const writes: string[] = []
+    const result = await DesktopInstallation.removeWindowsUserPathEntry("C:\\Synergy\\bin", {
+      async read() {
+        return "C:\\Windows;C:\\Synergy\\bin-extra"
+      },
+      async write(value) {
+        writes.push(value)
+      },
+    })
+
+    expect(result.removed).toBe(false)
+    expect(writes).toEqual([])
+  })
 })

--- a/packages/synergy/test/cli/upgrade-desktop.test.ts
+++ b/packages/synergy/test/cli/upgrade-desktop.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test"
+import { Installation } from "../../src/global/installation"
+
+describe("desktop-managed upgrade", () => {
+  test("does not execute package-manager upgrades", async () => {
+    const err = await Installation.upgrade("desktop", "999.0.0").catch((error) => error)
+
+    expect(err).toBeInstanceOf(Installation.DesktopManagedUpdateError)
+    expect(err.data.message).toContain("Synergy is installed with the Desktop app")
+    expect(err.data.message).toContain("Desktop updates are managed from the Synergy app")
+  })
+})

--- a/packages/synergy/test/global/installation.test.ts
+++ b/packages/synergy/test/global/installation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { Installation } from "../../src/global/installation"
+
+const env = {}
+
+describe("Installation desktop detection", () => {
+  test("detects macOS app bundle runtime paths", () => {
+    expect(
+      Installation.detectDesktopInstall({
+        platform: "darwin",
+        execPath: "/usr/local/bin/synergy",
+        realExecPath: "/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy",
+        env,
+      }),
+    ).toBe(true)
+  })
+
+  test("detects Windows installed runtime paths", () => {
+    expect(
+      Installation.detectDesktopInstall({
+        platform: "win32",
+        execPath: "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\bin\\synergy.cmd",
+        realExecPath: "C:\\Users\\Eric\\AppData\\Local\\Programs\\Synergy\\resources\\synergy\\bin\\synergy.exe",
+        env,
+      }),
+    ).toBe(true)
+  })
+
+  test("detects Linux deb runtime paths", () => {
+    expect(
+      Installation.detectDesktopInstall({
+        platform: "linux",
+        execPath: "/usr/bin/synergy",
+        realExecPath: "/opt/Synergy/resources/synergy/bin/synergy",
+        env,
+      }),
+    ).toBe(true)
+  })
+
+  test("does not claim package-manager or unknown binaries", () => {
+    expect(
+      Installation.detectDesktopInstall({
+        platform: "darwin",
+        execPath: "/opt/homebrew/bin/synergy",
+        realExecPath: "/opt/homebrew/bin/synergy",
+        env,
+      }),
+    ).toBe(false)
+    expect(
+      Installation.detectDesktopInstall({
+        platform: "linux",
+        execPath: "/home/eric/.bun/bin/synergy",
+        realExecPath: "/home/eric/.bun/install/global/node_modules/@ericsanchezok/synergy/bin/synergy",
+        env,
+      }),
+    ).toBe(false)
+  })
+
+  test("desktop upgrades are delegated to the Desktop app", async () => {
+    const err = await Installation.upgrade("desktop", "999.0.0").catch((error) => error)
+    expect(err).toBeInstanceOf(Installation.DesktopManagedUpdateError)
+    expect(err.data.message).toContain("Desktop updates are managed from the Synergy app")
+  })
+})

--- a/packages/synergy/test/server/update-route.test.ts
+++ b/packages/synergy/test/server/update-route.test.ts
@@ -166,6 +166,34 @@ describe("server update route", () => {
     expect(spawned).toEqual([])
   })
 
+  test("reports Desktop-managed updater guidance for desktop install methods", async () => {
+    process.env.SYNERGY_DAEMON = "1"
+    await writeManifest([
+      "/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy",
+      "server",
+      "--port",
+      "4096",
+    ])
+    setServerUpdateWorkerControlsForTest({
+      latestVersion: async () => "999.0.0",
+      installMethod: async () => "desktop",
+      spawn(command) {
+        spawned.push(command)
+      },
+    })
+
+    const app = testApp()
+    const response = await app.request("/global/update/check", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.capability).toBe("managed")
+    expect(body.phase).toBe("error")
+    expect(body.updateAvailable).toBe(true)
+    expect(body.error).toBe("This service uses the Synergy Desktop runtime. Update it from the Desktop app.")
+    expect(spawned).toEqual([])
+  })
+
   test("does not start a worker for unsupported managed install methods", async () => {
     process.env.SYNERGY_DAEMON = "1"
     await writeManifest(["/usr/local/bin/synergy", "server", "--port", "4096"])
@@ -188,6 +216,36 @@ describe("server update route", () => {
     const body = await response.json()
     expect(body.phase).toBe("error")
     expect(body.error).toBe("Managed service install method cannot be updated from Web.")
+    expect(spawned).toEqual([])
+  })
+
+  test("does not start a worker for Desktop-managed install methods", async () => {
+    process.env.SYNERGY_DAEMON = "1"
+    await writeManifest([
+      "/Applications/Synergy.app/Contents/Resources/synergy/bin/synergy",
+      "server",
+      "--port",
+      "4096",
+    ])
+    setServerUpdateWorkerControlsForTest({
+      latestVersion: async () => "999.0.0",
+      installMethod: async () => "desktop",
+      spawn(command) {
+        spawned.push(command)
+      },
+    })
+
+    const app = testApp()
+    const response = await app.request("/global/update/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: "999.0.0" }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.phase).toBe("error")
+    expect(body.error).toBe("This service uses the Synergy Desktop runtime. Update it from the Desktop app.")
     expect(spawned).toEqual([])
   })
 

--- a/script/release/nodes/verify-desktop-assets.ts
+++ b/script/release/nodes/verify-desktop-assets.ts
@@ -1,4 +1,8 @@
-import { desktopChecksumsName, expectedDesktopPrimaryArtifacts } from "../../../packages/desktop/src/release-assets"
+import {
+  desktopChecksumsName,
+  desktopPortableArtifactNames,
+  expectedDesktopPrimaryArtifacts,
+} from "../../../packages/desktop/src/release-assets"
 import { viewRelease } from "../shared/github"
 import type { ReleaseState } from "../shared/packages"
 
@@ -15,6 +19,11 @@ export async function verifyDesktopDraftAssets(state: ReleaseState) {
   for (const assetName of expectedDesktopPrimaryArtifacts(state.version)) {
     if (!names.has(assetName)) {
       throw new Error(`missing desktop release asset ${assetName}`)
+    }
+  }
+  for (const assetName of desktopPortableArtifactNames(state.version)) {
+    if (!names.has(assetName)) {
+      throw new Error(`missing desktop portable asset ${assetName}`)
     }
   }
   const checksums = desktopChecksumsName(state.version)


### PR DESCRIPTION
## Summary
- Expose the Desktop-embedded Synergy runtime as the public `synergy` CLI across installer-grade artifacts while keeping the Electron shell executable separate.
- Teach core install/update/uninstall/doctor flows about Desktop-managed runtimes, including Windows User PATH cleanup and Desktop package/runtime version consistency reporting.
- Fix Windows installer and doctor PATH semantics: NSIS de-dupes by exact PATH entry, and doctor treats the installer-managed `synergy.cmd` launcher as current for the active Desktop runtime without executing PATH candidates.
- Update release artifact wiring, desktop release docs, README install guidance, and focused coverage for packaging/runtime behavior.

## Verification
- `bun run --cwd packages/desktop desktop:test` — 51 pass, 3 skip
- `bun test test/global/installation.test.ts test/cli/upgrade-desktop.test.ts test/cli/uninstall-desktop.test.ts test/cli/doctor-desktop.test.ts test/server/update-route.test.ts` — 28 pass
- `bun run typecheck` — 10 successful
- `cd packages/desktop && SYNERGY_DESKTOP_ALLOW_MISSING_RUNTIME=1 bunx electron-builder --dir --publish=never --config electron-builder.json` — passed

## Notes
- Desktop-managed `synergy uninstall` removes the exact Windows HKCU/User PATH launcher directory entry without touching System PATH or substring paths.
- `synergy doctor` checks Desktop package metadata generated beside the embedded runtime and reports matching, mismatch, or unavailable states without executing PATH candidates.
- Manual clean-VM installer smoke checks remain release-candidate validation and were not run in this coding pass.