### PR TITLE
Fix plugin skill conflict diagnostics

### DIFF
--- a/docs/plugins/01-platform-overview.md
+++ b/docs/plugins/01-platform-overview.md
@@ -36,6 +36,8 @@ Runtime contributions:
 - MCP declarations
 - config/auth/cache stores
 
+Plugin-provided skills are marked with `source: "plugin"` and keep their `pluginId` in the skill catalog. Explicit project, workspace, and global skills take precedence over plugin skills; plugin skills take precedence over built-in skills. Duplicate skill names remain resolvable, and the catalog records diagnostics describing which source was ignored or overridden.
+
 Web contributions:
 
 - tool renderers

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3746,7 +3746,7 @@ export type SkillList = {
     description: string
     location: string
     builtin?: boolean
-    source?: "builtin" | "synergy" | "claude" | "openclaw" | "codex" | "generic"
+    source?: "builtin" | "plugin" | "synergy" | "claude" | "openclaw" | "codex" | "generic"
     scope: "builtin" | "project" | "global" | "workspace" | "external"
     compatibility?: {
       level: "native" | "compatible" | "partial"
@@ -3755,6 +3755,8 @@ export type SkillList = {
     }
     entryFile?: string
     baseDir?: string
+    pluginId?: string
+    pluginName?: string
     references?: Array<string>
     scripts?: Array<string>
   }>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -25066,7 +25066,7 @@
                 },
                 "source": {
                   "type": "string",
-                  "enum": ["builtin", "synergy", "claude", "openclaw", "codex", "generic"]
+                  "enum": ["builtin", "plugin", "synergy", "claude", "openclaw", "codex", "generic"]
                 },
                 "scope": {
                   "type": "string",
@@ -25100,6 +25100,12 @@
                   "type": "string"
                 },
                 "baseDir": {
+                  "type": "string"
+                },
+                "pluginId": {
+                  "type": "string"
+                },
+                "pluginName": {
                   "type": "string"
                 },
                 "references": {

--- a/packages/synergy/src/plugin/loader.ts
+++ b/packages/synergy/src/plugin/loader.ts
@@ -313,12 +313,14 @@ export async function getCliEntries(): Promise<Array<{ pluginId: string; command
   return result
 }
 
-export async function getSkillEntries(): Promise<Array<PluginSkill & { pluginDir: string }>> {
-  const result: Array<PluginSkill & { pluginDir: string }> = []
+export async function getSkillEntries(): Promise<
+  Array<PluginSkill & { pluginId: string; pluginName?: string; pluginDir: string }>
+> {
+  const result: Array<PluginSkill & { pluginId: string; pluginName?: string; pluginDir: string }> = []
   for (const p of await state().then((x) => x.loaded)) {
     if (p.skills) {
       for (const skill of p.skills) {
-        result.push({ ...skill, pluginDir: p.pluginDir })
+        result.push({ ...skill, pluginId: p.id, pluginName: p.name, pluginDir: p.pluginDir })
       }
     }
   }

--- a/packages/synergy/src/server/skill-route.ts
+++ b/packages/synergy/src/server/skill-route.ts
@@ -13,6 +13,7 @@ import { RuntimeReload } from "../runtime/reload"
 
 function resolveScope(skill: Skill.Info): Skill.Scope {
   if (skill.scope) return skill.scope
+  if (skill.source === "plugin") return "external"
   if (skill.builtin) return "builtin"
   const projectDir = ScopeContext.current.directory
   if (skill.location.startsWith(projectDir + path.sep)) return "project"
@@ -96,6 +97,8 @@ export const SkillRoute = new Hono()
                         compatibility: Skill.Compatibility.optional(),
                         entryFile: z.string().optional(),
                         baseDir: z.string().optional(),
+                        pluginId: z.string().optional(),
+                        pluginName: z.string().optional(),
                         references: z.array(z.string()).optional(),
                         scripts: z.array(z.string()).optional(),
                       }),
@@ -122,6 +125,8 @@ export const SkillRoute = new Hono()
           compatibility: s.compatibility,
           entryFile: s.entryFile,
           baseDir: s.baseDir,
+          pluginId: s.pluginId,
+          pluginName: s.pluginName,
           references: s.references ? Object.keys(s.references) : undefined,
           scripts: s.scripts ? Object.keys(s.scripts) : undefined,
         })),
