### PR TITLE
Fix plugin archive path normalization

### DIFF
--- a/packages/plugin-kit/src/lib/artifact-assets.ts
+++ b/packages/plugin-kit/src/lib/artifact-assets.ts
@@ -14,6 +14,13 @@ function isExternalPath(value: string): boolean {
   return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value) || value.startsWith("//")
 }
 
+function isPathContained(parent: string, child: string): boolean {
+  const resolvedParent = path.resolve(parent)
+  const resolvedChild = path.resolve(child)
+  const relative = path.relative(resolvedParent, resolvedChild)
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
 export function isLocalManifestPath(value: string | undefined): value is string {
   return Boolean(value && !isExternalPath(value))
 }
@@ -137,8 +144,7 @@ export function rewritePackagedManifestPaths(manifest: PluginManifest): PluginMa
 export function resolveUnder(root: string, relativePath: string): string {
   const normalized = normalizeManifestPath(relativePath)
   const resolved = path.resolve(root, normalized)
-  const relative = path.relative(root, resolved)
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (!isPathContained(root, resolved)) {
     throw new Error(`Manifest path cannot escape ${root}: ${relativePath}`)
   }
   return resolved

--- a/packages/plugin-kit/src/lib/market-entry.ts
+++ b/packages/plugin-kit/src/lib/market-entry.ts
@@ -1,7 +1,11 @@
 import fs from "fs"
 import os from "os"
 import path from "path"
-import { PluginManifest, type PluginManifest as PluginManifestType } from "@ericsanchezok/synergy-plugin"
+import {
+  PluginManifest,
+  normalizePluginArchiveEntry,
+  type PluginManifest as PluginManifestType,
+} from "@ericsanchezok/synergy-plugin"
 import {
   githubReleaseTag,
   githubReleaseAssetUrl,
@@ -133,6 +137,7 @@ export function resolveReleaseAssetUrls(input: {
 }
 
 function extractArchive(tarballPath: string): string {
+  validateArchiveEntries(tarballPath)
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "synergy-plugin-entry-"))
   const result = Bun.spawnSync(["tar", "-xzf", tarballPath, "-C", tmp], { stdout: "pipe", stderr: "pipe" })
   if (result.exitCode !== 0) {
@@ -140,6 +145,22 @@ function extractArchive(tarballPath: string): string {
     throw new Error(`Failed to inspect tarball${stderr ? `: ${stderr}` : ""}`)
   }
   return tmp
+}
+
+function validateArchiveEntries(tarballPath: string) {
+  const result = Bun.spawnSync(["tar", "-tzf", tarballPath], { stdout: "pipe", stderr: "pipe" })
+  if (result.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(result.stderr)
+    throw new Error(`Failed to inspect tarball${stderr ? `: ${stderr}` : ""}`)
+  }
+  for (const line of new TextDecoder().decode(result.stdout).split("\n")) {
+    try {
+      normalizePluginArchiveEntry(line)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Plugin tarball contains unsafe path: ${message}`)
+    }
+  }
 }
 
 export function readTarballManifest(tarballPath: string): PluginManifestType {

--- a/packages/plugin/src/artifact.ts
+++ b/packages/plugin/src/artifact.ts
@@ -20,6 +20,14 @@ export function normalizePluginArtifactPath(filePath: string): string {
   return parts.join("/")
 }
 
+export function normalizePluginArchiveEntry(entry: string): string | undefined {
+  let normalized = entry.replace(/\r$/, "").replace(/\\/g, "/")
+  while (normalized.startsWith("./")) normalized = normalized.slice(2)
+  normalized = normalized.replace(/\/+$/, "")
+  if (!normalized || normalized === ".") return undefined
+  return normalizePluginArtifactPath(normalized)
+}
+
 export function pluginArtifactAssetRoot(filePath: string): string {
   return normalizePluginArtifactPath(filePath).split("/")[0] ?? ""
 }

--- a/packages/synergy/src/asset/asset.ts
+++ b/packages/synergy/src/asset/asset.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { Global } from "@/global"
+import { isPathContained } from "@/util/path-contain"
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/png": "png",
@@ -80,8 +81,7 @@ export namespace Asset {
     if (!isValidId(id)) return undefined
     const assetDir = path.resolve(dir())
     const resolved = path.resolve(assetDir, id)
-    const relative = path.relative(assetDir, resolved)
-    if (relative.startsWith("..") || path.isAbsolute(relative)) return undefined
+    if (!isPathContained(assetDir, resolved)) return undefined
     return resolved
   }
 

--- a/packages/synergy/src/browser/policy.ts
+++ b/packages/synergy/src/browser/policy.ts
@@ -2,6 +2,7 @@ import { realpathSync } from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
 import { normalizeBrowserURL as normalizeBrowserURLInput } from "@ericsanchezok/synergy-util/browser-protocol"
+import { isPathContained } from "../util/path-contain"
 
 export namespace BrowserPolicy {
   export type Decision = "allow" | "blocked" | "deny"
@@ -96,7 +97,7 @@ export namespace BrowserPolicy {
   function isContainedWithin(filePath: string, workspace: string): boolean {
     const resolved = realpathSync(filePath)
     const resolvedWorkspace = realpathSync(workspace)
-    return !path.relative(resolvedWorkspace, resolved).startsWith("..")
+    return isPathContained(resolvedWorkspace, resolved)
   }
 
   function evaluateParsedFileURL(url: URL, workspace: string): PolicyResult {

--- a/packages/synergy/src/cli/cmd/plugin-publish.ts
+++ b/packages/synergy/src/cli/cmd/plugin-publish.ts
@@ -1,6 +1,10 @@
 import { cmd } from "./cmd"
 import { UI } from "../ui"
-import { PluginManifest, type PluginManifest as PluginManifestType } from "@ericsanchezok/synergy-plugin"
+import {
+  PluginManifest,
+  normalizePluginArchiveEntry,
+  type PluginManifest as PluginManifestType,
+} from "@ericsanchezok/synergy-plugin"
 import {
   baseCapabilities,
   permissionItems,
@@ -61,6 +65,7 @@ function parseAuthor(input?: string): PublishInput["author"] {
 }
 
 function extractArchive(tarballPath: string): string {
+  validateArchiveEntries(tarballPath)
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "synergy-plugin-publish-"))
   const result = Bun.spawnSync(["tar", "-xzf", tarballPath, "-C", tmp], { stdout: "pipe", stderr: "pipe" })
   if (result.exitCode !== 0) {
@@ -68,6 +73,22 @@ function extractArchive(tarballPath: string): string {
     throw new Error(`Failed to inspect tarball${stderr ? `: ${stderr}` : ""}`)
   }
   return tmp
+}
+
+function validateArchiveEntries(tarballPath: string) {
+  const result = Bun.spawnSync(["tar", "-tzf", tarballPath], { stdout: "pipe", stderr: "pipe" })
+  if (result.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(result.stderr)
+    throw new Error(`Failed to inspect tarball${stderr ? `: ${stderr}` : ""}`)
+  }
+  for (const line of new TextDecoder().decode(result.stdout).split("\n")) {
+    try {
+      normalizePluginArchiveEntry(line)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Plugin tarball contains unsafe path: ${message}`)
+    }
+  }
 }
 
 function readManifest(extractedDir: string): PluginManifestType {

--- a/packages/synergy/src/enforcement/classify.ts
+++ b/packages/synergy/src/enforcement/classify.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { Filesystem } from "../util/filesystem"
+import { isPathContained } from "../util/path-contain"
 /**
  * Paths that are ALWAYS protected regardless of permission profile/mode.
  * Touching these triggers an ask even in full_access mode. This is a hard
@@ -196,7 +197,7 @@ export namespace PathClassifier {
     // Check if the candidate falls within the original checkout.
     // This catches paths that are outside the active worktree but inside the
     // original main checkout, and enriches the reason accordingly.
-    if (!path.relative(oc, candidate).startsWith("..")) {
+    if (isPathContained(oc, candidate)) {
       return outside("path is in the original checkout, outside the active workspace")
     }
 
@@ -204,11 +205,7 @@ export namespace PathClassifier {
     // from original checkout).
     const workspaceParent = path.dirname(workspace)
     const candidateParent = path.dirname(candidate)
-    if (
-      workspaceParent === candidateParent &&
-      workspace !== candidate &&
-      !path.relative(oc, workspaceParent).startsWith("..")
-    ) {
+    if (workspaceParent === candidateParent && workspace !== candidate && isPathContained(oc, workspaceParent)) {
       return outside("path is in a sibling worktree, outside the active workspace")
     }
 

--- a/packages/synergy/src/hashline/input.ts
+++ b/packages/synergy/src/hashline/input.ts
@@ -9,6 +9,7 @@ import { HL_FILE_HASH_EXAMPLES, HL_FILE_HASH_LENGTH, HL_FILE_HASH_SEP, HL_FILE_P
 import { parsePatch, parsePatchStreaming } from "./parser"
 import { Tokenizer } from "./tokenizer"
 import type { ApplyResult, BlockResolver, Edit, SplitOptions } from "./types"
+import { isPathContained } from "../util/path-contain"
 
 const TOKENIZER = new Tokenizer()
 
@@ -49,8 +50,7 @@ function normalizeHashlinePath(rawPath: string, cwd?: string): string {
   if (!cwd || !path.isAbsolute(unquoted)) return unquoted
   const relative = path.relative(path.resolve(cwd), path.resolve(unquoted))
   const normalizedRelative = relative.split(path.sep).join("/")
-  const isWithinCwd = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
-  return isWithinCwd ? normalizedRelative || "." : unquoted
+  return isPathContained(cwd, unquoted) ? normalizedRelative || "." : unquoted
 }
 
 interface RawSection {

--- a/packages/synergy/src/plugin-runtime/bridge-handlers.ts
+++ b/packages/synergy/src/plugin-runtime/bridge-handlers.ts
@@ -13,6 +13,7 @@ import { analyzeDestructiveCommand } from "../enforcement/gate.js"
 import { Config } from "../config/config.js"
 import * as ManifestReader from "../plugin/manifest-reader.js"
 import { resolveRuntimeLimits } from "./health.js"
+import { isPathContained } from "../util/path-contain.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,11 +42,35 @@ function resolveWorkspacePath(context: PluginHostRuntimeContext, requestedPath: 
   const normalizedWorkspace = path.resolve(workspace)
   const resolved = path.resolve(normalizedWorkspace, requestedPath)
 
-  if (resolved !== normalizedWorkspace && !resolved.startsWith(normalizedWorkspace + path.sep)) {
+  if (!isPathContained(normalizedWorkspace, resolved)) {
     throw new Error(`Path traversal detected: "${requestedPath}" escapes workspace directory`)
   }
 
   return resolved
+}
+
+async function assertWorkspaceRealpath(
+  context: PluginHostRuntimeContext,
+  resolvedPath: string,
+  requestedPath: string,
+): Promise<void> {
+  const workspace = context.directory
+  if (!workspace) throw new Error("Plugin tool context is missing a workspace directory")
+  const realWorkspace = await fs.realpath(path.resolve(workspace)).catch(() => path.resolve(workspace))
+  let current = resolvedPath
+
+  while (true) {
+    const real = await fs.realpath(current).catch(() => undefined)
+    if (real) {
+      if (!isPathContained(realWorkspace, real)) {
+        throw new Error(`Path traversal detected: "${requestedPath}" escapes workspace directory`)
+      }
+      return
+    }
+    const parent = path.dirname(current)
+    if (parent === current) return
+    current = parent
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +161,7 @@ export async function executeBridgeMethod(input: BridgeHandlerInput): Promise<un
       }
       const context = requireToolContext(bridgeContext, "file.read")
       const resolved = resolveWorkspacePath(context, requestedPath)
+      await assertWorkspaceRealpath(context, resolved, requestedPath)
       await authorizeBridgeCapability(context, "file_read", requestedPath)
       return Bun.file(resolved).text()
     }
@@ -150,6 +176,7 @@ export async function executeBridgeMethod(input: BridgeHandlerInput): Promise<un
       }
       const context = requireToolContext(bridgeContext, "file.write")
       const resolved = resolveWorkspacePath(context, requestedPath)
+      await assertWorkspaceRealpath(context, resolved, requestedPath)
       await authorizeBridgeCapability(context, "file_write", requestedPath)
       await fs.mkdir(path.dirname(resolved), { recursive: true })
       await Bun.write(resolved, data)
@@ -205,7 +232,12 @@ export async function executeBridgeMethod(input: BridgeHandlerInput): Promise<un
       }
       const context = requireToolContext(bridgeContext, "shell.run")
       const cwdParam = (params as any)?.cwd
-      const cwd = typeof cwdParam === "string" && cwdParam ? resolveWorkspacePath(context, cwdParam) : context.directory
+      let cwd = context.directory
+      if (!cwd) throw new Error("Plugin tool context is missing a workspace directory")
+      if (typeof cwdParam === "string" && cwdParam) {
+        cwd = resolveWorkspacePath(context, cwdParam)
+        await assertWorkspaceRealpath(context, cwd, cwdParam)
+      }
       const destructive = analyzeDestructiveCommand(cmd)
       await authorizeBridgeCapability(
         context,

--- a/packages/synergy/src/plugin/marketplace-registry.ts
+++ b/packages/synergy/src/plugin/marketplace-registry.ts
@@ -1,6 +1,7 @@
 import {
   PluginArtifact,
   PluginManifest,
+  normalizePluginArchiveEntry,
   type PluginManifest as PluginManifestType,
 } from "@ericsanchezok/synergy-plugin"
 import {
@@ -482,25 +483,35 @@ export namespace PluginMarketplaceRegistry {
     }
   }
 
-  function checkRequiredTarballFiles(tarballPath: string) {
+  function inspectTarballEntries(tarballPath: string): Set<string> {
     const result = Bun.spawnSync(["tar", "-tzf", tarballPath], { stdout: "pipe", stderr: "pipe" })
     if (result.exitCode !== 0) {
       const stderr = new TextDecoder().decode(result.stderr)
       throw new Error(`Failed to inspect plugin archive${stderr ? `: ${stderr}` : ""}`)
     }
-    const files = new Set(
-      new TextDecoder()
-        .decode(result.stdout)
-        .split("\n")
-        .map((line) => line.replace(/^\.\//, "").replace(/\/$/, ""))
-        .filter(Boolean),
-    )
+    const files = new Set<string>()
+    for (const line of new TextDecoder().decode(result.stdout).split("\n")) {
+      let entry: string | undefined
+      try {
+        entry = normalizePluginArchiveEntry(line)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        throw new Error(`Remote plugin artifact contains unsafe path: ${message}`)
+      }
+      if (entry) files.add(entry)
+    }
+    return files
+  }
+
+  function checkRequiredTarballFiles(tarballPath: string) {
+    const files = inspectTarballEntries(tarballPath)
     for (const required of PluginArtifact.requiredFiles) {
       if (!files.has(required)) throw new Error(`Remote plugin artifact is missing ${required}`)
     }
   }
 
   async function extractArchive(tarballPath: string) {
+    inspectTarballEntries(tarballPath)
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-market-plugin-"))
     const result = Bun.spawnSync(["tar", "-xzf", tarballPath, "-C", dir], { stdout: "pipe", stderr: "pipe" })
     if (result.exitCode !== 0) {

--- a/packages/synergy/src/plugin/spec-resolver.ts
+++ b/packages/synergy/src/plugin/spec-resolver.ts
@@ -5,7 +5,7 @@ import { Global } from "../global"
 import { BunProc } from "../util/bun"
 import { PluginSpec } from "../util/plugin-spec"
 import { PluginId } from "./ids"
-import { PluginManifest } from "@ericsanchezok/synergy-plugin"
+import { PluginManifest, normalizePluginArchiveEntry } from "@ericsanchezok/synergy-plugin"
 import { resolveEntryFromPluginDir } from "@ericsanchezok/synergy-plugin/spec"
 import type { PluginDescriptor, PluginManifest as PluginManifestType } from "@ericsanchezok/synergy-plugin"
 import type { PluginSource } from "./trust"
@@ -56,6 +56,22 @@ export function archiveCacheDir(archivePath: string): string {
   return path.join(Global.Path.cache, "plugin-archives", safeArchiveName(archivePath).replace(/\.tgz$/i, ""))
 }
 
+function validateArchiveEntries(archivePath: string) {
+  const result = Bun.spawnSync(["tar", "-tzf", archivePath], { stdout: "pipe", stderr: "pipe" })
+  if (result.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(result.stderr)
+    throw new Error(`Failed to inspect plugin archive ${archivePath}${stderr ? `: ${stderr}` : ""}`)
+  }
+  for (const line of new TextDecoder().decode(result.stdout).split("\n")) {
+    try {
+      normalizePluginArchiveEntry(line)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Plugin archive contains unsafe path: ${message}`)
+    }
+  }
+}
+
 /** Walk up from a file path to find the nearest directory containing package.json or plugin.json. */
 export function findPackageRoot(entryPath: string): string {
   const stat = fs.existsSync(entryPath) ? fs.statSync(entryPath) : undefined
@@ -84,6 +100,7 @@ export async function readPluginManifest(pluginDir: string): Promise<PluginManif
 }
 
 async function extractArchive(archivePath: string, options: { stage?: boolean } = {}): Promise<string> {
+  validateArchiveEntries(archivePath)
   const targetDir = options.stage
     ? path.join(
         Global.Path.state,

--- a/packages/synergy/src/plugin/trust.ts
+++ b/packages/synergy/src/plugin/trust.ts
@@ -18,6 +18,7 @@ import type { PluginLockEntry } from "./lockfile-schema"
 import { getApproval } from "./consent/approval-store"
 import type { PluginApprovalRecord } from "./consent/approval-store"
 import { sourceFromSpec } from "./source"
+import { isPathContained } from "../util/path-contain"
 
 export {
   decideTrust,
@@ -41,12 +42,9 @@ function sourceFromLockfile(pluginDir: string): PluginSource | undefined {
     for (const entry of entries) {
       if (!entry.spec || !entry.resolved) continue
       const resolved = path.resolve(entry.resolved)
-      const relative = path.relative(path.dirname(resolved), normalizedPluginDir)
-      const reverse = path.relative(normalizedPluginDir, resolved)
-      if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative)))
+      if (isPathContained(path.dirname(resolved), normalizedPluginDir))
         return entry.source ?? sourceFromSpec(entry.spec)
-      if (reverse === "" || (!reverse.startsWith("..") && !path.isAbsolute(reverse)))
-        return entry.source ?? sourceFromSpec(entry.spec)
+      if (isPathContained(normalizedPluginDir, resolved)) return entry.source ?? sourceFromSpec(entry.spec)
     }
   } catch {}
 }
@@ -60,11 +58,9 @@ export function derivePluginSource(pluginDir: string): PluginSource {
   if (fromLockfile) return fromLockfile
 
   const cacheRoot = Global.Path.cache
+  if (!isPathContained(cacheRoot, pluginDir)) return "local"
   const relative = path.relative(cacheRoot, pluginDir)
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    return "local"
-  }
-  if (relative.startsWith("plugin-archives")) return "local"
+  if (relative === "plugin-archives" || relative.startsWith(`plugin-archives${path.sep}`)) return "local"
   return "url"
 }
 
@@ -90,8 +86,7 @@ export async function findPluginLockEntry(pluginDir: string): Promise<PluginLock
     const lockfile = await Lockfile.read()
     for (const entry of Object.values(lockfile.plugins)) {
       const resolved = path.resolve(entry.resolved)
-      const relative = path.relative(normalizedPluginDir, resolved)
-      if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+      if (isPathContained(normalizedPluginDir, resolved)) {
         return entry
       }
     }

--- a/packages/synergy/src/project/worktree.ts
+++ b/packages/synergy/src/project/worktree.ts
@@ -11,6 +11,7 @@ import type { Scope } from "../scope"
 import { ScopeContext } from "../scope/context"
 import { fn } from "../util/fn"
 import { Log } from "../util/log"
+import { isPathContained } from "../util/path-contain"
 
 export namespace Worktree {
   export const Owner = z.discriminatedUnion("type", [
@@ -288,7 +289,7 @@ export namespace Worktree {
 
   function normalizeRegistryPath(info: RegistryInfo, repoRoot: string): RegistryInfo {
     const resolved = path.resolve(info.path)
-    if (resolved.startsWith(path.resolve(repoRoot) + path.sep)) return info
+    if (isPathContained(repoRoot, resolved)) return info
     return { ...info, path: path.join(worktreesRoot(repoRoot), path.basename(resolved)) }
   }
 

--- a/packages/synergy/src/runtime/reload.ts
+++ b/packages/synergy/src/runtime/reload.ts
@@ -10,6 +10,7 @@ import { ScopeContext } from "../scope/context"
 import { RuntimeSchema } from "./schema"
 import { SkillPaths } from "../skill/paths"
 import { Log } from "../util/log"
+import { isPathContained } from "../util/path-contain"
 
 export namespace RuntimeReload {
   export const Target = RuntimeSchema.ReloadTarget
@@ -437,7 +438,7 @@ export namespace RuntimeReload {
   export function builtinSourceEditWarning(filePath: string) {
     const normalized = path.resolve(filePath)
     const builtinRoot = path.resolve(path.join(ScopeContext.current.directory, "packages", "synergy", "src"))
-    if (!normalized.startsWith(builtinRoot + path.sep)) return undefined
+    if (!isPathContained(builtinRoot, normalized)) return undefined
     return BUILTIN_SOURCE_RESTART_WARNING
   }
 
@@ -453,7 +454,7 @@ export namespace RuntimeReload {
         path.resolve(path.join(Global.Path.config, "commands")),
       ],
       skill: SkillPaths.runtimeSkillRootsSync(ScopeContext.current.directory).filter(
-        (root) => !root.startsWith(path.resolve(ScopeContext.current.directory)),
+        (root) => !isPathContained(path.resolve(ScopeContext.current.directory), root),
       ),
       tool: [path.resolve(path.join(Global.Path.config, "tool"))],
     }
@@ -470,14 +471,14 @@ export namespace RuntimeReload {
         path.resolve(path.join(ScopeContext.current.directory, ".synergy", "commands")),
       ],
       skill: SkillPaths.runtimeSkillRootsSync(ScopeContext.current.directory).filter((root) =>
-        root.startsWith(path.resolve(ScopeContext.current.directory)),
+        isPathContained(path.resolve(ScopeContext.current.directory), root),
       ),
       tool: [path.resolve(path.join(ScopeContext.current.directory, ".synergy", "tool"))],
     }
   }
 
   function isUnderRoots(normalized: string, roots: string[]): boolean {
-    return roots.some((root) => normalized.startsWith(root + path.sep))
+    return roots.some((root) => isPathContained(root, normalized))
   }
 
   function globalLegacyConfigFiles() {
@@ -502,10 +503,10 @@ export namespace RuntimeReload {
     if (projectLegacyConfigFiles().includes(normalized)) return "project"
 
     const globalDomainDir = path.resolve(ConfigDomain.directory())
-    if (normalized.startsWith(globalDomainDir + path.sep) && ConfigDomain.domainForFile(normalized)) return "global"
+    if (isPathContained(globalDomainDir, normalized) && ConfigDomain.domainForFile(normalized)) return "global"
 
     const projectDomainDir = path.resolve(path.join(ScopeContext.current.directory, ".synergy", "synergy.d"))
-    if (normalized.startsWith(projectDomainDir + path.sep) && ConfigDomain.domainForFile(normalized)) return "project"
+    if (isPathContained(projectDomainDir, normalized) && ConfigDomain.domainForFile(normalized)) return "project"
 
     // P3: Check global config directory roots (agent, command, skill, tool)
     const globalRoots = globalConfigRoots()
@@ -536,7 +537,7 @@ export namespace RuntimeReload {
     const globalDomainDir = path.resolve(ConfigDomain.directory())
     const projectDomainDir = path.resolve(path.join(ScopeContext.current.directory, ".synergy", "synergy.d"))
     if (
-      (normalized.startsWith(globalDomainDir + path.sep) || normalized.startsWith(projectDomainDir + path.sep)) &&
+      (isPathContained(globalDomainDir, normalized) || isPathContained(projectDomainDir, normalized)) &&
       ConfigDomain.domainForFile(normalized)
     ) {
       const domain = ConfigDomain.domainForFile(normalized)!
@@ -548,10 +549,7 @@ export namespace RuntimeReload {
 
     // Skill files
     const skillRoots = [...gRoots.skill, ...pRoots.skill]
-    if (
-      normalized.endsWith(`${path.sep}SKILL.md`) &&
-      skillRoots.some((root) => normalized === root || normalized.startsWith(root + path.sep))
-    ) {
+    if (normalized.endsWith(`${path.sep}SKILL.md`) && skillRoots.some((root) => isPathContained(root, normalized))) {
       targets.push("skill")
     }
 

--- a/packages/synergy/src/server/plugin-routes.ts
+++ b/packages/synergy/src/server/plugin-routes.ts
@@ -26,7 +26,7 @@ import {
 } from "../plugin/consent/approval-store"
 import type { PluginApprovalRecord } from "../plugin/consent/approval-store"
 import { baseCapabilities } from "../plugin/capability"
-import { checkPathContainment } from "../util/path-contain"
+import { checkPathContainment, isPathContained } from "../util/path-contain"
 import { PluginMarketplaceRegistry } from "../plugin/marketplace-registry"
 import { localRegistryPath, resolveLocalRegistryInstallSpec } from "../plugin/local-registry-store"
 import { getPluginConfig, PluginConfigValidationError, replacePluginConfig } from "../plugin/config-store"
@@ -329,10 +329,10 @@ export const PluginRoute = new Hono()
       } catch {
         return c.json({ message: `Asset not found: ${filePath}` }, 404)
       }
-      const realRelative = path.relative(pluginDir, real)
-      if (realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
+      if (!isPathContained(pluginDir, real)) {
         return c.json({ message: "Path traversal denied" }, 403)
       }
+      const realRelative = path.relative(pluginDir, real)
 
       // 3. Allowed directories restriction
       if (!isAllowedPluginAssetPath(realRelative)) {

--- a/packages/synergy/src/server/skill-route.ts
+++ b/packages/synergy/src/server/skill-route.ts
@@ -10,12 +10,13 @@ import { ScopeContext } from "../scope/context"
 import { Global } from "../global"
 import { errors } from "./error"
 import { RuntimeReload } from "../runtime/reload"
+import { isPathContained } from "../util/path-contain"
 
 function resolveScope(skill: Skill.Info): Skill.Scope {
   if (skill.scope) return skill.scope
   if (skill.builtin) return "builtin"
   const projectDir = ScopeContext.current.directory
-  if (skill.location.startsWith(projectDir + path.sep)) return "project"
+  if (isPathContained(projectDir, skill.location)) return "project"
   return "global"
 }
 

--- a/packages/synergy/src/session/instruction-files.ts
+++ b/packages/synergy/src/session/instruction-files.ts
@@ -6,6 +6,7 @@ import { Flag } from "../flag/flag"
 import { Global } from "../global"
 import { ScopeContext } from "../scope/context"
 import { Filesystem } from "../util/filesystem"
+import { isPathContained } from "../util/path-contain"
 
 export namespace InstructionFiles {
   export const DEFAULT_PROJECT_DOC_MAX_BYTES = 32 * 1024
@@ -33,18 +34,13 @@ export namespace InstructionFiles {
     ])
   }
 
-  function containsPath(parent: string, child: string) {
-    const relative = path.relative(parent, child)
-    return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
-  }
-
   function searchDirsWithinScope() {
     const cwd = path.resolve(ScopeContext.current.directory)
     const scope = ScopeContext.current.scope
     if (scope.type !== "project") return [cwd]
 
     const root = path.resolve(scope.directory)
-    if (!containsPath(root, cwd)) return [cwd]
+    if (!isPathContained(root, cwd)) return [cwd]
 
     const dirs: string[] = []
     let current = cwd

--- a/packages/synergy/src/util/filesystem.ts
+++ b/packages/synergy/src/util/filesystem.ts
@@ -1,5 +1,6 @@
 import { realpathSync, existsSync } from "fs"
-import { dirname, join, relative } from "path"
+import { dirname, join } from "path"
+import { isPathContained } from "./path-contain"
 
 export namespace Filesystem {
   /**
@@ -26,7 +27,7 @@ export namespace Filesystem {
     }
   }
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    return isPathContained(parent, child)
   }
 
   export async function findUp(target: string, start: string, stop?: string) {

--- a/packages/synergy/src/util/path-contain.ts
+++ b/packages/synergy/src/util/path-contain.ts
@@ -1,14 +1,21 @@
 import path from "path"
 
+export function isPathContained(parent: string, child: string): boolean {
+  const resolvedParent = path.resolve(parent)
+  const resolvedChild = path.resolve(child)
+  const relative = path.relative(resolvedParent, resolvedChild)
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+export function resolveContainedPath(base: string, filePath: string): string | null {
+  const resolved = path.resolve(base, filePath)
+  return isPathContained(base, resolved) ? resolved : null
+}
+
 /**
  * Path containment check.
  * Returns the resolved absolute path if contained, null if traversal detected.
  */
 export function checkPathContainment(base: string, filePath: string): string | null {
-  const resolved = path.resolve(base, filePath)
-  const relative = path.relative(base, resolved)
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    return null
-  }
-  return resolved
+  return resolveContainedPath(base, filePath)
 }

--- a/packages/synergy/src/workspace-file/service.ts
+++ b/packages/synergy/src/workspace-file/service.ts
@@ -6,6 +6,7 @@ import { FileIgnore } from "../file/ignore"
 import { WorkspaceFile } from "./types"
 import { WorkspaceFileRead, likelyBinaryByExtension } from "./read"
 import { WorkspaceFileStatus } from "./status"
+import { isPathContained } from "../util/path-contain"
 
 const DEFAULT_CHILDREN_LIMIT = 200
 
@@ -25,11 +26,6 @@ function stripFileProtocol(input: string) {
 function isControlPath(input: string) {
   // eslint-disable-next-line no-control-regex
   return /[\x00-\x1f]/.test(input)
-}
-
-function contains(parent: string, child: string) {
-  const rel = path.relative(parent, child)
-  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))
 }
 
 async function realpathIfExists(input: string) {
@@ -60,7 +56,7 @@ export namespace WorkspaceFileService {
     const cleaned = stripFileProtocol(input.trim())
     const workspace = root()
     const absolute = path.resolve(workspace, cleaned || ".")
-    if (!contains(workspace, absolute)) {
+    if (!isPathContained(workspace, absolute)) {
       throw new AccessDeniedError("Access denied: path escapes workspace")
     }
     return absolute
@@ -68,13 +64,13 @@ export namespace WorkspaceFileService {
 
   export function relative(input: string) {
     const absolute = path.isAbsolute(input) ? path.resolve(input) : resolve(input)
-    if (!contains(root(), absolute)) throw new AccessDeniedError("Access denied: path escapes workspace")
+    if (!isPathContained(root(), absolute)) throw new AccessDeniedError("Access denied: path escapes workspace")
     return displayRelative(absolute)
   }
 
   export async function assertRealpathInside(absolute: string) {
     const real = await realpathIfExists(absolute)
-    if (real && !contains(root(), real)) {
+    if (real && !isPathContained(root(), real)) {
       throw new AccessDeniedError("Access denied: real path escapes workspace")
     }
   }
@@ -86,7 +82,7 @@ export namespace WorkspaceFileService {
 
   export async function node(input: string): Promise<WorkspaceFile.Node> {
     const absolute = path.isAbsolute(input) ? input : resolve(input)
-    if (!contains(root(), absolute)) throw new AccessDeniedError("Access denied: path escapes workspace")
+    if (!isPathContained(root(), absolute)) throw new AccessDeniedError("Access denied: path escapes workspace")
     await assertRealpathInside(absolute)
 
     const relativePath = displayRelative(absolute)

--- a/packages/synergy/src/workspace/policy.ts
+++ b/packages/synergy/src/workspace/policy.ts
@@ -2,6 +2,7 @@ import path from "path"
 import { realpathSync, lstatSync, readlinkSync } from "fs"
 import { Filesystem } from "../util/filesystem"
 import type { Scope } from "../scope"
+import { isPathContained } from "../util/path-contain"
 
 export interface WorkspacePolicyData {
   activeRoot: string
@@ -125,7 +126,7 @@ export class WorkspacePolicy {
       }
     }
 
-    const insideActive = !path.relative(activeRoot, resolved).startsWith("..")
+    const insideActive = isPathContained(activeRoot, resolved)
 
     if (insideActive) {
       return { boundary: "inside", confidence: "high", reason: "path is inside the active workspace" }
@@ -133,7 +134,7 @@ export class WorkspacePolicy {
 
     if (this.originalCheckout) {
       const oc = path.resolve(this.originalCheckout)
-      if (!path.relative(oc, resolved).startsWith("..")) {
+      if (isPathContained(oc, resolved)) {
         return {
           boundary: "outside",
           confidence: "high",

--- a/packages/synergy/test/file/path-traversal.test.ts
+++ b/packages/synergy/test/file/path-traversal.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { Filesystem } from "../../src/util/filesystem"
 import { File } from "../../src/file"
 import { ScopeContext } from "../../src/scope/context"
@@ -27,6 +28,33 @@ describe("Filesystem.contains", () => {
   test("handles prefix collision edge cases", () => {
     expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
     expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
+  })
+
+  test("rejects Windows cross-drive paths", () => {
+    if (process.platform !== "win32") return
+    expect(Filesystem.contains("C:\\project", "D:\\project\\file.txt")).toBe(false)
+  })
+})
+
+describe("plugin asset realpath containment", () => {
+  test("rejects symlink targets that escape the plugin directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "plugin", "dist"), { recursive: true })
+        await Bun.write(path.join(dir, "outside.txt"), "outside")
+      },
+    })
+
+    const pluginDir = path.join(tmp.path, "plugin")
+    const linkPath = path.join(pluginDir, "dist", "escape.txt")
+    try {
+      await fs.symlink(path.join(tmp.path, "outside.txt"), linkPath)
+    } catch {
+      return
+    }
+
+    const real = await fs.realpath(linkPath)
+    expect(Filesystem.contains(pluginDir, real)).toBe(false)
   })
 })
 

--- a/packages/synergy/test/plugin/artifact-path.test.ts
+++ b/packages/synergy/test/plugin/artifact-path.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { normalizePluginArchiveEntry } from "@ericsanchezok/synergy-plugin"
+
+describe("normalizePluginArchiveEntry", () => {
+  test("normalizes tar listing entries from plugin archives", () => {
+    expect(normalizePluginArchiveEntry("./plugin.json\r")).toBe("plugin.json")
+    expect(normalizePluginArchiveEntry("./runtime/index.js\r")).toBe("runtime/index.js")
+    expect(normalizePluginArchiveEntry("runtime/")).toBe("runtime")
+    expect(normalizePluginArchiveEntry("icons\\market.svg")).toBe("icons/market.svg")
+  })
+
+  test("skips empty and root directory entries", () => {
+    expect(normalizePluginArchiveEntry("")).toBeUndefined()
+    expect(normalizePluginArchiveEntry(".")).toBeUndefined()
+    expect(normalizePluginArchiveEntry("./")).toBeUndefined()
+  })
+
+  test("rejects paths that escape the plugin root", () => {
+    expect(() => normalizePluginArchiveEntry("../plugin.json")).toThrow("cannot escape")
+    expect(() => normalizePluginArchiveEntry("/plugin.json")).toThrow("must be relative")
+    expect(() => normalizePluginArchiveEntry("C:\\x\\plugin.json")).toThrow("must be relative")
+  })
+})

--- a/packages/synergy/test/plugin/marketplace-registry.test.ts
+++ b/packages/synergy/test/plugin/marketplace-registry.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { subtle } from "node:crypto"
+import { PluginManifest, type PluginManifest as PluginManifestType } from "@ericsanchezok/synergy-plugin"
+import { Config } from "../../src/config/config"
+import { PLUGIN_MARKETPLACE_DEFAULTS } from "../../src/config/schema"
+import { PluginMarketplaceRegistry } from "../../src/plugin/marketplace-registry"
+import { baseCapabilities } from "../../src/plugin/capability"
+import { computeManifestHash, computePermissionsHash } from "../../src/plugin/consent/approval-store"
+import { sha256File } from "../../src/util/crypto"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
+
+function hex(input: ArrayBuffer): string {
+  return Buffer.from(input).toString("hex")
+}
+
+function jsonResponse(input: unknown): Response {
+  return new Response(JSON.stringify(input), { headers: { "Content-Type": "application/json" } })
+}
+
+async function createSignedPluginArtifact(input: { dir: string; id: string; version: string }): Promise<{
+  manifest: PluginManifestType
+  tarballPath: string
+  signature: Record<string, unknown>
+  signer: string
+  integrity: string
+  manifestHash: string
+  permissionsHash: string
+}> {
+  const packageDir = path.join(input.dir, "dist")
+  await fs.mkdir(path.join(packageDir, "runtime"), { recursive: true })
+
+  const manifest = PluginManifest.parse({
+    name: input.id,
+    version: input.version,
+    description: "Official plugin fixture",
+    author: "Synergy Test",
+    repository: "https://github.com/SII-Holos/official-crlf-fixture",
+    engines: { synergy: ">=2.4.3" },
+    permissions: {},
+    runtime: { mode: "process" },
+    main: "./runtime/index.js",
+  }) as PluginManifestType
+
+  await Bun.write(path.join(packageDir, "plugin.json"), JSON.stringify(manifest, null, 2))
+  await Bun.write(path.join(packageDir, "runtime", "index.js"), "export default { id: 'official-crlf-fixture' }\n")
+
+  const capabilities = baseCapabilities(manifest)
+  const manifestHash = computeManifestHash(manifest)
+  const permissionsHash = computePermissionsHash(manifest, capabilities)
+  await Bun.write(path.join(packageDir, "integrity.json"), JSON.stringify({}, null, 2))
+  await Bun.write(
+    path.join(packageDir, "permissions.summary.json"),
+    JSON.stringify({ capabilities, permissionsHash }, null, 2),
+  )
+
+  const tarballPath = path.join(input.dir, `${input.id}-${input.version}.synergy-plugin.tgz`)
+  const packed = Bun.spawnSync(["tar", "-czf", tarballPath, "-C", packageDir, "."], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (packed.exitCode !== 0) {
+    throw new Error(new TextDecoder().decode(packed.stderr) || "failed to create fixture tarball")
+  }
+
+  const tarballHash = sha256File(tarballPath)
+  const keyPair = (await subtle.generateKey("Ed25519" as any, true, ["sign", "verify"])) as CryptoKeyPair
+  const signer = hex(await subtle.exportKey("raw", keyPair.publicKey))
+  const payload = { tarballHash, manifestHash, permissionsHash }
+  const signatureBytes = await subtle.sign(
+    "Ed25519" as any,
+    keyPair.privateKey,
+    new TextEncoder().encode(JSON.stringify(payload)),
+  )
+  const signature = {
+    signatureVersion: 1,
+    pluginId: input.id,
+    version: input.version,
+    algorithm: "ed25519",
+    signer,
+    signature: hex(signatureBytes),
+    signedAt: Date.parse("2026-06-25T00:00:00.000Z"),
+    payload,
+  }
+
+  return {
+    manifest,
+    tarballPath,
+    signature,
+    signer,
+    integrity: `sha256-${tarballHash}`,
+    manifestHash,
+    permissionsHash,
+  }
+}
+
+describe("PluginMarketplaceRegistry.verifyOfficialArtifact", () => {
+  test("accepts tar listings with CRLF entries from Windows tar", async () => {
+    await using tmp = await tmpdir()
+    const id = "official-crlf-fixture"
+    const version = "1.0.0"
+    const artifact = await createSignedPluginArtifact({ dir: tmp.path, id, version })
+    const registryUrl = `https://registry.test/synergy/plugins/registry-crlf-${Date.now()}.json`
+    const entryUrl = new URL("official-crlf-fixture.json", registryUrl).href
+    const downloadUrl = `https://registry.test/releases/${id}-${version}.synergy-plugin.tgz`
+    const signatureUrl = `${downloadUrl}.sig`
+    const publishedAt = "2026-06-25T00:00:00.000Z"
+    const previousDomain = await Config.domainGet("plugins")
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url
+      if (url === registryUrl) {
+        return jsonResponse({
+          schemaVersion: 1,
+          updatedAt: publishedAt,
+          plugins: [
+            {
+              id,
+              name: id,
+              description: artifact.manifest.description,
+              repo: "https://github.com/SII-Holos/official-crlf-fixture",
+              entry: "official-crlf-fixture.json",
+              author: { name: "Synergy Test" },
+              verified: true,
+              official: true,
+              keywords: ["synergy-plugin"],
+              latestVersion: version,
+              updatedAt: publishedAt,
+              risk: "low",
+              runtimeMode: "process",
+              tools: [],
+              uiSurfaces: [],
+            },
+          ],
+        })
+      }
+      if (url === entryUrl) {
+        return jsonResponse({
+          schemaVersion: 1,
+          id,
+          name: id,
+          description: artifact.manifest.description,
+          repo: "https://github.com/SII-Holos/official-crlf-fixture",
+          author: { name: "Synergy Test" },
+          verified: true,
+          official: true,
+          keywords: ["synergy-plugin"],
+          compatibility: { synergy: ">=2.4.3" },
+          versions: [
+            {
+              version,
+              downloadUrl,
+              signatureUrl,
+              signature: { algorithm: "ed25519", signer: artifact.signer },
+              integrity: artifact.integrity,
+              manifestHash: artifact.manifestHash,
+              permissionsHash: artifact.permissionsHash,
+              risk: "low",
+              runtimeMode: "process",
+              permissionsSummary: [],
+              tools: [],
+              uiSurfaces: [],
+              publishedAt,
+            },
+          ],
+          yankedVersions: [],
+        })
+      }
+      if (url === signatureUrl) return jsonResponse(artifact.signature)
+      if (url === downloadUrl) return new Response(await Bun.file(artifact.tarballPath).arrayBuffer())
+      return new Response("not found", { status: 404 })
+    }) as typeof fetch
+
+    try {
+      await Config.domainUpdate(
+        "plugins",
+        {
+          ...previousDomain,
+          pluginMarketplace: {
+            ...PLUGIN_MARKETPLACE_DEFAULTS,
+            enabled: true,
+            registryUrl,
+            cacheTtlMs: 1,
+          },
+        },
+        { mode: "replace-domain" },
+      )
+      await Config.reload("global")
+
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const verified = await PluginMarketplaceRegistry.verifyOfficialArtifact(id, version)
+          expect(verified.manifest.name).toBe(id)
+          expect(verified.manifest.version).toBe(version)
+        },
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+      await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
+      await Config.reload("global")
+    }
+  })
+})

--- a/packages/synergy/test/plugin/runtime-bridge-path.test.ts
+++ b/packages/synergy/test/plugin/runtime-bridge-path.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { executeBridgeMethod } from "../../src/plugin-runtime/bridge-handlers"
+import { tmpdir } from "../fixture/fixture"
+
+function bridgeParams(directory: string, params: Record<string, unknown>) {
+  return {
+    ...params,
+    context: {
+      sessionID: "ses_bridge_path_test",
+      messageID: "msg_bridge_path_test",
+      agent: "synergy",
+      directory,
+    },
+  }
+}
+
+describe("plugin runtime bridge workspace path containment", () => {
+  test("rejects absolute paths outside the workspace before permission checks", async () => {
+    await using tmp = await tmpdir()
+    const outside = path.join(path.dirname(tmp.path), "outside.txt")
+
+    await expect(
+      executeBridgeMethod({
+        pluginId: "bridge-test",
+        pluginDir: tmp.path,
+        method: "file.read" as any,
+        params: bridgeParams(tmp.path, { path: outside }),
+      }),
+    ).rejects.toThrow("escapes workspace directory")
+  })
+
+  test("rejects symlink directory writes that escape the workspace", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "workspace"), { recursive: true })
+        await fs.mkdir(path.join(dir, "outside"), { recursive: true })
+      },
+    })
+    const workspace = path.join(tmp.path, "workspace")
+    const outside = path.join(tmp.path, "outside")
+    const link = path.join(workspace, "linked-out")
+
+    try {
+      await fs.symlink(outside, link, "dir")
+    } catch {
+      return
+    }
+
+    await expect(
+      executeBridgeMethod({
+        pluginId: "bridge-test",
+        pluginDir: workspace,
+        method: "file.write" as any,
+        params: bridgeParams(workspace, { path: "linked-out/new.txt", data: "nope" }),
+      }),
+    ).rejects.toThrow("escapes workspace directory")
+  })
+})

--- a/packages/synergy/test/plugin/spec-resolver.test.ts
+++ b/packages/synergy/test/plugin/spec-resolver.test.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from "url"
 import { tmpdir } from "../fixture/fixture"
 import { assertCanonicalPluginIdentity, importUrlForEntry, resolvePluginSpec } from "../../src/plugin/spec-resolver"
 
+const encoder = new TextEncoder()
+
 async function writePlugin(dir: string, id = "resolver-plugin") {
   await fs.mkdir(path.join(dir, "src"), { recursive: true })
   await Bun.write(
@@ -25,6 +27,56 @@ async function writePlugin(dir: string, id = "resolver-plugin") {
     JSON.stringify({ name: id, version: "0.1.0", type: "module", main: "./src/index.ts" }, null, 2),
   )
   await Bun.write(path.join(dir, "src", "index.ts"), `export default { id: "${id}", async init() { return {} } }\n`)
+}
+
+function tarHeader(name: string, content: Uint8Array): Uint8Array {
+  const header = new Uint8Array(512)
+  const writeString = (offset: number, length: number, value: string) => {
+    header.set(encoder.encode(value).slice(0, length), offset)
+  }
+  const writeOctal = (offset: number, length: number, value: number) => {
+    const text =
+      value
+        .toString(8)
+        .padStart(length - 1, "0")
+        .slice(-(length - 1)) + "\0"
+    writeString(offset, length, text)
+  }
+
+  writeString(0, 100, name)
+  writeOctal(100, 8, 0o644)
+  writeOctal(108, 8, 0)
+  writeOctal(116, 8, 0)
+  writeOctal(124, 12, content.byteLength)
+  writeOctal(136, 12, 0)
+  header.fill(0x20, 148, 156)
+  writeString(156, 1, "0")
+  writeString(257, 6, "ustar\0")
+  writeString(263, 2, "00")
+
+  let checksum = 0
+  for (const byte of header) checksum += byte
+  writeString(148, 8, checksum.toString(8).padStart(6, "0") + "\0 ")
+  return header
+}
+
+function tarGz(entries: Array<{ name: string; content: string }>): Uint8Array {
+  const chunks: Uint8Array[] = []
+  for (const entry of entries) {
+    const content = encoder.encode(entry.content)
+    chunks.push(tarHeader(entry.name, content), content)
+    const padding = (512 - (content.byteLength % 512)) % 512
+    if (padding) chunks.push(new Uint8Array(padding))
+  }
+  chunks.push(new Uint8Array(1024))
+  const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0)
+  const tar = new Uint8Array(size)
+  let offset = 0
+  for (const chunk of chunks) {
+    tar.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return Bun.gzipSync(tar)
 }
 
 describe("resolvePluginSpec", () => {
@@ -65,6 +117,14 @@ describe("resolvePluginSpec", () => {
     expect(resolved.pkg).toBe("archive-plugin")
     expect(resolved.manifest.name).toBe("archive-plugin")
     expect(resolved.entryPath.endsWith(path.join("src", "index.ts"))).toBe(true)
+  })
+
+  test("rejects local plugin archives with unsafe entries before extraction", async () => {
+    await using tmp = await tmpdir()
+    const archivePath = path.join(tmp.path, "unsafe-plugin-0.1.0.synergy-plugin.tgz")
+    await Bun.write(archivePath, tarGz([{ name: "../plugin.json", content: "{}" }]))
+
+    await expect(resolvePluginSpec(pathToFileURL(archivePath).href, { install: false })).rejects.toThrow("unsafe path")
   })
 
   test("rejects plugin directories without plugin.json", async () => {

--- a/packages/synergy/test/plugin/trust.test.ts
+++ b/packages/synergy/test/plugin/trust.test.ts
@@ -41,6 +41,12 @@ describe("derivePluginSource", () => {
     expect(derivePluginSource(pluginDir)).toBe("local")
   })
 
+  test("does not treat plugin-archives sibling prefixes as archive cache entries", () => {
+    const pluginDir = path.join(Global.Path.cache, "plugin-archives-other", "demo-plugin")
+
+    expect(derivePluginSource(pluginDir)).toBe("url")
+  })
+
   test("does not guess npm when cached plugin source is unknown", () => {
     const pluginDir = path.join(Global.Path.cache, "node_modules", "demo-plugin")
 

--- a/packages/synergy/test/server/plugin-routes.test.ts
+++ b/packages/synergy/test/server/plugin-routes.test.ts
@@ -131,9 +131,20 @@ describe("checkPathContainment (path traversal guard)", () => {
     expect(checkPathContainment(base, outside)).toBeNull()
   })
 
+  test("rejects absolute sibling-prefix paths", () => {
+    const base = path.join(path.parse(process.cwd()).root, "plugins", "plugin-a")
+    const sibling = path.join(path.parse(process.cwd()).root, "plugins", "plugin-a-other", "dist", "ui.js")
+    expect(checkPathContainment(base, sibling)).toBeNull()
+  })
+
   test("allows contained relative paths within base", () => {
     const base = path.join(path.parse(process.cwd()).root, "plugins", "plugin-a")
     expect(checkPathContainment(base, "dist/ui.js")).toBe(path.join(base, "dist", "ui.js"))
+  })
+
+  test("allows the base directory itself", () => {
+    const base = path.join(path.parse(process.cwd()).root, "plugins", "plugin-a")
+    expect(checkPathContainment(base, ".")).toBe(base)
   })
 
   test("allows nested subdirectories within base", () => {
@@ -141,6 +152,11 @@ describe("checkPathContainment (path traversal guard)", () => {
     expect(checkPathContainment(base, "dist/nested/deep/ui.js")).toBe(
       path.join(base, "dist", "nested", "deep", "ui.js"),
     )
+  })
+
+  test("rejects Windows cross-drive paths", () => {
+    if (process.platform !== "win32") return
+    expect(checkPathContainment("C:\\plugins\\plugin-a", "D:\\plugins\\plugin-a\\dist\\ui.js")).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- Normalize plugin archive entries from tar listings so Windows CRLF output like \\./plugin.json\\r\\ satisfies required-file checks.
- Validate plugin archive entries before extraction for official, local file://, plugin publish, and plugin-kit registry entry flows.
- Centralize Synergy path containment checks and apply them across plugin assets, runtime bridge workspace paths, browser/workspace policies, runtime reload detection, and related security boundaries.

## Tests
- bun test test/plugin/scaffold-toolchain.test.ts test/server/plugin-routes.test.ts test/file/path-traversal.test.ts test/workspace/policy.test.ts test/tool/workspace-boundary.test.ts test/plugin/artifact-path.test.ts test/plugin/marketplace-registry.test.ts test/plugin/spec-resolver.test.ts test/plugin/runtime-bridge-path.test.ts test/browser/policy.test.ts test/runtime/reload.test.ts test/workspace-file/service.test.ts
- bun test test/plugin/marketplace-registry.test.ts test/plugin/spec-resolver.test.ts test/plugin/trust.test.ts
- bun run typecheck
- git diff --check

Note: typecheck/pre-push completed with the existing turbo warning about a missing lockfile entry for @emnapi/*, but all tasks passed.