### PR TITLE
feat: structured compaction recovery card (fixes #194)

### DIFF
--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3425,6 +3425,23 @@ export type CompactionPart = {
   auto: boolean
 }
 
+export type CompactionRecoveryPart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "compaction_recovery"
+  summary: string
+  sections: Array<{
+    heading: string
+    items: Array<string>
+  }>
+  mechanical: boolean
+  recoverySessionIDs?: Array<string>
+  pendingDagCount?: number
+  nextStep?: string
+  validated: boolean
+}
+
 export type Part =
   | TextPart
   | ReasoningPart
@@ -3436,6 +3453,7 @@ export type Part =
   | PatchPart
   | RetryPart
   | CompactionPart
+  | CompactionRecoveryPart
 
 export type SessionRollbackEvent = {
   id: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -24183,6 +24183,66 @@
         },
         "required": ["id", "sessionID", "messageID", "type", "auto"]
       },
+      "CompactionRecoveryPart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "messageID": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "compaction_recovery"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": ["heading", "items"]
+            }
+          },
+          "mechanical": {
+            "type": "boolean"
+          },
+          "recoverySessionIDs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pendingDagCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "nextStep": {
+            "type": "string"
+          },
+          "validated": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "sessionID", "messageID", "type", "summary", "sections", "mechanical", "validated"]
+      },
       "Part": {
         "anyOf": [
           {
@@ -24214,6 +24274,9 @@
           },
           {
             "$ref": "#/components/schemas/CompactionPart"
+          },
+          {
+            "$ref": "#/components/schemas/CompactionRecoveryPart"
           }
         ]
       },

--- a/packages/synergy/src/agent/prompt/compaction/base.txt
+++ b/packages/synergy/src/agent/prompt/compaction/base.txt
@@ -37,13 +37,16 @@ Your summary MUST follow this structure with these exact section headers:
 - Non-obvious gotchas, edge cases, or traps the next session should know about
 - Any open questions or unresolved ambiguities
 
+## What NOT to Include
+
+- **Do NOT** include diff summaries, file change cards, or line-count listings (e.g. "+5 -12" blocks). These are implementation artifacts, not recovery context. Summarize *what* changed and *why*, not `git diff` output.
+- **Do NOT** list temporary files (`.tmp-*`, `*.bak`, `*.swp`) in the "Files involved" section. These are transient artifacts that should never appear in user-facing recovery content.
+- **Do NOT** embed raw tool output, shell transcripts, or log dumps. Describe outcomes, not the tool machinery.
+- **Do NOT** include full file contents — use paths and line references.
+
 ## Quality Standards
 
 - **Length**: Your summary should be proportional to the conversation's complexity. A conversation with substantial work should produce a substantial summary — typically 300-800 words. Never write a summary shorter than 200 words for a non-trivial conversation.
 - **Specificity**: Use exact file paths, function names, variable names, and line numbers. "Modified the auth module" is bad; "Modified `src/auth/session.ts:47` — fixed the token refresh race condition in `refreshToken()`" is good.
 - **Completeness**: If dropping any section would cause the next session to miss something important, include it. When in doubt, include more detail rather than less.
 - **No filler**: Every sentence should carry information. Do not pad with generic phrases like "We had a productive session" or "The work went smoothly."
-
-## Recovery Hint
-
-Always include a `### Recovery hint` section at the end of your summary. This section should tell the continuation agent that it can use the `session_read` tool with the current session ID to browse the full conversation history beyond the compaction boundary. Mention that offset/limit pagination can be used to go deeper into older messages. This allows the agent to recover exact details (file paths, decisions, discussion context) when the summary alone is insufficient.

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -153,7 +153,12 @@ export namespace SessionCompaction {
     for (const msg of messages) {
       for (const part of msg.parts) {
         if (part.type === "patch") {
-          for (const file of part.files) files.add(file)
+          for (const file of part.files) {
+            // Filter out temporary/internal files — they add noise to recovery UI
+            const base = file.split("/").pop() ?? file
+            if (base.startsWith(".tmp-") || base.startsWith("._")) continue
+            files.add(file)
+          }
         }
       }
     }
@@ -204,7 +209,39 @@ export namespace SessionCompaction {
     msg.finish = "stop"
     if (!msg.time.completed) msg.time.completed = Date.now()
     await Session.updateMessage(msg)
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: msg.id,
+      sessionID: input.sessionID,
+      type: "compaction_recovery",
+      summary,
+      sections: [{ heading: "Summary", items: [summary] }],
+      mechanical: true,
+      validated: false,
+    })
     log.info("wrote mechanical fallback summary", { sessionID: input.sessionID })
