### PR TITLE
Fix stale session working state after release

### DIFF
--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -128,6 +128,26 @@ export namespace SessionManager {
     })
   }
 
+  async function emitSessionUpdated(sessionID: string): Promise<void> {
+    const session = await getSession(sessionID)
+    if (!session) return
+    const { Session } = await import(".")
+    const properties = { info: await Session.withRuntimeInfo(session) }
+    try {
+      await Bus.publish(SessionEvent.Updated, properties)
+    } catch (error) {
+      if (!(error instanceof Context.NotFound)) throw error
+      const scope = session.scope as Scope
+      GlobalBus.emit("event", {
+        directory: scope.type === "home" ? "home" : scope.directory,
+        payload: {
+          type: SessionEvent.Updated.type,
+          properties,
+        },
+      })
+    }
+  }
+
   export function registerRuntime(sessionID: string): SessionRuntime {
     const existing = runtimes.get(sessionID)
     if (existing) {
@@ -238,6 +258,9 @@ export namespace SessionManager {
 
     runtime.status = { type: "idle" }
     emitStatus(runtime, runtime.status)
+    await emitSessionUpdated(sessionID).catch((error) => {
+      log.warn("failed to emit session update after release", { sessionID, error })
+    })
 
     if (runtime.mailbox.length > 0 && mailboxHandler) {
       await run(sessionID, () => mailboxHandler!(sessionID))

--- a/packages/synergy/test/session/manager.test.ts
+++ b/packages/synergy/test/session/manager.test.ts
@@ -6,6 +6,8 @@ import { Session } from "../../src/session"
 import { SessionEndpoint } from "../../src/session/endpoint"
 import { tmpdir } from "../fixture/fixture"
 import { Channel } from "../../src/channel"
+import { Bus } from "../../src/bus"
+import { SessionEvent } from "../../src/session/event"
 
 Log.init({ print: false })
 
@@ -138,6 +140,35 @@ describe("SessionManager.getSession", () => {
 
           const statuses = await SessionManager.listStatuses(scope.id)
           expect(statuses[session.id]).toBeUndefined()
+        },
+      })
+    })
+
+    test("release emits updated session info after clearing working state", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const updated: Session.Info[] = []
+          const unsub = Bus.subscribe(SessionEvent.Updated, (event) => {
+            if (event.properties.info.id === session.id) updated.push(event.properties.info as Session.Info)
+          })
+
+          try {
+            SessionManager.acquire(session.id)
+            await Session.update(session.id, (draft) => {
+              draft.pendingReply = true
+            })
+            expect(updated.at(-1)?.working?.status).toBe("busy")
+
+            await SessionManager.release(session.id)
+
+            expect(updated.at(-1)?.working).toBeUndefined()
+          } finally {
+            unsub()
+            SessionManager.unregisterRuntime(session.id)
+          }
         },
       })
     })


### PR DESCRIPTION
## Summary
- Republish session info after `SessionManager.release()` clears runtime state so clients receive an updated `Session.Info` without stale `working`.
- Add a focused session manager test that reproduces the stale `working` transition: a session emits `working: busy` while acquired, then emits no `working` after release.

## Root cause
The worktree action menu disables Enter/Exit worktree when `sessionInfo().working` is present. That is a reasonable UI guard because `working` is the session runtime-derived activity marker.

The stale state happened because the final `session.updated` emitted during loop completion could still be produced before `SessionManager.release()` cleared `runtime.abort`. At that point `Session.withRuntimeInfo()` still enriched the session with `working`. Release then emitted `session.status: idle`, but it did not emit a fresh `session.updated`, so the frontend could end up with contradictory state:

- `session_status[sessionID] = { type: "idle" }`
- `sync.session.get(sessionID).working` still set from the earlier session info event

That stale `working` left the worktree button disabled even after the assistant turn had a terminal `finish: "stop"` and `time.completed`.

## Fix
After release clears the runtime abort controller and emits idle status, it now republishes the session info with current runtime enrichment. Because `SessionWorking.resolve()` sees the released runtime, the emitted session info no longer includes `working`, allowing all clients to clear stale UI state without changing the intuitive `if (working)` guard.

The helper mirrors the existing `emitStatus` scope fallback behavior so session updates still route through `GlobalBus` when no scoped bus context is available.

## Verification
- `bun test test/session/manager.test.ts` from `packages/synergy` ✅
- `bun run typecheck` from repo root ✅
- `./script/format.ts --check` from repo root ✅

Note: the first focused test run immediately after installing dependencies had one startup timeout in an existing test; the immediate rerun passed all 12 tests.