### PR TITLE
perf: stale-while-revalidate registry cache with 1h TTL

### DIFF
--- a/packages/plugin/src/market.ts
+++ b/packages/plugin/src/market.ts
@@ -76,7 +76,7 @@ export const DEFAULT_PLUGIN_MARKETPLACE_CONFIG = {
   enabled: true,
   registryUrl: OFFICIAL_PLUGIN_REGISTRY_URL,
   includeLocalRegistry: true,
-  cacheTtlMs: 300_000,
+  cacheTtlMs: 3_600_000,
   offlineCache: true,
   requestTimeoutMs: 10_000,
   artifactDownloadTimeoutMs: 60_000,

--- a/packages/synergy/src/plugin/marketplace-registry.ts
+++ b/packages/synergy/src/plugin/marketplace-registry.ts
@@ -404,13 +404,37 @@ export namespace PluginMarketplaceRegistry {
     return new URL(entry, registryUrl).href
   }
 
+  const pendingRefreshes = new Map<string, Promise<z.infer<typeof RemoteRegistry>>>()
+
+  async function backgroundRefreshRegistry(config: Awaited<ReturnType<typeof currentConfig>>) {
+    const cachedPath = registryCachePath(config.registryUrl)
+    const key = cachedPath
+    const existing = pendingRefreshes.get(key)
+    if (existing) return existing
+    const promise = (async () => {
+      try {
+        const registry = await fetchJson(config.registryUrl, RemoteRegistry, config.requestTimeoutMs)
+        await writeJsonFile(cachedPath, registry)
+        return registry
+      } catch {
+        return null as unknown as z.infer<typeof RemoteRegistry>
+      } finally {
+        pendingRefreshes.delete(key)
+      }
+    })()
+    pendingRefreshes.set(key, promise)
+    return promise
+  }
+
   async function remoteRegistry(inputConfig?: Awaited<ReturnType<typeof currentConfig>>) {
     const config = inputConfig ?? (await currentConfig())
     if (!config.enabled) return { schemaVersion: 1 as const, updatedAt: new Date(0).toISOString(), plugins: [] }
     const cachedPath = registryCachePath(config.registryUrl)
-    if (await isFresh(cachedPath, config.cacheTtlMs)) {
-      const cached = await readJsonFile(cachedPath, RemoteRegistry)
-      if (cached) return cached
+    const cached = await readJsonFile(cachedPath, RemoteRegistry)
+    if (cached) {
+      if (await isFresh(cachedPath, config.cacheTtlMs)) return cached
+      backgroundRefreshRegistry(config)
+      return cached
     }
 
     try {
@@ -419,11 +443,19 @@ export namespace PluginMarketplaceRegistry {
       return registry
     } catch (err) {
       if (config.offlineCache) {
-        const cached = await readJsonFile(cachedPath, RemoteRegistry)
-        if (cached) return cached
+        const stale = await readJsonFile(cachedPath, RemoteRegistry)
+        if (stale) return stale
       }
       throw err
     }
+  }
+
+  export async function prefetchRegistry() {
+    const config = await currentConfig()
+    if (!config.enabled) return
+    const cachedPath = registryCachePath(config.registryUrl)
+    if (await isFresh(cachedPath, config.cacheTtlMs)) return
+    await backgroundRefreshRegistry(config)
   }
 
   export async function searchOfficial(input: { q?: string; offset?: number; limit?: number } = {}) {

--- a/packages/synergy/src/server/global-runtime.ts
+++ b/packages/synergy/src/server/global-runtime.ts
@@ -4,6 +4,7 @@ import { registerProviders } from "@/channel/provider"
 import { Channel } from "@/channel"
 import { Config } from "@/config/config"
 import { HolosRuntime } from "@/holos/runtime"
+import { PluginMarketplaceRegistry } from "@/plugin/marketplace-registry"
 import { MCP } from "@/mcp"
 import { Plugin } from "@/plugin"
 import { FileWatcher } from "@/file/watcher"
@@ -26,6 +27,7 @@ export namespace GlobalRuntime {
           await HolosRuntime.init()
           FileWatcher.init()
           MCP.ensureStarted()
+          PluginMarketplaceRegistry.prefetchRegistry()
           await Agenda.start()
           await AgendaBootstrap.seed()
           log.info("started")


### PR DESCRIPTION
## Summary
- Fixes #229: Marketplace search/detail routes are slow (~10s) due to blocking GitHub raw CDN registry fetch on every cache expiry
- Implements stale-while-revalidate pattern: return stale cache immediately while background-refreshing
- Increases `cacheTtlMs` from 5min to 1h to reduce cold fetches
- Adds `prefetchRegistry()` called at server startup so the registry is warm before the user opens the Marketplace

## What changed
| File | Change |
|---|---|
| `packages/plugin/src/market.ts` | `cacheTtlMs: 300_000` → `3_600_000` |
| `packages/synergy/src/plugin/marketplace-registry.ts` | Rewrite `remoteRegistry()` with SWR + deduped background refresh; export `prefetchRegistry()` |
| `packages/synergy/src/server/global-runtime.ts` | Call `prefetchRegistry()` during server startup |

## Verification
- Typecheck passes (10/10 packages)
- Format check passes
- `bun test test/plugin/marketplace-registry.test.ts` — 1/1 pass
- `bun test test/server/plugin-registry-routes.test.ts` — 12/12 pass