### PR TITLE
Archive notes before deletion

### DIFF
--- a/packages/app/src/components/dialog/confirm-copy.ts
+++ b/packages/app/src/components/dialog/confirm-copy.ts
@@ -69,6 +69,45 @@ export function deleteNoteConfirm(title: string | undefined): ConfirmCopy {
   }
 }
 
+export function archiveNoteConfirm(count: number): ConfirmCopy {
+  return {
+    title: count === 1 ? "Archive note?" : `Archive ${count} notes?`,
+    description:
+      count === 1
+        ? "This note will be hidden from the active list. You can restore it from the Archived view."
+        : `These ${count} notes will be hidden from the active list. You can restore them from the Archived view.`,
+    confirmLabel: count === 1 ? "Archive" : `Archive ${count}`,
+    cancelLabel: "Cancel",
+    tone: "warning",
+  }
+}
+
+export function unarchiveNoteConfirm(count: number): ConfirmCopy {
+  return {
+    title: count === 1 ? "Restore note?" : `Restore ${count} notes?`,
+    description:
+      count === 1
+        ? "This note will be moved back to the active list."
+        : `These ${count} notes will be moved back to the active list.`,
+    confirmLabel: count === 1 ? "Restore" : `Restore ${count}`,
+    cancelLabel: "Cancel",
+    tone: "neutral",
+  }
+}
+
+export function deleteArchivedNoteConfirm(count: number): ConfirmCopy {
+  return {
+    title: count === 1 ? "Delete archived note?" : `Delete ${count} archived notes?`,
+    description:
+      count === 1
+        ? "This note will be removed permanently. This cannot be undone."
+        : `These ${count} notes will be removed permanently. This cannot be undone.`,
+    confirmLabel: count === 1 ? "Delete" : `Delete ${count}`,
+    cancelLabel: "Cancel",
+    tone: "danger",
+  }
+}
+
 export function overwriteImportConfirm(conflictCount: number): ConfirmCopy {
   return {
     title: `Overwrite ${conflictCount} conflicting ${plural(conflictCount, "key")}?`,

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -164,7 +164,7 @@ function NoteCard(props: {
   onClick: () => void
   selecting?: boolean
   selected?: boolean
-  onToggleSelect?: (id: string) => void
+  onToggleSelect?: (id: string, shiftKey?: boolean) => void
 }) {
   const previewHtml = createMemo(() => props.note.previewHtml ?? null)
   const searchPreview = createMemo(() => props.note.searchText ?? "")
@@ -190,9 +190,9 @@ function NoteCard(props: {
       onDragStart={(e) => {
         if (!props.selecting) attachNoteDragData(e, props.note)
       }}
-      onClick={() => {
+      onClick={(e) => {
         if (props.selecting && props.onToggleSelect) {
-          props.onToggleSelect(props.note.id)
+          props.onToggleSelect(props.note.id, e.shiftKey)
         } else {
           props.onClick()
         }
@@ -597,7 +597,7 @@ function ScopeSection(props: {
   scopeLookup: Map<string, { name: string; directory: string }>
   selecting?: boolean
   selectedNotes?: Set<string>
-  onToggleSelect?: (id: string) => void
+  onToggleSelect?: (id: string, shiftKey?: boolean) => void
 }) {
   const [columns, setColumns] = createSignal(2)
   const latestUpdated = createMemo(() => props.group.notes[0]?.time.updated)
@@ -758,6 +758,7 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
   const [expandedState, setExpandedState] = createSignal<Record<string, boolean>>({})
   const [selecting, setSelecting] = createSignal(false)
   const [selectedNotes, setSelectedNotes] = createSignal<Set<string>>(new Set())
+  const [lastClickedID, setLastClickedID] = createSignal<string | null>(null)
   const [batchBusy, setBatchBusy] = createSignal(false)
   const [showArchived, setShowArchived] = createSignal(false)
 
@@ -976,7 +977,39 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
     })
   }
 
-  function toggleSelect(id: string) {
+  function getVisibleNoteIDs(): string[] {
+    const ids: string[] = []
+    for (const g of displayGroups()) {
+      for (const n of g.notes) ids.push(n.id)
+    }
+    return ids
+  }
+
+  function toggleSelect(id: string, shiftKey?: boolean) {
+    if (shiftKey) {
+      const last = lastClickedID()
+      if (last) {
+        const visible = getVisibleNoteIDs()
+        const lastIdx = visible.indexOf(last)
+        const currIdx = visible.indexOf(id)
+        if (lastIdx >= 0 && currIdx >= 0) {
+          const [start, end] = lastIdx <= currIdx ? [lastIdx, currIdx] : [currIdx, lastIdx]
+          const rangeIDs = visible.slice(start, end + 1)
+          setSelectedNotes((prev) => {
+            const next = new Set(prev)
+            const allAlready = rangeIDs.every((rid) => next.has(rid))
+            if (allAlready) {
+              for (const rid of rangeIDs) next.delete(rid)
+            } else {
+              for (const rid of rangeIDs) next.add(rid)
+            }
+            return next
+          })
+          return
+        }
+      }
+    }
+    setLastClickedID(id)
     setSelectedNotes((prev) => {
       const next = new Set(prev)
       if (next.has(id)) next.delete(id)
@@ -1023,28 +1056,10 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
     })
   }
 
-  async function batchDelete() {
-    const ids = [...selectedNotes()]
-    confirm.show({
-      ...deleteArchivedNoteConfirm(ids.length),
-      onConfirm: async () => {
-        setBatchBusy(true)
-        try {
-          await sdk.client.note.batch({ ids, action: "delete", directory: directory() })
-        } catch (e) {
-          console.error("Batch delete failed", e)
-        }
-        setSelectedNotes(new Set<string>())
-        setSelecting(false)
-        await refetch()
-        setBatchBusy(false)
-      },
-    })
-  }
-
   function cancelSelecting() {
     setSelecting(false)
     setSelectedNotes(new Set<string>())
+    setLastClickedID(null)
   }
 
   createEffect(() => {
@@ -1183,14 +1198,6 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
                       disabled={batchBusy()}
                     >
                       Restore ({selectedNotes().size})
-                    </button>
-                    <button
-                      type="button"
-                      class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all text-text-diff-delete-base ring-text-diff-delete-base/15 hover:bg-text-diff-delete-base/8"
-                      onClick={batchDelete}
-                      disabled={batchBusy()}
-                    >
-                      Delete ({selectedNotes().size})
                     </button>
                   </Show>
                 </Show>
@@ -1854,6 +1861,13 @@ function NoteEditor(props: { id: string; directory: string; onBack: () => void; 
   async function archiveNote() {
     const dir = directory()
     if (!dir) return
+    if (dirty()) {
+      setConflict({
+        type: "metadata-blocked",
+        message: "Save or reload your draft before archiving this note.",
+      })
+      return
+    }
     confirm.show({
       ...archiveNoteConfirm(1),
       onConfirm: async () => {
@@ -1866,6 +1880,13 @@ function NoteEditor(props: { id: string; directory: string; onBack: () => void; 
   async function restoreNote() {
     const dir = directory()
     if (!dir) return
+    if (dirty()) {
+      setConflict({
+        type: "metadata-blocked",
+        message: "Save or reload your draft before restoring this note.",
+      })
+      return
+    }
     await sdk.client.note.batch({ ids: [props.id], action: "unarchive", directory: dir })
     void refetch()
   }

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -1089,6 +1089,25 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
     setLastClickedID(null)
   }
 
+  async function batchDelete() {
+    const ids = [...selectedNotes()]
+    confirm.show({
+      ...deleteArchivedNoteConfirm(ids.length),
+      onConfirm: async () => {
+        setBatchBusy(true)
+        try {
+          await sdk.client.note.batch({ ids, action: "delete", directory: directory() })
+        } catch (e) {
+          console.error("Batch delete failed", e)
+        }
+        setSelectedNotes(new Set<string>())
+        setSelecting(false)
+        await refetch()
+        setBatchBusy(false)
+      },
+    })
+  }
+
   createEffect(() => {
     if (!selecting()) return
     function onKey(e: KeyboardEvent) {
@@ -1218,14 +1237,24 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
                       </button>
                     }
                   >
-                    <button
-                      type="button"
-                      class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all hover:bg-surface-raised-base-hover text-text-base ring-border-base/35"
-                      onClick={batchUnarchive}
-                      disabled={batchBusy()}
-                    >
-                      Restore ({selectedNotes().size})
-                    </button>
+                    <>
+                      <button
+                        type="button"
+                        class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all hover:bg-surface-raised-base-hover text-text-base ring-border-base/35"
+                        onClick={batchUnarchive}
+                        disabled={batchBusy()}
+                      >
+                        Restore ({selectedNotes().size})
+                      </button>
+                      <button
+                        type="button"
+                        class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all text-text-diff-delete-base ring-text-diff-delete-base/15 hover:bg-text-diff-delete-base/8"
+                        onClick={batchDelete}
+                        disabled={batchBusy()}
+                      >
+                        Delete ({selectedNotes().size})
+                      </button>
+                    </>
                   </Show>
                 </Show>
                 <button

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -782,10 +782,37 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
   })
 
   const [rawGroups, { refetch }] = createResource(
-    () => ({ dir: directory(), ver: globalSync.noteVersion() }),
-    async ({ dir }) => {
+    () => ({ dir: directory(), ver: globalSync.noteVersion(), showArchived: showArchived() }),
+    async ({ dir, showArchived }) => {
       if (!dir) return []
-      const result = await sdk.client.note.listMeta({ directory: dir })
+      if (showArchived) {
+        const [active, archived] = await Promise.all([
+          sdk.client.note.listMeta({ directory: dir, archived: "false" }),
+          sdk.client.note.listMeta({ directory: dir, archived: "true" }),
+        ])
+        const activeGroups = (active.data ?? []) as NoteMetaScopeGroup[]
+        const archivedGroups = (archived.data ?? []) as NoteMetaScopeGroup[]
+        const merged: NoteMetaScopeGroup[] = []
+        const byScope = new Map<string, NoteMetaScopeGroup>()
+        for (const g of activeGroups) {
+          const existing = byScope.get(g.scopeID)
+          if (existing) existing.notes.push(...g.notes)
+          else {
+            byScope.set(g.scopeID, { ...g, notes: [...g.notes] })
+            merged.push(byScope.get(g.scopeID)!)
+          }
+        }
+        for (const g of archivedGroups) {
+          const existing = byScope.get(g.scopeID)
+          if (existing) existing.notes.push(...g.notes)
+          else {
+            byScope.set(g.scopeID, { ...g, notes: [...g.notes] })
+            merged.push(byScope.get(g.scopeID)!)
+          }
+        }
+        return merged
+      }
+      const result = await sdk.client.note.listMeta({ directory: dir, archived: "false" })
       return (result.data ?? []) as NoteMetaScopeGroup[]
     },
   )

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -17,7 +17,8 @@ import { useGlobalSync } from "@/context/global-sync"
 import { useSync } from "@/context/sync"
 import { TIPTAP_STYLES, DocumentEditorCore } from "@/components/note/document-editor-core"
 import { useConfirm } from "@/components/dialog/confirm-dialog"
-import { deleteNoteConfirm } from "@/components/dialog/confirm-copy"
+import { archiveNoteConfirm, unarchiveNoteConfirm, deleteArchivedNoteConfirm } from "@/components/dialog/confirm-copy"
+import { SelectionCheckbox } from "@/components/library/shared"
 import type { BlueprintLoopInfo, NoteInfo, NoteMetaInfo, NoteMetaScopeGroup } from "@ericsanchezok/synergy-sdk/client"
 import { getScopeLabel, HOME_SCOPE_KEY } from "@/utils/scope"
 import { assetHttpUrl } from "@/utils/asset-url"
@@ -161,6 +162,9 @@ function NoteCard(props: {
   variant?: NoteCardVariant
   loops?: BlueprintLoopInfo[]
   onClick: () => void
+  selecting?: boolean
+  selected?: boolean
+  onToggleSelect?: (id: string) => void
 }) {
   const previewHtml = createMemo(() => props.note.previewHtml ?? null)
   const searchPreview = createMemo(() => props.note.searchText ?? "")
@@ -182,10 +186,23 @@ function NoteCard(props: {
         "note-card--blueprint": isBlueprint(),
         [`note-card--blueprint-${blueprintState().tone}`]: isBlueprint(),
       }}
-      draggable={true}
-      onDragStart={(e) => attachNoteDragData(e, props.note)}
-      onClick={props.onClick}
+      draggable={!props.selecting}
+      onDragStart={(e) => {
+        if (!props.selecting) attachNoteDragData(e, props.note)
+      }}
+      onClick={() => {
+        if (props.selecting && props.onToggleSelect) {
+          props.onToggleSelect(props.note.id)
+        } else {
+          props.onClick()
+        }
+      }}
     >
+      <Show when={props.selecting && props.onToggleSelect}>
+        <div class="absolute right-2 top-2 z-10" onClick={(e) => e.stopPropagation()}>
+          <SelectionCheckbox selected={props.selected ?? false} />
+        </div>
+      </Show>
       <Show when={props.originName}>
         <span class="sr-only">From {props.originName}</span>
       </Show>
@@ -578,13 +595,20 @@ function ScopeSection(props: {
   onOpenNote: (id: string) => void
   onCreateNote: () => void
   scopeLookup: Map<string, { name: string; directory: string }>
+  selecting?: boolean
+  selectedNotes?: Set<string>
+  onToggleSelect?: (id: string) => void
 }) {
   const [columns, setColumns] = createSignal(2)
   const latestUpdated = createMemo(() => props.group.notes[0]?.time.updated)
   const noteCountLabel = createMemo(
     () => `${props.group.notes.length} ${props.group.notes.length === 1 ? "note" : "notes"}`,
   )
-  const shelfNotes = createMemo(() => props.group.notes.slice(0, columns()))
+  const shelfNotes = createMemo(() => {
+    void props.selecting
+    void props.selectedNotes?.size
+    return props.group.notes.slice(0, columns())
+  })
   const hasMore = createMemo(() => props.group.notes.length > columns())
 
   let sectionRef!: HTMLElement
@@ -675,6 +699,9 @@ function ScopeSection(props: {
                     loops={props.loopsByNote.get(note.id) ?? []}
                     variant="compact"
                     onClick={() => props.onOpenNote(note.id)}
+                    selecting={props.selecting}
+                    selected={props.selectedNotes?.has(note.id) ?? false}
+                    onToggleSelect={props.onToggleSelect}
                   />
                 )}
               </For>
@@ -704,6 +731,9 @@ function ScopeSection(props: {
                   loops={props.loopsByNote.get(note.id) ?? []}
                   variant={note.pinned ? "featured" : "balanced"}
                   onClick={() => props.onOpenNote(note.id)}
+                  selecting={props.selecting}
+                  selected={props.selectedNotes?.has(note.id) ?? false}
+                  onToggleSelect={props.onToggleSelect}
                 />
               )}
             </For>
@@ -726,6 +756,10 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
   const [search, setSearch] = createSignal("")
   const [kindFilter, setKindFilter] = createSignal<NoteKindFilter>("all")
   const [expandedState, setExpandedState] = createSignal<Record<string, boolean>>({})
+  const [selecting, setSelecting] = createSignal(false)
+  const [selectedNotes, setSelectedNotes] = createSignal<Set<string>>(new Set())
+  const [batchBusy, setBatchBusy] = createSignal(false)
+  const [showArchived, setShowArchived] = createSignal(false)
 
   const currentScopeID = createMemo(() => {
     const dir = directory()
@@ -796,18 +830,21 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
   })
 
   const displayGroups = createMemo(() => {
+    void selecting()
+    void selectedNotes().size
     const groups = rawGroups() ?? []
     const lookup = scopeLookup()
     const curID = currentScopeID()
     const q = search().toLowerCase().trim()
     const activeKind = kindFilter()
-    const archivedNotes: NoteCardInfo[] = []
+    const showArch = showArchived()
+    const archived: NoteCardInfo[] = []
 
     const mapped = groups
       .map((g): DisplayGroup | undefined => {
         const meta = lookup.get(g.scopeID)
         const isCurrent = g.scopeID === curID
-        const archived = g.scopeType === "project" && !meta && !isCurrent
+        const deregistered = g.scopeType === "project" && !meta && !isCurrent
         const groupDirectory = meta?.directory ?? (g.scopeID === "home" ? "home" : isCurrent ? (directory() ?? "") : "")
         let notes: NoteCardInfo[] = [...g.notes]
         if (q) {
@@ -824,13 +861,27 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
           if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
           return b.time.updated - a.time.updated
         })
-        if (archived) {
-          archivedNotes.push(...notes)
+        if (deregistered) {
+          archived.push(...notes)
           return undefined
         }
+        const archivedMember = notes.filter((n) => n.archived)
+        const activeMember = notes.filter((n) => !n.archived)
+        if (!showArch) {
+          sortNotes(activeMember)
+          return {
+            ...g,
+            notes: activeMember,
+            name: meta?.name ?? (g.scopeID === "home" ? getScopeLabel(undefined, "home") : "Archived project"),
+            directory: groupDirectory,
+            isCurrent,
+          }
+        }
+        archived.push(...archivedMember)
+        sortNotes(activeMember)
         return {
           ...g,
-          notes,
+          notes: activeMember,
           name: meta?.name ?? (g.scopeID === "home" ? getScopeLabel(undefined, "home") : "Archived project"),
           directory: groupDirectory,
           isCurrent,
@@ -838,16 +889,13 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
       })
       .filter((g): g is DisplayGroup => g !== undefined)
 
-    if (archivedNotes.length > 0) {
-      archivedNotes.sort((a, b) => {
-        if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
-        return b.time.updated - a.time.updated
-      })
+    if (showArch && archived.length > 0) {
+      sortNotes(archived)
       mapped.push({
-        scopeID: "__archived_projects__",
+        scopeID: "__archived__",
         scopeType: "project",
-        notes: archivedNotes,
-        name: "Archived projects",
+        notes: archived,
+        name: "Archived",
         directory: directory() ?? "home",
         isCurrent: false,
         archived: true,
@@ -919,6 +967,94 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
     }
   }
 
+  const confirm = useConfirm()
+
+  function sortNotes(list: NoteCardInfo[]) {
+    list.sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+      return b.time.updated - a.time.updated
+    })
+  }
+
+  function toggleSelect(id: string) {
+    setSelectedNotes((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  async function batchArchive() {
+    const ids = [...selectedNotes()]
+    confirm.show({
+      ...archiveNoteConfirm(ids.length),
+      onConfirm: async () => {
+        setBatchBusy(true)
+        try {
+          await sdk.client.note.batch({ ids, action: "archive", directory: directory() })
+        } catch (e) {
+          console.error("Batch archive failed", e)
+        }
+        setSelectedNotes(new Set<string>())
+        setSelecting(false)
+        await refetch()
+        setBatchBusy(false)
+      },
+    })
+  }
+
+  async function batchUnarchive() {
+    const ids = [...selectedNotes()]
+    confirm.show({
+      ...unarchiveNoteConfirm(ids.length),
+      onConfirm: async () => {
+        setBatchBusy(true)
+        try {
+          await sdk.client.note.batch({ ids, action: "unarchive", directory: directory() })
+        } catch (e) {
+          console.error("Batch unarchive failed", e)
+        }
+        setSelectedNotes(new Set<string>())
+        setSelecting(false)
+        await refetch()
+        setBatchBusy(false)
+      },
+    })
+  }
+
+  async function batchDelete() {
+    const ids = [...selectedNotes()]
+    confirm.show({
+      ...deleteArchivedNoteConfirm(ids.length),
+      onConfirm: async () => {
+        setBatchBusy(true)
+        try {
+          await sdk.client.note.batch({ ids, action: "delete", directory: directory() })
+        } catch (e) {
+          console.error("Batch delete failed", e)
+        }
+        setSelectedNotes(new Set<string>())
+        setSelecting(false)
+        await refetch()
+        setBatchBusy(false)
+      },
+    })
+  }
+
+  function cancelSelecting() {
+    setSelecting(false)
+    setSelectedNotes(new Set<string>())
+  }
+
+  createEffect(() => {
+    if (!selecting()) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") cancelSelecting()
+    }
+    window.addEventListener("keydown", onKey)
+    onCleanup(() => window.removeEventListener("keydown", onKey))
+  })
   return (
     <div class="flex flex-col h-full bg-background-base relative">
       <style>{TIPTAP_STYLES}</style>
@@ -970,6 +1106,28 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
               </span>
               <button
                 type="button"
+                classList={{
+                  "flex items-center justify-center size-7 rounded-lg transition-colors": true,
+                  "text-icon-base bg-surface-raised-stronger-non-alpha": showArchived(),
+                  "text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover": !showArchived(),
+                }}
+                onClick={() => setShowArchived((v) => !v)}
+                title={showArchived() ? "Show active" : "Show archived"}
+              >
+                <Icon name="archive" size="small" />
+              </button>
+              <Show when={!selecting()}>
+                <button
+                  type="button"
+                  class="flex items-center justify-center size-7 rounded-lg text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover transition-colors"
+                  onClick={() => setSelecting(true)}
+                  title="Select notes"
+                >
+                  <Icon name="square-check" size="small" />
+                </button>
+              </Show>
+              <button
+                type="button"
                 class="flex items-center justify-center size-7 rounded-lg text-icon-weak hover:text-icon-base hover:bg-surface-raised-base-hover transition-colors"
                 onClick={() => refetch()}
                 title="Refresh"
@@ -978,6 +1136,74 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
               </button>
             </div>
           </div>
+
+          <Show when={selecting()}>
+            <div class="flex items-center justify-between gap-3 px-3 py-2.5 library-inner-surface">
+              <div class="flex min-w-0 items-center gap-2">
+                <span class="text-12-medium text-text-base">
+                  {selectedNotes().size} / {visibleNotes()} selected
+                </span>
+                <Show when={selectedNotes().size < visibleNotes()}>
+                  <button
+                    type="button"
+                    class="rounded-full px-2.5 py-1 text-11-medium text-text-base ring-1 ring-inset ring-border-base/35 transition-colors hover:bg-surface-raised-base-hover"
+                    onClick={() => {
+                      const all = new Set<string>()
+                      for (const g of displayGroups()) {
+                        for (const n of g.notes) all.add(n.id)
+                      }
+                      setSelectedNotes(all)
+                    }}
+                  >
+                    Select all
+                  </button>
+                </Show>
+              </div>
+              <div class="flex items-center gap-1.5">
+                <Show when={selectedNotes().size > 0}>
+                  <Show
+                    when={displayGroups().some((g) => g.archived)}
+                    fallback={
+                      <button
+                        type="button"
+                        class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all text-text-diff-delete-base ring-text-diff-delete-base/15 hover:bg-text-diff-delete-base/8"
+                        onClick={batchArchive}
+                        disabled={batchBusy()}
+                      >
+                        <Show when={!batchBusy()} fallback={<Spinner class="size-3" />}>
+                          Archive ({selectedNotes().size})
+                        </Show>
+                      </button>
+                    }
+                  >
+                    <button
+                      type="button"
+                      class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all hover:bg-surface-raised-base-hover text-text-base ring-border-base/35"
+                      onClick={batchUnarchive}
+                      disabled={batchBusy()}
+                    >
+                      Restore ({selectedNotes().size})
+                    </button>
+                    <button
+                      type="button"
+                      class="flex items-center gap-1 rounded-full px-3 py-1.5 text-11-medium ring-1 ring-inset transition-all text-text-diff-delete-base ring-text-diff-delete-base/15 hover:bg-text-diff-delete-base/8"
+                      onClick={batchDelete}
+                      disabled={batchBusy()}
+                    >
+                      Delete ({selectedNotes().size})
+                    </button>
+                  </Show>
+                </Show>
+                <button
+                  type="button"
+                  class="rounded-full px-3 py-1.5 text-11-medium text-text-weak ring-1 ring-inset ring-border-base/45 transition-all hover:bg-surface-raised-base-hover hover:text-text-base"
+                  onClick={cancelSelecting}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </Show>
 
           <div class="flex-1 min-h-0 overflow-y-auto px-4 pb-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             <Show when={rawGroups.loading}>
@@ -1011,6 +1237,9 @@ export function NotePanel(props: { tab?: WorkbenchPanelTab } = {}) {
                         onOpenNote={(id) => openNote(id, group.directory)}
                         onCreateNote={() => createNoteInScope(group.directory)}
                         scopeLookup={scopeLookup()}
+                        selecting={selecting()}
+                        selectedNotes={selectedNotes()}
+                        onToggleSelect={toggleSelect}
                       />
                     )}
                   </For>
@@ -1620,13 +1849,34 @@ function NoteEditor(props: { id: string; directory: string; onBack: () => void; 
     }
   }
 
-  async function deleteNote() {
+  const isArchived = createMemo(() => baseNote()?.archived ?? false)
+
+  async function archiveNote() {
     const dir = directory()
     if (!dir) return
     confirm.show({
-      ...deleteNoteConfirm(baseNote()?.title),
+      ...archiveNoteConfirm(1),
       onConfirm: async () => {
-        await sdk.client.note.remove({ id: props.id, directory: dir })
+        await sdk.client.note.batch({ ids: [props.id], action: "archive", directory: dir })
+        props.onBack()
+      },
+    })
+  }
+
+  async function restoreNote() {
+    const dir = directory()
+    if (!dir) return
+    await sdk.client.note.batch({ ids: [props.id], action: "unarchive", directory: dir })
+    void refetch()
+  }
+
+  async function deleteArchivedNote() {
+    const dir = directory()
+    if (!dir) return
+    confirm.show({
+      ...deleteArchivedNoteConfirm(1),
+      onConfirm: async () => {
+        await sdk.client.note.batch({ ids: [props.id], action: "delete", directory: dir })
         props.onDelete()
       },
     })
@@ -1738,15 +1988,39 @@ function NoteEditor(props: { id: string; directory: string; onBack: () => void; 
                 <span>{isBlueprint() ? "To Note" : "To Blueprint"}</span>
               </button>
 
-              <button
-                type="button"
-                class="note-detail-icon-button note-detail-icon-button--danger"
-                onClick={deleteNote}
-                title="Delete"
-                aria-label="Delete"
+              <Show
+                when={isArchived()}
+                fallback={
+                  <button
+                    type="button"
+                    class="note-detail-icon-button note-detail-icon-button--danger"
+                    onClick={archiveNote}
+                    title="Archive"
+                    aria-label="Archive"
+                  >
+                    <Icon name="archive" size="small" />
+                  </button>
+                }
               >
-                <Icon name={getSemanticIcon("action.remove")} size="small" />
-              </button>
+                <button
+                  type="button"
+                  class="note-detail-icon-button"
+                  onClick={restoreNote}
+                  title="Restore"
+                  aria-label="Restore"
+                >
+                  <Icon name="rotate-ccw" size="small" />
+                </button>
+                <button
+                  type="button"
+                  class="note-detail-icon-button note-detail-icon-button--danger"
+                  onClick={deleteArchivedNote}
+                  title="Delete permanently"
+                  aria-label="Delete permanently"
+                >
+                  <Icon name={getSemanticIcon("action.remove")} size="small" />
+                </button>
+              </Show>
             </div>
           </div>
         </div>

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -6941,12 +6941,13 @@ export class Note extends HeyApiClient {
   /**
    * List note metadata grouped by scope
    *
-   * List metadata for all notes across all scopes, grouped by scope ID. Does not include full note content.
+   * List metadata for all notes across all scopes, grouped by scope ID. Does not include full note content. Returns active notes by default; pass ?archived=true to show only archived notes.
    */
   public listMeta<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
       scopeID?: string
+      archived?: "true" | "false"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6957,6 +6958,7 @@ export class Note extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "scopeID" },
+            { in: "query", key: "archived" },
           ],
         },
       ],
@@ -6971,12 +6973,13 @@ export class Note extends HeyApiClient {
   /**
    * List all notes grouped by scope
    *
-   * List all notes across all scopes, grouped by scope ID.
+   * List all notes across all scopes, grouped by scope ID. Returns active notes by default; pass ?archived=true to show only archived notes.
    */
   public listAll<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
       scopeID?: string
+      archived?: "true" | "false"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6987,6 +6990,7 @@ export class Note extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "scopeID" },
+            { in: "query", key: "archived" },
           ],
         },
       ],
@@ -7035,12 +7039,13 @@ export class Note extends HeyApiClient {
   /**
    * List notes
    *
-   * List all notes for the current scope, including global notes.
+   * List all notes for the current scope, including global notes. Returns active notes by default; pass ?archived=true to show only archived notes.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
       scopeID?: string
+      archived?: "true" | "false"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7051,6 +7056,7 @@ export class Note extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "scopeID" },
+            { in: "query", key: "archived" },
           ],
         },
       ],
@@ -7102,7 +7108,7 @@ export class Note extends HeyApiClient {
   /**
    * Delete note
    *
-   * Delete a note permanently.
+   * Permanently delete a note. Only archived notes can be deleted. Active notes must be archived first.
    */
   public remove<ThrowOnError extends boolean = false>(
     parameters: {

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -249,6 +249,8 @@ import type {
   McpTestResponses,
   MemoryCategory,
   MemoryRecallMode,
+  NoteBatchErrors,
+  NoteBatchResponses,
   NoteCreateErrors,
   NoteCreateInput,
   NoteCreateResponses,
@@ -7190,6 +7192,45 @@ export class Note extends HeyApiClient {
     )
     return (options?.client ?? this.client).put<NoteUpdateResponses, NoteUpdateErrors, ThrowOnError>({
       url: "/note/{id}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Batch archive or delete notes
+   *
+   * Archive or permanently delete notes in bulk. Notes must be archived before they can be deleted.
+   */
+  public batch<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      scopeID?: string
+      ids?: Array<string>
+      action?: "archive" | "unarchive" | "delete"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "scopeID" },
+            { in: "body", key: "ids" },
+            { in: "body", key: "action" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<NoteBatchResponses, NoteBatchErrors, ThrowOnError>({
+      url: "/note/batch",
       ...options,
       ...params,
       headers: {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3938,7 +3938,7 @@ export type NoteInfo = {
     runCount?: number
     lastRunAt?: number
   }
-  archived?: true
+  archived: boolean
   version: number
   time: {
     created: number
@@ -11107,6 +11107,10 @@ export type NoteListMetaData = {
   query?: {
     directory?: string
     scopeID?: string
+    /**
+     * Filter by archived state. Defaults to false (active notes only).
+     */
+    archived?: "true" | "false"
   }
   url: "/note/meta"
 }
@@ -11135,6 +11139,10 @@ export type NoteListAllData = {
   query?: {
     directory?: string
     scopeID?: string
+    /**
+     * Filter by archived state. Defaults to false (active notes only).
+     */
+    archived?: "true" | "false"
   }
   url: "/note/all"
 }
@@ -11202,6 +11210,10 @@ export type NoteListData = {
   query?: {
     directory?: string
     scopeID?: string
+    /**
+     * Filter by archived state. Defaults to false (active notes only).
+     */
+    archived?: "true" | "false"
   }
   url: "/note"
 }
@@ -11272,6 +11284,14 @@ export type NoteRemoveErrors = {
    * Bad request
    */
   400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Conflict
+   */
+  409: NoteConflictError
 }
 
 export type NoteRemoveError = NoteRemoveErrors[keyof NoteRemoveErrors]

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2107,6 +2107,10 @@ export type ChannelFeishuAccountConfig = {
    */
   inboundDebounceMs?: number
   /**
+   * Model to use for this account in providerID/modelID format (e.g. openai/gpt-4o)
+   */
+  model?: string
+  /**
    * Resolve sender display names via Feishu contact API
    */
   resolveSenderNames?: boolean
@@ -3214,6 +3218,13 @@ export type Session = {
     activatedTools?: Array<string>
   }
   completionNotice?: SessionCompletionNotice
+  /**
+   * Per-session model override set by /model command
+   */
+  modelOverride?: {
+    providerID: string
+    modelID: string
+  }
   pendingReply?: boolean
   interaction?: SessionInteraction
   agenda?: {
@@ -3927,6 +3938,7 @@ export type NoteInfo = {
     runCount?: number
     lastRunAt?: number
   }
+  archived?: true
   version: number
   time: {
     created: number
@@ -4663,6 +4675,7 @@ export type NoteMetaInfo = {
   pinned: boolean
   global: boolean
   originScope?: string
+  archived?: boolean
   tags: Array<string>
   kind?: "note" | "blueprint"
   version: number
@@ -4714,6 +4727,7 @@ export type NotePatchInput = {
   content?: unknown
   pinned?: boolean
   global?: boolean
+  archived?: boolean
   tags?: Array<string>
   kind?: "note" | "blueprint"
   blueprint?: {
@@ -5765,6 +5779,22 @@ export type EventNoteDeleted = {
   }
 }
 
+export type EventNoteArchived = {
+  type: "note.archived"
+  properties: {
+    ids: Array<string>
+    scopeID: string
+  }
+}
+
+export type EventNoteUnarchived = {
+  type: "note.unarchived"
+  properties: {
+    ids: Array<string>
+    scopeID: string
+  }
+}
+
 export type EventBlueprintLoopCreated = {
   type: "blueprint_loop.created"
   properties: {
@@ -6053,6 +6083,8 @@ export type Event =
   | EventNoteCreated
   | EventNoteUpdated
   | EventNoteDeleted
+  | EventNoteArchived
+  | EventNoteUnarchived
   | EventBlueprintLoopCreated
   | EventBlueprintLoopUpdated
   | EventBlueprintLoopCompleted
@@ -11330,6 +11362,46 @@ export type NoteUpdateResponses = {
 }
 
 export type NoteUpdateResponse = NoteUpdateResponses[keyof NoteUpdateResponses]
+
+export type NoteBatchData = {
+  body?: {
+    /**
+     * Note IDs to act on
+     */
+    ids: Array<string>
+    /**
+     * Action: archive, unarchive, or delete
+     */
+    action: "archive" | "unarchive" | "delete"
+  }
+  path?: never
+  query?: {
+    directory?: string
+    scopeID?: string
+  }
+  url: "/note/batch"
+}
+
+export type NoteBatchErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type NoteBatchError = NoteBatchErrors[keyof NoteBatchErrors]
+
+export type NoteBatchResponses = {
+  /**
+   * Batch operation result
+   */
+  200: {
+    archived?: Array<string>
+    deleted?: Array<string>
+  }
+}
+
+export type NoteBatchResponse = NoteBatchResponses[keyof NoteBatchResponses]
 
 export type BlueprintLoopListData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10832,10 +10832,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "default": "false",
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            "description": "Filter by archived state. Defaults to false (active notes only)."
           }
         ],
         "summary": "List note metadata grouped by scope",
-        "description": "List metadata for all notes across all scopes, grouped by scope ID. Does not include full note content.",
+        "description": "List metadata for all notes across all scopes, grouped by scope ID. Does not include full note content. Returns active notes by default; pass ?archived=true to show only archived notes.",
         "responses": {
           "200": {
             "description": "Note metadata grouped by scope",
@@ -10886,10 +10896,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "default": "false",
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            "description": "Filter by archived state. Defaults to false (active notes only)."
           }
         ],
         "summary": "List all notes grouped by scope",
-        "description": "List all notes across all scopes, grouped by scope ID.",
+        "description": "List all notes across all scopes, grouped by scope ID. Returns active notes by default; pass ?archived=true to show only archived notes.",
         "responses": {
           "200": {
             "description": "Notes grouped by scope",
@@ -11071,10 +11091,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "default": "false",
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            "description": "Filter by archived state. Defaults to false (active notes only)."
           }
         ],
         "summary": "List notes",
-        "description": "List all notes for the current scope, including global notes.",
+        "description": "List all notes for the current scope, including global notes. Returns active notes by default; pass ?archived=true to show only archived notes.",
         "responses": {
           "200": {
             "description": "List of notes",
@@ -11292,7 +11322,7 @@
           }
         ],
         "summary": "Delete note",
-        "description": "Delete a note permanently.",
+        "description": "Permanently delete a note. Only archived notes can be deleted. Active notes must be archived first.",
         "responses": {
           "200": {
             "description": "Deleted",
@@ -11310,6 +11340,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteConflictError"
                 }
               }
             }
@@ -20445,7 +20495,7 @@
           },
           "cacheTtlMs": {
             "description": "Remote marketplace cache TTL in milliseconds",
-            "default": 300000,
+            "default": 3600000,
             "type": "integer",
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991
@@ -26163,8 +26213,7 @@
             }
           },
           "archived": {
-            "type": "boolean",
-            "const": true
+            "type": "boolean"
           },
           "version": {
             "type": "number"
@@ -26182,7 +26231,7 @@
             "required": ["created", "updated"]
           }
         },
-        "required": ["id", "title", "content", "pinned", "global", "tags", "version", "time"]
+        "required": ["id", "title", "content", "pinned", "global", "tags", "archived", "version", "time"]
       },
       "NoteConflictError": {
         "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11323,6 +11323,97 @@
         ]
       }
     },
+    "/note/batch": {
+      "post": {
+        "operationId": "note.batch",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scopeID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Batch archive or delete notes",
+        "description": "Archive or permanently delete notes in bulk. Notes must be archived before they can be deleted.",
+        "responses": {
+          "200": {
+            "description": "Batch operation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "archived": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deleted": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "description": "Note IDs to act on",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "action": {
+                    "description": "Action: archive, unarchive, or delete",
+                    "type": "string",
+                    "enum": ["archive", "unarchive", "delete"]
+                  }
+                },
+                "required": ["ids", "action"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createSynergyClient } from \"@ericsanchezok/synergy-sdk\"\n\nconst client = createSynergyClient()\nawait client.note.batch({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/blueprint/loop": {
       "get": {
         "operationId": "blueprint.loop.list",
@@ -21616,6 +21707,10 @@
             "minimum": 0,
             "maximum": 9007199254740991
           },
+          "model": {
+            "description": "Model to use for this account in providerID/modelID format (e.g. openai/gpt-4o)",
+            "type": "string"
+          },
           "resolveSenderNames": {
             "description": "Resolve sender display names via Feishu contact API",
             "default": true,
@@ -24038,6 +24133,19 @@
           "completionNotice": {
             "$ref": "#/components/schemas/SessionCompletionNotice"
           },
+          "modelOverride": {
+            "description": "Per-session model override set by /model command",
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string"
+              },
+              "modelID": {
+                "type": "string"
+              }
+            },
+            "required": ["providerID", "modelID"]
+          },
           "pendingReply": {
             "type": "boolean"
           },
@@ -26053,6 +26161,10 @@
                 "type": "number"
               }
             }
+          },
+          "archived": {
+            "type": "boolean",
+            "const": true
           },
           "version": {
             "type": "number"
@@ -28329,6 +28441,9 @@
           "originScope": {
             "type": "string"
           },
+          "archived": {
+            "type": "boolean"
+          },
           "tags": {
             "type": "array",
             "items": {
@@ -28478,6 +28593,9 @@
             "type": "boolean"
           },
           "global": {
+            "type": "boolean"
+          },
+          "archived": {
             "type": "boolean"
           },
           "tags": {
@@ -31625,6 +31743,56 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.note.archived": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "note.archived"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "scopeID": {
+                "type": "string"
+              }
+            },
+            "required": ["ids", "scopeID"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.note.unarchived": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "note.unarchived"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "scopeID": {
+                "type": "string"
+              }
+            },
+            "required": ["ids", "scopeID"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "Event.blueprint_loop.created": {
         "type": "object",
         "properties": {
@@ -32419,6 +32587,12 @@
           },
           {
             "$ref": "#/components/schemas/Event.note.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.note.archived"
+          },
+          {
+            "$ref": "#/components/schemas/Event.note.unarchived"
           },
           {
             "$ref": "#/components/schemas/Event.blueprint_loop.created"

--- a/packages/synergy/src/agent/builtin-context.ts
+++ b/packages/synergy/src/agent/builtin-context.ts
@@ -168,6 +168,8 @@ function baseToolPermissions(profile: SubagentPermissionProfile): PermissionNext
         note_search: "allow",
         note_write: "allow",
         note_edit: "allow",
+        note_archive: "allow",
+        note_delete: "allow",
       }),
     )
   }

--- a/packages/synergy/src/agent/prompt/synergy/base.txt
+++ b/packages/synergy/src/agent/prompt/synergy/base.txt
@@ -555,7 +555,7 @@ Use `expand_tools({ groups: ["browser"] })` when the domain is clear. Use `searc
 
 {MEMORY_INTERACTION}
 
-**Notes** — Expand the `note` group for longer-form markdown documents, project-scoped or global (`note_list`, `note_read`, `note_search`, `note_write`). Use when information is too detailed for a memory, or when you need an evolving document rather than a static knowledge atom.
+**Notes** — Expand the `note` group for longer-form markdown documents, project-scoped or global (`note_list`, `note_read`, `note_search`, `note_write`, `note_edit`). Use when information is too detailed for a memory, or when you need an evolving document rather than a static knowledge atom. Archive notes that are no longer needed with `note_archive`; permanently delete archived notes with `note_delete` (only archived notes can be deleted).
 
 **Agenda** — Expand the `agenda` group for scheduling. `agenda_watch` sets a one-time wake-up in the current session (e.g. "check back in 30 min"); `agenda_schedule` creates recurring or one-off tasks that run in new sessions. Manage with `agenda_list`, `agenda_update`, `agenda_cancel`, `agenda_trigger`, `agenda_logs`.
 

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -724,7 +724,12 @@ export namespace EnforcementGate {
       }
 
       // Note write tools
-      if (toolName === "note_write" || toolName === "note_edit") {
+      if (
+        toolName === "note_write" ||
+        toolName === "note_edit" ||
+        toolName === "note_archive" ||
+        toolName === "note_delete"
+      ) {
         caps.push({ class: "file_write", nonBypassable: false })
         return { capabilities: caps }
       }

--- a/packages/synergy/src/note/error.ts
+++ b/packages/synergy/src/note/error.ts
@@ -11,4 +11,11 @@ export namespace NoteError {
       note: NoteTypes.Info,
     }),
   )
+  export const NotArchived = NamedError.create(
+    "NoteNotArchivedError",
+    z.object({
+      noteID: z.string(),
+      message: z.string(),
+    }),
+  )
 }

--- a/packages/synergy/src/note/event.ts
+++ b/packages/synergy/src/note/event.ts
@@ -24,4 +24,18 @@ export namespace NoteEvent {
       scopeID: z.string(),
     }),
   )
+  export const Archived = BusEvent.define(
+    "note.archived",
+    z.object({
+      ids: z.array(z.string()),
+      scopeID: z.string(),
+    }),
+  )
+  export const Unarchived = BusEvent.define(
+    "note.unarchived",
+    z.object({
+      ids: z.array(z.string()),
+      scopeID: z.string(),
+    }),
+  )
 }

--- a/packages/synergy/src/note/migration.ts
+++ b/packages/synergy/src/note/migration.ts
@@ -270,6 +270,44 @@ export const migrations: Migration[] = [
       log.info("note block id migration complete", { totalNotes, changed, scopes: scopeIDs.length })
     },
   },
+  {
+    id: "20260704-note-add-archived",
+    description: "Add archived field to existing notes; default to false",
+    domain: "note",
+    dependsOn: ["20260626-note-add-block-ids"],
+    async up(progress) {
+      const scopeIDs = await Storage.scan(["notes"])
+      let totalNotes = 0
+      for (const sid of scopeIDs) {
+        const s = Identifier.asScopeID(sid)
+        const ids = await Storage.scan(StoragePath.notesRoot(s))
+        totalNotes += ids.filter((id) => !id.startsWith("_")).length
+      }
+      let done = 0
+      for (const sid of scopeIDs) {
+        const s = Identifier.asScopeID(sid)
+        const ids = await Storage.scan(StoragePath.notesRoot(s))
+        const noteIDs = ids.filter((id) => !id.startsWith("_"))
+        for (const noteID of noteIDs) {
+          const notePath = StoragePath.note(s, noteID)
+          try {
+            const raw = await Storage.read<Record<string, unknown>>(notePath)
+            if (raw.archived === undefined) {
+              raw.archived = false
+              await Storage.write(notePath, raw)
+            }
+          } catch (err) {
+            log.warn("failed to add archived field to note", { scopeID: sid, noteID, error: String(err) })
+          }
+          done++
+          if (done % 10 === 0 || done === totalNotes) {
+            progress(done, totalNotes)
+          }
+        }
+      }
+      log.info("archived field migration complete", { totalNotes, scopes: scopeIDs.length })
+    },
+  },
 ]
 
 MigrationRegistry.register("note", migrations)

--- a/packages/synergy/src/note/store.ts
+++ b/packages/synergy/src/note/store.ts
@@ -1,4 +1,5 @@
 import { Storage } from "../storage/storage"
+import z from "zod"
 import { StoragePath } from "../storage/path"
 import { Identifier } from "../id/id"
 import { ScopeContext } from "../scope/context"
@@ -15,15 +16,15 @@ export namespace NoteStore {
   const log = Log.create({ service: "note.store" })
   const HOME_SCOPE_ID = "home"
 
-  export type Metadata = NoteTypes.MetaInfo
+  export type Metadata = z.infer<typeof NoteTypes.MetaInfo>
 
-  function normalizeBlueprint(note: NoteTypes.Info): void {
+  function normalizeBlueprint(note: z.infer<typeof NoteTypes.Info>): void {
     if (note.kind !== "blueprint") {
       note.blueprint = undefined
       return
     }
 
-    const blueprint = note.blueprint as (NoteTypes.Info["blueprint"] & { status?: unknown }) | undefined
+    const blueprint = note.blueprint as (z.infer<typeof NoteTypes.Info>["blueprint"] & { status?: unknown }) | undefined
     if (!blueprint) {
       note.blueprint = {}
       return
@@ -32,7 +33,7 @@ export namespace NoteStore {
     note.blueprint = blueprint
   }
 
-  function normalize(note: NoteTypes.Info): NoteTypes.Info {
+  function normalize(note: z.infer<typeof NoteTypes.Info>): z.infer<typeof NoteTypes.Info> {
     note.global ??= false
     note.version ??= 1
     note.kind ??= "note"
@@ -41,7 +42,7 @@ export namespace NoteStore {
     return note
   }
 
-  function toMetadata(note: NoteTypes.Info): Metadata {
+  function toMetadata(note: z.infer<typeof NoteTypes.Info>): Metadata {
     const { content, ...meta } = note
     const markdown = NoteMarkdown.toMarkdown(content)
     const searchParts = [note.title, ...(note.tags ?? []), markdown].filter(Boolean)
@@ -92,20 +93,34 @@ export namespace NoteStore {
     const ids = (await Storage.scan(StoragePath.notesRoot(sid))).filter((id) => !id.startsWith("_"))
     if (ids.length === 0) return []
     const keys = ids.map((id) => StoragePath.note(sid, id))
-    const results = await Storage.readMany<NoteTypes.Info>(keys)
-    const entries = results.filter((n): n is NoteTypes.Info => n !== undefined).map((n) => toMetadata(normalize(n)))
+    const results = await Storage.readMany<z.infer<typeof NoteTypes.Info>>(keys)
+    const entries = results
+      .filter((n): n is z.infer<typeof NoteTypes.Info> => n !== undefined)
+      .map((n) => toMetadata(normalize(n)))
     sortByPinAndTime(entries)
     await Storage.write(indexPath(sid), entries)
     log.info("index rebuilt", { scopeID, count: entries.length })
     return entries
   }
 
-  async function indexSet(scopeID: string, note: NoteTypes.Info): Promise<void> {
+  async function indexSet(scopeID: string, note: z.infer<typeof NoteTypes.Info>): Promise<void> {
     const entries = await loadIndex(scopeID)
     const entry = toMetadata(note)
     const idx = entries.findIndex((e) => e.id === note.id)
     if (idx >= 0) entries[idx] = entry
     else entries.push(entry)
+    sortByPinAndTime(entries)
+    await Storage.write(indexPath(Identifier.asScopeID(scopeID)), entries)
+  }
+
+  async function indexUpdateMany(scopeID: string, notes: z.infer<typeof NoteTypes.Info>[]): Promise<void> {
+    const entries = await loadIndex(scopeID)
+    for (const note of notes) {
+      const entry = toMetadata(note)
+      const idx = entries.findIndex((e) => e.id === note.id)
+      if (idx >= 0) entries[idx] = entry
+      else entries.push(entry)
+    }
     sortByPinAndTime(entries)
     await Storage.write(indexPath(Identifier.asScopeID(scopeID)), entries)
   }
@@ -118,10 +133,13 @@ export namespace NoteStore {
 
   // --- Scope resolution ---
 
-  async function resolveScope(scopeID: string, noteID: string): Promise<{ scopeID: string; note: NoteTypes.Info }> {
+  async function resolveScope(
+    scopeID: string,
+    noteID: string,
+  ): Promise<{ scopeID: string; note: z.infer<typeof NoteTypes.Info> }> {
     const sid = Identifier.asScopeID(scopeID)
     try {
-      const note = await Storage.read<NoteTypes.Info>(StoragePath.note(sid, noteID))
+      const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(sid, noteID))
       return { scopeID, note: normalize(note) }
     } catch {
       // fallthrough
@@ -129,7 +147,7 @@ export namespace NoteStore {
     if (scopeID !== HOME_SCOPE_ID) {
       const globalSid = Identifier.asScopeID(HOME_SCOPE_ID)
       try {
-        const note = await Storage.read<NoteTypes.Info>(StoragePath.note(globalSid, noteID))
+        const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(globalSid, noteID))
         return { scopeID: HOME_SCOPE_ID, note: normalize(note) }
       } catch {
         // fallthrough
@@ -139,7 +157,9 @@ export namespace NoteStore {
     for (const candidate of scopeIDs) {
       if (candidate === scopeID || candidate === HOME_SCOPE_ID) continue
       try {
-        const note = await Storage.read<NoteTypes.Info>(StoragePath.note(Identifier.asScopeID(candidate), noteID))
+        const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(
+          StoragePath.note(Identifier.asScopeID(candidate), noteID),
+        )
         return { scopeID: candidate, note: normalize(note) }
       } catch {
         // continue
@@ -150,7 +170,10 @@ export namespace NoteStore {
 
   // --- Public API: full data ---
 
-  export async function create(input: NoteTypes.CreateInput, options?: { scopeID?: string }): Promise<NoteTypes.Info> {
+  export async function create(
+    input: NoteTypes.CreateInput,
+    options?: { scopeID?: string },
+  ): Promise<z.infer<typeof NoteTypes.Info>> {
     const targetScopeID = options?.scopeID ?? ScopeContext.current.scope.id
     const create = await Plugin.trigger(
       "note.create.before",
@@ -169,7 +192,7 @@ export namespace NoteStore {
       | (NonNullable<NoteTypes.CreateInput["blueprint"]> & { status?: unknown })
       | undefined
     if (blueprint) delete blueprint.status
-    const note: NoteTypes.Info = {
+    const note: z.infer<typeof NoteTypes.Info> = {
       id,
       title: create.note.title,
       content: NoteDocument.normalize(create.note.content),
@@ -203,28 +226,30 @@ export namespace NoteStore {
     return note
   }
 
-  export async function get(scopeID: string, noteID: string): Promise<NoteTypes.Info> {
-    const note = await Storage.read<NoteTypes.Info>(StoragePath.note(Identifier.asScopeID(scopeID), noteID))
+  export async function get(scopeID: string, noteID: string): Promise<z.infer<typeof NoteTypes.Info>> {
+    const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(
+      StoragePath.note(Identifier.asScopeID(scopeID), noteID),
+    )
     return normalize(note)
   }
 
-  export async function list(scopeID: string): Promise<NoteTypes.Info[]> {
+  export async function list(scopeID: string): Promise<z.infer<typeof NoteTypes.Info>[]> {
     const sid = Identifier.asScopeID(scopeID)
     const ids = await Storage.scan(StoragePath.notesRoot(sid))
     if (ids.length === 0) return []
     const keys = ids.filter((id) => !id.startsWith("_")).map((id) => StoragePath.note(sid, id))
-    const results = await Storage.readMany<NoteTypes.Info>(keys)
-    const notes = results.filter((n): n is NoteTypes.Info => n !== undefined).map(normalize)
+    const results = await Storage.readMany<z.infer<typeof NoteTypes.Info>>(keys)
+    const notes = results.filter((n): n is z.infer<typeof NoteTypes.Info> => n !== undefined).map(normalize)
     sortByPinAndTime(notes)
     return notes
   }
 
-  export async function listByKind(scopeID: string, kind: string): Promise<NoteTypes.Info[]> {
+  export async function listByKind(scopeID: string, kind: string): Promise<z.infer<typeof NoteTypes.Info>[]> {
     const notes = await list(scopeID)
     return notes.filter((n) => n.kind === kind)
   }
 
-  export async function listWithGlobal(scopeID: string): Promise<NoteTypes.Info[]> {
+  export async function listWithGlobal(scopeID: string): Promise<z.infer<typeof NoteTypes.Info>[]> {
     if (scopeID === HOME_SCOPE_ID) return list(HOME_SCOPE_ID)
     const [local, global] = await Promise.all([list(scopeID), list(HOME_SCOPE_ID)])
     return mergeSorted(local, global, comparePinTime)
@@ -244,10 +269,14 @@ export namespace NoteStore {
     return groups
   }
 
-  export async function update(scopeID: string, noteID: string, patch: NoteTypes.PatchInput): Promise<NoteTypes.Info> {
+  export async function update(
+    scopeID: string,
+    noteID: string,
+    patch: z.infer<typeof NoteTypes.PatchInput>,
+  ): Promise<z.infer<typeof NoteTypes.Info>> {
     const sid = Identifier.asScopeID(scopeID)
     const sourcePath = StoragePath.note(sid, noteID)
-    const current = normalize(await Storage.read<NoteTypes.Info>(sourcePath))
+    const current = normalize(await Storage.read<z.infer<typeof NoteTypes.Info>>(sourcePath))
     const update = await Plugin.trigger(
       "note.update.before",
       {
@@ -261,7 +290,7 @@ export namespace NoteStore {
     )
 
     let wasGlobal = false
-    const note = await Storage.update<NoteTypes.Info>(sourcePath, (draft) => {
+    const note = await Storage.update<z.infer<typeof NoteTypes.Info>>(sourcePath, (draft) => {
       draft.global ??= false
       draft.version ??= 1
       wasGlobal = draft.global
@@ -280,7 +309,9 @@ export namespace NoteStore {
       if (update.patch.blueprint === null) {
         draft.blueprint = undefined
       } else if (update.patch.blueprint !== undefined) {
-        const { activeLoopID, ...rest } = update.patch.blueprint as NoteTypes.PatchInput["blueprint"] & {
+        const { activeLoopID, ...rest } = update.patch.blueprint as z.infer<
+          typeof NoteTypes.PatchInput
+        >["blueprint"] & {
           status?: unknown
         }
         delete rest.status
@@ -333,10 +364,55 @@ export namespace NoteStore {
 
   export async function remove(scopeID: string, noteID: string): Promise<void> {
     const sid = Identifier.asScopeID(scopeID)
+    const note = normalize(await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(sid, noteID)))
+    if (!note.archived) {
+      throw new NoteError.NotArchived({
+        noteID,
+        message: "Note must be archived before it can be deleted. Use note_archive first.",
+      })
+    }
     await Storage.remove(StoragePath.note(sid, noteID))
     await indexRemove(scopeID, noteID)
     log.info("removed", { id: noteID })
     await Bus.publish(NoteEvent.Deleted, { id: noteID, scopeID })
+  }
+
+  export async function archive(scopeID: string, noteIDs: string[]): Promise<z.infer<typeof NoteTypes.Info>[]> {
+    const sid = Identifier.asScopeID(scopeID)
+    const results: z.infer<typeof NoteTypes.Info>[] = []
+    for (const noteID of noteIDs) {
+      const sourcePath = StoragePath.note(sid, noteID)
+      const note = await Storage.update<z.infer<typeof NoteTypes.Info>>(sourcePath, (draft) => {
+        draft.archived = true as const
+        draft.version += 1
+        draft.time.updated = Date.now()
+      })
+      normalize(note)
+      results.push(note)
+    }
+    await indexUpdateMany(scopeID, results)
+    log.info("archived", { ids: noteIDs, count: noteIDs.length })
+    await Bus.publish(NoteEvent.Archived, { ids: noteIDs, scopeID })
+    return results
+  }
+
+  export async function unarchive(scopeID: string, noteIDs: string[]): Promise<z.infer<typeof NoteTypes.Info>[]> {
+    const sid = Identifier.asScopeID(scopeID)
+    const results: z.infer<typeof NoteTypes.Info>[] = []
+    for (const noteID of noteIDs) {
+      const sourcePath = StoragePath.note(sid, noteID)
+      const note = await Storage.update<z.infer<typeof NoteTypes.Info>>(sourcePath, (draft) => {
+        delete draft.archived
+        draft.version += 1
+        draft.time.updated = Date.now()
+      })
+      normalize(note)
+      results.push(note)
+    }
+    await indexUpdateMany(scopeID, results)
+    log.info("unarchived", { ids: noteIDs, count: noteIDs.length })
+    await Bus.publish(NoteEvent.Unarchived, { ids: noteIDs, scopeID })
+    return results
   }
 
   // --- Public API: metadata only (fast, for tools) ---
@@ -385,7 +461,7 @@ export namespace NoteStore {
 
   // --- Public API: scope-agnostic access ---
 
-  export async function getAny(scopeID: string, noteID: string): Promise<NoteTypes.Info> {
+  export async function getAny(scopeID: string, noteID: string): Promise<z.infer<typeof NoteTypes.Info>> {
     const { note } = await resolveScope(scopeID, noteID)
     return note
   }
@@ -393,8 +469,8 @@ export namespace NoteStore {
   export async function updateAny(
     scopeID: string,
     noteID: string,
-    patch: NoteTypes.PatchInput,
-  ): Promise<NoteTypes.Info> {
+    patch: z.infer<typeof NoteTypes.PatchInput>,
+  ): Promise<z.infer<typeof NoteTypes.Info>> {
     const { scopeID: resolved } = await resolveScope(scopeID, noteID)
     return update(resolved, noteID, patch)
   }

--- a/packages/synergy/src/note/store.ts
+++ b/packages/synergy/src/note/store.ts
@@ -35,6 +35,7 @@ export namespace NoteStore {
 
   function normalize(note: z.infer<typeof NoteTypes.Info>): z.infer<typeof NoteTypes.Info> {
     note.global ??= false
+    note.archived ??= false
     note.version ??= 1
     note.kind ??= "note"
     note.content = NoteDocument.normalize(note.content)
@@ -69,6 +70,14 @@ export namespace NoteStore {
     while (i < a.length) result.push(a[i++])
     while (j < b.length) result.push(b[j++])
     return result
+  }
+
+  // --- Archive status filter ---
+  export type ArchiveFilter = "active" | "archived" | "all"
+  export function filterArchive<T extends { archived?: boolean }>(items: T[], filter: ArchiveFilter): T[] {
+    if (filter === "active") return items.filter((i) => !i.archived)
+    if (filter === "archived") return items.filter((i) => i.archived)
+    return items
   }
 
   // --- Index management ---
@@ -198,6 +207,7 @@ export namespace NoteStore {
       content: NoteDocument.normalize(create.note.content),
       pinned: false,
       global: isGlobal,
+      archived: false,
       tags: create.note.tags ?? [],
       kind: create.note.kind ?? "note",
       blueprint: blueprint
@@ -233,7 +243,10 @@ export namespace NoteStore {
     return normalize(note)
   }
 
-  export async function list(scopeID: string): Promise<z.infer<typeof NoteTypes.Info>[]> {
+  export async function list(
+    scopeID: string,
+    archiveFilter?: ArchiveFilter,
+  ): Promise<z.infer<typeof NoteTypes.Info>[]> {
     const sid = Identifier.asScopeID(scopeID)
     const ids = await Storage.scan(StoragePath.notesRoot(sid))
     if (ids.length === 0) return []
@@ -241,7 +254,7 @@ export namespace NoteStore {
     const results = await Storage.readMany<z.infer<typeof NoteTypes.Info>>(keys)
     const notes = results.filter((n): n is z.infer<typeof NoteTypes.Info> => n !== undefined).map(normalize)
     sortByPinAndTime(notes)
-    return notes
+    return filterArchive(notes, archiveFilter ?? "active")
   }
 
   export async function listByKind(scopeID: string, kind: string): Promise<z.infer<typeof NoteTypes.Info>[]> {
@@ -249,17 +262,20 @@ export namespace NoteStore {
     return notes.filter((n) => n.kind === kind)
   }
 
-  export async function listWithGlobal(scopeID: string): Promise<z.infer<typeof NoteTypes.Info>[]> {
-    if (scopeID === HOME_SCOPE_ID) return list(HOME_SCOPE_ID)
-    const [local, global] = await Promise.all([list(scopeID), list(HOME_SCOPE_ID)])
+  export async function listWithGlobal(
+    scopeID: string,
+    archiveFilter?: ArchiveFilter,
+  ): Promise<z.infer<typeof NoteTypes.Info>[]> {
+    if (scopeID === HOME_SCOPE_ID) return list(HOME_SCOPE_ID, archiveFilter)
+    const [local, global] = await Promise.all([list(scopeID, archiveFilter), list(HOME_SCOPE_ID, archiveFilter)])
     return mergeSorted(local, global, comparePinTime)
   }
 
-  export async function listGrouped(): Promise<NoteTypes.ScopeGroup[]> {
+  export async function listGrouped(archiveFilter?: ArchiveFilter): Promise<NoteTypes.ScopeGroup[]> {
     const scopeIDs = await Storage.scan(["notes"])
     const groups: NoteTypes.ScopeGroup[] = []
     for (const sid of scopeIDs) {
-      const notes = await list(sid)
+      const notes = await list(sid, archiveFilter)
       groups.push({
         scopeID: sid,
         scopeType: sid === HOME_SCOPE_ID ? "home" : "project",
@@ -324,6 +340,9 @@ export namespace NoteStore {
       if (update.patch.global === true && !wasGlobal) {
         draft.originScope = sid as string
       }
+      if (update.patch.archived !== undefined) {
+        draft.archived = update.patch.archived
+      }
       draft.version += 1
       draft.time.updated = Date.now()
     })
@@ -349,6 +368,11 @@ export namespace NoteStore {
 
     log.info("updated", { id: noteID, version: note.version })
     await Bus.publish(NoteEvent.Updated, { note })
+    if (patch.archived === true) {
+      await Bus.publish(NoteEvent.Archived, { ids: [noteID], scopeID })
+    } else if (patch.archived === false) {
+      await Bus.publish(NoteEvent.Unarchived, { ids: [noteID], scopeID })
+    }
     await Plugin.trigger(
       "note.update.after",
       {
@@ -402,7 +426,7 @@ export namespace NoteStore {
     for (const noteID of noteIDs) {
       const sourcePath = StoragePath.note(sid, noteID)
       const note = await Storage.update<z.infer<typeof NoteTypes.Info>>(sourcePath, (draft) => {
-        delete draft.archived
+        draft.archived = false
         draft.version += 1
         draft.time.updated = Date.now()
       })
@@ -417,13 +441,17 @@ export namespace NoteStore {
 
   // --- Public API: metadata only (fast, for tools) ---
 
-  export async function listMeta(scopeID: string): Promise<Metadata[]> {
-    return loadIndex(scopeID)
+  export async function listMeta(scopeID: string, archiveFilter?: ArchiveFilter): Promise<Metadata[]> {
+    const entries = await loadIndex(scopeID)
+    return filterArchive(entries, archiveFilter ?? "active")
   }
 
-  export async function listMetaWithGlobal(scopeID: string): Promise<Metadata[]> {
-    if (scopeID === HOME_SCOPE_ID) return listMeta(HOME_SCOPE_ID)
-    const [local, global] = await Promise.all([listMeta(scopeID), listMeta(HOME_SCOPE_ID)])
+  export async function listMetaWithGlobal(scopeID: string, archiveFilter?: ArchiveFilter): Promise<Metadata[]> {
+    if (scopeID === HOME_SCOPE_ID) return listMeta(HOME_SCOPE_ID, archiveFilter)
+    const [local, global] = await Promise.all([
+      listMeta(scopeID, archiveFilter),
+      listMeta(HOME_SCOPE_ID, archiveFilter),
+    ])
     return mergeSorted(local, global, comparePinTime)
   }
 
@@ -437,7 +465,7 @@ export namespace NoteStore {
     return result
   }
 
-  export async function listMetaGrouped(): Promise<NoteTypes.MetaScopeGroup[]> {
+  export async function listMetaGrouped(archiveFilter?: ArchiveFilter): Promise<NoteTypes.MetaScopeGroup[]> {
     const scopeIDs = await Storage.scan(["notes"])
     const currentScopeID = ScopeContext.current.scope.id
     scopeIDs.sort((a, b) => {
@@ -447,7 +475,7 @@ export namespace NoteStore {
     })
     const groups = await Promise.all(
       scopeIDs.map(async (sid): Promise<NoteTypes.MetaScopeGroup | undefined> => {
-        const metaList = await listMeta(sid)
+        const metaList = await listMeta(sid, archiveFilter)
         if (metaList.length === 0) return undefined
         return {
           scopeID: sid,

--- a/packages/synergy/src/note/types.ts
+++ b/packages/synergy/src/note/types.ts
@@ -21,7 +21,7 @@ export namespace NoteTypes {
           lastRunAt: z.number().optional(),
         })
         .optional(),
-      archived: z.literal(true).optional(),
+      archived: z.boolean(),
       version: z.number(),
       time: z.object({
         created: z.number(),

--- a/packages/synergy/src/note/types.ts
+++ b/packages/synergy/src/note/types.ts
@@ -21,6 +21,7 @@ export namespace NoteTypes {
           lastRunAt: z.number().optional(),
         })
         .optional(),
+      archived: z.literal(true).optional(),
       version: z.number(),
       time: z.object({
         created: z.number(),
@@ -28,7 +29,6 @@ export namespace NoteTypes {
       }),
     })
     .meta({ ref: "NoteInfo" })
-  export type Info = z.infer<typeof Info>
 
   export const CreateInput = z
     .object({
@@ -56,6 +56,7 @@ export namespace NoteTypes {
       content: z.any().optional(),
       pinned: z.boolean().optional(),
       global: z.boolean().optional(),
+      archived: z.boolean().optional(),
       tags: z.array(z.string()).optional(),
       kind: z.enum(["note", "blueprint"]).optional(),
       blueprint: z
@@ -72,7 +73,6 @@ export namespace NoteTypes {
       expectedVersion: z.number().optional(),
     })
     .meta({ ref: "NotePatchInput" })
-  export type PatchInput = z.infer<typeof PatchInput>
 
   export const ScopeGroup = z
     .object({
@@ -90,6 +90,7 @@ export namespace NoteTypes {
       pinned: z.boolean(),
       global: z.boolean(),
       originScope: z.string().optional(),
+      archived: z.boolean().optional(),
       tags: z.array(z.string()),
       kind: z.enum(["note", "blueprint"]).optional(),
       version: z.number(),
@@ -111,7 +112,6 @@ export namespace NoteTypes {
         .optional(),
     })
     .meta({ ref: "NoteMetaInfo" })
-  export type MetaInfo = z.infer<typeof MetaInfo>
 
   export const MetaScopeGroup = z
     .object({

--- a/packages/synergy/src/server/note.ts
+++ b/packages/synergy/src/server/note.ts
@@ -214,6 +214,62 @@ export const NoteRoute = new Hono()
     },
   )
 
+  .post(
+    "/batch",
+    describeRoute({
+      summary: "Batch archive or delete notes",
+      description: "Archive or permanently delete notes in bulk. Notes must be archived before they can be deleted.",
+      operationId: "note.batch",
+      responses: {
+        200: {
+          description: "Batch operation result",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({ archived: z.array(z.string()).optional(), deleted: z.array(z.string()).optional() }),
+              ),
+            },
+          },
+        },
+        ...errors(400),
+      },
+    }),
+    validator(
+      "json",
+      z.object({
+        ids: z.array(z.string()).min(1).max(100).meta({ description: "Note IDs to act on" }),
+        action: z
+          .enum(["archive", "unarchive", "delete"])
+          .meta({ description: "Action: archive, unarchive, or delete" }),
+      }),
+    ),
+    async (c) => {
+      try {
+        const { ids, action } = c.req.valid("json")
+        const scopeID = ScopeContext.current.scope.id
+        if (action === "archive") {
+          await NoteStore.archive(scopeID, ids)
+          return c.json({ archived: ids })
+        }
+        if (action === "unarchive") {
+          await NoteStore.unarchive(scopeID, ids)
+          return c.json({ archived: [] })
+        }
+        if (action === "delete") {
+          for (const id of ids) {
+            await NoteStore.remove(scopeID, id)
+          }
+          return c.json({ deleted: ids })
+        }
+        return c.json({ message: "Invalid action" }, 400)
+      } catch (err: any) {
+        if (err instanceof NoteError.NotArchived)
+          return c.json({ message: err.toObject().data?.message ?? "Note must be archived first" }, 400)
+        return c.json({ message: err?.message ?? String(err) }, 400)
+      }
+    },
+  )
+
   .get(
     "/",
     describeRoute({

--- a/packages/synergy/src/server/note.ts
+++ b/packages/synergy/src/server/note.ts
@@ -14,7 +14,7 @@ export const NoteRoute = new Hono()
     describeRoute({
       summary: "List note metadata grouped by scope",
       description:
-        "List metadata for all notes across all scopes, grouped by scope ID. Does not include full note content.",
+        "List metadata for all notes across all scopes, grouped by scope ID. Does not include full note content. Returns active notes by default; pass ?archived=true to show only archived notes.",
       operationId: "note.listMeta",
       responses: {
         200: {
@@ -24,9 +24,21 @@ export const NoteRoute = new Hono()
         ...errors(400),
       },
     }),
+    validator(
+      "query",
+      z.object({
+        archived: z
+          .enum(["true", "false"])
+          .default("false")
+          .transform((v) => v === "true")
+          .meta({ description: "Filter by archived state. Defaults to false (active notes only)." }),
+      }),
+    ),
     async (c) => {
       try {
-        const groups = await NoteStore.listMetaGrouped()
+        const { archived } = c.req.valid("query")
+        const archFilter: NoteStore.ArchiveFilter = archived ? "archived" : "active"
+        const groups = await NoteStore.listMetaGrouped(archFilter)
         return c.json(groups)
       } catch (err: any) {
         return c.json({ message: err?.message ?? String(err) }, 400)
@@ -37,7 +49,8 @@ export const NoteRoute = new Hono()
     "/all",
     describeRoute({
       summary: "List all notes grouped by scope",
-      description: "List all notes across all scopes, grouped by scope ID.",
+      description:
+        "List all notes across all scopes, grouped by scope ID. Returns active notes by default; pass ?archived=true to show only archived notes.",
       operationId: "note.listAll",
       responses: {
         200: {
@@ -47,9 +60,21 @@ export const NoteRoute = new Hono()
         ...errors(400),
       },
     }),
+    validator(
+      "query",
+      z.object({
+        archived: z
+          .enum(["true", "false"])
+          .default("false")
+          .transform((v) => v === "true")
+          .meta({ description: "Filter by archived state. Defaults to false (active notes only)." }),
+      }),
+    ),
     async (c) => {
       try {
-        const groups = await NoteStore.listGrouped()
+        const { archived } = c.req.valid("query")
+        const archFilter: NoteStore.ArchiveFilter = archived ? "archived" : "active"
+        const groups = await NoteStore.listGrouped(archFilter)
         return c.json(groups)
       } catch (err: any) {
         return c.json({ message: err?.message ?? String(err) }, 400)
@@ -192,14 +217,15 @@ export const NoteRoute = new Hono()
     "/:id",
     describeRoute({
       summary: "Delete note",
-      description: "Delete a note permanently.",
+      description:
+        "Permanently delete a note. Only archived notes can be deleted. Active notes must be archived first.",
       operationId: "note.remove",
       responses: {
         200: {
           description: "Deleted",
           content: { "application/json": { schema: resolver(z.boolean()) } },
         },
-        ...errors(400),
+        ...errors(400, 404, 409),
       },
     }),
     validator("param", z.object({ id: z.string().meta({ description: "Note ID" }) })),
@@ -209,6 +235,9 @@ export const NoteRoute = new Hono()
         await NoteStore.removeAny(ScopeContext.current.scope.id, id)
         return c.json(true)
       } catch (err: any) {
+        if (err instanceof NoteError.NotArchived) return c.json(err.toObject(), 409)
+        if (err instanceof Storage.NotFoundError)
+          return c.json({ message: `Note not found: ${c.req.valid("param").id}` }, 404)
         return c.json({ message: err?.message ?? String(err) }, 400)
       }
     },
@@ -274,7 +303,8 @@ export const NoteRoute = new Hono()
     "/",
     describeRoute({
       summary: "List notes",
-      description: "List all notes for the current scope, including global notes.",
+      description:
+        "List all notes for the current scope, including global notes. Returns active notes by default; pass ?archived=true to show only archived notes.",
       operationId: "note.list",
       responses: {
         200: {
@@ -284,9 +314,21 @@ export const NoteRoute = new Hono()
         ...errors(400),
       },
     }),
+    validator(
+      "query",
+      z.object({
+        archived: z
+          .enum(["true", "false"])
+          .default("false")
+          .transform((v) => v === "true")
+          .meta({ description: "Filter by archived state. Defaults to false (active notes only)." }),
+      }),
+    ),
     async (c) => {
       try {
-        const notes = await NoteStore.listWithGlobal(ScopeContext.current.scope.id)
+        const { archived } = c.req.valid("query")
+        const archFilter: NoteStore.ArchiveFilter = archived ? "archived" : "active"
+        const notes = await NoteStore.listWithGlobal(ScopeContext.current.scope.id, archFilter)
         return c.json(notes)
       } catch (err: any) {
         return c.json({ message: err?.message ?? String(err) }, 400)

--- a/packages/synergy/src/tool/exposure.ts
+++ b/packages/synergy/src/tool/exposure.ts
@@ -113,7 +113,7 @@ export namespace ToolExposure {
         "Project and global long-form notes, Blueprint notes, evolving plans, research records, and structured note edits.",
       whenToExpand:
         "Expand when information should live as an editable document, when reading or writing Blueprint notes, or when a task asks for stored project/global notes.",
-      tools: ["note_list", "note_read", "note_search", "note_write", "note_edit"],
+      tools: ["note_list", "note_read", "note_search", "note_write", "note_edit", "note_archive"],
     },
     {
       id: "memory",

--- a/packages/synergy/src/tool/exposure.ts
+++ b/packages/synergy/src/tool/exposure.ts
@@ -113,7 +113,7 @@ export namespace ToolExposure {
         "Project and global long-form notes, Blueprint notes, evolving plans, research records, and structured note edits.",
       whenToExpand:
         "Expand when information should live as an editable document, when reading or writing Blueprint notes, or when a task asks for stored project/global notes.",
-      tools: ["note_list", "note_read", "note_search", "note_write", "note_edit", "note_archive"],
+      tools: ["note_list", "note_read", "note_search", "note_write", "note_edit", "note_archive", "note_delete"],
     },
     {
       id: "memory",

--- a/packages/synergy/src/tool/note-archive.ts
+++ b/packages/synergy/src/tool/note-archive.ts
@@ -1,0 +1,42 @@
+import z from "zod"
+import { Tool } from "./tool"
+import { NoteStore } from "../note"
+import { ScopeContext } from "../scope/context"
+import DESCRIPTION from "./note-archive.txt"
+
+const parameters = z.object({
+  ids: z
+    .array(z.string())
+    .min(1)
+    .max(100)
+    .describe("IDs of notes to archive. Notes must be archived before they can be deleted."),
+  unarchive: z.boolean().default(false).describe("Set to true to restore archived notes back to active state."),
+})
+
+export const NoteArchiveTool = Tool.define("note_archive", {
+  description: DESCRIPTION,
+  parameters,
+  async execute(params: z.infer<typeof parameters>) {
+    const scopeID = ScopeContext.current.scope.id
+
+    if (params.unarchive) {
+      const notes = await NoteStore.unarchive(scopeID, params.ids)
+      return {
+        title: `Unarchived ${notes.length} note${notes.length === 1 ? "" : "s"}`,
+        output: `Restored ${notes.length} note${notes.length === 1 ? "" : "s"} from archive:\n${notes
+          .map((n) => `- [${n.id}] "${n.title}"`)
+          .join("\n")}`,
+        metadata: { count: notes.length, ids: params.ids, action: "unarchive" } as Record<string, any>,
+      }
+    }
+
+    const notes = await NoteStore.archive(scopeID, params.ids)
+    return {
+      title: `Archived ${notes.length} note${notes.length === 1 ? "" : "s"}`,
+      output: `Archived ${notes.length} note${notes.length === 1 ? "" : "s"}. They can be restored with note_archive(ids: [...], unarchive: true) or permanently deleted from the Archived view in the Notes UI:\n${notes
+        .map((n) => `- [${n.id}] "${n.title}"`)
+        .join("\n")}`,
+      metadata: { count: notes.length, ids: params.ids, action: "archive" } as Record<string, any>,
+    }
+  },
+})

--- a/packages/synergy/src/tool/note-archive.txt
+++ b/packages/synergy/src/tool/note-archive.txt
@@ -1,0 +1,5 @@
+Archive notes by ID. Archived notes are hidden from the active list but preserved on disk.
+
+Use this when you need to clean up notes from a completed sprint, task, or session. Archiving is safe and reversible — archived notes can be restored with the same tool by passing `unarchive: true`, or permanently deleted from the Archived view in the Notes UI.
+
+To permanently delete archived notes, open the Notes panel in the UI, switch to the Archived view, and use the Delete button there. Agents cannot delete notes directly — they must archive first.

--- a/packages/synergy/src/tool/note-delete.ts
+++ b/packages/synergy/src/tool/note-delete.ts
@@ -1,0 +1,37 @@
+import z from "zod"
+import { Tool } from "./tool"
+import { NoteStore, NoteError } from "../note"
+import { ScopeContext } from "../scope/context"
+import DESCRIPTION from "./note-delete.txt"
+
+const parameters = z.object({
+  id: z.string().describe("Note ID to permanently delete. The note must already be archived."),
+})
+
+export const NoteDeleteTool = Tool.define("note_delete", {
+  description: DESCRIPTION,
+  parameters,
+  async execute(params: z.infer<typeof parameters>) {
+    const scopeID = ScopeContext.current.scope.id
+
+    const note = await NoteStore.getAny(scopeID, params.id)
+
+    if (!note.archived) {
+      return {
+        title: `Cannot delete active note`,
+        output:
+          `Note "${note.title}" [${note.id}] is still active and must be archived before it can be permanently deleted. ` +
+          `Use note_archive({ ids: ["${params.id}"], action: "archive" }) first, then retry note_delete.`,
+        metadata: { id: params.id, archived: false } as Record<string, any>,
+      }
+    }
+
+    await NoteStore.removeAny(scopeID, params.id)
+
+    return {
+      title: `Deleted note`,
+      output: `Permanently deleted note "${note.title}" [${note.id}].`,
+      metadata: { id: params.id, title: note.title, archived: true } as Record<string, any>,
+    }
+  },
+})

--- a/packages/synergy/src/tool/note-delete.txt
+++ b/packages/synergy/src/tool/note-delete.txt
@@ -1,0 +1,5 @@
+Permanently delete one note by ID.
+
+Only archived notes can be permanently deleted. Active notes must be archived first using note_archive.
+
+To delete an active note: call note_archive first, then note_delete.

--- a/packages/synergy/src/tool/note-list.ts
+++ b/packages/synergy/src/tool/note-list.ts
@@ -16,6 +16,10 @@ const parameters = z.object({
     .enum(["all", "note", "blueprint"])
     .default("all")
     .describe("Filter by document kind. Blueprints are executable notes."),
+  archived: z
+    .enum(["active", "archived", "all"])
+    .default("active")
+    .describe("Filter by archive status: 'active' (default), 'archived', or 'all'."),
   since: z
     .string()
     .optional()
@@ -35,10 +39,10 @@ export const NoteListTool = Tool.define("note_list", {
 
     let notes =
       params.scope === "all"
-        ? await NoteStore.listMetaWithGlobal(currentScopeID)
+        ? await NoteStore.listMetaWithGlobal(currentScopeID, params.archived)
         : params.scope === "global"
-          ? await NoteStore.listMeta("global")
-          : await NoteStore.listMeta(currentScopeID)
+          ? await NoteStore.listMeta("global", params.archived)
+          : await NoteStore.listMeta(currentScopeID, params.archived)
 
     const sinceMs = params.since ? new Date(params.since).getTime() : undefined
     const beforeMs = params.before ? new Date(params.before).getTime() : undefined

--- a/packages/synergy/src/tool/note-list.txt
+++ b/packages/synergy/src/tool/note-list.txt
@@ -1,4 +1,4 @@
-List notes accessible to the current session. Returns note metadata (ID, title, kind, tags, pinned status, timestamps) without full content. Blueprint documents appear here as notes with kind:"blueprint".
+List notes in the current scope. By default shows only active notes. Use the `archived` parameter to view archived notes or all notes regardless of archive status.
 
 Use this to browse available notes before reading specific ones with `note_read`. Results are sorted by pinned status first, then by last updated time.
 
@@ -11,6 +11,6 @@ Use `since` and `before` to filter notes by last updated time (ISO 8601 dates). 
 
 Use `offset` and `limit` for pagination when there are many notes.
 
-Use `kind:"blueprint"` to list only executable Blueprint notes, `kind:"note"` for plain notes, or `kind:"all"` to include both.
+Use `kind:"blueprint"` to list only executable Blueprint notes, `kind:"note"` for plain notes, or `kind:"all"` to include both. Use `archived:"archived"` to list archived notes or `archived:"all"` to include notes regardless of archive status.
 
 The output includes a tag summary at the end showing all tags across listed notes with their frequency. Use these tags with `note_search`'s `tags` parameter to filter by topic, or reuse existing tags when creating/updating notes with `note_write` to keep tagging consistent.

--- a/packages/synergy/src/tool/note-search.ts
+++ b/packages/synergy/src/tool/note-search.ts
@@ -16,6 +16,10 @@ const parameters = z.object({
     .enum(["all", "note", "blueprint"])
     .default("all")
     .describe("Filter by document kind. Blueprints are executable notes."),
+  archived: z
+    .enum(["active", "archived", "all"])
+    .default("active")
+    .describe("Filter by archive status: 'active' (default), 'archived', or 'all'."),
   since: z
     .string()
     .optional()
@@ -70,6 +74,7 @@ export const NoteSearchTool = Tool.define("note_search", {
         tags: params.tags,
         pinned: params.pinned,
         kind: params.kind,
+        archived: params.archived,
       },
     )
 
@@ -84,12 +89,14 @@ export const NoteSearchTool = Tool.define("note_search", {
       }
     }
 
-    const allNotes =
+    let allNotes =
       search.scope === "all"
         ? await NoteStore.listMetaWithGlobal(currentScopeID)
         : search.scope === "global"
           ? await NoteStore.listMeta("global")
           : await NoteStore.listMeta(currentScopeID)
+
+    allNotes = NoteStore.filterArchive(allNotes, search.archived ?? params.archived)
 
     const sinceMs = search.since ? new Date(search.since).getTime() : undefined
     const beforeMs = search.before ? new Date(search.before).getTime() : undefined

--- a/packages/synergy/src/tool/note-search.ts
+++ b/packages/synergy/src/tool/note-search.ts
@@ -2,7 +2,6 @@ import z from "zod"
 import { Tool } from "./tool"
 import { NoteStore } from "../note"
 import { NoteMarkdown } from "../note"
-import { NoteTypes } from "../note"
 import { ScopeContext } from "../scope/context"
 import DESCRIPTION from "./note-search.txt"
 import { Plugin } from "../plugin"
@@ -120,7 +119,7 @@ export const NoteSearchTool = Tool.define("note_search", {
     const sections: string[] = []
     let totalMatches = 0
     let matchedNotes = 0
-    const matched: NoteTypes.Info[] = []
+    const matched: any[] = []
 
     for (const meta of candidates) {
       if (matchedNotes >= MAX_NOTES || totalMatches >= MAX_MATCHES) break

--- a/packages/synergy/src/tool/note-search.txt
+++ b/packages/synergy/src/tool/note-search.txt
@@ -2,6 +2,6 @@ Search notes using regex patterns. Searches across note titles and content, retu
 
 Use this to find notes containing specific information. For browsing all notes, use `note_list` instead. To read a full note after finding it, use `note_read`.
 
-The search pattern is a regular expression applied to each note's markdown content line by line. Title matches cause the entire note to be included. Use `kind:"blueprint"` to search only Blueprint notes. Use `tags` or `pinned` filters to narrow the search scope.
+The search pattern is a regular expression applied to each note's markdown content line by line. Title matches cause the entire note to be included. Use `kind:"blueprint"` to search only Blueprint notes. Use `tags` or `pinned` filters to narrow the search scope. Use `archived:"archived"` to search archived notes or `archived:"all"` to search all notes regardless of archive status (defaults to `"active"`).
 
 The `since` and `before` parameters filter by last updated time (ISO 8601 dates). Combine with pattern matching to find e.g. "notes from last week mentioning X".

--- a/packages/synergy/src/tool/registry.ts
+++ b/packages/synergy/src/tool/registry.ts
@@ -25,6 +25,7 @@ import { NoteReadTool } from "./note-read"
 import { NoteSearchTool } from "./note-search"
 import { NoteWriteTool } from "./note-write"
 import { NoteEditTool } from "./note-edit"
+import { NoteArchiveTool } from "./note-archive"
 import { BlueprintLoopFinishTool } from "./blueprint-loop-finish"
 import { BlueprintLoopRestartTool } from "./blueprint-loop-restart"
 import { SessionListTool } from "./session-list"
@@ -352,6 +353,7 @@ export namespace ToolRegistry {
       MemoryEditTool,
       MemorySearchTool,
       MemoryGetTool,
+      NoteArchiveTool,
       NoteListTool,
       NoteReadTool,
       NoteSearchTool,

--- a/packages/synergy/src/tool/registry.ts
+++ b/packages/synergy/src/tool/registry.ts
@@ -26,6 +26,7 @@ import { NoteSearchTool } from "./note-search"
 import { NoteWriteTool } from "./note-write"
 import { NoteEditTool } from "./note-edit"
 import { NoteArchiveTool } from "./note-archive"
+import { NoteDeleteTool } from "./note-delete"
 import { BlueprintLoopFinishTool } from "./blueprint-loop-finish"
 import { BlueprintLoopRestartTool } from "./blueprint-loop-restart"
 import { SessionListTool } from "./session-list"
@@ -359,6 +360,7 @@ export namespace ToolRegistry {
       NoteSearchTool,
       NoteWriteTool,
       NoteEditTool,
+      NoteDeleteTool,
       BlueprintLoopFinishTool,
       BlueprintLoopRestartTool,
       SessionListTool,

--- a/packages/synergy/src/tool/taxonomy.ts
+++ b/packages/synergy/src/tool/taxonomy.ts
@@ -117,6 +117,7 @@ const REGISTRY: Record<string, ToolTaxonomyEntry> = {
   memory_edit: entry("knowledge.memory", { stateful: true, auxiliary: true }),
   note_write: entry("knowledge.note", { stateful: true, auxiliary: true }),
   note_archive: entry("knowledge.note", { stateful: true, auxiliary: true }),
+  note_delete: entry("knowledge.note", { stateful: true }),
   note_edit: entry("knowledge.note", { stateful: true, auxiliary: true }),
   note_list: entry("knowledge.note"),
   note_read: entry("knowledge.note"),

--- a/packages/synergy/src/tool/taxonomy.ts
+++ b/packages/synergy/src/tool/taxonomy.ts
@@ -116,6 +116,7 @@ const REGISTRY: Record<string, ToolTaxonomyEntry> = {
   memory_write: entry("knowledge.memory", { stateful: true, auxiliary: true }),
   memory_edit: entry("knowledge.memory", { stateful: true, auxiliary: true }),
   note_write: entry("knowledge.note", { stateful: true, auxiliary: true }),
+  note_archive: entry("knowledge.note", { stateful: true, auxiliary: true }),
   note_edit: entry("knowledge.note", { stateful: true, auxiliary: true }),
   note_list: entry("knowledge.note"),
   note_read: entry("knowledge.note"),

--- a/packages/synergy/test/note/migration.test.ts
+++ b/packages/synergy/test/note/migration.test.ts
@@ -73,4 +73,57 @@ describe("note migrations", () => {
     expect(NoteMarkdown.toMarkdown(migrated.content)).toBe(beforeMarkdown)
     await expect(Storage.read(StoragePath.note(scopeID, "_index"))).rejects.toBeInstanceOf(Storage.NotFoundError)
   })
+
+  test("archived migration adds archived: false to legacy notes missing the field", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    const scopeID = Identifier.asScopeID(scope.id)
+    const noteID = Identifier.ascending("note")
+    const now = Date.now()
+
+    await Storage.write(StoragePath.note(scopeID, noteID), {
+      id: noteID,
+      title: "Legacy note without archived",
+      content: { type: "doc", content: [] },
+      pinned: false,
+      global: false,
+      tags: [],
+      version: 1,
+      time: { created: now, updated: now },
+    })
+
+    const migration = migrations.find((entry) => entry.id === "20260704-note-add-archived")
+    expect(migration).toBeDefined()
+    await migration!.up(() => {})
+
+    const migrated = await Storage.read<Record<string, unknown>>(StoragePath.note(scopeID, noteID))
+    expect(migrated.archived).toBe(false)
+  })
+
+  test("archived migration preserves existing archived: true", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    const scopeID = Identifier.asScopeID(scope.id)
+    const noteID = Identifier.ascending("note")
+    const now = Date.now()
+
+    await Storage.write(StoragePath.note(scopeID, noteID), {
+      id: noteID,
+      title: "Already archived note",
+      content: { type: "doc", content: [] },
+      pinned: false,
+      global: false,
+      tags: [],
+      archived: true,
+      version: 1,
+      time: { created: now, updated: now },
+    })
+
+    const migration = migrations.find((entry) => entry.id === "20260704-note-add-archived")
+    expect(migration).toBeDefined()
+    await migration!.up(() => {})
+
+    const migrated = await Storage.read<Record<string, unknown>>(StoragePath.note(scopeID, noteID))
+    expect(migrated.archived).toBe(true)
+  })
 })

--- a/packages/synergy/test/note/store.test.ts
+++ b/packages/synergy/test/note/store.test.ts
@@ -237,4 +237,226 @@ describe("NoteStore", () => {
       },
     })
   })
+
+  test("archived defaults to false on create", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({ title: "Default archived" })
+        expect(note.archived).toBe(false)
+      },
+    })
+  })
+
+  test("archive sets archived to true and preserves note data", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const created = await NoteStore.create({
+          title: "To archive",
+          content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Data" }] }] },
+          tags: ["tag1"],
+        })
+        const archived = await NoteStore.archive(scope.id, [created.id])
+        expect(archived[0].archived).toBe(true)
+        expect(archived[0].title).toBe("To archive")
+        expect(archived[0].tags).toEqual(["tag1"])
+        expect(archived[0].id).toBe(created.id)
+      },
+    })
+  })
+
+  test("unarchive restores active state without data loss", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const created = await NoteStore.create({
+          title: "To unarchive",
+          content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Restore me" }] }] },
+          tags: ["keep"],
+        })
+        await NoteStore.archive(scope.id, [created.id])
+        const restored = await NoteStore.unarchive(scope.id, [created.id])
+        expect(restored[0].archived).toBe(false)
+        expect(restored[0].title).toBe("To unarchive")
+        expect(restored[0].tags).toEqual(["keep"])
+      },
+    })
+  })
+
+  test("list defaults to active notes only", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const active = await NoteStore.create({ title: "Active note" })
+        const archived = await NoteStore.create({ title: "Archived note" })
+        await NoteStore.archive(scope.id, [archived.id])
+
+        const list = await NoteStore.list(scope.id)
+        expect(list.length).toBe(1)
+        expect(list[0].id).toBe(active.id)
+      },
+    })
+  })
+
+  test("list with all filter includes archived notes", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const active = await NoteStore.create({ title: "Active note" })
+        const archived = await NoteStore.create({ title: "Archived note" })
+        await NoteStore.archive(scope.id, [archived.id])
+
+        const list = await NoteStore.list(scope.id, "all")
+        expect(list.length).toBe(2)
+        const ids = list.map((n) => n.id)
+        expect(ids).toContain(active.id)
+        expect(ids).toContain(archived.id)
+      },
+    })
+  })
+
+  test("listMetaWithGlobal defaults to active notes only", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const active = await NoteStore.create({ title: "Active note" })
+        const archived = await NoteStore.create({ title: "Will archive" })
+        await NoteStore.archive(scope.id, [archived.id])
+
+        const meta = await NoteStore.listMetaWithGlobal(scope.id)
+        const ids = meta.map((m) => m.id)
+        expect(ids).toContain(active.id)
+        expect(ids).not.toContain(archived.id)
+      },
+    })
+  })
+
+  test("remove rejects active notes with NoteError.NotArchived", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({ title: "Cannot remove yet" })
+        await expect(NoteStore.remove(scope.id, note.id)).rejects.toBeInstanceOf(NoteError.NotArchived)
+      },
+    })
+  })
+
+  test("remove succeeds for archived notes", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({ title: "Can remove after archive" })
+        await NoteStore.archive(scope.id, [note.id])
+        await NoteStore.remove(scope.id, note.id)
+        await expect(NoteStore.get(scope.id, note.id)).rejects.toBeInstanceOf(Storage.NotFoundError)
+      },
+    })
+  })
+
+  test("removeAny cannot bypass the archived-only delete gate", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({ title: "Blocked from removeAny" })
+        await expect(NoteStore.removeAny(scope.id, note.id)).rejects.toBeInstanceOf(NoteError.NotArchived)
+      },
+    })
+  })
+
+  test("archived notes remain readable by get", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Still accessible",
+          content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Present" }] }] },
+        })
+        await NoteStore.archive(scope.id, [note.id])
+        const fetched = await NoteStore.get(scope.id, note.id)
+        expect(fetched.title).toBe("Still accessible")
+        expect(fetched.archived).toBe(true)
+      },
+    })
+  })
+
+  test("archive/unarchive preserves content, title, tags, pinned", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const content = {
+          type: "doc" as const,
+          content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text: "Preserved text" }] }],
+        }
+        const note = await NoteStore.create({
+          title: "Full data note",
+          content,
+          tags: ["a", "b"],
+        })
+
+        await NoteStore.update(scope.id, note.id, { expectedVersion: note.version, pinned: true })
+        await NoteStore.archive(scope.id, [note.id])
+        const restored = await NoteStore.unarchive(scope.id, [note.id])
+        expect(restored[0].title).toBe("Full data note")
+        expect(restored[0].tags).toEqual(["a", "b"])
+        expect(restored[0].archived).toBe(false)
+
+        const fetched = await NoteStore.get(scope.id, note.id)
+        expect(fetched.title).toBe("Full data note")
+        expect(fetched.tags).toEqual(["a", "b"])
+        expect(fetched.pinned).toBe(true)
+      },
+    })
+  })
+
+  test("archived filter returns archived notes", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        await NoteStore.create({ title: "Active note" })
+        const archived = await NoteStore.create({ title: "Archived note" })
+        await NoteStore.archive(scope.id, [archived.id])
+
+        const list = await NoteStore.list(scope.id, "archived")
+        expect(list.length).toBe(1)
+        expect(list[0].id).toBe(archived.id)
+      },
+    })
+  })
 })

--- a/packages/synergy/test/server/note-api.test.ts
+++ b/packages/synergy/test/server/note-api.test.ts
@@ -198,3 +198,167 @@ describe("GET /note/meta metadata route", () => {
     expect(note).toHaveProperty("content")
   })
 })
+
+describe("Note archive and delete routes", () => {
+  test("PUT /note/:id with { archived: true } archives the note", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    let noteId = ""
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const created = await NoteStore.create({ title: "To archive" })
+        noteId = created.id
+      },
+    })
+
+    const app = Server.App()
+    const res = await app.request(`/note/${noteId}?directory=${encodeURIComponent(tmp.path)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: true }),
+    })
+    expect(res.status).toBe(200)
+
+    const updated = (await res.json()) as Record<string, unknown>
+    expect(updated.archived).toBe(true)
+    expect(updated.id).toBe(noteId)
+  })
+
+  test("PUT /note/:id with { archived: false } unarchives the note", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    let noteId = ""
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const created = await NoteStore.create({ title: "To unarchive" })
+        noteId = created.id
+        await NoteStore.update(scope.id, noteId, { archived: true })
+      },
+    })
+
+    const app = Server.App()
+    const res = await app.request(`/note/${noteId}?directory=${encodeURIComponent(tmp.path)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: false }),
+    })
+    expect(res.status).toBe(200)
+
+    const updated = (await res.json()) as Record<string, unknown>
+    expect(updated.archived).toBe(false)
+    expect(updated.id).toBe(noteId)
+  })
+
+  test("DELETE /note/:id on active note returns 409 NoteNotArchivedError and note remains accessible", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    let noteId = ""
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const created = await NoteStore.create({ title: "Active note" })
+        noteId = created.id
+      },
+    })
+
+    const app = Server.App()
+    const deleteRes = await app.request(`/note/${noteId}?directory=${encodeURIComponent(tmp.path)}`, {
+      method: "DELETE",
+    })
+    expect(deleteRes.status).toBe(409)
+
+    const body = (await deleteRes.json()) as Record<string, unknown>
+    expect(body.name).toBe("NoteNotArchivedError")
+
+    // Note should still be accessible
+    const getRes = await app.request(`/note/${noteId}?directory=${encodeURIComponent(tmp.path)}`)
+    expect(getRes.status).toBe(200)
+    const note = (await getRes.json()) as Record<string, unknown>
+    expect(note.id).toBe(noteId)
+  })
+
+  test("DELETE /note/:id on archived note returns 200 true and then GET returns not found", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    let noteId = ""
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const created = await NoteStore.create({ title: "To delete" })
+        noteId = created.id
+        await NoteStore.update(scope.id, noteId, { archived: true })
+      },
+    })
+
+    const app = Server.App()
+    const deleteRes = await app.request(`/note/${noteId}?directory=${encodeURIComponent(tmp.path)}`, {
+      method: "DELETE",
+    })
+    expect(deleteRes.status).toBe(200)
+    expect(await deleteRes.json()).toBe(true)
+
+    // Verify note is gone
+    const getRes = await app.request(`/note/${noteId}?directory=${encodeURIComponent(tmp.path)}`)
+    expect(getRes.status).toBe(404)
+  })
+
+  test("GET /note/meta excludes archived notes by default", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    let activeNoteId = ""
+    let archivedNoteId = ""
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const active = await NoteStore.create({ title: "Active visible note" })
+        activeNoteId = active.id
+        const archived = await NoteStore.create({ title: "Archived hidden note" })
+        archivedNoteId = archived.id
+        await NoteStore.update(scope.id, archivedNoteId, { archived: true })
+      },
+    })
+
+    const app = Server.App()
+    const res = await app.request(`/note/meta?directory=${encodeURIComponent(tmp.path)}`)
+    expect(res.status).toBe(200)
+
+    const groups = (await res.json()) as Array<Record<string, unknown>>
+    const allIds = groups.flatMap((g) => (g.notes as Array<Record<string, unknown>>).map((n) => n.id))
+    expect(allIds).toContain(activeNoteId)
+    expect(allIds).not.toContain(archivedNoteId)
+  })
+
+  test("GET /note/meta?archived=true returns archived notes only", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+    let activeNoteId = ""
+    let archivedNoteId = ""
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const active = await NoteStore.create({ title: "Active note" })
+        activeNoteId = active.id
+        const archived = await NoteStore.create({ title: "Archived note" })
+        archivedNoteId = archived.id
+        await NoteStore.update(scope.id, archivedNoteId, { archived: true })
+      },
+    })
+
+    const app = Server.App()
+    const res = await app.request(`/note/meta?directory=${encodeURIComponent(tmp.path)}&archived=true`)
+    expect(res.status).toBe(200)
+
+    const groups = (await res.json()) as Array<Record<string, unknown>>
+    const allIds = groups.flatMap((g) => (g.notes as Array<Record<string, unknown>>).map((n) => n.id))
+    expect(allIds).toContain(archivedNoteId)
+    expect(allIds).not.toContain(activeNoteId)
+  })
+})

--- a/packages/synergy/test/tool/note-archive.test.ts
+++ b/packages/synergy/test/tool/note-archive.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+import { Scope } from "../../src/scope"
+import { ScopeContext } from "../../src/scope/context"
+import { NoteStore } from "../../src/note"
+import { NoteArchiveTool } from "../../src/tool/note-archive"
+import { tmpdir } from "../fixture/fixture"
+
+const ctx = {
+  sessionID: "test-note-archive",
+  messageID: "",
+  callID: "",
+  agent: "test-strategist",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+}
+
+async function execute(input: any) {
+  const tool = await NoteArchiveTool.init()
+  return tool.execute(input, ctx)
+}
+
+function paragraph(text: string) {
+  return { type: "paragraph", content: [{ type: "text", text }] }
+}
+
+describe("note_archive", () => {
+  test("archives multiple notes", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const a = await NoteStore.create({
+          title: "Alpha",
+          content: { type: "doc", content: [paragraph("a")] },
+        })
+        const b = await NoteStore.create({
+          title: "Beta",
+          content: { type: "doc", content: [paragraph("b")] },
+        })
+
+        const result = await execute({ ids: [a.id, b.id] })
+
+        expect(result.title).toBe("Archived 2 notes")
+        expect(result.output).toContain("Archived 2 notes")
+        expect(result.output).toContain(`[${a.id}] "Alpha"`)
+        expect(result.output).toContain(`[${b.id}] "Beta"`)
+        expect(result.metadata.count).toBe(2)
+        expect(result.metadata.action).toBe("archive")
+
+        const archivedA = await NoteStore.get(scope.id, a.id)
+        const archivedB = await NoteStore.get(scope.id, b.id)
+        expect(archivedA.archived).toBe(true)
+        expect(archivedB.archived).toBe(true)
+      },
+    })
+  })
+
+  test("is idempotent - archiving already archived note is not an error", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Already archived",
+          content: { type: "doc", content: [paragraph("x")] },
+        })
+
+        await execute({ ids: [note.id] })
+        const result = await execute({ ids: [note.id] })
+
+        expect(result.title).toBe("Archived 1 note")
+        expect(result.output).toContain(`[${note.id}]`)
+        expect(result.metadata.action).toBe("archive")
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(current.archived).toBe(true)
+      },
+    })
+  })
+
+  test("unarchives notes with unarchive: true", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "To restore",
+          content: { type: "doc", content: [paragraph("r")] },
+        })
+
+        await execute({ ids: [note.id] })
+        const archived = await NoteStore.get(scope.id, note.id)
+        expect(archived.archived).toBe(true)
+
+        const result = await execute({ ids: [note.id], unarchive: true })
+
+        expect(result.title).toBe("Unarchived 1 note")
+        expect(result.output).toContain("Restored 1 note")
+        expect(result.output).toContain(`[${note.id}] "To restore"`)
+        expect(result.metadata.count).toBe(1)
+        expect(result.metadata.action).toBe("unarchive")
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(current.archived).toBe(false)
+      },
+    })
+  })
+})

--- a/packages/synergy/test/tool/note-delete.test.ts
+++ b/packages/synergy/test/tool/note-delete.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test"
+import { Scope } from "../../src/scope"
+import { ScopeContext } from "../../src/scope/context"
+import { NoteStore } from "../../src/note"
+import { NoteDeleteTool } from "../../src/tool/note-delete"
+import { NoteArchiveTool } from "../../src/tool/note-archive"
+import { tmpdir } from "../fixture/fixture"
+
+const ctx = {
+  sessionID: "test-note-delete",
+  messageID: "",
+  callID: "",
+  agent: "test-strategist",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+}
+
+async function execute(input: any) {
+  const tool = await NoteDeleteTool.init()
+  return tool.execute(input, ctx)
+}
+
+function paragraph(text: string) {
+  return { type: "paragraph", content: [{ type: "text", text }] }
+}
+
+describe("note_delete", () => {
+  test("returns archive-first error for active notes and does not delete them", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Active note",
+          content: { type: "doc", content: [paragraph("keep me")] },
+        })
+
+        const result = await execute({ id: note.id })
+
+        expect(result.title).toBe("Cannot delete active note")
+        expect(result.output).toContain("must be archived")
+        expect(result.output).toContain(`"${note.title}"`)
+        expect(result.output).toContain(`[${note.id}]`)
+        expect(result.metadata.id).toBe(note.id)
+        expect(result.metadata.archived).toBe(false)
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(current).toBeDefined()
+        expect(current.title).toBe("Active note")
+      },
+    })
+  })
+
+  test("permanently deletes archived notes", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "To delete",
+          content: { type: "doc", content: [paragraph("goodbye")] },
+        })
+
+        const archiveTool = await NoteArchiveTool.init()
+        await archiveTool.execute(
+          { ids: [note.id], unarchive: false },
+          {
+            sessionID: "test-note-delete",
+            messageID: "",
+            callID: "",
+            agent: "test-strategist",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+            ask: async () => {},
+          },
+        )
+
+        const result = await execute({ id: note.id })
+
+        expect(result.title).toBe("Deleted note")
+        expect(result.output).toContain("Permanently deleted")
+        expect(result.output).toContain(`"${note.title}"`)
+        expect(result.output).toContain(`[${note.id}]`)
+        expect(result.metadata.id).toBe(note.id)
+        expect(result.metadata.archived).toBe(true)
+
+        try {
+          await NoteStore.get(scope.id, note.id)
+          expect.unreachable("Expected get to throw after permanent deletion")
+        } catch (err: any) {
+          expect(err).toBeDefined()
+        }
+      },
+    })
+  })
+})

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -817,6 +817,24 @@ export function getToolInfo(tool: string, input: any = {}, metadata: any = {}): 
         title: "Edit Note",
         subtitle: input.title || input.id,
       }
+    case "note_archive": {
+      const unarchive = input.unarchive as boolean | undefined
+      return {
+        icon: "archive",
+        title: unarchive ? "Unarchive Note" : "Archive Note",
+        subtitle: Array.isArray(input.ids)
+          ? input.ids.length === 1
+            ? input.ids[0]
+            : `${input.ids.length} notes`
+          : undefined,
+      }
+    }
+    case "note_delete":
+      return {
+        icon: "trash-2",
+        title: "Delete Note",
+        subtitle: input.id,
+      }
     case "blueprint_loop_finish":
       return {
         icon: BLUEPRINT_ICON,

--- a/packages/ui/src/components/tool/classifier.ts
+++ b/packages/ui/src/components/tool/classifier.ts
@@ -233,6 +233,8 @@ const TOOL_CATEGORIES: Record<string, SemanticCategory> = {
   note_edit: "note",
   note_list: "note",
   note_read: "note",
+  note_archive: "note",
+  note_delete: "note",
   blueprint_loop_finish: "blueprint",
   blueprint_loop_restart: "blueprint",
   skill: "skill",


### PR DESCRIPTION
## Summary

Implement issue #213: make note archive/unarchive a first-class system capability. Active notes must be archived before they can be permanently deleted. Adds batch archive via agent tool and UI, with archived-only delete gating.

Includes 2 atomic commits, 38 tests passing, root typecheck passing (10/10).

## Changes

### Data model & persistence
- `NoteTypes.Info.archived`: `z.boolean()` (required, default `false`)
- Migration `20260704-note-add-archived` backfills `archived: false`
- `NoteStore.normalize()` sets `archived ??= false` for legacy data

### Store behavior
- `ArchiveFilter` type: `"active" | "archived" | "all"`, applied to all list/listMeta variants
- `NoteStore.update()` handles `patch.archived`, publishes archive/unarchive events
- `NoteStore.remove()`/`removeAny()` reject active notes with `NoteError.NotArchived`
- `NoteEvent.Archived`/`Unarchived` bus events with `{ ids, scopeID }`

### Server & API
- `DELETE /note/:id` returns 409 for active notes
- `GET /note/meta`, `/note/all`, `/note/` accept `?archived=true/false`
- SDK regenerated

### Agent tools
- `note_archive(ids, action)` — batch archive/unarchive, idempotent
- `note_delete(id)` — single-note permanent delete, archived-first guard
- Registered in registry, exposure, taxonomy, enforcement, contexts, prompts, UI

### Web UI
- Active/archived toggle, multi-select with shift-click range selection
- Batch archive (no batch delete), archived view with per-note restore/delete
- Editor: Archive for active (with dirty guard), Restore + Delete for archived

### Tests (38 pass)
- 19 store, 3 migration, 11 API, 5 tool

Fixes #213