@@ -180,6 +185,9 @@ export const SkillRoute = new Hono()
       }
       if (skill.builtin) {
         return c.json({ error: "Cannot delete builtin skills", name }, 400)
+      }
+      if (skill.source === "plugin") {
+        return c.json({ error: "Cannot delete plugin skills", name, pluginId: skill.pluginId }, 400)
       }
       const skillDir = path.dirname(skill.location)
       await fs.rm(skillDir, { recursive: true, force: true })

--- a/packages/synergy/src/skill/skill.ts
+++ b/packages/synergy/src/skill/skill.ts
@@ -17,7 +17,7 @@ import { Plugin } from "../plugin"
 export namespace Skill {
   const log = Log.create({ service: "skill" })
 
-  export const Source = z.enum(["builtin", "synergy", "claude", "openclaw", "codex", "generic"])
+  export const Source = z.enum(["builtin", "plugin", "synergy", "claude", "openclaw", "codex", "generic"])
   export type Source = z.infer<typeof Source>
 
   export const Scope = z.enum(["builtin", "project", "global", "workspace", "external"])
@@ -39,6 +39,8 @@ export namespace Skill {
     scope: Scope.optional(),
     entryFile: z.string().optional(),
     baseDir: z.string().optional(),
+    pluginId: z.string().optional(),
+    pluginName: z.string().optional(),
     content: z.string().optional(),
     references: z.record(z.string(), z.string()).optional(),
     scripts: z.record(z.string(), z.string()).optional(),
@@ -93,6 +95,8 @@ export namespace Skill {
     switch (source) {
       case "synergy":
         return 100
+      case "plugin":
+        return 90
       case "openclaw":
         return 80
       case "claude":
@@ -126,7 +130,7 @@ export namespace Skill {
   }
 
   function analyzeCompatibility(source: Source, frontmatter: Record<string, unknown>): Compatibility {
-    if (source === "builtin" || source === "synergy") {
+    if (source === "builtin" || source === "plugin" || source === "synergy") {
       return {
         level: "native",
         warnings: [],
@@ -246,7 +250,11 @@ export namespace Skill {
   const SKILL_CONTENT_FILES = ["SKILL.md", "Skill.md", "content.txt", "content.md"]
   const SKILL_REF_GLOB = new Bun.Glob("*")
 
-  type PluginSkillInput = import("@ericsanchezok/synergy-plugin").PluginSkill & { pluginDir: string }
+  type PluginSkillInput = import("@ericsanchezok/synergy-plugin").PluginSkill & {
+    pluginId: string
+    pluginName?: string
+    pluginDir: string
+  }
 
   async function resolvePluginSkill(skill: PluginSkillInput, pluginDir: string): Promise<Info> {
     let content = skill.content
@@ -300,10 +308,12 @@ export namespace Skill {
       description: skill.description,
       location: baseDir,
       builtin: false,
-      source: "builtin",
-      scope: "global",
+      source: "plugin",
+      scope: "external",
       entryFile: "plugin",
       baseDir,
+      pluginId: skill.pluginId,
+      pluginName: skill.pluginName,
       content,
       references,
       scripts,
@@ -325,37 +335,73 @@ export namespace Skill {
       })
     }
 
+    const skillLabel = (skill: Info) => {
+      if (skill.source === "plugin" && skill.pluginId) return `plugin ${skill.pluginId}`
+      if (skill.builtin) return "builtin"
+      return skill.location
+    }
+
+    const registerSkill = (entry: Info, priority: number) => {
+      const existing = skills[entry.name]
+      const existingPriority = priorities[entry.name] ?? -1
+      if (existing && priority < existingPriority) {
+        recordDiagnostic({
+          path: entry.location,
+          name: entry.name,
+          message: `Duplicate skill name ignored due to lower precedence than ${skillLabel(existing)}`,
+        })
+        return
+      }
+
+      if (existing) {
+        log.warn("duplicate skill name", {
+          name: entry.name,
+          existing: existing.location,
+          duplicate: entry.location,
+        })
+        recordDiagnostic({
+          path: entry.location,
+          name: entry.name,
+          message: `Duplicate skill name overrides ${skillLabel(existing)}`,
+        })
+      }
+
+      skills[entry.name] = entry
+      priorities[entry.name] = priority
+    }
+
     for (const builtin of BUILTIN_SKILLS) {
       if (builtin.condition) {
         const ok = await builtin.condition()
         if (!ok) continue
       }
-      skills[builtin.name] = {
-        name: builtin.name,
-        description: builtin.description,
-        location: "builtin",
-        builtin: true,
-        source: "builtin",
-        scope: "builtin",
-        entryFile: "builtin",
-        baseDir: "builtin",
-        content: builtin.content,
-        references: builtin.references,
-        scripts: builtin.scripts,
-        rawFrontmatter: {},
-        compatibility: {
-          level: "native",
-          warnings: [],
-          unsupported: [],
+      registerSkill(
+        {
+          name: builtin.name,
+          description: builtin.description,
+          location: "builtin",
+          builtin: true,
+          source: "builtin",
+          scope: "builtin",
+          entryFile: "builtin",
+          baseDir: "builtin",
+          content: builtin.content,
+          references: builtin.references,
+          scripts: builtin.scripts,
+          rawFrontmatter: {},
+          compatibility: {
+            level: "native",
+            warnings: [],
+            unsupported: [],
+          },
         },
-      }
-      priorities[builtin.name] = computePriority("builtin", "builtin")
+        computePriority("builtin", "builtin"),
+      )
     }
 
     for (const pluginSkill of await Plugin.skillEntries()) {
       const resolved = await resolvePluginSkill(pluginSkill, pluginSkill.pluginDir)
-      skills[resolved.name] = resolved
-      priorities[resolved.name] = computePriority("builtin", "builtin")
+      registerSkill(resolved, computePriority("plugin", "external"))
     }
 
     const addCandidate = async (candidate: SkillCandidate) => {
@@ -401,33 +447,7 @@ export namespace Skill {
         compatibility,
       } satisfies Info
 
-      const existing = skills[name]
-      const existingPriority = priorities[name] ?? -1
-      if (existing && priority < existingPriority) {
-        recordDiagnostic({
-          path: candidate.location,
-          name,
-          message: `Duplicate skill name ignored due to lower precedence than ${existing.location}`,
-        })
-        return
-      }
-
-      if (existing) {
-        const label = existing.builtin ? "builtin" : existing.location
-        log.warn("duplicate skill name", {
-          name,
-          existing: existing.location,
-          duplicate: candidate.location,
-        })
-        recordDiagnostic({
-          path: candidate.location,
-          name,
-          message: `Duplicate skill name overrides ${label}`,
-        })
-      }
-
-      skills[name] = entry
-      priorities[name] = priority
+      registerSkill(entry, priority)
     }
 
     const candidates = [] as SkillCandidate[]

--- a/packages/synergy/test/server/skill-route.test.ts
+++ b/packages/synergy/test/server/skill-route.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, test, mock } from "bun:test"
 import path from "path"
 import { Server } from "../../src/server/server"
 import { ScopeContext } from "../../src/scope/context"
+import { Plugin } from "../../src/plugin"
+import { Skill } from "../../src/skill"
 import { tmpdir } from "../fixture/fixture"
 
-describe("skill route", () => {
+describe.serial("skill route", () => {
   test("lists valid skills and diagnostics for broken ones", async () => {
     await using tmp = await tmpdir({
       git: true,
@@ -41,5 +43,58 @@ description: bad: yaml: here
     expect(data.items.some((item: any) => item.name === "valid-skill")).toBe(true)
     expect(data.items.some((item: any) => item.name === "broken-skill")).toBe(false)
     expect(data.diagnostics.some((item: any) => item.name === "broken-skill")).toBe(true)
+  })
+
+  test("lists plugin skill metadata and prevents deleting plugin skills", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalSkillEntries = Plugin.skillEntries
+    ;(Plugin as any).skillEntries = mock(async () => [
+      {
+        name: "plugin-route-skill",
+        description: "Plugin route skill.",
+        content: "# Plugin Route Skill",
+        pluginId: "route-plugin",
+        pluginName: "Route Plugin",
+        pluginDir: path.join(tmp.path, "route-plugin"),
+      },
+    ])
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          await Skill.reload()
+          const app = Server.App()
+          const response = await app.request(`/skill?directory=${encodeURIComponent(tmp.path)}`, { method: "GET" })
+          expect(response.status).toBe(200)
+          const data = await response.json()
+          const skill = data.items.find((item: any) => item.name === "plugin-route-skill")
+          expect(skill).toBeDefined()
+          expect(skill.source).toBe("plugin")
+          expect(skill.scope).toBe("external")
+          expect(skill.pluginId).toBe("route-plugin")
+          expect(skill.pluginName).toBe("Route Plugin")
+
+          const deleteResponse = await app.request(
+            `/skill/plugin-route-skill?directory=${encodeURIComponent(tmp.path)}`,
+            {
+              method: "DELETE",
+            },
+          )
+          expect(deleteResponse.status).toBe(400)
+          const deleteData = await deleteResponse.json()
+          expect(deleteData.error).toBe("Cannot delete plugin skills")
+          expect(deleteData.pluginId).toBe("route-plugin")
+        },
+      })
+    } finally {
+      ;(Plugin as any).skillEntries = originalSkillEntries
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          await Skill.reload()
+        },
+      })
+    }
   })
 })

--- a/packages/synergy/test/skill/skill.test.ts
+++ b/packages/synergy/test/skill/skill.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect } from "bun:test"
+import { describe, test, expect, mock } from "bun:test"
 import { Skill } from "../../src/skill"
+import { Plugin } from "../../src/plugin"
 import { BUILTIN_SKILLS } from "../../src/skill/builtin"
 import { ScopeContext } from "../../src/scope/context"
 import { tmpdir } from "../fixture/fixture"
@@ -489,5 +490,111 @@ description: Synergy version.
         expect(diagnostics.some((item) => item.name === "shared-name")).toBe(true)
       },
     })
+  })
+
+  test("plugin skill duplicates are resolved with diagnostics", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalSkillEntries = Plugin.skillEntries
+    ;(Plugin as any).skillEntries = mock(async () => [
+      {
+        name: "plugin-shared",
+        description: "First plugin skill.",
+        content: "# First Plugin Skill",
+        pluginId: "plugin-one",
+        pluginName: "Plugin One",
+        pluginDir: path.join(tmp.path, "plugin-one"),
+      },
+      {
+        name: "plugin-shared",
+        description: "Second plugin skill.",
+        content: "# Second Plugin Skill",
+        pluginId: "plugin-two",
+        pluginName: "Plugin Two",
+        pluginDir: path.join(tmp.path, "plugin-two"),
+      },
+    ])
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          await Skill.reload()
+          const [skills, diagnostics] = await Promise.all([Skill.all(), Skill.diagnostics()])
+          const skill = skills.find((s) => s.name === "plugin-shared")
+          expect(skill).toBeDefined()
+          expect(skill!.source).toBe("plugin")
+          expect(skill!.scope).toBe("external")
+          expect(skill!.pluginId).toBe("plugin-two")
+          expect(skill!.description).toBe("Second plugin skill.")
+          expect(
+            diagnostics.some((item) => item.name === "plugin-shared" && item.message.includes("plugin plugin-one")),
+          ).toBe(true)
+        },
+      })
+    } finally {
+      ;(Plugin as any).skillEntries = originalSkillEntries
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          await Skill.reload()
+        },
+      })
+    }
+  })
+
+  test("project skills override plugin skill duplicates with diagnostics", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await createSkill(
+          dir,
+          ".synergy/skill/plugin-shared",
+          `---
+name: plugin-shared
+description: Project version.
+---
+
+# Project Version
+`,
+        )
+      },
+    })
+    const originalSkillEntries = Plugin.skillEntries
+    ;(Plugin as any).skillEntries = mock(async () => [
+      {
+        name: "plugin-shared",
+        description: "Plugin version.",
+        content: "# Plugin Version",
+        pluginId: "plugin-one",
+        pluginName: "Plugin One",
+        pluginDir: path.join(tmp.path, "plugin-one"),
+      },
+    ])
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          await Skill.reload()
+          const [skills, diagnostics] = await Promise.all([Skill.all(), Skill.diagnostics()])
+          const skill = skills.find((s) => s.name === "plugin-shared")
+          expect(skill).toBeDefined()
+          expect(skill!.source).toBe("synergy")
+          expect(skill!.scope).toBe("project")
+          expect(skill!.description).toBe("Project version.")
+          expect(
+            diagnostics.some((item) => item.name === "plugin-shared" && item.message.includes("plugin plugin-one")),
+          ).toBe(true)
+        },
+      })
+    } finally {
+      ;(Plugin as any).skillEntries = originalSkillEntries
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          await Skill.reload()
+        },
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Model plugin-provided skills as `source: "plugin"` with plugin metadata in the skill catalog and SDK schema.
- Route plugin skills through the shared precedence/diagnostics path so duplicate skill names are visible instead of silently overwritten.
- Prevent deleting plugin-provided skills through the skill delete route and document plugin skill precedence.

## Tests
- `bun test test/skill/skill.test.ts`
- `bun test test/server/skill-route.test.ts`
- `bun test test/tool/skill.test.ts`
- `bun test test/skill/skill.test.ts test/server/skill-route.test.ts`
- `bun run typecheck`