### PR TITLE
Fix stale Solid Show accessors in UI rendering

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1652,6 +1652,7 @@ function HighlightedText(props: { text: string; references: AttachmentPart[] }) 
     <For each={segments()}>
       {(segment) => (
         <Show
+          keyed
           when={resourceOpen ? segment.file : undefined}
           fallback={
             <span
@@ -1671,9 +1672,9 @@ function HighlightedText(props: { text: string; references: AttachmentPart[] }) 
                 resourceOpen?.open(
                   {
                     kind: "workspace-file",
-                    path: fileReferencePath(file()),
-                    mime: file().mime,
-                    filename: file().filename,
+                    path: fileReferencePath(file),
+                    mime: file.mime,
+                    filename: file.filename,
                   },
                   { prefer: "workspace" },
                 )

--- a/packages/ui/src/components/tool/renders/file-ops.tsx
+++ b/packages/ui/src/components/tool/renders/file-ops.tsx
@@ -118,14 +118,15 @@ ToolRegistry.register({
           subtitlePath: (props.input.filePath as string | undefined) ?? undefined,
         }}
       >
-        <Show when={props.status !== "generating" && props.metadata.results}>
+        <Show keyed when={props.status !== "generating" ? props.metadata.results : undefined}>
           {(results) => {
-            const lastResult = () => {
-              const r = results()
-              if (!Array.isArray(r) || r.length === 0) return undefined
-              return r[r.length - 1]
-            }
-            return <Show when={lastResult()?.filediff}>{(filediff) => <ToolDiffPreview diff={filediff()} />}</Show>
+            if (!Array.isArray(results) || results.length === 0) return null
+            const lastResult = results[results.length - 1]
+            return (
+              <Show keyed when={lastResult?.filediff}>
+                {(filediff) => <ToolDiffPreview diff={filediff} />}
+              </Show>
+            )
           }}
         </Show>
       </BasicTool>


### PR DESCRIPTION
## Summary

This fixes a Solid dev-runtime error:

> Attempting to access a stale value from <Show> that could possibly be undefined.

The precise issue was in UI rendering code that used non-keyed `<Show>` function children. In Solid, a non-keyed `<Show>` passes an accessor, not a stable value. That accessor throws if it is read after the `<Show>` condition has become falsy or the branch has unmounted.

## Problem

The primary failure path was in `HighlightedText` in `packages/ui/src/components/message-part.tsx`.

The inline file-reference branch captured the `<Show>` child accessor as `file`, then read `file()` later inside an `onClick` handler. If the message part re-rendered or unmounted before the click handler ran, Solid correctly treated that accessor as stale and threw the reported error.

I also fixed the same stale-accessor pattern in the `multiedit` renderer in `packages/ui/src/components/tool/renders/file-ops.tsx`. It was reading the outer `<Show>` accessor from nested reactive logic while tool status/results could change.

## Fix

- Changed the inline file reference `<Show>` to `keyed`, so the child receives the current `AttachmentPart` value directly instead of a temporary accessor.
- Updated the click handler to read `fileReferencePath(file)`, `file.mime`, and `file.filename` from that stable value.
- Changed the multiedit results `<Show>` to `keyed` and compute the last result synchronously from the stable `results` value.
- Changed the inner filediff `<Show>` to `keyed` so `ToolDiffPreview` receives a stable diff object.

## Why This Fix

`keyed` is the Solid-supported way to request the narrowed value directly from `<Show>` when that value needs to be captured or passed through code that may run after the render call. It preserves the existing conditional rendering behavior while removing the stale accessor lifetime hazard.

## Verification

- `bun run --cwd packages/ui typecheck`
- `bun run typecheck`
- Pre-push hook: repository typecheck and Prettier formatting check passed