### PR TITLE
Persist BlueprintLoop start context

### DIFF
--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -4271,6 +4271,7 @@ export type BlueprintLoopInfo = {
   runMode?: "current" | "new" | "worktree"
   parentSessionID?: string
   firstPrompt?: string
+  userPrompt?: string
   error?: string
   loopIndex?: number
   audit?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -26729,6 +26729,9 @@
           "firstPrompt": {
             "type": "string"
           },
+          "userPrompt": {
+            "type": "string"
+          },
           "error": {
             "type": "string"
           },

--- a/packages/synergy/src/agent/prompt/supervisor/base.txt
+++ b/packages/synergy/src/agent/prompt/supervisor/base.txt
@@ -14,7 +14,7 @@ Audit whether the Blueprint outcome has been fully and correctly delivered. You 
 
 ## 1. Read the Blueprint
 
-Use `note_read` with the Blueprint noteID from context. Read the full document. For each distinct requirement, section, or acceptance criterion in the Blueprint, you must produce one of four evidence states:
+Use `note_read` with the Blueprint noteID from context. Read the full document. If the BlueprintLoop context includes a start user instruction, treat that instruction as part of the run-specific contract alongside the Blueprint note. For each distinct requirement, section, acceptance criterion, or start-instruction constraint, you must produce one of four evidence states:
 
 | Evidence state | Definition |
 |---|---|
@@ -96,10 +96,10 @@ Before calling `blueprint_loop_finish(status="completed")`, produce a completion
 
 ### Verdict
 All required outcomes have evidence of completion. Deferred or manual-only items are documented and non-blocking.
-Calling blueprint_loop_finish(status="completed") now.
+Calling blueprint_loop_finish(status="completed") now. The finish tool will automatically notify the original execution session; do not send a separate completion notification.
 ```
 
-Then call `blueprint_loop_finish(status="completed")`.
+Then call `blueprint_loop_finish(status="completed")`. The tool wakes the original execution session automatically so the primary agent can acknowledge completion or perform allowed final follow-up.
 
 # Constraints
 

--- a/packages/synergy/src/blueprint/loop-store.ts
+++ b/packages/synergy/src/blueprint/loop-store.ts
@@ -120,6 +120,7 @@ export namespace BlueprintLoopStore {
       error?: string
       audit?: Info["audit"]
       auditSessionID?: string | null
+      userPrompt?: string | null
     },
   ): Promise<Info> {
     const sid = Identifier.asScopeID(scopeID)
@@ -148,6 +149,7 @@ export namespace BlueprintLoopStore {
       }
       if (patch.audit) draft.audit = patch.audit
       if (patch.auditSessionID !== undefined) draft.auditSessionID = patch.auditSessionID ?? undefined
+      if (patch.userPrompt !== undefined) draft.userPrompt = patch.userPrompt ?? undefined
       if (patch.error !== undefined) draft.error = patch.error
     })
 

--- a/packages/synergy/src/blueprint/migration.ts
+++ b/packages/synergy/src/blueprint/migration.ts
@@ -17,6 +17,11 @@ function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined
 }
 
+function trimmedString(value: unknown): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : ""
+  return trimmed ? trimmed : undefined
+}
+
 function asNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }
@@ -97,6 +102,23 @@ async function cancelDuplicateActiveLoop(loop: BlueprintLoopInfo) {
   if (await clearSessionLoop(loop)) clearedSessions++
   if (loop.auditSessionID && (await clearSessionLoop(loop, loop.auditSessionID))) clearedSessions++
   return clearedSessions
+}
+
+async function userPromptFromStartMessage(loop: BlueprintLoopInfo): Promise<string | undefined> {
+  const scope = Identifier.asScopeID(loop.scopeID)
+  const session = Identifier.asSessionID(loop.sessionID)
+  const messageIDs = await Storage.scan(StoragePath.sessionMessagesRoot(scope, session)).catch(() => [])
+  for (const messageID of messageIDs) {
+    const message = await Storage.read<Record<string, unknown>>(
+      StoragePath.messageInfo(scope, session, Identifier.asMessageID(messageID)),
+    ).catch(() => undefined)
+    const metadata = asRecord(message?.metadata)
+    if (message?.role !== "user") continue
+    if (metadata?.source !== "blueprint_loop_start") continue
+    if (metadata?.loopID !== loop.id) continue
+    const userPrompt = trimmedString(metadata.userPrompt)
+    if (userPrompt) return userPrompt
+  }
 }
 
 export const migrations: Migration[] = [
@@ -273,6 +295,60 @@ export const migrations: Migration[] = [
         clearedSessions,
         normalizedNotes,
       })
+    },
+  },
+  {
+    id: "20260704-blueprint-loop-user-prompt",
+    description: "Backfill BlueprintLoop start userPrompt from execution session start messages",
+    domain: "blueprint_loop",
+    dependsOn: ["20260703-blueprint-single-active-loop"],
+    async up(progress) {
+      const scopeIDs = await Storage.scan(["blueprint_loops"])
+      const loops: BlueprintLoopInfo[] = []
+
+      for (const scopeID of scopeIDs) {
+        const scope = Identifier.asScopeID(scopeID)
+        const loopIDs = await Storage.scan(StoragePath.blueprintLoopsRoot(scope))
+        for (const loopID of loopIDs) {
+          try {
+            loops.push(await Storage.read<BlueprintLoopInfo>(StoragePath.blueprintLoop(scope, loopID)))
+          } catch (err) {
+            log.warn("failed to read BlueprintLoop for userPrompt migration", {
+              scopeID,
+              loopID,
+              error: String(err),
+            })
+          }
+        }
+      }
+
+      let done = 0
+      let changed = 0
+      for (const loop of loops) {
+        try {
+          if (!trimmedString(loop.userPrompt)) {
+            const userPrompt = await userPromptFromStartMessage(loop)
+            if (userPrompt) {
+              loop.userPrompt = userPrompt
+              await Storage.write(StoragePath.blueprintLoop(Identifier.asScopeID(loop.scopeID), loop.id), loop)
+              changed++
+            }
+          }
+        } catch (err) {
+          log.warn("failed to migrate BlueprintLoop userPrompt", {
+            scopeID: loop.scopeID,
+            loopID: loop.id,
+            error: String(err),
+          })
+        }
+
+        done++
+        if (done % 10 === 0 || done === loops.length) {
+          progress(done, loops.length)
+        }
+      }
+
+      log.info("BlueprintLoop userPrompt migration complete", { totalLoops: loops.length, changed })
     },
   },
 ]

--- a/packages/synergy/src/blueprint/types.ts
+++ b/packages/synergy/src/blueprint/types.ts
@@ -19,6 +19,7 @@ export const Info = z
     runMode: z.enum(["current", "new", "worktree"]).optional(),
     parentSessionID: z.string().optional(),
     firstPrompt: z.string().optional(),
+    userPrompt: z.string().optional(),
     error: z.string().optional(),
     loopIndex: z.number().optional(),
     audit: z

--- a/packages/synergy/src/server/blueprint.ts
+++ b/packages/synergy/src/server/blueprint.ts
@@ -66,6 +66,10 @@ async function resolveBlueprintAuditAgent(noteID: string): Promise<string> {
   const noteAgent = await knownAgentName(note?.blueprint?.auditAgent)
   return noteAgent ?? "supervisor"
 }
+function normalizeBlueprintStartUserPrompt(userPrompt?: string): string | undefined {
+  const trimmed = userPrompt?.trim()
+  return trimmed ? trimmed : undefined
+}
 
 function defaultFirstPrompt(loop: { id: string; title: string; noteID: string }, agentName?: string) {
   if (isCodingBlueprintAgent(agentName)) {
@@ -112,8 +116,8 @@ async function deliverFirstPrompt(
 ) {
   const agentName = loop.executionAgent ?? (await resolveBlueprintAgent(sessionID, loop.noteID))
   let text = loop.firstPrompt?.trim() || defaultFirstPrompt(loop, agentName)
-  if (userPrompt?.trim()) {
-    text += `\n\nUser instruction:\n${userPrompt.trim()}`
+  if (userPrompt) {
+    text += `\n\nUser instruction:\n${userPrompt}`
   }
   const textPart: MessageV2.TextPart = {
     id: Identifier.ascending("part"),
@@ -135,7 +139,7 @@ async function deliverFirstPrompt(
       noteID: loop.noteID,
       title: loop.title,
       ...(agentName ? { agent: agentName } : {}),
-      ...(userPrompt?.trim() ? { userPrompt: userPrompt.trim() } : {}),
+      ...(userPrompt ? { userPrompt } : {}),
     },
   }
   await SessionManager.deliver({ target: sessionID, mail })
@@ -346,12 +350,16 @@ export const BlueprintRoute = new Hono()
       let started = false
       try {
         const body = c.req.valid("json")
+        const userPrompt = normalizeBlueprintStartUserPrompt(body?.userPrompt)
         const before = await BlueprintLoopStore.get(ScopeContext.current.scope.id, id)
-        const loop = await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, id, { status: "running" })
+        const loop = await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, id, {
+          status: "running",
+          userPrompt: userPrompt ?? null,
+        })
         started = true
         await bindSessionToLoop(before.sessionID, id, "execution")
         const scopeID = ScopeContext.current.scope.id
-        void deliverFirstPrompt(before.sessionID, before, body?.userPrompt).catch((err) => {
+        void deliverFirstPrompt(before.sessionID, before, userPrompt).catch((err) => {
           log.error("failed to deliver BlueprintLoop start prompt", { loopID: id, error: err })
           BlueprintLoopStore.updateStatus(scopeID, id, {
             status: "failed",

--- a/packages/synergy/src/session/blueprint-continuation.ts
+++ b/packages/synergy/src/session/blueprint-continuation.ts
@@ -111,11 +111,15 @@ export namespace BlueprintContinuation {
     return [
       `BlueprintLoop ${loop.id} status is \`running\`.`,
       "",
-      `A normal final response does not finish this loop. Inspect the Blueprint note (${loop.noteID}), the current delivered state, and any domain-appropriate quality evidence before deciding what to do next.`,
+      `A normal final response does not finish this loop. Inspect the Blueprint note (${loop.noteID}), any start user instruction, the current delivered state, and any domain-appropriate quality evidence before deciding what to do next.`,
+      loop.userPrompt ? `Start user instruction: ${loop.userPrompt}` : "",
+      loop.userPrompt ? `This start user instruction is run-specific contract for execution and audit.` : "",
       "",
       `If the Blueprint outcome is not complete, continue the remaining execution work now.`,
       `If the Blueprint outcome is complete and ready for review, call blueprint_loop_finish({ loopID: "${loop.id}", status: "auditing", summary: "..." }).`,
       `If the task is blocked beyond recovery, call blueprint_loop_finish({ loopID: "${loop.id}", status: "failed", summary: "..." }).`,
-    ].join("\n")
+    ]
+      .filter(Boolean)
+      .join("\n")
   }
 }

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -618,10 +618,16 @@ export namespace SessionInvoke {
           if (loop) {
             const isAuditSession = sessionBlueprint.loopRole === "audit" || session?.id === loop.auditSessionID
             const loopInstruction = isAuditSession
-              ? `You are auditing this BlueprintLoop. Read the Blueprint note with note_read ids=["${loop.noteID}"], inspect the execution evidence, and decide whether the Blueprint outcome is complete. If changes are required, call blueprint_loop_restart({ loopID: "${loop.id}", reason: "...", completed: "...", remaining: "...", instructions: "..." }). If complete, call blueprint_loop_finish({ loopID: "${loop.id}", status: "completed", summary: "..." }).`
+              ? `You are auditing this BlueprintLoop. Read the Blueprint note with note_read ids=["${loop.noteID}"] and audit the start user instruction when present. Inspect the execution evidence, and decide whether the Blueprint outcome is complete. If changes are required, call blueprint_loop_restart({ loopID: "${loop.id}", reason: "...", completed: "...", remaining: "...", instructions: "..." }). If complete, call blueprint_loop_finish({ loopID: "${loop.id}", status: "completed", summary: "..." }).`
               : agent.name === "synergy-max"
-                ? `You are executing this coding BlueprintLoop. Before editing code, call note_read with ids=["${loop.noteID}"] and read the full Blueprint content. Continue until the Blueprint is fully implemented and verified. When ready for audit, call blueprint_loop_finish({ loopID: "${loop.id}", status: "auditing", summary: "..." }).`
-                : `You are executing this BlueprintLoop. Before carrying out the Blueprint, call note_read with ids=["${loop.noteID}"] and read the full Blueprint content. Continue until the requested outcome is fully delivered. When ready for audit, call blueprint_loop_finish({ loopID: "${loop.id}", status: "auditing", summary: "..." }).`
+                ? `You are executing this coding BlueprintLoop. Before editing code, call note_read with ids=["${loop.noteID}"] and read the full Blueprint content. Satisfy both the Blueprint note and any start user instruction before requesting audit. Continue until the Blueprint is fully implemented and verified. When ready for audit, call blueprint_loop_finish({ loopID: "${loop.id}", status: "auditing", summary: "..." }).`
+                : `You are executing this BlueprintLoop. Before carrying out the Blueprint, call note_read with ids=["${loop.noteID}"] and read the full Blueprint content. Satisfy both the Blueprint note and any start user instruction before requesting audit. Continue until the requested outcome is fully delivered. When ready for audit, call blueprint_loop_finish({ loopID: "${loop.id}", status: "auditing", summary: "..." }).`
+            const startUserInstruction = loop.userPrompt
+              ? [
+                  `Start user instruction: ${loop.userPrompt}`,
+                  `This start user instruction is run-specific contract for execution and audit.`,
+                ]
+              : []
             systemParts.push(
               [
                 "<blueprint-loop-context>",
@@ -631,6 +637,7 @@ export namespace SessionInvoke {
                 `Title: ${loop.title}`,
                 `Description: ${loop.description ?? "N/A"}`,
                 `Status: ${loop.status}`,
+                ...startUserInstruction,
                 "",
                 loopInstruction,
                 "</blueprint-loop-context>",

--- a/packages/synergy/src/tool/blueprint-loop-finish.ts
+++ b/packages/synergy/src/tool/blueprint-loop-finish.ts
@@ -4,6 +4,7 @@ import { BlueprintLoopStore, LoopError } from "../blueprint"
 import { ScopeContext } from "../scope/context"
 import { Bus } from "../bus"
 import { LoopEvent } from "../blueprint/event"
+import { Identifier } from "../id/id"
 import DESCRIPTION from "./blueprint-loop-finish.txt"
 import { SessionManager } from "../session/manager"
 
@@ -16,6 +17,28 @@ const parameters = z.object({
     ),
   summary: z.string().optional().describe("Optional summary of the finish reason or audit result."),
 })
+
+function startUserInstructionBlock(userPrompt?: string): string {
+  if (!userPrompt) return ""
+  return `
+
+Start user instruction for this run:
+${userPrompt}
+
+Treat this start user instruction as part of the BlueprintLoop contract alongside the Blueprint note. If it conflicts with the Blueprint note or cannot be satisfied, classify that as a blocking audit issue and use blueprint_loop_restart with concrete next actions.`
+}
+
+function completionNotificationText(input: { loopID: string; summary?: string; userPrompt?: string }) {
+  return [
+    `BlueprintLoop ${input.loopID} passed supervisor audit and is now complete.`,
+    input.summary ? `Audit summary: ${input.summary}` : "",
+    input.userPrompt ? `Start user instruction: ${input.userPrompt}` : "",
+    `Do not call blueprint_loop_finish or blueprint_loop_restart for this loop again; the loop is already complete.`,
+    `If there is user-requested final follow-up outside the BlueprintLoop, perform the allowed follow-up now. Otherwise, summarize completion for the user.`,
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
 
 export const BlueprintLoopFinishTool = Tool.define("blueprint_loop_finish", {
   description: DESCRIPTION,
@@ -98,9 +121,9 @@ export const BlueprintLoopFinishTool = Tool.define("blueprint_loop_finish", {
 
     if (params.status === "auditing") {
       const auditPrompt = `Audit BlueprintLoop ${params.loopID} (Note ${loop.noteID}) in session ${loop.sessionID}.
-Read the Blueprint Note via note_read, examine the execution evidence (session trajectory, produced artifacts or workspace changes, and domain-appropriate quality checks), and determine if the Blueprint outcome is complete.
+Read the Blueprint Note via note_read and audit any start user instruction included below. Examine the execution evidence (session trajectory, produced artifacts or workspace changes, and domain-appropriate quality checks), and determine if the Blueprint outcome is complete.
 If NOT complete, call blueprint_loop_restart({ loopID: "${params.loopID}", reason: "...", completed: "...", remaining: "...", instructions: "..." }) with a detailed reason and concrete next actions.
-If complete, call blueprint_loop_finish({ loopID: "${params.loopID}", status: "completed", summary: "..." }).`
+If complete, call blueprint_loop_finish({ loopID: "${params.loopID}", status: "completed", summary: "..." }).${startUserInstructionBlock(loop.userPrompt)}`
       const { Cortex } = await import("../cortex")
       const auditAgent = loop.auditAgent || "supervisor"
       const task = await Cortex.launch({
@@ -129,6 +152,31 @@ If complete, call blueprint_loop_finish({ loopID: "${params.loopID}", status: "c
       await Cortex.cancelAll(ctx.sessionID)
       SessionManager.signalAbort(ctx.sessionID)
     } else if (params.status === "completed") {
+      const completionMail: SessionManager.SessionMail.User = {
+        type: "user",
+        ...(loop.executionAgent ? { agent: loop.executionAgent } : {}),
+        summary: { title: "Blueprint audit completed" },
+        parts: [
+          {
+            id: Identifier.ascending("part"),
+            sessionID: loop.sessionID,
+            messageID: Identifier.ascending("message"),
+            type: "text",
+            text: completionNotificationText({ loopID: loop.id, summary: params.summary, userPrompt: loop.userPrompt }),
+          },
+        ],
+        metadata: {
+          source: "blueprint_loop_completed",
+          sourceSessionID: ctx.sessionID,
+          loopID: loop.id,
+          noteID: loop.noteID,
+          title: loop.title,
+          status: "completed",
+          ...(params.summary ? { summary: params.summary } : {}),
+          ...(loop.userPrompt ? { userPrompt: loop.userPrompt } : {}),
+        },
+      }
+      await SessionManager.deliver({ target: loop.sessionID, mail: completionMail, waitForProcessing: false })
       await BlueprintLoopStore.updateStatus(scopeID, params.loopID, { status: "completed" })
       await Bus.publish(LoopEvent.Completed, { loopID: params.loopID })
       const { Cortex } = await import("../cortex")

--- a/packages/synergy/src/tool/blueprint-loop-finish.txt
+++ b/packages/synergy/src/tool/blueprint-loop-finish.txt
@@ -8,6 +8,8 @@ Audit agents may set:
 - completed: audit passed
 - failed: audit cannot continue
 
+When an audit agent completes a loop, this tool automatically delivers a completion notification to the original execution session and wakes it asynchronously. The execution session should use that final turn for acknowledgement or allowed follow-up, not to call BlueprintLoop finish/restart tools again.
+
 Parameters:
 - loopID: The active BlueprintLoop ID
 - status: "auditing", "failed", or "completed" according to the role rules above

--- a/packages/synergy/test/blueprint/migration.test.ts
+++ b/packages/synergy/test/blueprint/migration.test.ts
@@ -200,4 +200,82 @@ describe("blueprint migrations", () => {
     expect(newer.status).toBe("auditing")
     expect((note.blueprint as { activeLoopID?: string }).activeLoopID).toBe(newerLoopID)
   })
+
+  test("backfills BlueprintLoop userPrompt from start message metadata", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    const scopeID = Identifier.asScopeID(scope.id)
+    const loopID = Identifier.ascending("blueprint_loop")
+    const sessionID = Identifier.ascending("session")
+    const messageID = Identifier.ascending("message")
+    const now = Date.now()
+
+    await Storage.write(
+      StoragePath.blueprintLoop(scopeID, loopID),
+      blueprintLoop({
+        id: loopID,
+        noteID: Identifier.ascending("note"),
+        sessionID,
+        scopeID,
+        status: "running",
+        updated: now,
+      }),
+    )
+    await Storage.write(StoragePath.messageInfo(scopeID, Identifier.asSessionID(sessionID), messageID), {
+      id: messageID,
+      sessionID,
+      role: "user",
+      metadata: {
+        source: "blueprint_loop_start",
+        loopID,
+        userPrompt: "  Critical constraint  ",
+      },
+    })
+
+    const migration = migrations.find((entry) => entry.id === "20260704-blueprint-loop-user-prompt")
+    expect(migration).toBeDefined()
+    await migration!.up(() => {})
+
+    const migrated = await Storage.read<Record<string, unknown>>(StoragePath.blueprintLoop(scopeID, loopID))
+    expect(migrated.userPrompt).toBe("Critical constraint")
+  })
+
+  test("leaves BlueprintLoop userPrompt unchanged when start metadata is blank", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    const scopeID = Identifier.asScopeID(scope.id)
+    const loopID = Identifier.ascending("blueprint_loop")
+    const sessionID = Identifier.ascending("session")
+    const messageID = Identifier.ascending("message")
+    const now = Date.now()
+
+    await Storage.write(
+      StoragePath.blueprintLoop(scopeID, loopID),
+      blueprintLoop({
+        id: loopID,
+        noteID: Identifier.ascending("note"),
+        sessionID,
+        scopeID,
+        status: "running",
+        updated: now,
+      }),
+    )
+    await Storage.write(StoragePath.messageInfo(scopeID, Identifier.asSessionID(sessionID), messageID), {
+      id: messageID,
+      sessionID,
+      role: "user",
+      metadata: {
+        source: "blueprint_loop_start",
+        loopID,
+        userPrompt: "  ",
+      },
+    })
+
+    const migration = migrations.find((entry) => entry.id === "20260704-blueprint-loop-user-prompt")
+    expect(migration).toBeDefined()
+    await migration!.up(() => {})
+
+    const migrated = await Storage.read<Record<string, unknown>>(StoragePath.blueprintLoop(scopeID, loopID))
+    expect(migrated.userPrompt).toBeUndefined()
+  })
 })

--- a/packages/synergy/test/blueprint/types.test.ts
+++ b/packages/synergy/test/blueprint/types.test.ts
@@ -61,6 +61,28 @@ describe("Blueprint types", () => {
       expect(result.success).toBe(true)
     })
 
+    test("validates loop with durable user prompt context", () => {
+      const now = Date.now()
+      const loop = {
+        id: "bll_prompt1",
+        noteID: "note_abc",
+        title: "Prompted Blueprint",
+        sessionID: "ses_xyz",
+        auditAgent: "supervisor",
+        scopeID: "scp_test",
+        status: "running",
+        userPrompt: "Only change the CLI behavior; do not touch desktop.",
+        time: {
+          created: now,
+          started: now,
+          updated: now,
+        },
+      }
+
+      const result = BlueprintLoopInfo.safeParse(loop)
+      expect(result.success).toBe(true)
+    })
+
     test("validates loop in running status with started time", () => {
       const now = Date.now()
       const loop = {

--- a/packages/synergy/test/server/blueprint-route.test.ts
+++ b/packages/synergy/test/server/blueprint-route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
+import { BlueprintLoopStore } from "../../src/blueprint"
 import { NoteStore } from "../../src/note"
 import { BlueprintRoute } from "../../src/server/blueprint"
 import { Session } from "../../src/session"
@@ -46,7 +47,7 @@ async function createLoop(noteID: string, sessionID: string) {
     }),
   })
   expect(response.status).toBe(200)
-  return response.json() as Promise<{ id: string; executionAgent?: string; auditAgent: string }>
+  return response.json() as Promise<{ id: string; noteID: string; executionAgent?: string; auditAgent: string }>
 }
 
 describe("BlueprintRoute start prompt", () => {
@@ -129,6 +130,62 @@ describe("BlueprintRoute start prompt", () => {
           sessionID: firstSession.id,
           status: "armed",
         })
+      },
+    })
+  })
+
+  test("start persists user prompt as durable loop context", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const note = await createBlueprint("synergy-max")
+        const loop = await createLoop(note.id, session.id)
+        const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+        ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+          deliveries.push(input)
+        })
+
+        const response = await app().request(`/blueprint/loop/${loop.id}/start`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userPrompt: "  Treat API compatibility as a hard requirement.  " }),
+        })
+
+        expect(response.status).toBe(200)
+        const stored = await BlueprintLoopStore.get(ScopeContext.current.scope.id, loop.id)
+        expect(stored.userPrompt).toBe("Treat API compatibility as a hard requirement.")
+        expect(deliveries).toHaveLength(1)
+        const mail = deliveries[0].mail
+        expect(mail.type).toBe("user")
+        if (mail.type !== "user") throw new Error("expected user mail")
+        const text = (mail.parts[0] as MessageV2.TextPart).text
+        expect(text).toContain("User instruction:")
+        expect(text).toContain("Treat API compatibility as a hard requirement.")
+      },
+    })
+  })
+
+  test("start does not persist blank user prompt context", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const note = await createBlueprint("synergy")
+        const loop = await createLoop(note.id, session.id)
+        ;(SessionManager.deliver as any) = mock(async () => {})
+
+        const response = await app().request(`/blueprint/loop/${loop.id}/start`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userPrompt: "   \n\t  " }),
+        })
+
+        expect(response.status).toBe(200)
+        const stored = await BlueprintLoopStore.get(ScopeContext.current.scope.id, loop.id)
+        expect(stored.userPrompt).toBeUndefined()
       },
     })
   })

--- a/packages/synergy/test/tool/blueprint-loop-tools.test.ts
+++ b/packages/synergy/test/tool/blueprint-loop-tools.test.ts
@@ -40,7 +40,7 @@ function ctx(sessionID: string, agent: string): Tool.Context {
   }
 }
 
-async function createRunningLoop(input?: { auditAgent?: string }) {
+async function createRunningLoop(input?: { auditAgent?: string; userPrompt?: string }) {
   const session = await Session.create({})
   const loop = await BlueprintLoopStore.create({
     noteID: "note_blueprint",
@@ -48,7 +48,10 @@ async function createRunningLoop(input?: { auditAgent?: string }) {
     sessionID: session.id,
     auditAgent: input?.auditAgent,
   })
-  const running = await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+  const running = await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, {
+    status: "running",
+    userPrompt: input?.userPrompt ?? null,
+  })
   await Session.update(session.id, (draft) => {
     draft.blueprint = { loopID: loop.id }
   })
@@ -99,6 +102,42 @@ describe("BlueprintLoop tools", () => {
         const auditSession = await Session.get(updated.auditSessionID!)
         expect(auditSession.blueprint?.loopID).toBe(loop.id)
         expect(auditSession.blueprint?.loopRole).toBe("audit")
+      },
+    })
+  })
+
+  test("audit launch includes durable start user prompt context", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const { session, loop } = await createRunningLoop({ userPrompt: "Do not change the public CLI contract." })
+        const launches: Parameters<typeof Cortex.launch>[0][] = []
+        ;(Cortex.launch as any) = mock(async (input: Parameters<typeof Cortex.launch>[0]) => {
+          const auditSession = await Session.create({})
+          launches.push(input)
+          return {
+            id: Identifier.short("cortex"),
+            sessionID: auditSession.id,
+            parentSessionID: input.parentSessionID,
+            parentMessageID: input.parentMessageID,
+            description: input.description,
+            prompt: input.prompt,
+            agent: input.agent,
+            executionRole: input.executionRole,
+            category: input.category,
+            status: "running",
+            startedAt: Date.now(),
+            notifyParentOnComplete: input.notifyParentOnComplete,
+          }
+        })
+
+        const tool = await BlueprintLoopFinishTool.init()
+        await tool.execute({ loopID: loop.id, status: "auditing" }, ctx(session.id, "synergy"))
+
+        expect(launches).toHaveLength(1)
+        expect(launches[0].prompt).toContain("Start user instruction")
+        expect(launches[0].prompt).toContain("Do not change the public CLI contract.")
       },
     })
   })
@@ -192,7 +231,7 @@ describe("BlueprintLoop tools", () => {
     await ScopeContext.provide({
       scope: await tmp.scope(),
       fn: async () => {
-        const { session, loop } = await createRunningLoop()
+        const { loop } = await createRunningLoop()
         const auditSession = await Session.create({})
         await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, {
           status: "auditing",
@@ -203,6 +242,7 @@ describe("BlueprintLoop tools", () => {
         })
         let cancelAllCalls: string[] = []
         let signalAbortCalls: string[] = []
+        ;(SessionManager.deliver as any) = mock(async () => {})
         ;(Cortex.cancelAll as any) = mock(async (sessionID: string) => {
           cancelAllCalls.push(sessionID)
           return 0
@@ -222,6 +262,67 @@ describe("BlueprintLoop tools", () => {
 
         const updated = await BlueprintLoopStore.get(ScopeContext.current.scope.id, loop.id)
         expect(updated.status).toBe("completed")
+      },
+    })
+  })
+
+  test("finish with status=completed wakes the execution session with user mail", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const { session, loop } = await createRunningLoop({ userPrompt: "Prepare a PR after completion." })
+        const auditSession = await Session.create({})
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, {
+          status: "auditing",
+          auditSessionID: auditSession.id,
+        })
+        await Session.update(auditSession.id, (draft) => {
+          draft.blueprint = { loopID: loop.id, loopRole: "audit" }
+        })
+        const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+        const cancelAllCalls: string[] = []
+        const signalAbortCalls: string[] = []
+        ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+          deliveries.push(input)
+        })
+        ;(Cortex.cancelAll as any) = mock(async (sessionID: string) => {
+          cancelAllCalls.push(sessionID)
+          return 0
+        })
+        ;(SessionManager.signalAbort as any) = mock((sessionID: string) => {
+          signalAbortCalls.push(sessionID)
+        })
+
+        const tool = await BlueprintLoopFinishTool.init()
+        await tool.execute(
+          { loopID: loop.id, status: "completed", summary: "Audit passed; ready for final follow-up." },
+          ctx(auditSession.id, "security-reviewer"),
+        )
+
+        expect(deliveries).toHaveLength(1)
+        expect(deliveries[0].target).toBe(session.id)
+        expect(deliveries[0].waitForProcessing).toBe(false)
+        const mail = deliveries[0].mail
+        expect(mail.type).toBe("user")
+        if (mail.type !== "user") throw new Error("expected user mail")
+        expect(mail.noReply).not.toBe(true)
+        expect(mail.summary?.title).toBe("Blueprint audit completed")
+        expect(mail.metadata?.source).toBe("blueprint_loop_completed")
+        expect(mail.metadata?.sourceSessionID).toBe(auditSession.id)
+        expect(mail.metadata?.loopID).toBe(loop.id)
+        expect(mail.metadata?.noteID).toBe(loop.noteID)
+        expect(mail.metadata?.title).toBe(loop.title)
+        expect(mail.metadata?.status).toBe("completed")
+        expect(mail.metadata?.summary).toBe("Audit passed; ready for final follow-up.")
+        expect(mail.metadata?.userPrompt).toBe("Prepare a PR after completion.")
+        expect(mail.parts[0].type).toBe("text")
+        const text = mail.parts[0].type === "text" ? mail.parts[0].text : ""
+        expect(text).toContain("Audit passed")
+        expect(text).toContain("now complete")
+        expect(text).toContain("Do not call blueprint_loop_finish or blueprint_loop_restart")
+        expect(cancelAllCalls).toEqual([auditSession.id])
+        expect(signalAbortCalls).toEqual([auditSession.id])
       },
     })
   })


### PR DESCRIPTION
## Summary
- Persist run-specific BlueprintLoop start instructions as optional loop context and backfill them from existing start-message metadata.
- Include start instructions in execution, continuation, and audit prompts so supervisor review treats them as part of the run contract.
- Wake the original execution session with reply-required internal mail when supervisor audit completes, including generated SDK updates and focused coverage.

## Verification
- ./script/generate.ts
- ./script/format.ts
- bun test test/tool/blueprint-loop-tools.test.ts test/server/blueprint-route.test.ts test/blueprint/types.test.ts test/blueprint/migration.test.ts (from packages/synergy)
- bun run typecheck
- bun run test:changed (known unrelated failures: 1276 pass / 11 fail in note, compaction, and tool exposure tests)