+  }
+
+  export function parseCompactionSections(markdown: string): { heading: string; items: string[] }[] {
+    const sections: { heading: string; items: string[] }[] = []
+    const lines = markdown.split("\n")
+    let currentHeading = ""
+    let currentItems: string[] = []
+
+    for (const line of lines) {
+      const headingMatch = line.match(/^### (.+)/)
+      if (headingMatch) {
+        if (currentHeading) sections.push({ heading: currentHeading, items: currentItems })
+        currentHeading = headingMatch[1].trim()
+        currentItems = []
+      } else {
+        const itemMatch = line.match(/^- (.+)/)
+        if (itemMatch) currentItems.push(itemMatch[1].trim())
+      }
+    }
+    if (currentHeading) sections.push({ heading: currentHeading, items: currentItems })
+
+    return sections.length > 0 ? sections : [{ heading: "Summary", items: [markdown] }]
   }
 
   // goes backwards through parts until there are 40_000 tokens worth of tool
@@ -456,6 +493,32 @@ export namespace SessionCompaction {
       msg.time.completed = Date.now()
     }
     await Session.updateMessage(msg)
+
+    // Emit a CompactionRecoveryPart with the parsed sections for the frontend.
+    const msgParts = await MessageV2.parts({ sessionID: input.sessionID, messageID: msg.id })
+    const textParts = msgParts.filter((p): p is MessageV2.TextPart => p.type === "text")
+    const allText = textParts.map((p) => p.text).join("\n")
+    const sections = parseCompactionSections(allText)
+
+    const nextStepsSection = sections.find((s) => s.heading.toLowerCase().includes("next step"))
+    const nextStep = nextStepsSection?.items[0]
+
+    const inProgressSection = sections.find((s) => s.heading.toLowerCase().includes("in progress"))
+    const rawDagCount = inProgressSection?.items.filter((i) => i.toLowerCase().includes("dag")).length
+    const pendingDagCount = rawDagCount != null && rawDagCount > 0 ? rawDagCount : undefined
+
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: msg.id,
+      sessionID: input.sessionID,
+      type: "compaction_recovery",
+      summary: allText,
+      sections,
+      mechanical: false,
+      nextStep,
+      pendingDagCount,
+      validated: true,
+    })
 
     if (input.auto) {
       const anchor = resolveAnchor(input.messages, input.parentID)

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -261,6 +261,24 @@ export namespace MessageV2 {
   })
   export type CompactionPart = z.infer<typeof CompactionPart>
 
