### PR TITLE
Allow autonomous branch publish workflows

### DIFF
--- a/packages/synergy/src/control-profile/profiles.ts
+++ b/packages/synergy/src/control-profile/profiles.ts
@@ -41,6 +41,8 @@ function rulesFor(actions: {
 
 const GUARDED_MEDIUM_ALLOWED = new Set(["file_write", "network_request", "session_state", "browser_interact"])
 
+const AUTONOMOUS_MEDIUM_ALLOWED = new Set(["shell_remote_publish"])
+
 const AUTONOMOUS_DENIED = new Set([
   "shell_hardline",
   "shell_remote_write",
@@ -70,6 +72,7 @@ function guardedRules() {
 function autonomousRules() {
   const guarded = new Map(guardedRules().map((item) => [item.permission, item]))
   return SYNERGY_PROFILE_CAPABILITIES.map((permission) => {
+    if (AUTONOMOUS_MEDIUM_ALLOWED.has(permission)) return capabilityRule(permission, "allow")
     if (AUTONOMOUS_DENIED.has(permission)) return capabilityRule(permission, "deny")
     if (permission === "protected_op") return capabilityRule(permission, "ask")
     const guardedRule = guarded.get(permission)

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -124,7 +124,7 @@ const DESTRUCTIVE_PATTERNS = [
   "vgremove ",
   // Privilege escalation
   "sudo ",
-  // Git destructive operations (force/delete/hard-reset only — normal push is shell_remote_write)
+  // Git destructive operations (force/delete/hard-reset only — ordinary feature-branch push is shell_remote_publish)
   "git reset --hard",
   "git clean -f",
   "git clean -x",
@@ -613,11 +613,11 @@ export namespace EnforcementGate {
         }
         // shell_destructive is high-risk by definition; it must always be a hard
         // boundary so Smart allow can never bypass a profile deny on it.
-        // shell_remote_write is medium-risk and is Smart allow eligible.
+        // shell_remote_publish covers ordinary branch push and PR creation.
+        // shell_remote_write is broader remote mutation and stays Smart allow eligible.
         caps.push({ class: risk, nonBypassable: risk === "shell_destructive" })
 
         // Defense-in-depth: secondary destructive pattern checks.
-        // For shell_remote_write, only flag if a force/delete pattern is matched.
         if (risk !== "shell_destructive") {
           const resilient = analyzeDestructiveCommand(command)
           if (resilient.matched) {

--- a/packages/synergy/src/enforcement/shell-safety.ts
+++ b/packages/synergy/src/enforcement/shell-safety.ts
@@ -32,7 +32,7 @@ const GIT_TAXONOMY: Map<string, BashRisk> = new Map([
   ["commit", "shell"],
   ["merge", "shell"],
   ["pull", "shell"],
-  ["push", "shell_remote_write"],
+  ["push", "shell_remote_publish"],
   ["tag", "shell"],
   ["revert", "shell_destructive"],
   ["rm", "shell_destructive"],
@@ -43,13 +43,150 @@ const GIT_TAXONOMY: Map<string, BashRisk> = new Map([
   ["filter-repo", "shell_destructive"],
 ])
 
+const PROTECTED_PUSH_TARGETS = new Set(["main", "master", "dev", "develop", "trunk"])
+
+function pushTargetBranchName(target: string): string | null {
+  if (target.startsWith("refs/heads/")) return target.slice("refs/heads/".length) || null
+  if (target.startsWith("refs/")) return null
+  return target || null
+}
+
+function analyzePushTargets(
+  words: string[],
+  subIndex: number,
+): { destructive: boolean; protected: boolean; explicitPublish: boolean } {
+  const positionals = words.slice(subIndex + 1).filter((word) => word && !word.startsWith("-") && !word.includes("="))
+  if (positionals.length <= 1) return { destructive: false, protected: false, explicitPublish: false }
+  return positionals.slice(1).reduce<{ destructive: boolean; protected: boolean; explicitPublish: boolean }>(
+    (result, refspec) => {
+      const force = refspec.startsWith("+")
+      const target = refspec.replace(/^\+/, "").split(":").pop() ?? refspec
+      const deletesRef = target.length === 0 || refspec.startsWith(":")
+      const branchName = pushTargetBranchName(target)
+      const protectedTarget = branchName !== null && PROTECTED_PUSH_TARGETS.has(branchName)
+      const publishableBranch = !force && !deletesRef && branchName !== null && !protectedTarget
+      return {
+        destructive: result.destructive || force || deletesRef,
+        protected: result.protected || protectedTarget,
+        explicitPublish: result.explicitPublish || publishableBranch,
+      }
+    },
+    { destructive: false, protected: false, explicitPublish: false },
+  )
+}
+
+function isGitRepoSelectorAssignment(word: string | undefined): boolean {
+  return (
+    word?.startsWith("GIT_DIR=") || word?.startsWith("GIT_WORK_TREE=") || word?.startsWith("GIT_NAMESPACE=") || false
+  )
+}
+
+function isAttachedGitRepoSelector(word: string | undefined): boolean {
+  return (
+    word?.startsWith("-C") ||
+    word?.startsWith("-c") ||
+    word?.startsWith("--git-dir=") ||
+    word?.startsWith("--work-tree=") ||
+    word?.startsWith("--namespace=") ||
+    word?.startsWith("--exec-path=") ||
+    false
+  )
+}
+
+function expandEnvSplitString(words: string[], idx: number): string[] | null {
+  if (words[idx] !== "env") return null
+
+  const splitIndex = words.findIndex(
+    (word, wordIndex) =>
+      wordIndex > idx &&
+      (word === "-S" || word === "--split-string" || word.startsWith("-S") || word.startsWith("--split-string=")),
+  )
+  if (splitIndex === -1) return null
+
+  const splitWord = words[splitIndex]
+  let payload: string | undefined
+  let afterPayloadIndex = splitIndex + 1
+  if (splitWord === "-S" || splitWord === "--split-string") {
+    payload = words[splitIndex + 1]
+    afterPayloadIndex = splitIndex + 2
+  } else if (splitWord.startsWith("-S")) {
+    payload = splitWord.slice(2)
+  } else if (splitWord.startsWith("--split-string=")) {
+    payload = splitWord.slice("--split-string=".length)
+  }
+
+  if (!payload) return null
+  return [...words.slice(0, idx), ...shellWords(payload), ...words.slice(afterPayloadIndex)]
+}
+
+function skipEnvWrapper(
+  words: string[],
+  idx: number,
+): { idx: number; hasEnvWrapper: boolean; hasRepoSelector: boolean } {
+  if (words[idx] !== "env") return { idx, hasEnvWrapper: false, hasRepoSelector: false }
+
+  let hasRepoSelector = false
+  idx++
+  while (idx < words.length) {
+    const word = words[idx]
+    if (!word) break
+    if (word === "--") {
+      idx++
+      break
+    }
+    if (word.includes("=") && !word.startsWith("-")) {
+      if (isGitRepoSelectorAssignment(word)) hasRepoSelector = true
+      idx++
+      continue
+    }
+    if (word === "-u" || word === "--unset" || word === "-C" || word === "--chdir") {
+      idx += 2
+      continue
+    }
+    if (word.startsWith("--unset=") || word.startsWith("--chdir=") || word.startsWith("-u") || word.startsWith("-C")) {
+      idx++
+      continue
+    }
+    if (word.startsWith("-")) {
+      idx++
+      continue
+    }
+    break
+  }
+
+  return { idx, hasEnvWrapper: true, hasRepoSelector }
+}
+
 /** Flag-aware git subcommand classification.
  *  Extracts subcommand + flags from tokenized words and returns a BashRisk
  *  for dangerous flag combinations, or falls through to GIT_TAXONOMY. */
 function classifyGitCommand(words: string[]): BashRisk | null {
-  // Skip env var assignments like FOO=bar git ...
+  const expandedEnv = expandEnvSplitString(words, 0)
+  if (expandedEnv) return classifyGitCommand(expandedEnv)
+
   let idx = 0
-  while (idx < words.length && words[idx]?.includes("=") && !words[idx]?.startsWith("-")) idx++
+  while (words[idx] === "command") {
+    idx++
+    if (words[idx] === "--") idx++
+  }
+
+  const expandedWrappedEnv = expandEnvSplitString(words, idx)
+  if (expandedWrappedEnv) return classifyGitCommand(expandedWrappedEnv)
+
+  // Skip env var assignments like FOO=bar git ...
+  let hasRepoSelector = false
+  while (idx < words.length && words[idx]?.includes("=") && !words[idx]?.startsWith("-")) {
+    const assignment = words[idx]
+    if (isGitRepoSelectorAssignment(assignment)) {
+      hasRepoSelector = true
+    }
+    idx++
+  }
+
+  const envWrapper = skipEnvWrapper(words, idx)
+  idx = envWrapper.idx
+  hasRepoSelector = hasRepoSelector || envWrapper.hasRepoSelector
+
   if (words[idx] !== "git") return null
 
   let subIndex = idx + 1
@@ -63,8 +200,12 @@ function classifyGitCommand(words: string[]): BashRisk | null {
       word === "--namespace" ||
       word === "--exec-path"
     ) {
+      hasRepoSelector = true
       subIndex += 2
       continue
+    }
+    if (isAttachedGitRepoSelector(word)) {
+      hasRepoSelector = true
     }
     subIndex++
   }
@@ -117,9 +258,18 @@ function classifyGitCommand(words: string[]): BashRisk | null {
       hasExact("-f") ||
       hasExact("--mirror") ||
       flags.some((f) => f.startsWith("--force-with-lease"))
-    const hasDelete = hasExact("--delete")
-    if (hasForce || hasDelete) return "shell_destructive"
-    return "shell_remote_write" // normal push → remote write, Smart allow eligible
+    const hasDelete = hasExact("--delete") || hasExact("-d")
+    const targetRisk = analyzePushTargets(words, subIndex)
+    if (hasForce || hasDelete || targetRisk.destructive) return "shell_destructive"
+    if (
+      hasRepoSelector ||
+      hasExact("--all") ||
+      hasExact("--tags") ||
+      targetRisk.protected ||
+      !targetRisk.explicitPublish
+    )
+      return "shell_remote_write"
+    return "shell_remote_publish" // explicit non-protected feature-branch push for PR automation
   }
 
   // ── reset ──────────────────────────────────────────────────
@@ -210,8 +360,8 @@ function classifyGitCommand(words: string[]): BashRisk | null {
 
 /** Classify GitHub CLI (gh) commands into BashRisk categories.
  *  gh pr view/list/status/checks/diff → shell_read
- *  gh pr create/edit/ready → shell_remote_write
- *  gh pr comment/review/merge/close → shell_remote_write
+ *  gh pr create → shell_remote_publish
+ *  gh pr edit/ready/comment/review → shell_remote_write
  *  gh issue view/list/status → shell_read
  *  gh issue create/edit/comment/close/reopen → shell_remote_write */
 function classifyGitHubCommand(words: string[]): BashRisk | null {
@@ -229,17 +379,17 @@ function classifyGitHubCommand(words: string[]): BashRisk | null {
     if (subsub === "view" || subsub === "list" || subsub === "status" || subsub === "checks" || subsub === "diff") {
       return "shell_read"
     }
-    // PR creation/update — remote write
-    if (subsub === "create" || subsub === "edit" || subsub === "ready") {
+    // PR creation is the normal end of an autonomous worktree-to-PR workflow.
+    if (subsub === "create") {
+      return "shell_remote_publish"
+    }
+    // PR updates and communication remain generic remote writes.
+    if (subsub === "edit" || subsub === "ready" || subsub === "comment" || subsub === "review") {
       return "shell_remote_write"
     }
-    // PR communication — remote write (crosses identity boundary)
-    if (subsub === "comment" || subsub === "review") {
-      return "shell_remote_write"
-    }
-    // PR merge/close — remote write (dangerous side effects)
+    // PR merge/close/reopen terminate or reopen review state and are destructive for automation.
     if (subsub === "merge" || subsub === "close" || subsub === "reopen") {
-      return "shell_remote_write"
+      return "shell_destructive"
     }
     // Default: gh pr <unknown> → shell_remote_write
     return "shell_remote_write"
@@ -557,7 +707,13 @@ function checkHardline(command: string): boolean {
   return false
 }
 
-export type BashRisk = "shell_read" | "shell" | "shell_remote_write" | "shell_destructive" | "shell_hardline"
+export type BashRisk =
+  | "shell_read"
+  | "shell"
+  | "shell_remote_publish"
+  | "shell_remote_write"
+  | "shell_destructive"
+  | "shell_hardline"
 
 export namespace ShellSafety {
   export function isReadOnly(command: string): boolean {
@@ -584,9 +740,10 @@ export namespace ShellSafety {
   const RISK_ORDER: Record<BashRisk, number> = {
     shell_read: 0,
     shell: 1,
-    shell_remote_write: 2,
-    shell_destructive: 3,
-    shell_hardline: 4,
+    shell_remote_publish: 2,
+    shell_remote_write: 3,
+    shell_destructive: 4,
+    shell_hardline: 5,
   }
 
   function maxRisk(a: BashRisk, b: BashRisk): BashRisk {

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -135,7 +135,8 @@ export namespace ToolResolver {
 
   function permissionForGateCapability(toolName: string, className: string): string {
     if (className === "file_external_read" || className === "file_external_write") return "external_directory"
-    if (className === "shell_read" || className === "shell_remote_write") return "bash"
+    if (className === "shell_read" || className === "shell_remote_publish" || className === "shell_remote_write")
+      return "bash"
     if (className === "shell_destructive") return "bash"
     if (className === "network_request")
       return toolName === "webfetch" || toolName === "websearch" ? toolName : "network_request"
@@ -145,7 +146,8 @@ export namespace ToolResolver {
   function patternsForGateCapability(toolName: string, cap: Capability, args: Record<string, any>): string[] {
     if (cap.class === "file_external_read" || cap.class === "file_external_write")
       return cap.paths?.length ? cap.paths : [externalPathFromArgs(toolName, args) || "*"]
-    if (cap.class === "shell_destructive" || cap.class === "shell_remote_write") return [String(args.command ?? "*")]
+    if (cap.class === "shell_destructive" || cap.class === "shell_remote_publish" || cap.class === "shell_remote_write")
+      return [String(args.command ?? "*")]
     if (cap.class === "network_request") return [String(args.url ?? args.query ?? "*")]
     if (cap.class === "communication_email") return [String(args.to ?? args.from ?? args.subject ?? "*")]
     if (cap.class === "identity_act") return [`${toolName} role=${args.role ?? "*"} to ${args.target ?? "*"}`]
@@ -170,6 +172,7 @@ export namespace ToolResolver {
       permission === "bash" ||
       capability === "shell" ||
       capability === "shell_read" ||
+      capability === "shell_remote_publish" ||
       capability === "shell_remote_write" ||
       capability === "shell_destructive"
     ) {

--- a/packages/synergy/test/control-profile/autonomous.test.ts
+++ b/packages/synergy/test/control-profile/autonomous.test.ts
@@ -55,6 +55,18 @@ describe("autonomous profile capabilities", () => {
     })
   })
 
+  test("autonomous allows PR publication while denying generic remote writes", async () => {
+    await using tmp = await tmpdir()
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const profile = await autonomousProfile()
+        expect(rule(profile, "shell_remote_publish")?.action).toBe("allow")
+        expect(rule(profile, "shell_remote_write")?.action).toBe("deny")
+      },
+    })
+  })
+
   test("autonomous allows mcp and ordinary delegated capabilities but denies secrets", async () => {
     await using tmp = await tmpdir()
     await ScopeContext.provide({
@@ -203,6 +215,7 @@ describe("autonomous profile approval risk", () => {
         const profile = await autonomousProfile()
         expect(ApprovalPolicy.decidePermission(profile, "task", {}).action).toBe("allow")
         expect(ApprovalPolicy.decidePermission(profile, "mcp_invoke", {}).action).toBe("allow")
+
         expect(ApprovalPolicy.decidePermission(profile, "secrets", {}).action).toBe("deny")
       },
     })

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -642,23 +642,49 @@ describe("EnforcementGate profile integration", () => {
     expect(envelope.decision).toBe("allow")
   })
 
-  test("autonomous denies git push as shell_destructive", async () => {
+  test("autonomous allows worktree publish workflow while denying merge", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
       profileId: "autonomous",
     })
-    const envelope = gate.evaluate("bash", { command: "git push" })
-    expect(envelope.decision).toBe("deny")
+
+    expect(gate.evaluate("worktree_enter", { target: "feature", baseRef: "current", force: false }).decision).toBe(
+      "allow",
+    )
+    expect(gate.evaluate("bash", { command: "git push origin feature" }).decision).toBe("allow")
+    expect(gate.evaluate("bash", { command: "gh pr create --title fix --body body" }).decision).toBe("allow")
+    expect(gate.evaluate("bash", { command: "gh pr merge 123 --squash" }).decision).toBe("deny")
+    expect(gate.evaluate("worktree_leave", { cleanup: "keep" }).decision).toBe("allow")
   })
 
-  test("autonomous denies git push through git global options", async () => {
+  test("autonomous allows explicit branch push publication", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
       profileId: "autonomous",
     })
-    const envelope = gate.evaluate("bash", { command: "git -C /tmp push" })
+    const envelope = gate.evaluate("bash", { command: "git push origin feature" })
+    expect(envelope.decision).toBe("allow")
+  })
+
+  test("autonomous allows PR creation but denies PR merge", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "autonomous",
+    })
+    expect(gate.evaluate("bash", { command: "gh pr create --title fix --body body" }).decision).toBe("allow")
+    expect(gate.evaluate("bash", { command: "gh pr merge 123 --squash" }).decision).toBe("deny")
+  })
+
+  test("autonomous denies ambiguous git push through git global options", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "autonomous",
+    })
+    const envelope = gate.evaluate("bash", { command: "git -C /tmp push origin feature" })
     expect(envelope.decision).toBe("deny")
   })
 
@@ -1214,7 +1240,7 @@ describe("EnforcementGate DESTRUCTIVE_PATTERNS — expanded", () => {
 
   // ── Refined git classifications (classifyBashRisk primary path) ──
 
-  test("git push (plain) is classified as shell_remote_write (Smart Allow eligible)", async () => {
+  test("git push (plain) is classified as shell_remote_write", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
@@ -1225,7 +1251,7 @@ describe("EnforcementGate DESTRUCTIVE_PATTERNS — expanded", () => {
     expect(remoteWrite.nonBypassable).toBe(false)
   })
 
-  test("git push origin main is classified as shell_remote_write (Smart Allow eligible)", async () => {
+  test("git push origin main is classified as shell_remote_write", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
@@ -1241,7 +1267,7 @@ describe("EnforcementGate DESTRUCTIVE_PATTERNS — expanded", () => {
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
     })
-    const result = gate.classify("bash", { command: "git -C /tmp push" })
+    const result = gate.classify("bash", { command: "git -C /tmp push origin feature" })
     const remoteWrite = result.capabilities.find((c: any) => c.class === "shell_remote_write")!
     expect(remoteWrite).toBeDefined()
     expect(remoteWrite.nonBypassable).toBe(false)
@@ -2361,17 +2387,17 @@ describe("EnforcementGate file_external split", () => {
 })
 
 describe("security invariants: nonBypassable permission boundaries", () => {
-  test("autonomous denies git push via shell_remote_write; destructive stays hard", async () => {
+  test("autonomous allows publish commands while destructive commands stay hard", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",
       workspaceType: "worktree",
       profileId: "autonomous",
     })
 
-    const envelope = gate.evaluate("bash", { command: "git push" })
-    expect(envelope.decision).toBe("deny")
+    const envelope = gate.evaluate("bash", { command: "git push origin feature" })
+    expect(envelope.decision).toBe("allow")
 
-    const caps = envelope.capabilities.filter((c: any) => c.class === "shell_remote_write")
+    const caps = envelope.capabilities.filter((c: any) => c.class === "shell_remote_publish")
     expect(caps.length).toBeGreaterThan(0)
     expect(caps.every((c: any) => c.nonBypassable === false)).toBe(true)
   })

--- a/packages/synergy/test/enforcement/shell-safety.test.ts
+++ b/packages/synergy/test/enforcement/shell-safety.test.ts
@@ -295,14 +295,14 @@ describe("ShellSafety classifyBashRisk", () => {
     expect(ShellSafety.classifyBashRisk("wc -l input.txt")).toBe("shell_read")
   })
 
-  test("non-read-only non-hardline commands return shell or shell_remote_write", () => {
+  test("non-read-only non-hardline commands return shell or remote publish/write", () => {
     expect(ShellSafety.classifyBashRisk("git add file.ts")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("npm install")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("pip install requests")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("curl https://example.com")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("bun run build")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("mkdir newdir")).toBe("shell")
-    expect(ShellSafety.classifyBashRisk("git push")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git push origin feature")).toBe("shell_remote_publish")
     expect(ShellSafety.classifyBashRisk("rm file.txt")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("python3 -c 'print(1)'")).toBe("shell")
     expect(ShellSafety.classifyBashRisk("ssh user@host")).toBe("shell")
@@ -773,11 +773,29 @@ describe("ShellSafety git taxonomy — warn (shell)", () => {
     expect(ShellSafety.classifyBashRisk("git pull -r")).toBe("shell_destructive")
   })
 
-  test("git push (normal) is shell_remote_write; force/delete are shell_destructive", () => {
+  test("explicit branch push is shell_remote_publish; ambiguous/protected/force/delete pushes are stricter", () => {
     expect(ShellSafety.classifyBashRisk("git push")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git push origin")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git -c push.default=matching push origin")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git -c remote.origin.push=refs/heads/main:refs/heads/main push origin")).toBe(
+      "shell_remote_write",
+    )
+    expect(ShellSafety.classifyBashRisk("git push origin feature")).toBe("shell_remote_publish")
+    expect(ShellSafety.classifyBashRisk("git push -u origin feature")).toBe("shell_remote_publish")
+    expect(ShellSafety.classifyBashRisk("git push origin HEAD:refs/heads/feature")).toBe("shell_remote_publish")
+    expect(ShellSafety.classifyBashRisk("git push origin HEAD:refs/tags/v1.0")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git push origin refs/tags/v1.0")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git push origin HEAD:refs/notes/test")).toBe("shell_remote_write")
     expect(ShellSafety.classifyBashRisk("git push origin main")).toBe("shell_remote_write")
-    expect(ShellSafety.classifyBashRisk("git -C /tmp push")).toBe("shell_remote_write")
-    expect(ShellSafety.classifyBashRisk("git --git-dir=/tmp/repo/.git push origin main")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git push origin dev")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git -C /tmp push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git --git-dir=/tmp/repo/.git push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git --exec-path=/tmp/git-core push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git -C/tmp push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("git -cfoo.bar=baz push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("command git push origin feature")).toBe("shell_remote_publish")
+    expect(ShellSafety.classifyBashRisk("command git push origin main")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("command git push --force origin feature")).toBe("shell_destructive")
   })
 
   test("git revert is shell_destructive (history-rewriting inverse commit)", () => {
@@ -836,6 +854,24 @@ describe("ShellSafety git taxonomy — warn (shell)", () => {
   })
 })
 
+describe("ShellSafety GitHub CLI PR taxonomy", () => {
+  const { ShellSafety } = require("../../src/enforcement/shell-safety")
+
+  test("gh pr create is remote publish", () => {
+    expect(ShellSafety.classifyBashRisk("gh pr create --title fix --body body")).toBe("shell_remote_publish")
+  })
+
+  test("gh pr merge and close are destructive", () => {
+    expect(ShellSafety.classifyBashRisk("gh pr merge 123 --squash")).toBe("shell_destructive")
+    expect(ShellSafety.classifyBashRisk("gh pr close 123")).toBe("shell_destructive")
+  })
+
+  test("gh pr edit and comment remain generic remote writes", () => {
+    expect(ShellSafety.classifyBashRisk("gh pr edit 123 --title updated")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("gh pr comment 123 --body note")).toBe("shell_remote_write")
+  })
+})
+
 // ------------------------------------------------------------------
 // 15. Git subcommand taxonomy — destructive
 // ------------------------------------------------------------------
@@ -875,6 +911,11 @@ describe("ShellSafety git taxonomy — destructive", () => {
 
   test("git push --delete is shell_destructive", () => {
     expect(ShellSafety.classifyBashRisk("git push --delete origin old-branch")).toBe("shell_destructive")
+  })
+
+  test("git push deleting by refspec is shell_destructive", () => {
+    expect(ShellSafety.classifyBashRisk("git push origin :old-branch")).toBe("shell_destructive")
+    expect(ShellSafety.classifyBashRisk("git push origin +feature")).toBe("shell_destructive")
   })
 
   test("git push --mirror is shell_destructive", () => {
@@ -969,6 +1010,24 @@ describe("ShellSafety git taxonomy — non-git commands unaffected", () => {
     // env vars before git should be skipped
     expect(ShellSafety.classifyBashRisk("GIT_DIR=/tmp git log")).toBe("shell_read")
     expect(ShellSafety.classifyBashRisk("GIT_DIR=/tmp git push --force")).toBe("shell_destructive")
+    expect(ShellSafety.classifyBashRisk("GIT_DIR=/tmp git push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("env GIT_DIR=/tmp git push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("env GIT_WORK_TREE=/tmp git push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("env -i GIT_NAMESPACE=test git push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("command env GIT_DIR=/tmp git push origin feature")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("env -S 'GIT_DIR=/tmp git push origin feature'")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("env --split-string='GIT_NAMESPACE=test git push origin feature'")).toBe(
+      "shell_remote_write",
+    )
+    expect(ShellSafety.classifyBashRisk("env -S 'git push origin main'")).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("env -S 'git push --force origin feature'")).toBe("shell_destructive")
+    expect(ShellSafety.classifyBashRisk("env -i -S 'GIT_DIR=/tmp git push origin feature'")).toBe("shell_remote_write")
+    expect(
+      ShellSafety.classifyBashRisk("env --ignore-environment -S 'GIT_NAMESPACE=test git push origin feature'"),
+    ).toBe("shell_remote_write")
+    expect(ShellSafety.classifyBashRisk("command env -i -S 'GIT_DIR=/tmp git push origin feature'")).toBe(
+      "shell_remote_write",
+    )
   })
 })
 

--- a/packages/util/src/capability.ts
+++ b/packages/util/src/capability.ts
@@ -146,7 +146,13 @@ export const SYNERGY_CAPABILITY_DETAILS: Record<string, SynergyCapabilityDefinit
     category: "runtime",
     severity: "medium",
     title: "Run remote-write shell commands",
-    description: "Can run commands that push, create, or modify remote state without local destruction.",
+    description: "Can modify existing remote state outside ordinary branch/PR publication workflows.",
+  },
+  shell_remote_publish: {
+    category: "runtime",
+    severity: "medium",
+    title: "Publish development changes",
+    description: "Can push explicit non-protected branches or create pull requests without destructive remote updates.",
   },
   shell_destructive: {
     category: "runtime",
@@ -372,6 +378,7 @@ export const SYNERGY_PROFILE_CAPABILITIES = [
   "shell_read",
   "shell",
   "shell_remote_write",
+  "shell_remote_publish",
   "shell_destructive",
   "shell_hardline",
   "file_external_read",


### PR DESCRIPTION
## Summary
- Add a narrow `shell_remote_publish` capability for explicit non-protected branch pushes and `gh pr create`.
- Allow autonomous profiles to use that publish capability while keeping generic remote writes, PR merge/close, force/delete/mirror pushes, protected branch pushes, and non-branch refs denied.
- Add regression coverage for the autonomous worktree → push branch → create PR workflow and shell classification bypass cases.

## Verification
- `bun test test/enforcement/gate.test.ts test/control-profile/autonomous.test.ts test/enforcement/shell-safety.test.ts`
- Security reviewer recheck passed with no blocker/high findings for the final shell boundary.