### PR TITLE
Fix stale timeline item rendering

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -535,7 +535,7 @@ export function SessionTurn(
                           {(key, index) => {
                             const item = () => timelineItemMap().get(key)
                             return (
-                              <Show when={item()}>
+                              <Show when={item()} keyed>
                                 {(current) => (
                                   <>
                                     <Show when={index() === timelineSlotIndexes().firstReasoning}>
@@ -546,9 +546,9 @@ export function SessionTurn(
                                     </Show>
                                     <div
                                       data-slot="session-turn-timeline-item"
-                                      data-kind={displayItemVisualKind(current())}
+                                      data-kind={displayItemVisualKind(current)}
                                     >
-                                      <TimelineDisplay item={current()} serverUrl={data.serverUrl} />
+                                      <TimelineDisplay item={current} serverUrl={data.serverUrl} />
                                     </div>
                                     <Show when={index() === timelineSlotIndexes().lastReasoning}>
                                       {renderMessageSlot("after-reasoning")}


### PR DESCRIPTION
## Summary
- Prevent `SessionTurn` timeline rendering from reading the accessor returned by Solid's non-keyed `<Show>` after the guarded value can disappear.
- Use `keyed` `<Show>` for timeline items so the render body receives the current item as a concrete value, then pass that value directly into `TimelineDisplay` and `data-kind`.

## Why
The timeline preserves DOM by iterating stable item keys and looking up the current item through a memoized map. When an item is removed or the component is remounted during development refresh, the non-keyed `<Show>` child accessor can become stale. Reading it later triggers Solid's runtime error:

`Attempting to access a stale value from <Show> that could possibly be undefined.`

Using `keyed` avoids the stale accessor path while preserving the existing stable-key timeline structure.

## Verification
- `bun test src/components/session-turn-timeline.test.ts` from `packages/ui`
- `bun run typecheck` from `packages/ui`
- pre-push hook: full `bun turbo typecheck` and Prettier format check