### PR TITLE
fix(cortex): suppress spurious parent notification when session is mid-turn

### DIFF
--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -435,7 +435,11 @@ export namespace Cortex {
       taskWaiters.delete(taskID)
       log.info("task result delivered to waiters, skipping mail", { taskID, waiterCount: waiters.size })
     } else if (task.notifyParentOnComplete !== false) {
-      notifyParentSession(task)
+      if (SessionManager.isRunning(task.parentSessionID)) {
+        log.info("skipping parent notification: session is mid-turn", { taskID: task.id })
+      } else {
+        notifyParentSession(task)
+      }
     } else {
       log.info("task parent notification suppressed", { taskID })
     }


### PR DESCRIPTION
## Summary
- Fixes #244: background subagent completion notification in inbox re-triggers primary agent after `task_output(block:true)` already consumed the result
- Root cause: race between `notifyParentSession` and `task_output` waiter registration — when subagent completes before waiter is registered, the `agent_update` mail persists in inbox and triggers an extra session turn after the turn ends
- Fix: check `SessionManager.isRunning()` in `updateTaskStatus` before calling `notifyParentSession`. When the parent session is mid-turn, it will query the task result itself via `task_output` — skip the inbox notification to prevent redundant wakeup

## Test
- Format check: passed
- Unit tests: blocked by missing SDK dependency (`@ericsanchezok/synergy-util/model-limit`) — pre-existing environment issue, not related to this change

## Risk
- Minimal: `isRunning` is synchronous and cheap (checks `runtime.abort`), used elsewhere in cortex (e.g. `launch()` line 108)
- Only suppresses notifications when parent is actively processing; idle sessions still receive notifications as before