+  export const CompactionRecoveryPart = PartBase.extend({
+    type: z.literal("compaction_recovery"),
+    summary: z.string(),
+    sections: z.array(
+      z.object({
+        heading: z.string(),
+        items: z.string().array(),
+      }),
+    ),
+    mechanical: z.boolean(),
+    recoverySessionIDs: z.string().array().optional(),
+    pendingDagCount: z.number().int().nonnegative().optional(),
+    nextStep: z.string().optional(),
+    validated: z.boolean(),
+  }).meta({
+    ref: "CompactionRecoveryPart",
+  })
+  export type CompactionRecoveryPart = z.infer<typeof CompactionRecoveryPart>
   export const RetryPart = PartBase.extend({
     type: z.literal("retry"),
     attempt: z.number(),
@@ -452,6 +470,7 @@ export namespace MessageV2 {
       PatchPart,
       RetryPart,
       CompactionPart,
+      CompactionRecoveryPart,
     ])
     .meta({
       ref: "Part",

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -752,3 +752,77 @@ describe("session.compaction.selectPartsToPrune", () => {
     expect(withModel).toHaveLength(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// SessionCompaction.parseCompactionSections
+// ---------------------------------------------------------------------------
+
+describe("session.compaction.parseCompactionSections", () => {
+  test("parses structured markdown with headings and list items", () => {
+    const markdown = [
+      "### What was accomplished",
+      "- Built the user auth module",
+      "- Added login endpoint",
+      "",
+      "### What is currently in progress",
+      "- Fixing the session timeout bug",
+      "- DAG: tests_docs pending",
+      "",
+      "### Next steps",
+      "- Write integration tests",
+      "- Deploy to staging",
+    ].join("\n")
+
+    const result = SessionCompaction.parseCompactionSections(markdown)
+    expect(result).toHaveLength(3)
+    expect(result[0].heading).toBe("What was accomplished")
+    expect(result[0].items).toEqual(["Built the user auth module", "Added login endpoint"])
+    expect(result[1].heading).toBe("What is currently in progress")
+    expect(result[1].items).toEqual(["Fixing the session timeout bug", "DAG: tests_docs pending"])
+    expect(result[2].heading).toBe("Next steps")
+    expect(result[2].items).toEqual(["Write integration tests", "Deploy to staging"])
+  })
+
+  test("handles empty input as fallback section", () => {
+    const result = SessionCompaction.parseCompactionSections("")
+    expect(result).toHaveLength(1)
+    expect(result[0].heading).toBe("Summary")
+    expect(result[0].items).toEqual([""])
+  })
+
+  test("handles text without headings as fallback section", () => {
+    const result = SessionCompaction.parseCompactionSections("Just some text")
+    expect(result).toHaveLength(1)
+    expect(result[0].heading).toBe("Summary")
+    expect(result[0].items).toEqual(["Just some text"])
+  })
+
+  test("handles headings without any list items", () => {
+    const markdown = ["### Section A", "", "### Section B", "- item 1"].join("\n")
+
+    const result = SessionCompaction.parseCompactionSections(markdown)
+    expect(result).toHaveLength(2)
+    expect(result[0].heading).toBe("Section A")
+    expect(result[0].items).toEqual([])
+    expect(result[1].heading).toBe("Section B")
+    expect(result[1].items).toEqual(["item 1"])
+  })
+
+  test("ignores non-list, non-heading lines", () => {
+    const markdown = ["### Tasks", "- task 1", "Some prose text here", "- task 2", "More prose"].join("\n")
+
+    const result = SessionCompaction.parseCompactionSections(markdown)
+    expect(result).toHaveLength(1)
+    expect(result[0].items).toEqual(["task 1", "task 2"])
+  })
+
+  test("trims heading text", () => {
+    const result = SessionCompaction.parseCompactionSections("###   Padded Heading   \n- item")
+    expect(result[0].heading).toBe("Padded Heading")
+  })
+
+  test("trims item text", () => {
+    const result = SessionCompaction.parseCompactionSections("### H\n-   padded item   ")
+    expect(result[0].items).toEqual(["padded item"])
+  })
+})

--- a/packages/ui/src/components/compaction-card.css
+++ b/packages/ui/src/components/compaction-card.css
@@ -1,0 +1,220 @@
+[data-component="compaction-card"] {
+  width: 100%;
+  min-width: 0;
+  margin-top: 6px;
+  border: 1px solid var(--color-border-base);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised-base);
+  overflow: hidden;
+}
+
+/* ── Collapsed header ── */
+
+[data-slot="compaction-card-header"] {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 14px;
+  cursor: pointer;
+  box-sizing: border-box;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: var(--surface-raised-base-hover);
+  }
+}
+
+[data-slot="compaction-card-header-left"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+[data-slot="compaction-card-header-left"] [data-slot="icon-svg"] {
+  color: var(--icon-info-base);
+  flex-shrink: 0;
+}
+
+[data-slot="compaction-card-title"] {
+  font-size: 0.8125rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-base);
+  white-space: nowrap;
+}
+
+[data-slot="compaction-card-badge"] {
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-on-warning-base);
+  background: var(--color-surface-warning-weak);
+  padding: 1px 6px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+[data-slot="compaction-card-header-right"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+[data-slot="compaction-card-time"] {
+  font-size: 0.75rem;
+  color: var(--color-text-weak);
+  white-space: nowrap;
+}
+
+[data-slot="compaction-card-arrow"] [data-slot="icon-svg"] {
+  color: var(--icon-weak);
+  transition: transform 0.2s ease;
+}
+
+[data-expanded] [data-slot="compaction-card-arrow"] [data-slot="icon-svg"] {
+  transform: rotate(90deg);
+}
+
+/* ── Expanded content ── */
+
+[data-slot="compaction-card-content"] {
+  padding: 4px 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* ── Warning banner ── */
+
+[data-slot="compaction-card-warning"] {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 10px;
+  background: var(--color-surface-warning-weak);
+  border-radius: var(--radius-sm);
+}
+
+[data-slot="compaction-card-warning"] [data-slot="icon-svg"] {
+  color: var(--icon-warning-base);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+[data-slot="compaction-card-warning-text"] {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--color-text-on-warning-base);
+}
+
+/* ── Summary markdown ── */
+
+[data-slot="compaction-card-summary"] {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-base);
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+[data-slot="compaction-card-summary"] {
+  & > *:first-child {
+    margin-top: 0;
+  }
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+/* ── Sections ── */
+
+[data-slot="compaction-card-section"] {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+[data-slot="compaction-card-section-heading"] {
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-weak);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+  padding: 0;
+}
+
+[data-slot="compaction-card-section-item"] {
+  display: flex;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+[data-slot="compaction-card-bullet"] {
+  color: var(--color-text-weaker);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+[data-slot="compaction-card-section-item-text"] {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-text-base);
+  min-width: 0;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+[data-slot="compaction-card-section-item-text"] {
+  & > *:first-child {
+    margin-top: 0;
+  }
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+/* ── Next step callout ── */
+
+[data-slot="compaction-card-next-step"] {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 10px;
+  background: var(--color-surface-info-weak);
+  border-radius: var(--radius-sm);
+  margin-top: 2px;
+}
+
+[data-slot="compaction-card-next-step"] [data-slot="icon-svg"] {
+  color: var(--icon-info-base);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+[data-slot="compaction-card-next-step-content"] {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+[data-slot="compaction-card-next-step-label"] {
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-weak);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+[data-slot="compaction-card-next-step-text"] {
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--color-text-base);
+}

--- a/packages/ui/src/components/compaction-card.tsx
+++ b/packages/ui/src/components/compaction-card.tsx
@@ -50,8 +50,8 @@ const CompactionCard: Component<MessagePartProps> = (props) => {
             <div data-slot="compaction-card-header-left">
               <Icon name={getSemanticIcon("settings.compaction")} size="small" />
               <span data-slot="compaction-card-title">Session Compacted</span>
-              <Show when={p().pendingDagCount != null && p().pendingDagCount > 0}>
-                <span data-slot="compaction-card-badge">{p().pendingDagCount!} pending</span>
+              <Show when={(p().pendingDagCount ?? 0) > 0}>
+                <span data-slot="compaction-card-badge">{p().pendingDagCount} pending</span>
               </Show>
             </div>
             <div data-slot="compaction-card-header-right">

--- a/packages/ui/src/components/compaction-card.tsx
+++ b/packages/ui/src/components/compaction-card.tsx
@@ -51,7 +51,7 @@ const CompactionCard: Component<MessagePartProps> = (props) => {
               <Icon name={getSemanticIcon("settings.compaction")} size="small" />
               <span data-slot="compaction-card-title">Session Compacted</span>
               <Show when={p().pendingDagCount != null && p().pendingDagCount > 0}>
-                <span data-slot="compaction-card-badge">{p().pendingDagCount} pending</span>
+                <span data-slot="compaction-card-badge">{p().pendingDagCount!} pending</span>
               </Show>
             </div>
             <div data-slot="compaction-card-header-right">

--- a/packages/ui/src/components/compaction-card.tsx
+++ b/packages/ui/src/components/compaction-card.tsx
@@ -1,0 +1,115 @@
+import { Show, For, createMemo, createSignal, type Component } from "solid-js"
+import { DateTime } from "luxon"
+import type { MessagePartProps } from "./message-part"
+import { Markdown } from "./markdown"
+import { Icon } from "./icon"
+import { getSemanticIcon } from "./semantic-icon"
+
+import "./compaction-card.css"
+
+interface CompactionRecoverySection {
+  heading: string
+  items: string[]
+}
+
+interface CompactionRecoveryPayload {
+  type: string
+  summary: string
+  sections: CompactionRecoverySection[]
+  mechanical: boolean
+  recoverySessionIDs?: string[]
+  pendingDagCount?: number
+  nextStep?: string
+  validated: boolean
+}
+
+function asCompactionRecovery(part: MessagePartProps["part"]): CompactionRecoveryPayload | null {
+  if ((part as unknown as CompactionRecoveryPayload).type !== "compaction_recovery") return null
+  return part as unknown as CompactionRecoveryPayload
+}
+
+const CompactionCard: Component<MessagePartProps> = (props) => {
+  const match = createMemo(() => asCompactionRecovery(props.part))
+
+  const [expanded, setExpanded] = createSignal(props.defaultOpen ?? false)
+
+  const timestamp = createMemo(() => {
+    const ms = props.message.time.created
+    return DateTime.fromMillis(ms).toFormat("HH:mm")
+  })
+
+  const expandIcon = createMemo(() =>
+    expanded() ? getSemanticIcon("navigation.collapse") : getSemanticIcon("navigation.expand"),
+  )
+
+  return (
+    <Show when={match()}>
+      {(p) => (
+        <div data-component="compaction-card" data-expanded={expanded() ? "" : undefined}>
+          <button type="button" data-slot="compaction-card-header" onClick={() => setExpanded((v) => !v)}>
+            <div data-slot="compaction-card-header-left">
+              <Icon name={getSemanticIcon("settings.compaction")} size="small" />
+              <span data-slot="compaction-card-title">Session Compacted</span>
+              <Show when={p().pendingDagCount != null && p().pendingDagCount > 0}>
+                <span data-slot="compaction-card-badge">{p().pendingDagCount} pending</span>
+              </Show>
+            </div>
+            <div data-slot="compaction-card-header-right">
+              <span data-slot="compaction-card-time">{timestamp()}</span>
+              <div data-slot="compaction-card-arrow">
+                <Icon name={expandIcon()} size="small" />
+              </div>
+            </div>
+          </button>
+
+          <Show when={expanded()}>
+            <div data-slot="compaction-card-content">
+              <Show when={p().mechanical}>
+                <div data-slot="compaction-card-warning">
+                  <Icon name="alert-triangle" size="small" />
+                  <span data-slot="compaction-card-warning-text">
+                    This summary was mechanically generated due to context limits. Some detail may be missing.
+                  </span>
+                </div>
+              </Show>
+
+              <div data-slot="compaction-card-summary">
+                <Markdown text={p().summary} />
+              </div>
+
+              <For each={p().sections}>
+                {(section) => (
+                  <div data-slot="compaction-card-section">
+                    <h4 data-slot="compaction-card-section-heading">{section.heading}</h4>
+                    <For each={section.items}>
+                      {(item) => (
+                        <div data-slot="compaction-card-section-item">
+                          <span data-slot="compaction-card-bullet">•</span>
+                          <div data-slot="compaction-card-section-item-text">
+                            <Markdown text={item} />
+                          </div>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                )}
+              </For>
+
+              <Show when={p().nextStep}>
+                <div data-slot="compaction-card-next-step">
+                  <Icon name={getSemanticIcon("action.info")} size="small" />
+                  <div data-slot="compaction-card-next-step-content">
+                    <span data-slot="compaction-card-next-step-label">Next step</span>
+                    <span data-slot="compaction-card-next-step-text">{p().nextStep}</span>
+                  </div>
+                </div>
+              </Show>
+            </div>
+          </Show>
+        </div>
+      )}
+    </Show>
+  )
+}
+
+export { CompactionCard }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -51,6 +51,7 @@ import { getApprovalAudit } from "../utils/approval-audit"
 import { getSemanticIcon } from "./semantic-icon"
 import { isToolCardHidden } from "./tool-result-presentation"
 import { shouldCollapseUserMessage, visibleUserMessageText } from "./user-message-utils"
+import { CompactionCard } from "./compaction-card"
 
 export type UserMessageVariant = "default" | "turn-bubble"
 
@@ -1975,3 +1976,5 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
     </Show>
   )
 }
+
+PART_MAPPING["compaction_recovery"] = CompactionCard

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -99,6 +99,7 @@ export function timelineKindForPart(part: PartType, working: boolean): SessionTu
   if (part.type === "text") return part.text.trim() ? "part" : undefined
   if (part.type === "attachment") return resolveAttachmentPresentation(part).hidden ? undefined : "part"
   if (part.type === "reasoning") return working && part.text.trim() ? "reasoning" : undefined
+  if (part.type === "compaction_recovery") return "part"
   if (part.type !== "tool") return undefined
   if (isActiveMediaGenerationToolPart(part)) return "media-pending"
   if (isToolCardHidden(part)) {
@@ -128,9 +129,14 @@ export function collectSessionTurnTimelineItems(
 
   for (const message of messages) {
     const parts = partsByMessage[message.id] ?? []
+    const hasCompactionRecovery = parts.some((p) => p.type === "compaction_recovery")
     for (const part of parts) {
       const kind = timelineKindForPart(part, working)
       if (!kind) continue
+
+      // When a compaction recovery card is present, suppress raw text parts
+      // so only the structured card renders — no duplicate markdown output.
+      if (hasCompactionRecovery && part.type === "text") continue
 
       if (kind === "media-pending") {
         items.push({ kind, message, part: part as ToolPart })


### PR DESCRIPTION
## Summary
- 新增 `CompactionRecoveryPart` 结构化消息部分类型，替代当前原始的 markdown 压缩输出
- 前端新增 `CompactionCard` 组件——默认折叠，展开后按结构化 sections 渲染
- 压缩 prompt 新增 "What NOT to Include" 节——排除 diff 摘要、`.tmp-*` 文件和原始工具输出
- `collectSessionTurnTimelineItems` 中：当存在 `compaction_recovery` part 时，抑制原始 text parts 以避免重复输出
- `buildMechanicalSummary` 过滤 `.tmp-*` 和 `._*` 文件

## Files Changed
| File | Change |
|---|---|
| `packages/synergy/src/session/message-v2.ts` | +`CompactionRecoveryPart` schema |
| `packages/synergy/src/session/compaction.ts` | +`parseCompactionSections()`, emit structured part, filter `.tmp-*` |
| `packages/synergy/src/agent/prompt/compaction/base.txt` | +排除规则 |
| `packages/ui/src/components/compaction-card.tsx` | **New** — 折叠卡片组件 |
| `packages/ui/src/components/compaction-card.css` | **New** — 样式 |
| `packages/ui/src/components/message-part.tsx` | PART_MAPPING 注册 |
| `packages/ui/src/components/session-turn.tsx` | timeline + text 抑制 |
| `packages/synergy/test/session/compaction.test.ts` | +7 个 parseCompactionSections 测试 |
| `packages/sdk/js/src/gen/types.gen.ts` + OpenAPI | 自动生成 |

## Test
- 7 个 `parseCompactionSections` 单元测试全部通过
- 项目 typecheck 无新增错误
- 格式化全部通过