### PR TITLE
fix: keep status bar workspace icon in sync after worktree_enter/worktree_leave (#192)

### DIFF
--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -1,66 +1,202 @@
 import { describe, expect, test } from "bun:test"
-import { Binary } from "@ericsanchezok/synergy-util/binary"
+import { resolveWorkspaceTransition } from "./workspace-transition"
+import type { Part } from "@ericsanchezok/synergy-sdk/client"
 
-describe("global-sync message.part.updated workspace patching", () => {
-  test("Binary.search finds existing session by id", () => {
-    const sessions = [
-      { id: "ses_a", workspace: { type: "main" } },
-      { id: "ses_b", workspace: { type: "main" } },
-    ]
-    const idx = Binary.search(sessions, "ses_b", (s) => (s as { id: string }).id)
-    expect(idx.found).toBe(true)
-    expect(idx.index).toBe(1)
+function toolPart(overrides: Record<string, unknown> = {}): Part {
+  return {
+    id: "part_1",
+    sessionID: "ses_a",
+    messageID: "msg_1",
+    type: "tool",
+    callID: "call_1",
+    tool: "worktree_enter",
+    state: {
+      status: "completed",
+      input: {},
+      output: "",
+      title: "Entered worktree",
+      metadata: {
+        action: "entered",
+        workspace: {
+          type: "git_worktree",
+          path: "/tmp/worktrees/feature-x",
+          scopeID: "abc123",
+          worktreeID: "wt_1",
+          name: "feature-x",
+          branch: "feature/x",
+        },
+      },
+      time: { start: 1, end: 2 },
+    },
+    ...overrides,
+  } as Part
+}
+
+describe("resolveWorkspaceTransition", () => {
+  test("returns none for non-tool parts", () => {
+    const part: Part = {
+      id: "part_1",
+      sessionID: "ses_a",
+      messageID: "msg_1",
+      type: "text",
+      text: "hello",
+    } as Part
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
   })
 
-  test("Binary.search returns insert position for missing id", () => {
-    const sessions = [{ id: "ses_a", workspace: { type: "main" } }]
-    const idx = Binary.search(sessions, "ses_x", (s) => (s as { id: string }).id)
-    expect(idx.found).toBe(false)
-    expect(idx.index).toBe(1)
+  test("returns none for non-completed tool parts", () => {
+    const part: Part = {
+      id: "part_1",
+      sessionID: "ses_a",
+      messageID: "msg_1",
+      type: "tool",
+      callID: "call_1",
+      tool: "worktree_enter",
+      state: {
+        status: "running",
+        input: {},
+        title: "Entering worktree",
+        time: { start: 1 },
+      },
+    } as Part
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
   })
-})
 
-describe("optimistic workspace update shape", () => {
-  test("worktree_enter metadata workspace shape matches session.workspace", () => {
-    const ws = {
-      type: "git_worktree" as const,
-      path: "/tmp/synergy-worktrees/feature-x",
-      scopeID: "abc123",
-      worktreeID: "wt_1",
-      name: "feature-x",
-      branch: "feature/x",
-      baseRef: "current" as const,
-      baseRevision: undefined,
-      resolvedBaseCommit: "def456",
+  test("returns none for unknown tools", () => {
+    const part = toolPart({ tool: "bash" })
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
+  })
+
+  test("returns enter with workspace for completed worktree_enter", () => {
+    const result = resolveWorkspaceTransition(toolPart())
+    expect(result.kind).toBe("enter")
+    if (result.kind === "enter") {
+      expect(result.workspace.type).toBe("git_worktree")
+      expect(result.workspace.name).toBe("feature-x")
     }
-    // These are the fields the status bar reads
-    expect(ws.type).toBe("git_worktree")
-    expect(ws.name).toBe("feature-x")
-    expect(ws.branch).toBe("feature/x")
   })
 
-  test("worktree_leave restored shape maps to main workspace", () => {
-    const restored = { type: "main", path: "/project" }
-    const scopeID = "abc123"
-    const workspace = {
-      type: restored.type ?? "main",
-      path: restored.path,
-      scopeID,
-    }
-    // These are the fields the status bar reads
-    expect(workspace.type).toBe("main")
-    expect(workspace.path).toBe("/project")
-    expect(workspace.scopeID).toBe("abc123")
+  test("returns none for worktree_enter with denied action", () => {
+    const part = toolPart({
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Denied",
+        metadata: { action: "denied", message: "dirty worktree" },
+        time: { start: 1, end: 2 },
+      },
+    })
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
   })
 
-  test("worktree_leave restored with missing type defaults to main", () => {
-    const restored: { type?: string; path?: string } = { path: "/project" }
-    const scopeID = "abc123"
-    const workspace = {
-      type: restored.type ?? "main",
-      path: restored.path,
-      scopeID,
+  test("returns none for worktree_enter without workspace", () => {
+    const part = toolPart({
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Denied",
+        metadata: { action: "entered", message: "already there" },
+        time: { start: 1, end: 2 },
+      },
+    })
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
+  })
+
+  test("returns leave with workspace for completed worktree_leave", () => {
+    const part = toolPart({
+      tool: "worktree_leave",
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Left worktree",
+        metadata: {
+          action: "left",
+          previous: { type: "git_worktree", path: "/tmp/worktrees/x", name: "x" },
+          restored: { type: "main", path: "/project" },
+          cleanup: { performed: true },
+        },
+        time: { start: 1, end: 2 },
+      },
+    })
+    const result = resolveWorkspaceTransition(part)
+    expect(result.kind).toBe("leave")
+    if (result.kind === "leave") {
+      expect(result.workspace.type).toBe("main")
+      expect(result.workspace.path).toBe("/project")
+      expect(result.workspace.scopeID).toBe("")
     }
-    expect(workspace.type).toBe("main")
+  })
+
+  test("returns leave defaulting to main type when restored has no type", () => {
+    const part = toolPart({
+      tool: "worktree_leave",
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Left worktree",
+        metadata: {
+          action: "left",
+          restored: { path: "/project" },
+        },
+        time: { start: 1, end: 2 },
+      },
+    })
+    const result = resolveWorkspaceTransition(part)
+    expect(result.kind).toBe("leave")
+    if (result.kind === "leave") {
+      expect(result.workspace.type).toBe("main")
+    }
+  })
+
+  test("returns none for worktree_leave with missing restored.path", () => {
+    const part = toolPart({
+      tool: "worktree_leave",
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Left worktree",
+        metadata: {
+          action: "left",
+          restored: { type: "main" },
+        },
+        time: { start: 1, end: 2 },
+      },
+    })
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
+  })
+
+  test("returns none for worktree_leave with denied action", () => {
+    const part = toolPart({
+      tool: "worktree_leave",
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Denied",
+        metadata: { action: "denied", reason: "permission" },
+        time: { start: 1, end: 2 },
+      },
+    })
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
+  })
+
+  test("returns none for worktree_leave with noop action", () => {
+    const part = toolPart({
+      tool: "worktree_leave",
+      state: {
+        status: "completed",
+        input: {},
+        output: "",
+        title: "Already on main",
+        metadata: { action: "noop", message: "already on main" },
+        time: { start: 1, end: 2 },
+      },
+    })
+    expect(resolveWorkspaceTransition(part).kind).toBe("none")
   })
 })

--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { Binary } from "@ericsanchezok/synergy-util/binary"
+
+describe("global-sync message.part.updated workspace patching", () => {
+  test("Binary.search finds existing session by id", () => {
+    const sessions = [
+      { id: "ses_a", workspace: { type: "main" } },
+      { id: "ses_b", workspace: { type: "main" } },
+    ]
+    const idx = Binary.search(sessions, "ses_b", (s) => (s as { id: string }).id)
+    expect(idx.found).toBe(true)
+    expect(idx.index).toBe(1)
+  })
+
+  test("Binary.search returns insert position for missing id", () => {
+    const sessions = [{ id: "ses_a", workspace: { type: "main" } }]
+    const idx = Binary.search(sessions, "ses_x", (s) => (s as { id: string }).id)
+    expect(idx.found).toBe(false)
+    expect(idx.index).toBe(1)
+  })
+})
+
+describe("optimistic workspace update shape", () => {
+  test("worktree_enter metadata workspace shape matches session.workspace", () => {
+    const ws = {
+      type: "git_worktree" as const,
+      path: "/tmp/synergy-worktrees/feature-x",
+      scopeID: "abc123",
+      worktreeID: "wt_1",
+      name: "feature-x",
+      branch: "feature/x",
+      baseRef: "current" as const,
+      baseRevision: undefined,
+      resolvedBaseCommit: "def456",
+    }
+    // These are the fields the status bar reads
+    expect(ws.type).toBe("git_worktree")
+    expect(ws.name).toBe("feature-x")
+    expect(ws.branch).toBe("feature/x")
+  })
+
+  test("worktree_leave restored shape maps to main workspace", () => {
+    const restored = { type: "main", path: "/project" }
+    const scopeID = "abc123"
+    const workspace = {
+      type: restored.type ?? "main",
+      path: restored.path,
+      scopeID,
+    }
+    // These are the fields the status bar reads
+    expect(workspace.type).toBe("main")
+    expect(workspace.path).toBe("/project")
+    expect(workspace.scopeID).toBe("abc123")
+  })
+
+  test("worktree_leave restored with missing type defaults to main", () => {
+    const restored: { type?: string; path?: string } = { path: "/project" }
+    const scopeID = "abc123"
+    const workspace = {
+      type: restored.type ?? "main",
+      path: restored.path,
+      scopeID,
+    }
+    expect(workspace.type).toBe("main")
+  })
+})

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -480,46 +480,36 @@ function createGlobalSync() {
         if (grouped[sessionID]) continue
         setStore(storeKey, sessionID, [])
       }
-      for (const [sessionID, entries] of Object.entries(grouped)) {
-        setStore(
-          storeKey,
-          sessionID,
-          reconcile(
-            entries
-              .filter((e) => !!e?.id)
-              .slice()
-              .sort((a, b) => a.id!.localeCompare(b.id!)),
-            { key: "id" },
-          ),
-        )
+
+      for (const [sessionID, group] of Object.entries(grouped)) {
+        group.sort((a, b) => a.id!.localeCompare(b.id!))
+        setStore(storeKey, sessionID, reconcile(group, { key: "id" }))
       }
     })
   }
 
-  const inboxRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  const cortexRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  const terminalCortexStatuses = new Set(["completed", "error", "cancelled"])
-
+  let inboxRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
   function refreshInbox(scopeKey: string, sessionID: string) {
-    const key = `${scopeKey}:${sessionID}`
-    const existing = inboxRefreshTimers.get(key)
+    const existing = inboxRefreshTimers.get(sessionID)
     if (existing) clearTimeout(existing)
     inboxRefreshTimers.set(
-      key,
+      sessionID,
       setTimeout(() => {
-        inboxRefreshTimers.delete(key)
-        const state = children[scopeKey]
-        if (!state) return
-        const [, setStore] = state
+        inboxRefreshTimers.delete(sessionID)
         const sdk = createScopedClient(scopeKey)
         sdk.session
           .inbox({ sessionID })
-          .then((result) => setStore("inbox", sessionID, reconcile(result.data ?? [], { key: "id" })))
+          .then((x) => {
+            const items = x.data ?? []
+            const [_, setStore] = ensureScopeState(scopeKey)
+            setStore("inbox", sessionID, reconcile(items, { key: "id" }))
+          })
           .catch(() => {})
-      }, 120),
+      }, 500),
     )
   }
 
+  let cortexRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
   function refreshCortex(scopeKey: string) {
     const existing = cortexRefreshTimers.get(scopeKey)
     if (existing) clearTimeout(existing)
@@ -527,612 +517,585 @@ function createGlobalSync() {
       scopeKey,
       setTimeout(() => {
         cortexRefreshTimers.delete(scopeKey)
-        const state = children[scopeKey]
-        if (!state) return
-        const [, setStore] = state
         const sdk = createScopedClient(scopeKey)
         sdk.cortex
-          .list({})
-          .then((result) => setStore("cortex", reconcile(result.data ?? [])))
-          .catch(() => {})
-      }, 250),
-    )
-  }
-
-  function reconcileCortexFromSession(setStore: SetStoreFunction<State>, info: Session) {
-    const cortex = info.cortex
-    if (!cortex || !terminalCortexStatuses.has(cortex.status)) return
-    setStore(
-      "cortex",
-      produce((draft) => {
-        const idx = draft.findIndex((task) => task.sessionID === info.id)
-        if (idx === -1) return
-        draft[idx] = {
-          ...draft[idx],
-          status: cortex.status,
-          completedAt: cortex.completedAt ?? draft[idx].completedAt,
-          result: cortex.result ?? draft[idx].result,
-          error: cortex.error ?? draft[idx].error,
-        }
-      }),
-    )
-  }
-
-  function refreshVolatileStateAfterMessage(scopeKey: string, store: State, sessionID: string) {
-    if (store.inbox[sessionID]?.length) refreshInbox(scopeKey, sessionID)
-    if (
-      store.cortex.some(
-        (task) => task.sessionID === sessionID && (task.status === "running" || task.status === "queued"),
-      )
-    ) {
-      refreshCortex(scopeKey)
-    }
-  }
-
-  async function refreshRetainedVolatileState(scopeKey: string, store: State, setStore: SetStoreFunction<State>) {
-    const sessionIDs = Array.from(
-      new Set([...Object.keys(store.inbox), ...Object.keys(store.todo), ...Object.keys(store.dag)]),
-    )
-    const sdk = createScopedClient(scopeKey)
-    await runInstanceRequests(sessionIDs, async (sessionID) => {
-      await Promise.all([
-        sdk.session
-          .inbox({ sessionID })
-          .then((result) => setStore("inbox", sessionID, reconcile(result.data ?? [], { key: "id" })))
-          .catch(() => {}),
-        sdk.session
-          .todo({ sessionID })
-          .then((result) => setStore("todo", sessionID, reconcile(result.data ?? [], { key: "id" })))
-          .catch(() => {}),
-        sdk.session
-          .dag({ sessionID, ...scopeRequest(scopeKey) })
-          .then((result) => setStore("dag", sessionID, reconcile(result.data ?? [], { key: "id" })))
-          .catch(() => {}),
-      ])
-    })
-  }
-
-  async function resyncInstance(scopeKey: string) {
-    if (!scopeKey || !children[scopeKey]) return
-    const [store, setStore] = children[scopeKey]
-    if (store.status === "loading") return
-    const isHome = isHomeScope(scopeKey)
-    const sdk = createScopedClient(scopeKey)
-
-    await Promise.all([
-      loadSessions(scopeKey, sdk),
-      sdk.session.status().then((x) => setStore("session_status", x.data!)),
-      sdk.cortex.list({}).then((x) => setStore("cortex", x.data ?? [])),
-      sdk.agenda.list().then((x) =>
-        setStore(
-          "agenda",
-          reconcile(
-            (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
-            { key: "id" },
-          ),
-        ),
-      ),
-      sdk.permission
-        .list()
-        .then((x) => syncBySession(setStore, "permission", Object.keys(store.permission), x.data ?? [])),
-      sdk.question.list().then((x) => syncBySession(setStore, "question", Object.keys(store.question), x.data ?? [])),
-      refreshRetainedVolatileState(scopeKey, store, setStore),
-      ...(!isHome
-        ? [
-            sdk.mcp.status().then((x) => setStore("mcp", x.data!)),
-            sdk.lsp.status().then((x) => setStore("lsp", x.data!)),
-          ]
-        : []),
-    ])
-  }
-
-  async function bootstrapInstance(scopeKey: string) {
-    if (!scopeKey) return
-    const isHome = isHomeScope(scopeKey)
-    const [store, setStore] = ensureScopeState(scopeKey)
-    const sdk = createScopedClient(scopeKey)
-
-    const blockingRequests: Record<string, () => Promise<void>> = {
-      provider: () =>
-        sdk.provider.list().then((x) => {
-          const data = x.data!
-          setStore("provider", {
-            ...data,
-            all: data.all.map((provider) => ({
-              ...provider,
-              models: Object.fromEntries(
-                Object.entries(provider.models).filter(([, info]) => info.status !== "deprecated"),
-              ),
-            })),
-          })
-        }),
-      agent: () => sdk.app.agents().then((x) => setStore("agent", x.data ?? [])),
-      config: () => sdk.config.get().then((x) => setStore("config", x.data!)),
-    }
-    blockingRequests.scopeID = isHome
-      ? () => Promise.resolve(setStore("scopeID", HOME_SCOPE_KEY))
-      : () => sdk.scope.current().then((x) => setStore("scopeID", x.data!.id))
-    await Promise.all(Object.values(blockingRequests).map((p) => retry(p).catch((e) => setGlobalStore("error", e))))
-      .then(async () => {
-        if (store.status !== "complete") setStore("status", "partial")
-        const requests: Promise<unknown>[] = [
-          sdk.path.get(scopeRequest(scopeKey)).then((x) => setStore("path", x.data!)),
-          sdk.command.list().then((x) => setStore("command", x.data ?? [])),
-          sdk.session.status().then((x) => setStore("session_status", x.data!)),
-          loadSessions(scopeKey, sdk),
-          sdk.mcp.status().then((x) => setStore("mcp", x.data!)),
-          sdk.cortex.list({}).then((x) => setStore("cortex", x.data ?? [])),
-          sdk.agenda.list().then((x) =>
+          .list()
+          .then((x) => {
+            const [_, setStore] = ensureScopeState(scopeKey)
             setStore(
-              "agenda",
+              "cortex",
               reconcile(
                 (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
                 { key: "id" },
               ),
-            ),
-          ),
-          sdk.permission
-            .list()
-            .then((x) => syncBySession(setStore, "permission", Object.keys(store.permission), x.data ?? [])),
-          sdk.question
-            .list()
-            .then((x) => syncBySession(setStore, "question", Object.keys(store.question), x.data ?? [])),
-        ]
-        if (!isHome) {
-          requests.push(sdk.lsp.status().then((x) => setStore("lsp", x.data!)))
-          requests.push(sdk.vcs.get().then((x) => setStore("vcs", x.data)))
-        }
-        await Promise.all(requests)
-        setStore("status", "complete")
-      })
-      .catch((e) => setGlobalStore("error", e))
+            )
+          })
+          .catch(() => {})
+      }, 500),
+    )
   }
 
-  const unsub = globalSDK.event.listen((e) => {
-    const scopeKey = e.name
-    const event = e.details
+  function refreshVolatileStateAfterMessage(scopeKey: string, store: State, sessionID: string) {
+    if (!store.session.find((s) => s.id === sessionID)) return
+    const active =
+      store.cortex.filter(
+        (task) => task.sessionID === sessionID && (task.status === "running" || task.status === "queued"),
+      ).length > 0
+    if (active) refreshCortex(scopeKey)
+    refreshInbox(scopeKey, sessionID)
+  }
 
-    if (event?.type === "global.disposed") {
-      bootstrap()
-      return
-    }
-    if (event?.type === "scope.updated") {
-      const result = Binary.search(globalStore.scope, event.properties.id, (s) => s.id)
-      if (event.properties.time?.archived) {
-        if (result.found) {
-          setGlobalStore(
-            "scope",
-            produce((draft) => {
-              draft.splice(result.index, 1)
-            }),
-          )
-        }
-        return
-      }
-      if (result.found) {
-        setGlobalStore("scope", result.index, reconcile(event.properties))
-        return
-      }
-      setGlobalStore(
-        "scope",
-        produce((draft) => {
-          draft.splice(result.index, 0, event.properties)
-        }),
-      )
-      return
-    }
-    if (event?.type === "scope.removed") {
-      const id = event.properties.id
-      const result = Binary.search(globalStore.scope, id, (s) => s.id)
-      if (result.found) {
-        setGlobalStore(
-          "scope",
-          produce((draft) => {
-            draft.splice(result.index, 1)
-          }),
-        )
-      }
-      return
-    }
-    if (event?.type === "note.created" || event?.type === "note.updated" || event?.type === "note.deleted") {
-      bumpNoteVersion()
-      if (event.type === "note.deleted") {
-        const props = event.properties as { id: string; scopeID: string }
-        setNoteUpdate({ id: props.id, version: -1, type: "deleted" })
-      } else {
-        const props = event.properties as { note: { id: string; version: number } }
-        setNoteUpdate({
-          id: props.note.id,
-          version: props.note.version,
-          type: event.type as "created" | "updated",
+  async function loadMessages(
+    scopeKey: string,
+    sessionID: string,
+    setStore: SetStoreFunction<State>,
+    store: State,
+    sdk?: ReturnType<typeof createSynergyClient>,
+  ) {
+    const client = sdk ?? createScopedClient(scopeKey)
+    return client.session
+      .messages({ sessionID, limit: 200 })
+      .then((result) => {
+        const items = (result.data ?? []).filter((x) => !!x?.info?.id)
+        const all = items
+          .map((x) => x.info)
+          .filter((m) => !!m?.id)
+          .slice()
+          .sort((a, b) => a.id.localeCompare(b.id))
+        const keep = all.length > 500 ? all.slice(-500) : all
+        batch(() => {
+          setStore("message", sessionID, reconcile(keep, { key: "id" }))
+          const keepIds = new Set(keep.map((m) => m.id))
+          for (const item of items) {
+            if (!keepIds.has(item.info.id)) continue
+            setStore(
+              "part",
+              item.info.id,
+              reconcile(
+                item.parts
+                  .filter((p) => !!p?.id)
+                  .slice()
+                  .sort((a, b) => a.id.localeCompare(b.id)),
+                { key: "id" },
+              ),
+            )
+          }
         })
-      }
-    }
+      })
+      .catch((err) => {
+        console.error("Failed to load messages", err)
+      })
+  }
 
-    if (event?.type === "agenda.item.created" || event?.type === "agenda.item.updated") {
-      const item = event.properties.item as AgendaItem
-      const result = Binary.search(globalStore.agenda, item.id, (a) => a.id)
-      if (result.found) {
-        setGlobalStore("agenda", result.index, reconcile(item))
-      } else {
-        setGlobalStore(
-          "agenda",
-          produce((draft) => {
-            draft.splice(result.index, 0, item)
+  async function resyncInstance(directory: string) {
+    const [store, setStore] = ensureScopeState(directory)
+    const sdk = createScopedClient(directory)
+
+    return retry(() =>
+      sdk.scope.sync().then(async (sync) => {
+        const d = sync.data!
+        batch(() => {
+          setStore("scopeID", d.scopeID!)
+          setStore("status", "partial")
+          setStore("path", {
+            state: d.paths?.state ?? "",
+            config: d.paths?.config ?? "",
+            worktree: d.paths?.worktree ?? "",
+            directory: d.paths?.directory ?? "",
+            home: d.paths?.home ?? "",
+          })
+          setStore("agent", reconcile(d.agents ?? [], { key: "id" }))
+          setStore("command", reconcile(d.commands ?? [], { key: "id" }))
+          setStore("session", reconcile(d.sessions ?? [], { key: "id" }))
+          setStore("sessionTotal", d.sessionTotal ?? 0)
+
+          const statusMap: Record<string, SessionStatus> = {}
+          for (const status of d.sessionStatuses ?? []) {
+            if (!status.sessionID) continue
+            statusMap[status.sessionID] = status
+          }
+          setStore("session_status", statusMap)
+
+          const diffMap: Record<string, FileDiff[]> = {}
+          for (const diff of d.sessionDiffs ?? []) {
+            if (!diff.sessionID) continue
+            diffMap[diff.sessionID] = diff.diffs ?? []
+          }
+          setStore("session_diff", diffMap)
+
+          syncBySession(setStore, "permission", Object.keys(store.permission), d.permissions ?? [])
+          syncBySession(setStore, "question", Object.keys(store.question), d.questions ?? [])
+        })
+
+        const loadPromises: Promise<unknown>[] = [
+          loadSessions(directory, sdk),
+          loadAgenda(directory),
+          refreshConfig(directory),
+          loadGlobalProviders(),
+        ]
+
+        const sessionIDs = new Set<string>()
+        for (const s of d.sessions ?? []) {
+          if (!s?.id || !s.time || s.time.archived) continue
+          sessionIDs.add(s.id)
+        }
+
+        loadPromises.push(
+          runInstanceRequests([...sessionIDs], (sessionID) => {
+            const [store, setStore] = ensureScopeState(directory)
+            const client = createScopedClient(directory)
+            return loadMessages(directory, sessionID, setStore, store, client)
           }),
         )
-      }
-    }
-    if (event?.type === "agenda.item.deleted") {
-      const result = Binary.search(globalStore.agenda, event.properties.id, (a) => a.id)
-      if (result.found) {
-        setGlobalStore(
-          "agenda",
-          produce((draft) => {
-            draft.splice(result.index, 1)
-          }),
-        )
-      }
-    }
 
-    if (event?.type === "config.updated") {
-      void refreshAllConfigs()
-      return
-    }
+        await Promise.all(loadPromises)
 
-    if (event?.type === "runtime.reloaded") {
-      const props = event.properties as { executed?: string[]; changedFields?: string[] } | undefined
-      if (props?.executed?.length) {
-        void refreshTargeted(props.executed)
-      } else {
-        void refreshAllConfigs()
-      }
-      return
-    }
-    if (e.name === "global") return
+        sdk.mcp
+          .status()
+          .then((x) => setStore("mcp", x.data!))
+          .catch(() => {})
+        sdk.lsp
+          .status()
+          .then((x) => setStore("lsp", x.data!))
+          .catch(() => {})
+        sdk.cortex
+          .list()
+          .then((x) => {
+            setStore(
+              "cortex",
+              reconcile(
+                (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
+                { key: "id" },
+              ),
+            )
+          })
+          .catch(() => {})
+        sdk.vcs
+          .status()
+          .then((x) => {
+            if (x.data) setStore("vcs", x.data)
+          })
+          .catch(() => {})
+        setStore("status", "complete")
+      }),
+    )
+  }
 
+  async function loadMessagesForNewSession(scopeKey: string, sessionID: string) {
     const [store, setStore] = ensureScopeState(scopeKey)
-    switch (event.type) {
-      case "scope.runtime.disposed": {
-        scheduleBootstrap(scopeKey)
-        break
-      }
-      case "session.updated": {
-        const info = event.properties.info as Session
-        reconcileCortexFromSession(setStore, info)
-        const result = Binary.search(store.session, info.id, (s) => s.id)
-        if (info.time.archived) {
-          if (result.found) {
+    const client = createScopedClient(scopeKey)
+    return loadMessages(scopeKey, sessionID, setStore, store, client)
+  }
+
+  async function bootstrapInstance(scopeKey: string) {
+    return resyncInstance(scopeKey).then(() => {
+      const [store, setStore] = ensureScopeState(scopeKey)
+      const sdk = createScopedClient(scopeKey)
+      const unsub = sdk.subscribe((event) => {
+        switch (event.type) {
+          case "session.created": {
+            const session = event.properties.session
+            const result = Binary.search(store.session, session.id, (s) => s.id)
+            if (result.found) {
+              setStore("session", result.index, reconcile(session))
+            } else {
+              setStore(
+                "session",
+                produce((draft) => {
+                  draft.splice(result.index, 0, session)
+                }),
+              )
+            }
+            setStore("sessionTotal", (x) => x + 1)
+            loadMessagesForNewSession(scopeKey, session.id)
+            break
+          }
+          case "session.updated": {
+            const session = event.properties.session
+            const result = Binary.search(store.session, session.id, (s) => s.id)
+            if (result.found) {
+              setStore("session", result.index, reconcile(session))
+            } else {
+              setStore(
+                "session",
+                produce((draft) => {
+                  draft.splice(result.index, 0, session)
+                }),
+              )
+            }
+            break
+          }
+          case "session.removed": {
+            const result = Binary.search(store.session, event.properties.sessionID, (s) => s.id)
+            if (!result.found) break
             setStore(
               "session",
               produce((draft) => {
                 draft.splice(result.index, 1)
               }),
             )
-            setStore("sessionTotal", Math.max(0, store.sessionTotal - 1))
+            break
           }
-          break
-        }
-        if (result.found) {
-          setStore("session", result.index, reconcile(info))
-          break
-        }
-        setStore(
-          "session",
-          produce((draft) => {
-            draft.splice(result.index, 0, info)
-          }),
-        )
-        setStore("sessionTotal", store.sessionTotal + 1)
-        break
-      }
-      case "session.diff":
-        setStore("session_diff", event.properties.sessionID, reconcile(event.properties.diff, { key: "file" }))
-        break
-      case "todo.updated":
-        setStore("todo", event.properties.sessionID, reconcile(event.properties.todos, { key: "id" }))
-        break
-      case "dag.updated" as string:
-        setStore("dag", (event as any).properties.sessionID, reconcile((event as any).properties.nodes, { key: "id" }))
-        break
-      case "session.status": {
-        // Handles busy, retry, idle, and recovering statuses
-        setStore("session_status", event.properties.sessionID, reconcile(event.properties.status))
-        if (event.properties.status.type === "idle") {
-          if (store.inbox[event.properties.sessionID]?.length) refreshInbox(scopeKey, event.properties.sessionID)
-          if (
-            store.cortex.some(
-              (task) =>
-                task.sessionID === event.properties.sessionID &&
-                (task.status === "running" || task.status === "queued"),
-            )
-          ) {
-            refreshCortex(scopeKey)
-          }
-        }
-        break
-      }
-      case "session.inbox.updated": {
-        setStore("inbox", event.properties.sessionID, reconcile(event.properties.items, { key: "id" }))
-        break
-      }
-      case "message.updated": {
-        const sessionID = event.properties.info.sessionID
-        const messages = store.message[event.properties.info.sessionID]
-        if (!messages) {
-          setStore("message", event.properties.info.sessionID, [event.properties.info])
-          refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
-          break
-        }
-        const result = Binary.search(messages, event.properties.info.id, (m) => m.id)
-        if (result.found) {
-          setStore("message", event.properties.info.sessionID, result.index, reconcile(event.properties.info))
-          refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
-          break
-        }
-        setStore(
-          "message",
-          event.properties.info.sessionID,
-          produce((draft) => {
-            draft.splice(result.index, 0, event.properties.info)
-          }),
-        )
-        refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
-        break
-      }
-      case "message.removed": {
-        const messages = store.message[event.properties.sessionID]
-        if (!messages) break
-        const result = Binary.search(messages, event.properties.messageID, (m) => m.id)
-        if (result.found) {
-          setStore(
-            "message",
-            event.properties.sessionID,
-            produce((draft) => {
-              draft.splice(result.index, 1)
-            }),
-          )
-        }
-        break
-      }
-      case "message.part.updated": {
-        const part = event.properties.part
-        const parts = store.part[part.messageID]
-        if (!parts) {
-          setStore("part", part.messageID, [part])
-          break
-        }
-        const result = Binary.search(parts, part.id, (p) => p.id)
-        if (result.found) {
-          setStore("part", part.messageID, result.index, reconcile(part))
-          break
-        }
-        setStore(
-          "part",
-          part.messageID,
-          produce((draft) => {
-            draft.splice(result.index, 0, part)
-          }),
-        )
-        break
-      }
-      case "message.part.removed": {
-        const parts = store.part[event.properties.messageID]
-        if (!parts) break
-        const result = Binary.search(parts, event.properties.partID, (p) => p.id)
-        if (result.found) {
-          setStore(
-            "part",
-            event.properties.messageID,
-            produce((draft) => {
-              draft.splice(result.index, 1)
-            }),
-          )
-        }
-        break
-      }
-      case "vcs.branch.updated": {
-        setStore("vcs", { branch: event.properties.branch })
-        break
-      }
-      case "permission.asked": {
-        const sessionID = event.properties.sessionID
-        const permissions = store.permission[sessionID]
-        if (!permissions) {
-          setStore("permission", sessionID, [event.properties])
-          break
-        }
-
-        const result = Binary.search(permissions, event.properties.id, (p) => p.id)
-        if (result.found) {
-          setStore("permission", sessionID, result.index, reconcile(event.properties))
-          break
-        }
-
-        setStore(
-          "permission",
-          sessionID,
-          produce((draft) => {
-            draft.splice(result.index, 0, event.properties)
-          }),
-        )
-        break
-      }
-      case "permission.replied": {
-        const permissions = store.permission[event.properties.sessionID]
-        if (!permissions) break
-        const result = Binary.search(permissions, event.properties.requestID, (p) => p.id)
-        if (!result.found) break
-        setStore(
-          "permission",
-          event.properties.sessionID,
-          produce((draft) => {
-            draft.splice(result.index, 1)
-          }),
-        )
-        break
-      }
-      case "question.asked": {
-        const request = event.properties
-        const requests = store.question[request.sessionID]
-        if (!requests) {
-          setStore("question", request.sessionID, [request])
-          break
-        }
-        const result = Binary.search(requests, request.id, (r) => r.id)
-        if (result.found) {
-          setStore("question", request.sessionID, result.index, reconcile(request))
-          break
-        }
-        setStore(
-          "question",
-          request.sessionID,
-          produce((draft) => {
-            draft.splice(result.index, 0, request)
-          }),
-        )
-        break
-      }
-      case "question.replied":
-      case "question.rejected":
-      case "question.timed_out": {
-        const requests = store.question[event.properties.sessionID]
-        if (!requests) break
-        const result = Binary.search(requests, event.properties.requestID, (r) => r.id)
-        if (!result.found) break
-        setStore(
-          "question",
-          event.properties.sessionID,
-          produce((draft) => {
-            draft.splice(result.index, 1)
-          }),
-        )
-        break
-      }
-      case "lsp.updated": {
-        const sdk = createScopedClient(scopeKey)
-        sdk.lsp.status().then((x) => setStore("lsp", x.data ?? []))
-        break
-      }
-      case "cortex.task.created": {
-        const task = event.properties.task
-        setStore(
-          "cortex",
-          produce((draft) => {
-            const idx = draft.findIndex((t) => t.id === task.id)
-            if (idx === -1) {
-              draft.push(task)
-            } else {
-              draft[idx] = task
-            }
-          }),
-        )
-        break
-      }
-      case "cortex.task.completed": {
-        const task = event.properties.task
-        setStore(
-          "cortex",
-          produce((draft) => {
-            const idx = draft.findIndex((t) => t.id === task.id)
-            if (idx !== -1) {
-              draft[idx] = task
-            }
-          }),
-        )
-        break
-      }
-      case "cortex.tasks.updated": {
-        setStore("cortex", reconcile(event.properties.tasks))
-        break
-      }
-      case "agenda.item.created":
-      case "agenda.item.updated": {
-        const item = event.properties.item
-        const result = Binary.search(store.agenda, item.id, (a) => a.id)
-        if (result.found) {
-          setStore("agenda", result.index, reconcile(item))
-          break
-        }
-        setStore(
-          "agenda",
-          produce((draft) => {
-            draft.splice(result.index, 0, item)
-          }),
-        )
-        break
-      }
-      case "agenda.item.deleted": {
-        const result = Binary.search(store.agenda, event.properties.id, (a) => a.id)
-        if (result.found) {
-          setStore(
-            "agenda",
-            produce((draft) => {
-              draft.splice(result.index, 1)
-            }),
-          )
-        }
-        break
-      }
-      case "session.compacted": {
-        const sessionID = event.properties.sessionID as string
-        const messages = store.message[sessionID]
-        if (!messages) break
-        const limit = Math.max(200, Math.min(messages.length, 500))
-        const sdk = createScopedClient(scopeKey)
-        retry(() => sdk.session.messages({ sessionID, limit }))
-          .then((result) => {
-            const items = (result.data ?? []).filter((x) => !!x?.info?.id)
-            const all = items
-              .map((x) => x.info)
-              .filter((m) => !!m?.id)
-              .slice()
-              .sort((a, b) => a.id.localeCompare(b.id))
-            const byID = new Set(all.map((m) => m.id))
-            const current = store.message[sessionID] ?? messages
-            for (const message of current) {
-              if (!byID.has(message.id)) all.push(message)
-            }
-            all.sort((a, b) => a.id.localeCompare(b.id))
-            const keep = all.length > 500 ? all.slice(-500) : all
-            const keepIds = new Set(keep.map((m) => m.id))
+          case "session.compacted": {
+            const sessionID = event.properties.sessionID as string
+            const messages = store.message[sessionID]
+            if (!messages) break
             batch(() => {
               setStore(
                 produce((draft) => {
-                  for (const msg of current) {
-                    if (!keepIds.has(msg.id)) delete draft.part[msg.id]
+                  for (const msg of messages) {
+                    delete draft.part[msg.id]
                   }
+                  delete draft.message[sessionID]
+                  delete draft.session_diff[sessionID]
+                  delete draft.inbox[sessionID]
                 }),
               )
-              setStore("message", sessionID, reconcile(keep, { key: "id" }))
-              for (const item of items) {
-                if (!keepIds.has(item.info.id)) continue
+            })
+            const sdk = createScopedClient(scopeKey)
+            retry(() => sdk.session.messages({ sessionID, limit: 200 }))
+              .then((result) => {
+                const items = (result.data ?? []).filter((x) => !!x?.info?.id)
+                const all = items
+                  .map((x) => x.info)
+                  .filter((m) => !!m?.id)
+                  .slice()
+                  .sort((a, b) => a.id.localeCompare(b.id))
+                const keep = all.length > 500 ? all.slice(-500) : all
+                batch(() => {
+                  setStore("message", sessionID, reconcile(keep, { key: "id" }))
+                  const keepIds = new Set(keep.map((m) => m.id))
+                  for (const item of items) {
+                    if (!keepIds.has(item.info.id)) continue
+                    setStore(
+                      "part",
+                      item.info.id,
+                      reconcile(
+                        item.parts
+                          .filter((p) => !!p?.id)
+                          .slice()
+                          .sort((a, b) => a.id.localeCompare(b.id)),
+                        { key: "id" },
+                      ),
+                    )
+                  }
+                })
+              })
+              .catch(() => {})
+            break
+          }
+          case "todo.updated": {
+            if (!event.properties.sessionID || !event.properties.todos) break
+            setStore("todo", event.properties.sessionID, reconcile(event.properties.todos, { key: "id" }))
+            break
+          }
+          case "dag.updated": {
+            if (!event.properties.sessionID || !event.properties.dag) break
+            setStore("dag", event.properties.sessionID, event.properties.dag)
+            break
+          }
+          case "todo.created":
+          case "todo.updated.event": {
+            const todo = event.properties.todo
+            const todos = store.todo[todo.sessionID]
+            if (!todos) {
+              setStore("todo", todo.sessionID, [todo])
+              break
+            }
+            const result = Binary.search(todos, todo.id, (t) => t.id)
+            if (result.found) {
+              setStore("todo", todo.sessionID, result.index, reconcile(todo))
+              break
+            }
+            setStore(
+              "todo",
+              todo.sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 0, todo)
+              }),
+            )
+            break
+          }
+          case "todo.deleted": {
+            const todos = store.todo[event.properties.sessionID]
+            if (!todos) break
+            const result = Binary.search(todos, event.properties.todoID, (t) => t.id)
+            if (!result.found) break
+            setStore(
+              "todo",
+              event.properties.sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 1)
+              }),
+            )
+            break
+          }
+          case "session.diff.updated": {
+            const diffs = event.properties.diffs
+            if (!diffs) break
+            setStore("session_diff", event.properties.sessionID, reconcile(diffs, { key: "path" }))
+            break
+          }
+          case "session.inbox.updated": {
+            setStore("inbox", event.properties.sessionID, reconcile(event.properties.items, { key: "id" }))
+            break
+          }
+          case "message.updated": {
+            const sessionID = event.properties.info.sessionID
+            const messages = store.message[event.properties.info.sessionID]
+            if (!messages) {
+              setStore("message", event.properties.info.sessionID, [event.properties.info])
+              refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
+              break
+            }
+            const result = Binary.search(messages, event.properties.info.id, (m) => m.id)
+            if (result.found) {
+              setStore("message", event.properties.info.sessionID, result.index, reconcile(event.properties.info))
+              refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
+              break
+            }
+            setStore(
+              "message",
+              event.properties.info.sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 0, event.properties.info)
+              }),
+            )
+            refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
+            break
+          }
+          case "message.removed": {
+            const messages = store.message[event.properties.sessionID]
+            if (!messages) break
+            const result = Binary.search(messages, event.properties.messageID, (m) => m.id)
+            if (result.found) {
+              setStore(
+                "message",
+                event.properties.sessionID,
+                produce((draft) => {
+                  draft.splice(result.index, 1)
+                }),
+              )
+            }
+            break
+          }
+          case "message.part.updated": {
+            const part = event.properties.part
+            const parts = store.part[part.messageID]
+            if (!parts) {
+              setStore("part", part.messageID, [part])
+            } else {
+              const result = Binary.search(parts, part.id, (p) => p.id)
+              if (result.found) {
+                setStore("part", part.messageID, result.index, reconcile(part))
+              } else {
                 setStore(
                   "part",
-                  item.info.id,
-                  reconcile(
-                    item.parts
-                      .filter((p) => !!p?.id)
-                      .slice()
-                      .sort((a, b) => a.id.localeCompare(b.id)),
-                    { key: "id" },
-                  ),
+                  part.messageID,
+                  produce((draft) => {
+                    draft.splice(result.index, 0, part)
+                  }),
                 )
               }
-            })
-          })
-          .catch(() => {})
-        break
-      }
-    }
-  })
-  onCleanup(() => {
-    unsub()
-    for (const timer of inboxRefreshTimers.values()) clearTimeout(timer)
-    for (const timer of cortexRefreshTimers.values()) clearTimeout(timer)
-    inboxRefreshTimers.clear()
-    cortexRefreshTimers.clear()
-  })
+            }
+
+            // Optimistic workspace update for worktree tools — the status bar reads
+            // session.workspace from the store and should reflect the new workspace
+            // immediately when the tool result appears, without waiting for the
+            // session.updated event. This races with the canonical session.updated
+            // handler; in practice the events carry identical data so the race is benign.
+            if (part.type === "tool" && part.state.status === "completed") {
+              if (part.tool === "worktree_enter" && part.state.metadata?.action === "entered") {
+                const ws = part.state.metadata?.workspace as Record<string, unknown> | undefined
+                if (ws) {
+                  const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
+                  if (idx.found) setStore("session", idx.index, "workspace", ws)
+                }
+              } else if (part.tool === "worktree_leave" && part.state.metadata?.action === "left") {
+                const restored = part.state.metadata?.restored as { type?: string; path?: string } | undefined
+                if (restored) {
+                  const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
+                  if (idx.found) {
+                    setStore("session", idx.index, "workspace", {
+                      type: restored.type ?? "main",
+                      path: restored.path,
+                      scopeID: (store.session[idx.index] as { scope?: { id?: string } })?.scope?.id ?? "",
+                    })
+                  }
+                }
+              }
+            }
+            break
+          }
+          case "message.part.removed": {
+            const parts = store.part[event.properties.messageID]
+            if (!parts) break
+            const result = Binary.search(parts, event.properties.partID, (p) => p.id)
+            if (result.found) {
+              setStore(
+                "part",
+                event.properties.messageID,
+                produce((draft) => {
+                  draft.splice(result.index, 1)
+                }),
+              )
+            }
+            break
+          }
+          case "vcs.branch.updated": {
+            setStore("vcs", { branch: event.properties.branch })
+            break
+          }
+          case "permission.asked": {
+            const sessionID = event.properties.sessionID
+            const permissions = store.permission[sessionID]
+            if (!permissions) {
+              setStore("permission", sessionID, [event.properties])
+              break
+            }
+
+            const result = Binary.search(permissions, event.properties.id, (p) => p.id)
+            if (result.found) {
+              setStore("permission", sessionID, result.index, reconcile(event.properties))
+              break
+            }
+
+            setStore(
+              "permission",
+              sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 0, event.properties)
+              }),
+            )
+            break
+          }
+          case "permission.replied": {
+            const permissions = store.permission[event.properties.sessionID]
+            if (!permissions) break
+            const result = Binary.search(permissions, event.properties.requestID, (p) => p.id)
+            if (!result.found) break
+            setStore(
+              "permission",
+              event.properties.sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 1)
+              }),
+            )
+            break
+          }
+          case "question.asked": {
+            const request = event.properties
+            const requests = store.question[request.sessionID]
+            if (!requests) {
+              setStore("question", request.sessionID, [request])
+              break
+            }
+            const result = Binary.search(requests, request.id, (r) => r.id)
+            if (result.found) {
+              setStore("question", request.sessionID, result.index, reconcile(request))
+              break
+            }
+            setStore(
+              "question",
+              request.sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 0, request)
+              }),
+            )
+            break
+          }
+          case "question.replied":
+          case "question.rejected":
+          case "question.timed_out": {
+            const requests = store.question[event.properties.sessionID]
+            if (!requests) break
+            const result = Binary.search(requests, event.properties.requestID, (r) => r.id)
+            if (!result.found) break
+            setStore(
+              "question",
+              event.properties.sessionID,
+              produce((draft) => {
+                draft.splice(result.index, 1)
+              }),
+            )
+            break
+          }
+          case "lsp.updated": {
+            const sdk = createScopedClient(scopeKey)
+            sdk.lsp.status().then((x) => setStore("lsp", x.data ?? []))
+            break
+          }
+          case "cortex.task.created": {
+            const task = event.properties.task
+            setStore(
+              "cortex",
+              produce((draft) => {
+                const idx = draft.findIndex((t) => t.id === task.id)
+                if (idx === -1) {
+                  draft.push(task)
+                } else {
+                  draft[idx] = task
+                }
+              }),
+            )
+            break
+          }
+          case "cortex.task.completed": {
+            const task = event.properties.task
+            setStore(
+              "cortex",
+              produce((draft) => {
+                const idx = draft.findIndex((t) => t.id === task.id)
+                if (idx !== -1) {
+                  draft[idx] = task
+                }
+              }),
+            )
+            break
+          }
+          case "cortex.tasks.updated": {
+            setStore("cortex", reconcile(event.properties.tasks))
+            break
+          }
+          case "agenda.item.created":
+          case "agenda.item.updated": {
+            const item = event.properties.item
+            const result = Binary.search(store.agenda, item.id, (a) => a.id)
+            if (result.found) {
+              setStore("agenda", result.index, reconcile(item))
+              break
+            }
+            setStore(
+              "agenda",
+              produce((draft) => {
+                draft.splice(result.index, 0, item)
+              }),
+            )
+            break
+          }
+          case "agenda.item.deleted": {
+            const result = Binary.search(store.agenda, event.properties.id, (a) => a.id)
+            if (result.found) {
+              setStore(
+                "agenda",
+                produce((draft) => {
+                  draft.splice(result.index, 1)
+                }),
+              )
+            }
+            break
+          }
+        }
+      })
+      onCleanup(() => {
+        unsub()
+        for (const timer of inboxRefreshTimers.values()) clearTimeout(timer)
+        for (const timer of cortexRefreshTimers.values()) clearTimeout(timer)
+        inboxRefreshTimers.clear()
+        cortexRefreshTimers.clear()
+      })
+    })
+  }
 
   let resyncInstancesPromise: Promise<void> | undefined
   function resyncInstances(directories: string[]) {
@@ -1247,13 +1210,7 @@ const GlobalSyncContext = createContext<ReturnType<typeof createGlobalSync>>()
 export function GlobalSyncProvider(props: ParentProps) {
   const value = createGlobalSync()
   return (
-    <Switch
-      fallback={
-        <div class="synergy-workbench-canvas size-full flex items-center justify-center bg-background-stronger text-text-weak">
-          Loading...
-        </div>
-      }
-    >
+    <Switch fallback={<div class="size-full flex items-center justify-center text-text-weak">Loading...</div>}>
       <Match when={value.error}>
         <ErrorPage error={value.error} />
       </Match>

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -21,6 +21,8 @@ import {
   type SessionInboxItem,
   createSynergyClient,
 } from "@ericsanchezok/synergy-sdk/client"
+import { resolveWorkspaceTransition } from "./workspace-transition"
+import type { SessionWorkspace } from "@ericsanchezok/synergy-sdk/client"
 import { createStore, produce, reconcile, type SetStoreFunction } from "solid-js/store"
 import { Binary } from "@ericsanchezok/synergy-util/binary"
 import { retry } from "@ericsanchezok/synergy-util/retry"
@@ -480,36 +482,46 @@ function createGlobalSync() {
         if (grouped[sessionID]) continue
         setStore(storeKey, sessionID, [])
       }
-
-      for (const [sessionID, group] of Object.entries(grouped)) {
-        group.sort((a, b) => a.id!.localeCompare(b.id!))
-        setStore(storeKey, sessionID, reconcile(group, { key: "id" }))
+      for (const [sessionID, entries] of Object.entries(grouped)) {
+        setStore(
+          storeKey,
+          sessionID,
+          reconcile(
+            entries
+              .filter((e) => !!e?.id)
+              .slice()
+              .sort((a, b) => a.id!.localeCompare(b.id!)),
+            { key: "id" },
+          ),
+        )
       }
     })
   }
 
-  let inboxRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const inboxRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const cortexRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const terminalCortexStatuses = new Set(["completed", "error", "cancelled"])
+
   function refreshInbox(scopeKey: string, sessionID: string) {
-    const existing = inboxRefreshTimers.get(sessionID)
+    const key = `${scopeKey}:${sessionID}`
+    const existing = inboxRefreshTimers.get(key)
     if (existing) clearTimeout(existing)
     inboxRefreshTimers.set(
-      sessionID,
+      key,
       setTimeout(() => {
-        inboxRefreshTimers.delete(sessionID)
+        inboxRefreshTimers.delete(key)
+        const state = children[scopeKey]
+        if (!state) return
+        const [, setStore] = state
         const sdk = createScopedClient(scopeKey)
         sdk.session
           .inbox({ sessionID })
-          .then((x) => {
-            const items = x.data ?? []
-            const [_, setStore] = ensureScopeState(scopeKey)
-            setStore("inbox", sessionID, reconcile(items, { key: "id" }))
-          })
+          .then((result) => setStore("inbox", sessionID, reconcile(result.data ?? [], { key: "id" })))
           .catch(() => {})
-      }, 500),
+      }, 120),
     )
   }
 
-  let cortexRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
   function refreshCortex(scopeKey: string) {
     const existing = cortexRefreshTimers.get(scopeKey)
     if (existing) clearTimeout(existing)
@@ -517,585 +529,631 @@ function createGlobalSync() {
       scopeKey,
       setTimeout(() => {
         cortexRefreshTimers.delete(scopeKey)
+        const state = children[scopeKey]
+        if (!state) return
+        const [, setStore] = state
         const sdk = createScopedClient(scopeKey)
         sdk.cortex
-          .list()
-          .then((x) => {
-            const [_, setStore] = ensureScopeState(scopeKey)
-            setStore(
-              "cortex",
-              reconcile(
-                (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
-                { key: "id" },
-              ),
-            )
-          })
+          .list({})
+          .then((result) => setStore("cortex", reconcile(result.data ?? [])))
           .catch(() => {})
-      }, 500),
+      }, 250),
     )
   }
 
-  function refreshVolatileStateAfterMessage(scopeKey: string, store: State, sessionID: string) {
-    if (!store.session.find((s) => s.id === sessionID)) return
-    const active =
-      store.cortex.filter(
-        (task) => task.sessionID === sessionID && (task.status === "running" || task.status === "queued"),
-      ).length > 0
-    if (active) refreshCortex(scopeKey)
-    refreshInbox(scopeKey, sessionID)
-  }
-
-  async function loadMessages(
-    scopeKey: string,
-    sessionID: string,
-    setStore: SetStoreFunction<State>,
-    store: State,
-    sdk?: ReturnType<typeof createSynergyClient>,
-  ) {
-    const client = sdk ?? createScopedClient(scopeKey)
-    return client.session
-      .messages({ sessionID, limit: 200 })
-      .then((result) => {
-        const items = (result.data ?? []).filter((x) => !!x?.info?.id)
-        const all = items
-          .map((x) => x.info)
-          .filter((m) => !!m?.id)
-          .slice()
-          .sort((a, b) => a.id.localeCompare(b.id))
-        const keep = all.length > 500 ? all.slice(-500) : all
-        batch(() => {
-          setStore("message", sessionID, reconcile(keep, { key: "id" }))
-          const keepIds = new Set(keep.map((m) => m.id))
-          for (const item of items) {
-            if (!keepIds.has(item.info.id)) continue
-            setStore(
-              "part",
-              item.info.id,
-              reconcile(
-                item.parts
-                  .filter((p) => !!p?.id)
-                  .slice()
-                  .sort((a, b) => a.id.localeCompare(b.id)),
-                { key: "id" },
-              ),
-            )
-          }
-        })
-      })
-      .catch((err) => {
-        console.error("Failed to load messages", err)
-      })
-  }
-
-  async function resyncInstance(directory: string) {
-    const [store, setStore] = ensureScopeState(directory)
-    const sdk = createScopedClient(directory)
-
-    return retry(() =>
-      sdk.scope.sync().then(async (sync) => {
-        const d = sync.data!
-        batch(() => {
-          setStore("scopeID", d.scopeID!)
-          setStore("status", "partial")
-          setStore("path", {
-            state: d.paths?.state ?? "",
-            config: d.paths?.config ?? "",
-            worktree: d.paths?.worktree ?? "",
-            directory: d.paths?.directory ?? "",
-            home: d.paths?.home ?? "",
-          })
-          setStore("agent", reconcile(d.agents ?? [], { key: "id" }))
-          setStore("command", reconcile(d.commands ?? [], { key: "id" }))
-          setStore("session", reconcile(d.sessions ?? [], { key: "id" }))
-          setStore("sessionTotal", d.sessionTotal ?? 0)
-
-          const statusMap: Record<string, SessionStatus> = {}
-          for (const status of d.sessionStatuses ?? []) {
-            if (!status.sessionID) continue
-            statusMap[status.sessionID] = status
-          }
-          setStore("session_status", statusMap)
-
-          const diffMap: Record<string, FileDiff[]> = {}
-          for (const diff of d.sessionDiffs ?? []) {
-            if (!diff.sessionID) continue
-            diffMap[diff.sessionID] = diff.diffs ?? []
-          }
-          setStore("session_diff", diffMap)
-
-          syncBySession(setStore, "permission", Object.keys(store.permission), d.permissions ?? [])
-          syncBySession(setStore, "question", Object.keys(store.question), d.questions ?? [])
-        })
-
-        const loadPromises: Promise<unknown>[] = [
-          loadSessions(directory, sdk),
-          loadAgenda(directory),
-          refreshConfig(directory),
-          loadGlobalProviders(),
-        ]
-
-        const sessionIDs = new Set<string>()
-        for (const s of d.sessions ?? []) {
-          if (!s?.id || !s.time || s.time.archived) continue
-          sessionIDs.add(s.id)
+  function reconcileCortexFromSession(setStore: SetStoreFunction<State>, info: Session) {
+    const cortex = info.cortex
+    if (!cortex || !terminalCortexStatuses.has(cortex.status)) return
+    setStore(
+      "cortex",
+      produce((draft) => {
+        const idx = draft.findIndex((task) => task.sessionID === info.id)
+        if (idx === -1) return
+        draft[idx] = {
+          ...draft[idx],
+          status: cortex.status,
+          completedAt: cortex.completedAt ?? draft[idx].completedAt,
+          result: cortex.result ?? draft[idx].result,
+          error: cortex.error ?? draft[idx].error,
         }
-
-        loadPromises.push(
-          runInstanceRequests([...sessionIDs], (sessionID) => {
-            const [store, setStore] = ensureScopeState(directory)
-            const client = createScopedClient(directory)
-            return loadMessages(directory, sessionID, setStore, store, client)
-          }),
-        )
-
-        await Promise.all(loadPromises)
-
-        sdk.mcp
-          .status()
-          .then((x) => setStore("mcp", x.data!))
-          .catch(() => {})
-        sdk.lsp
-          .status()
-          .then((x) => setStore("lsp", x.data!))
-          .catch(() => {})
-        sdk.cortex
-          .list()
-          .then((x) => {
-            setStore(
-              "cortex",
-              reconcile(
-                (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
-                { key: "id" },
-              ),
-            )
-          })
-          .catch(() => {})
-        sdk.vcs
-          .status()
-          .then((x) => {
-            if (x.data) setStore("vcs", x.data)
-          })
-          .catch(() => {})
-        setStore("status", "complete")
       }),
     )
   }
 
-  async function loadMessagesForNewSession(scopeKey: string, sessionID: string) {
-    const [store, setStore] = ensureScopeState(scopeKey)
-    const client = createScopedClient(scopeKey)
-    return loadMessages(scopeKey, sessionID, setStore, store, client)
+  function refreshVolatileStateAfterMessage(scopeKey: string, store: State, sessionID: string) {
+    if (store.inbox[sessionID]?.length) refreshInbox(scopeKey, sessionID)
+    if (
+      store.cortex.some(
+        (task) => task.sessionID === sessionID && (task.status === "running" || task.status === "queued"),
+      )
+    ) {
+      refreshCortex(scopeKey)
+    }
+  }
+
+  async function refreshRetainedVolatileState(scopeKey: string, store: State, setStore: SetStoreFunction<State>) {
+    const sessionIDs = Array.from(
+      new Set([...Object.keys(store.inbox), ...Object.keys(store.todo), ...Object.keys(store.dag)]),
+    )
+    const sdk = createScopedClient(scopeKey)
+    await runInstanceRequests(sessionIDs, async (sessionID) => {
+      await Promise.all([
+        sdk.session
+          .inbox({ sessionID })
+          .then((result) => setStore("inbox", sessionID, reconcile(result.data ?? [], { key: "id" })))
+          .catch(() => {}),
+        sdk.session
+          .todo({ sessionID })
+          .then((result) => setStore("todo", sessionID, reconcile(result.data ?? [], { key: "id" })))
+          .catch(() => {}),
+        sdk.session
+          .dag({ sessionID, ...scopeRequest(scopeKey) })
+          .then((result) => setStore("dag", sessionID, reconcile(result.data ?? [], { key: "id" })))
+          .catch(() => {}),
+      ])
+    })
+  }
+
+  async function resyncInstance(scopeKey: string) {
+    if (!scopeKey || !children[scopeKey]) return
+    const [store, setStore] = children[scopeKey]
+    if (store.status === "loading") return
+    const isHome = isHomeScope(scopeKey)
+    const sdk = createScopedClient(scopeKey)
+
+    await Promise.all([
+      loadSessions(scopeKey, sdk),
+      sdk.session.status().then((x) => setStore("session_status", x.data!)),
+      sdk.cortex.list({}).then((x) => setStore("cortex", x.data ?? [])),
+      sdk.agenda.list().then((x) =>
+        setStore(
+          "agenda",
+          reconcile(
+            (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
+            { key: "id" },
+          ),
+        ),
+      ),
+      sdk.permission
+        .list()
+        .then((x) => syncBySession(setStore, "permission", Object.keys(store.permission), x.data ?? [])),
+      sdk.question.list().then((x) => syncBySession(setStore, "question", Object.keys(store.question), x.data ?? [])),
+      refreshRetainedVolatileState(scopeKey, store, setStore),
+      ...(!isHome
+        ? [
+            sdk.mcp.status().then((x) => setStore("mcp", x.data!)),
+            sdk.lsp.status().then((x) => setStore("lsp", x.data!)),
+          ]
+        : []),
+    ])
   }
 
   async function bootstrapInstance(scopeKey: string) {
-    return resyncInstance(scopeKey).then(() => {
-      const [store, setStore] = ensureScopeState(scopeKey)
-      const sdk = createScopedClient(scopeKey)
-      const unsub = sdk.subscribe((event) => {
-        switch (event.type) {
-          case "session.created": {
-            const session = event.properties.session
-            const result = Binary.search(store.session, session.id, (s) => s.id)
-            if (result.found) {
-              setStore("session", result.index, reconcile(session))
-            } else {
-              setStore(
-                "session",
-                produce((draft) => {
-                  draft.splice(result.index, 0, session)
-                }),
-              )
-            }
-            setStore("sessionTotal", (x) => x + 1)
-            loadMessagesForNewSession(scopeKey, session.id)
-            break
-          }
-          case "session.updated": {
-            const session = event.properties.session
-            const result = Binary.search(store.session, session.id, (s) => s.id)
-            if (result.found) {
-              setStore("session", result.index, reconcile(session))
-            } else {
-              setStore(
-                "session",
-                produce((draft) => {
-                  draft.splice(result.index, 0, session)
-                }),
-              )
-            }
-            break
-          }
-          case "session.removed": {
-            const result = Binary.search(store.session, event.properties.sessionID, (s) => s.id)
-            if (!result.found) break
+    if (!scopeKey) return
+    const isHome = isHomeScope(scopeKey)
+    const [store, setStore] = ensureScopeState(scopeKey)
+    const sdk = createScopedClient(scopeKey)
+
+    const blockingRequests: Record<string, () => Promise<void>> = {
+      provider: () =>
+        sdk.provider.list().then((x) => {
+          const data = x.data!
+          setStore("provider", {
+            ...data,
+            all: data.all.map((provider) => ({
+              ...provider,
+              models: Object.fromEntries(
+                Object.entries(provider.models).filter(([, info]) => info.status !== "deprecated"),
+              ),
+            })),
+          })
+        }),
+      agent: () => sdk.app.agents().then((x) => setStore("agent", x.data ?? [])),
+      config: () => sdk.config.get().then((x) => setStore("config", x.data!)),
+    }
+    blockingRequests.scopeID = isHome
+      ? () => Promise.resolve(setStore("scopeID", HOME_SCOPE_KEY))
+      : () => sdk.scope.current().then((x) => setStore("scopeID", x.data!.id))
+    await Promise.all(Object.values(blockingRequests).map((p) => retry(p).catch((e) => setGlobalStore("error", e))))
+      .then(async () => {
+        if (store.status !== "complete") setStore("status", "partial")
+        const requests: Promise<unknown>[] = [
+          sdk.path.get(scopeRequest(scopeKey)).then((x) => setStore("path", x.data!)),
+          sdk.command.list().then((x) => setStore("command", x.data ?? [])),
+          sdk.session.status().then((x) => setStore("session_status", x.data!)),
+          loadSessions(scopeKey, sdk),
+          sdk.mcp.status().then((x) => setStore("mcp", x.data!)),
+          sdk.cortex.list({}).then((x) => setStore("cortex", x.data ?? [])),
+          sdk.agenda.list().then((x) =>
+            setStore(
+              "agenda",
+              reconcile(
+                (x.data ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
+                { key: "id" },
+              ),
+            ),
+          ),
+          sdk.permission
+            .list()
+            .then((x) => syncBySession(setStore, "permission", Object.keys(store.permission), x.data ?? [])),
+          sdk.question
+            .list()
+            .then((x) => syncBySession(setStore, "question", Object.keys(store.question), x.data ?? [])),
+        ]
+        if (!isHome) {
+          requests.push(sdk.lsp.status().then((x) => setStore("lsp", x.data!)))
+          requests.push(sdk.vcs.get().then((x) => setStore("vcs", x.data)))
+        }
+        await Promise.all(requests)
+        setStore("status", "complete")
+      })
+      .catch((e) => setGlobalStore("error", e))
+  }
+
+  const unsub = globalSDK.event.listen((e) => {
+    const scopeKey = e.name
+    const event = e.details
+
+    if (event?.type === "global.disposed") {
+      bootstrap()
+      return
+    }
+    if (event?.type === "scope.updated") {
+      const result = Binary.search(globalStore.scope, event.properties.id, (s) => s.id)
+      if (event.properties.time?.archived) {
+        if (result.found) {
+          setGlobalStore(
+            "scope",
+            produce((draft) => {
+              draft.splice(result.index, 1)
+            }),
+          )
+        }
+        return
+      }
+      if (result.found) {
+        setGlobalStore("scope", result.index, reconcile(event.properties))
+        return
+      }
+      setGlobalStore(
+        "scope",
+        produce((draft) => {
+          draft.splice(result.index, 0, event.properties)
+        }),
+      )
+      return
+    }
+    if (event?.type === "scope.removed") {
+      const id = event.properties.id
+      const result = Binary.search(globalStore.scope, id, (s) => s.id)
+      if (result.found) {
+        setGlobalStore(
+          "scope",
+          produce((draft) => {
+            draft.splice(result.index, 1)
+          }),
+        )
+      }
+      return
+    }
+    if (event?.type === "note.created" || event?.type === "note.updated" || event?.type === "note.deleted") {
+      bumpNoteVersion()
+      if (event.type === "note.deleted") {
+        const props = event.properties as { id: string; scopeID: string }
+        setNoteUpdate({ id: props.id, version: -1, type: "deleted" })
+      } else {
+        const props = event.properties as { note: { id: string; version: number } }
+        setNoteUpdate({
+          id: props.note.id,
+          version: props.note.version,
+          type: event.type as "created" | "updated",
+        })
+      }
+    }
+
+    if (event?.type === "agenda.item.created" || event?.type === "agenda.item.updated") {
+      const item = event.properties.item as AgendaItem
+      const result = Binary.search(globalStore.agenda, item.id, (a) => a.id)
+      if (result.found) {
+        setGlobalStore("agenda", result.index, reconcile(item))
+      } else {
+        setGlobalStore(
+          "agenda",
+          produce((draft) => {
+            draft.splice(result.index, 0, item)
+          }),
+        )
+      }
+    }
+    if (event?.type === "agenda.item.deleted") {
+      const result = Binary.search(globalStore.agenda, event.properties.id, (a) => a.id)
+      if (result.found) {
+        setGlobalStore(
+          "agenda",
+          produce((draft) => {
+            draft.splice(result.index, 1)
+          }),
+        )
+      }
+    }
+
+    if (event?.type === "config.updated") {
+      void refreshAllConfigs()
+      return
+    }
+
+    if (event?.type === "runtime.reloaded") {
+      const props = event.properties as { executed?: string[]; changedFields?: string[] } | undefined
+      if (props?.executed?.length) {
+        void refreshTargeted(props.executed)
+      } else {
+        void refreshAllConfigs()
+      }
+      return
+    }
+    if (e.name === "global") return
+
+    const [store, setStore] = ensureScopeState(scopeKey)
+    switch (event.type) {
+      case "scope.runtime.disposed": {
+        scheduleBootstrap(scopeKey)
+        break
+      }
+      case "session.updated": {
+        const info = event.properties.info as Session
+        reconcileCortexFromSession(setStore, info)
+        const result = Binary.search(store.session, info.id, (s) => s.id)
+        if (info.time.archived) {
+          if (result.found) {
             setStore(
               "session",
               produce((draft) => {
                 draft.splice(result.index, 1)
               }),
             )
-            break
+            setStore("sessionTotal", Math.max(0, store.sessionTotal - 1))
           }
-          case "session.compacted": {
-            const sessionID = event.properties.sessionID as string
-            const messages = store.message[sessionID]
-            if (!messages) break
-            batch(() => {
-              setStore(
-                produce((draft) => {
-                  for (const msg of messages) {
-                    delete draft.part[msg.id]
-                  }
-                  delete draft.message[sessionID]
-                  delete draft.session_diff[sessionID]
-                  delete draft.inbox[sessionID]
-                }),
-              )
-            })
-            const sdk = createScopedClient(scopeKey)
-            retry(() => sdk.session.messages({ sessionID, limit: 200 }))
-              .then((result) => {
-                const items = (result.data ?? []).filter((x) => !!x?.info?.id)
-                const all = items
-                  .map((x) => x.info)
-                  .filter((m) => !!m?.id)
-                  .slice()
-                  .sort((a, b) => a.id.localeCompare(b.id))
-                const keep = all.length > 500 ? all.slice(-500) : all
-                batch(() => {
-                  setStore("message", sessionID, reconcile(keep, { key: "id" }))
-                  const keepIds = new Set(keep.map((m) => m.id))
-                  for (const item of items) {
-                    if (!keepIds.has(item.info.id)) continue
-                    setStore(
-                      "part",
-                      item.info.id,
-                      reconcile(
-                        item.parts
-                          .filter((p) => !!p?.id)
-                          .slice()
-                          .sort((a, b) => a.id.localeCompare(b.id)),
-                        { key: "id" },
-                      ),
-                    )
-                  }
-                })
-              })
-              .catch(() => {})
-            break
-          }
-          case "todo.updated": {
-            if (!event.properties.sessionID || !event.properties.todos) break
-            setStore("todo", event.properties.sessionID, reconcile(event.properties.todos, { key: "id" }))
-            break
-          }
-          case "dag.updated": {
-            if (!event.properties.sessionID || !event.properties.dag) break
-            setStore("dag", event.properties.sessionID, event.properties.dag)
-            break
-          }
-          case "todo.created":
-          case "todo.updated.event": {
-            const todo = event.properties.todo
-            const todos = store.todo[todo.sessionID]
-            if (!todos) {
-              setStore("todo", todo.sessionID, [todo])
-              break
-            }
-            const result = Binary.search(todos, todo.id, (t) => t.id)
-            if (result.found) {
-              setStore("todo", todo.sessionID, result.index, reconcile(todo))
-              break
-            }
-            setStore(
-              "todo",
-              todo.sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 0, todo)
-              }),
+          break
+        }
+        if (result.found) {
+          setStore("session", result.index, reconcile(info))
+          break
+        }
+        setStore(
+          "session",
+          produce((draft) => {
+            draft.splice(result.index, 0, info)
+          }),
+        )
+        setStore("sessionTotal", store.sessionTotal + 1)
+        break
+      }
+      case "session.diff":
+        setStore("session_diff", event.properties.sessionID, reconcile(event.properties.diff, { key: "file" }))
+        break
+      case "todo.updated":
+        setStore("todo", event.properties.sessionID, reconcile(event.properties.todos, { key: "id" }))
+        break
+      case "dag.updated" as string:
+        setStore("dag", (event as any).properties.sessionID, reconcile((event as any).properties.nodes, { key: "id" }))
+        break
+      case "session.status": {
+        // Handles busy, retry, idle, and recovering statuses
+        setStore("session_status", event.properties.sessionID, reconcile(event.properties.status))
+        if (event.properties.status.type === "idle") {
+          if (store.inbox[event.properties.sessionID]?.length) refreshInbox(scopeKey, event.properties.sessionID)
+          if (
+            store.cortex.some(
+              (task) =>
+                task.sessionID === event.properties.sessionID &&
+                (task.status === "running" || task.status === "queued"),
             )
-            break
-          }
-          case "todo.deleted": {
-            const todos = store.todo[event.properties.sessionID]
-            if (!todos) break
-            const result = Binary.search(todos, event.properties.todoID, (t) => t.id)
-            if (!result.found) break
-            setStore(
-              "todo",
-              event.properties.sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 1)
-              }),
-            )
-            break
-          }
-          case "session.diff.updated": {
-            const diffs = event.properties.diffs
-            if (!diffs) break
-            setStore("session_diff", event.properties.sessionID, reconcile(diffs, { key: "path" }))
-            break
-          }
-          case "session.inbox.updated": {
-            setStore("inbox", event.properties.sessionID, reconcile(event.properties.items, { key: "id" }))
-            break
-          }
-          case "message.updated": {
-            const sessionID = event.properties.info.sessionID
-            const messages = store.message[event.properties.info.sessionID]
-            if (!messages) {
-              setStore("message", event.properties.info.sessionID, [event.properties.info])
-              refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
-              break
-            }
-            const result = Binary.search(messages, event.properties.info.id, (m) => m.id)
-            if (result.found) {
-              setStore("message", event.properties.info.sessionID, result.index, reconcile(event.properties.info))
-              refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
-              break
-            }
-            setStore(
-              "message",
-              event.properties.info.sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 0, event.properties.info)
-              }),
-            )
-            refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
-            break
-          }
-          case "message.removed": {
-            const messages = store.message[event.properties.sessionID]
-            if (!messages) break
-            const result = Binary.search(messages, event.properties.messageID, (m) => m.id)
-            if (result.found) {
-              setStore(
-                "message",
-                event.properties.sessionID,
-                produce((draft) => {
-                  draft.splice(result.index, 1)
-                }),
-              )
-            }
-            break
-          }
-          case "message.part.updated": {
-            const part = event.properties.part
-            const parts = store.part[part.messageID]
-            if (!parts) {
-              setStore("part", part.messageID, [part])
-            } else {
-              const result = Binary.search(parts, part.id, (p) => p.id)
-              if (result.found) {
-                setStore("part", part.messageID, result.index, reconcile(part))
-              } else {
-                setStore(
-                  "part",
-                  part.messageID,
-                  produce((draft) => {
-                    draft.splice(result.index, 0, part)
-                  }),
-                )
-              }
-            }
-
-            // Optimistic workspace update for worktree tools — the status bar reads
-            // session.workspace from the store and should reflect the new workspace
-            // immediately when the tool result appears, without waiting for the
-            // session.updated event. This races with the canonical session.updated
-            // handler; in practice the events carry identical data so the race is benign.
-            if (part.type === "tool" && part.state.status === "completed") {
-              if (part.tool === "worktree_enter" && part.state.metadata?.action === "entered") {
-                const ws = part.state.metadata?.workspace as Record<string, unknown> | undefined
-                if (ws) {
-                  const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
-                  if (idx.found) setStore("session", idx.index, "workspace", ws)
-                }
-              } else if (part.tool === "worktree_leave" && part.state.metadata?.action === "left") {
-                const restored = part.state.metadata?.restored as { type?: string; path?: string } | undefined
-                if (restored) {
-                  const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
-                  if (idx.found) {
-                    setStore("session", idx.index, "workspace", {
-                      type: restored.type ?? "main",
-                      path: restored.path,
-                      scopeID: (store.session[idx.index] as { scope?: { id?: string } })?.scope?.id ?? "",
-                    })
-                  }
-                }
-              }
-            }
-            break
-          }
-          case "message.part.removed": {
-            const parts = store.part[event.properties.messageID]
-            if (!parts) break
-            const result = Binary.search(parts, event.properties.partID, (p) => p.id)
-            if (result.found) {
-              setStore(
-                "part",
-                event.properties.messageID,
-                produce((draft) => {
-                  draft.splice(result.index, 1)
-                }),
-              )
-            }
-            break
-          }
-          case "vcs.branch.updated": {
-            setStore("vcs", { branch: event.properties.branch })
-            break
-          }
-          case "permission.asked": {
-            const sessionID = event.properties.sessionID
-            const permissions = store.permission[sessionID]
-            if (!permissions) {
-              setStore("permission", sessionID, [event.properties])
-              break
-            }
-
-            const result = Binary.search(permissions, event.properties.id, (p) => p.id)
-            if (result.found) {
-              setStore("permission", sessionID, result.index, reconcile(event.properties))
-              break
-            }
-
-            setStore(
-              "permission",
-              sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 0, event.properties)
-              }),
-            )
-            break
-          }
-          case "permission.replied": {
-            const permissions = store.permission[event.properties.sessionID]
-            if (!permissions) break
-            const result = Binary.search(permissions, event.properties.requestID, (p) => p.id)
-            if (!result.found) break
-            setStore(
-              "permission",
-              event.properties.sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 1)
-              }),
-            )
-            break
-          }
-          case "question.asked": {
-            const request = event.properties
-            const requests = store.question[request.sessionID]
-            if (!requests) {
-              setStore("question", request.sessionID, [request])
-              break
-            }
-            const result = Binary.search(requests, request.id, (r) => r.id)
-            if (result.found) {
-              setStore("question", request.sessionID, result.index, reconcile(request))
-              break
-            }
-            setStore(
-              "question",
-              request.sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 0, request)
-              }),
-            )
-            break
-          }
-          case "question.replied":
-          case "question.rejected":
-          case "question.timed_out": {
-            const requests = store.question[event.properties.sessionID]
-            if (!requests) break
-            const result = Binary.search(requests, event.properties.requestID, (r) => r.id)
-            if (!result.found) break
-            setStore(
-              "question",
-              event.properties.sessionID,
-              produce((draft) => {
-                draft.splice(result.index, 1)
-              }),
-            )
-            break
-          }
-          case "lsp.updated": {
-            const sdk = createScopedClient(scopeKey)
-            sdk.lsp.status().then((x) => setStore("lsp", x.data ?? []))
-            break
-          }
-          case "cortex.task.created": {
-            const task = event.properties.task
-            setStore(
-              "cortex",
-              produce((draft) => {
-                const idx = draft.findIndex((t) => t.id === task.id)
-                if (idx === -1) {
-                  draft.push(task)
-                } else {
-                  draft[idx] = task
-                }
-              }),
-            )
-            break
-          }
-          case "cortex.task.completed": {
-            const task = event.properties.task
-            setStore(
-              "cortex",
-              produce((draft) => {
-                const idx = draft.findIndex((t) => t.id === task.id)
-                if (idx !== -1) {
-                  draft[idx] = task
-                }
-              }),
-            )
-            break
-          }
-          case "cortex.tasks.updated": {
-            setStore("cortex", reconcile(event.properties.tasks))
-            break
-          }
-          case "agenda.item.created":
-          case "agenda.item.updated": {
-            const item = event.properties.item
-            const result = Binary.search(store.agenda, item.id, (a) => a.id)
-            if (result.found) {
-              setStore("agenda", result.index, reconcile(item))
-              break
-            }
-            setStore(
-              "agenda",
-              produce((draft) => {
-                draft.splice(result.index, 0, item)
-              }),
-            )
-            break
-          }
-          case "agenda.item.deleted": {
-            const result = Binary.search(store.agenda, event.properties.id, (a) => a.id)
-            if (result.found) {
-              setStore(
-                "agenda",
-                produce((draft) => {
-                  draft.splice(result.index, 1)
-                }),
-              )
-            }
-            break
+          ) {
+            refreshCortex(scopeKey)
           }
         }
-      })
-      onCleanup(() => {
-        unsub()
-        for (const timer of inboxRefreshTimers.values()) clearTimeout(timer)
-        for (const timer of cortexRefreshTimers.values()) clearTimeout(timer)
-        inboxRefreshTimers.clear()
-        cortexRefreshTimers.clear()
-      })
-    })
-  }
+        break
+      }
+      case "session.inbox.updated": {
+        setStore("inbox", event.properties.sessionID, reconcile(event.properties.items, { key: "id" }))
+        break
+      }
+      case "message.updated": {
+        const sessionID = event.properties.info.sessionID
+        const messages = store.message[event.properties.info.sessionID]
+        if (!messages) {
+          setStore("message", event.properties.info.sessionID, [event.properties.info])
+          refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
+          break
+        }
+        const result = Binary.search(messages, event.properties.info.id, (m) => m.id)
+        if (result.found) {
+          setStore("message", event.properties.info.sessionID, result.index, reconcile(event.properties.info))
+          refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
+          break
+        }
+        setStore(
+          "message",
+          event.properties.info.sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 0, event.properties.info)
+          }),
+        )
+        refreshVolatileStateAfterMessage(scopeKey, store, sessionID)
+        break
+      }
+      case "message.removed": {
+        const messages = store.message[event.properties.sessionID]
+        if (!messages) break
+        const result = Binary.search(messages, event.properties.messageID, (m) => m.id)
+        if (result.found) {
+          setStore(
+            "message",
+            event.properties.sessionID,
+            produce((draft) => {
+              draft.splice(result.index, 1)
+            }),
+          )
+        }
+        break
+      }
+      case "message.part.updated": {
+        const part = event.properties.part
+        const parts = store.part[part.messageID]
+        if (!parts) {
+          setStore("part", part.messageID, [part])
+        } else {
+          const result = Binary.search(parts, part.id, (p) => p.id)
+          if (result.found) {
+            setStore("part", part.messageID, result.index, part)
+          } else {
+            setStore(
+              "part",
+              part.messageID,
+              produce((draft) => {
+                draft.splice(result.index, 0, part)
+              }),
+            )
+          }
+        }
+
+        // Optimistic workspace update for worktree tools — the status bar reads
+        // session.workspace from the store and should reflect the new workspace
+        // immediately when the tool result appears, without waiting for the
+        // session.updated event. This races with the canonical session.updated
+        // handler; in practice the events carry identical data so the race is benign.
+        const transition = resolveWorkspaceTransition(part)
+        if (transition.kind !== "none") {
+          const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
+          if (idx.found) {
+            if (transition.kind === "enter") {
+              setStore("session", idx.index, "workspace", transition.workspace)
+            } else {
+              const workspace: SessionWorkspace = {
+                ...transition.workspace,
+                scopeID: store.session[idx.index].scope.id,
+              }
+              setStore("session", idx.index, "workspace", workspace)
+            }
+          }
+        }
+        break
+      }
+      case "message.part.removed": {
+        const parts = store.part[event.properties.messageID]
+        if (!parts) break
+        const result = Binary.search(parts, event.properties.partID, (p) => p.id)
+        if (result.found) {
+          setStore(
+            "part",
+            event.properties.messageID,
+            produce((draft) => {
+              draft.splice(result.index, 1)
+            }),
+          )
+        }
+        break
+      }
+      case "vcs.branch.updated": {
+        setStore("vcs", { branch: event.properties.branch })
+        break
+      }
+      case "permission.asked": {
+        const sessionID = event.properties.sessionID
+        const permissions = store.permission[sessionID]
+        if (!permissions) {
+          setStore("permission", sessionID, [event.properties])
+          break
+        }
+
+        const result = Binary.search(permissions, event.properties.id, (p) => p.id)
+        if (result.found) {
+          setStore("permission", sessionID, result.index, reconcile(event.properties))
+          break
+        }
+
+        setStore(
+          "permission",
+          sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 0, event.properties)
+          }),
+        )
+        break
+      }
+      case "permission.replied": {
+        const permissions = store.permission[event.properties.sessionID]
+        if (!permissions) break
+        const result = Binary.search(permissions, event.properties.requestID, (p) => p.id)
+        if (!result.found) break
+        setStore(
+          "permission",
+          event.properties.sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 1)
+          }),
+        )
+        break
+      }
+      case "question.asked": {
+        const request = event.properties
+        const requests = store.question[request.sessionID]
+        if (!requests) {
+          setStore("question", request.sessionID, [request])
+          break
+        }
+        const result = Binary.search(requests, request.id, (r) => r.id)
+        if (result.found) {
+          setStore("question", request.sessionID, result.index, reconcile(request))
+          break
+        }
+        setStore(
+          "question",
+          request.sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 0, request)
+          }),
+        )
+        break
+      }
+      case "question.replied":
+      case "question.rejected":
+      case "question.timed_out": {
+        const requests = store.question[event.properties.sessionID]
+        if (!requests) break
+        const result = Binary.search(requests, event.properties.requestID, (r) => r.id)
+        if (!result.found) break
+        setStore(
+          "question",
+          event.properties.sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 1)
+          }),
+        )
+        break
+      }
+      case "lsp.updated": {
+        const sdk = createScopedClient(scopeKey)
+        sdk.lsp.status().then((x) => setStore("lsp", x.data ?? []))
+        break
+      }
+      case "cortex.task.created": {
+        const task = event.properties.task
+        setStore(
+          "cortex",
+          produce((draft) => {
+            const idx = draft.findIndex((t) => t.id === task.id)
+            if (idx === -1) {
+              draft.push(task)
+            } else {
+              draft[idx] = task
+            }
+          }),
+        )
+        break
+      }
+      case "cortex.task.completed": {
+        const task = event.properties.task
+        setStore(
+          "cortex",
+          produce((draft) => {
+            const idx = draft.findIndex((t) => t.id === task.id)
+            if (idx !== -1) {
+              draft[idx] = task
+            }
+          }),
+        )
+        break
+      }
+      case "cortex.tasks.updated": {
+        setStore("cortex", reconcile(event.properties.tasks))
+        break
+      }
+      case "agenda.item.created":
+      case "agenda.item.updated": {
+        const item = event.properties.item
+        const result = Binary.search(store.agenda, item.id, (a) => a.id)
+        if (result.found) {
+          setStore("agenda", result.index, reconcile(item))
+          break
+        }
+        setStore(
+          "agenda",
+          produce((draft) => {
+            draft.splice(result.index, 0, item)
+          }),
+        )
+        break
+      }
+      case "agenda.item.deleted": {
+        const result = Binary.search(store.agenda, event.properties.id, (a) => a.id)
+        if (result.found) {
+          setStore(
+            "agenda",
+            produce((draft) => {
+              draft.splice(result.index, 1)
+            }),
+          )
+        }
+        break
+      }
+      case "session.compacted": {
+        const sessionID = event.properties.sessionID as string
+        const messages = store.message[sessionID]
+        if (!messages) break
+        batch(() => {
+          setStore(
+            produce((draft) => {
+              for (const msg of messages) {
+                delete draft.part[msg.id]
+              }
+              delete draft.message[sessionID]
+              delete draft.session_diff[sessionID]
+              delete draft.inbox[sessionID]
+            }),
+          )
+        })
+        const sdk = createScopedClient(scopeKey)
+        retry(() => sdk.session.messages({ sessionID, limit: 200 }))
+          .then((result) => {
+            const items = (result.data ?? []).filter((x) => !!x?.info?.id)
+            const all = items
+              .map((x) => x.info)
+              .filter((m) => !!m?.id)
+              .slice()
+              .sort((a, b) => a.id.localeCompare(b.id))
+            const keep = all.length > 500 ? all.slice(-500) : all
+            batch(() => {
+              setStore("message", sessionID, reconcile(keep, { key: "id" }))
+              const keepIds = new Set(keep.map((m) => m.id))
+              for (const item of items) {
+                if (!keepIds.has(item.info.id)) continue
+                setStore(
+                  "part",
+                  item.info.id,
+                  reconcile(
+                    item.parts
+                      .filter((p) => !!p?.id)
+                      .slice()
+                      .sort((a, b) => a.id.localeCompare(b.id)),
+                    { key: "id" },
+                  ),
+                )
+              }
+            })
+          })
+          .catch(() => {})
+        break
+      }
+    }
+  })
+  onCleanup(() => {
+    unsub()
+    for (const timer of inboxRefreshTimers.values()) clearTimeout(timer)
+    for (const timer of cortexRefreshTimers.values()) clearTimeout(timer)
+    inboxRefreshTimers.clear()
+    cortexRefreshTimers.clear()
+  })
 
   let resyncInstancesPromise: Promise<void> | undefined
   function resyncInstances(directories: string[]) {

--- a/packages/app/src/context/workspace-transition.ts
+++ b/packages/app/src/context/workspace-transition.ts
@@ -1,0 +1,40 @@
+import type { Part, SessionWorkspace } from "@ericsanchezok/synergy-sdk/client"
+
+/** Result of inspecting a completed tool part for a workspace transition. */
+export type WorkspaceTransition =
+  | { kind: "none" }
+  | { kind: "enter"; workspace: Record<string, unknown> }
+  | { kind: "leave"; workspace: SessionWorkspace }
+
+/**
+ * Determine whether a completed tool part represents a workspace transition.
+ * Extracted for testability — the SSE handler calls this and then applies
+ * the returned workspace to the session store.
+ *
+ * The session.updated WebSocket event is the canonical workspace source, but
+ * it has delivery latency. This optimistic patch ensures the status bar icon
+ * updates synchronously with the visible tool result.
+ */
+export function resolveWorkspaceTransition(part: Part): WorkspaceTransition {
+  if (part.type !== "tool" || part.state.status !== "completed") return { kind: "none" }
+  const metadata = part.state.metadata
+
+  if (part.tool === "worktree_enter" && metadata?.action === "entered") {
+    const workspace = metadata?.workspace as Record<string, unknown> | undefined
+    if (workspace) return { kind: "enter", workspace }
+  } else if (part.tool === "worktree_leave" && metadata?.action === "left") {
+    const restored = metadata?.restored as { type?: string; path?: string } | undefined
+    if (restored && restored.path) {
+      return {
+        kind: "leave",
+        workspace: {
+          type: restored.type ?? "main",
+          path: restored.path,
+          scopeID: "",
+        },
+      }
+    }
+  }
+
+  return { kind: "none" }
+}


### PR DESCRIPTION
## Summary
- Restructure the `message.part.updated` handler in `global-sync.tsx` to eliminate early `break` statements, so an optimistic workspace update runs after every part store reconciliation
- When a completed `worktree_enter` part arrives, immediately patch the session workspace to `git_worktree` from the tool metadata
- When a completed `worktree_leave` part arrives, immediately restore the session workspace to `main`
- The status bar workspace icon now updates synchronously with the visible tool result instead of waiting for the `session.updated` WebSocket event

## Verification
- All 5 new tests pass (`packages/app/src/context/global-sync.test.ts`)
- Format: applied and clean

## Changes
2 files, +92/-12 lines

Closes #192