### PR TITLE
fix: eliminate Blueprint frontend flicker during loop execution

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -75,6 +75,7 @@ import {
   blueprintRequestErrorMessage,
   isTerminalBlueprintLoopStatus,
   resolveBlueprintSlotDisplay,
+  resolveEffectiveBlueprintActiveLoopID,
   type BlueprintSlotDisplay,
 } from "@/components/prompt-input/blueprint-slot"
 import { isWorktreeWorkspaceSelection, worktreeOptionSelection } from "@/components/session/worktree-session"
@@ -105,6 +106,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const [localArmedLoop, setLocalArmedLoop] = createSignal<BlueprintSlot | null>(null)
   const [blueprintLoading, setBlueprintLoading] = createSignal(false)
+  const [optimisticLoopID, setOptimisticLoopID] = createSignal<string | null>(null)
   const idle = { type: "idle" as const }
   const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
   const tabs = createMemo(() => layout.tabs(sessionKey()))
@@ -119,7 +121,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const working = createMemo(() => status()?.type !== "idle")
   const [pendingPlanMode, setPendingPlanMode] = createSignal(false)
   const storedPlanMode = createMemo(() => (params.id ? (info()?.blueprint?.planMode ?? false) : pendingPlanMode()))
-  const blueprintModeLocked = createMemo(() => !!localArmedLoop() || !!info()?.blueprint?.loopID)
+  const blueprintModeLocked = createMemo(() => !!localArmedLoop() || !!effectiveActiveLoopID())
   const planMode = createMemo(() => !blueprintModeLocked() && storedPlanMode())
   const sessionScopeDirectory = createMemo(() => {
     const scope = info()?.scope
@@ -163,10 +165,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       sessionLoopSource,
       (source) => {
         const loop = untrack(sessionLoop)
-        if (!source || (loop && loop.id !== source.loopID)) mutateSessionLoop(null)
+        if (!source) {
+          // Only clear if current loop doesn't already belong to this session.
+          if (loop && loop.sessionID !== params.id) mutateSessionLoop(null)
+          return
+        }
+        if (loop && loop.id !== source.loopID) mutateSessionLoop(null)
       },
       { defer: true },
     ),
+  )
+
+  const effectiveActiveLoopID = createMemo(() =>
+    resolveEffectiveBlueprintActiveLoopID({
+      sessionID: params.id,
+      sessionActiveLoopID: params.id ? info()?.blueprint?.loopID : undefined,
+      optimisticLoopID: optimisticLoopID(),
+      sessionLoop: sessionLoop(),
+    }),
   )
 
   const getBlueprintSlotStatusLabel = (status: string) => {
@@ -256,21 +272,28 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const applySessionLoopEvent = (loop: BlueprintLoopInfo) => {
+    // Accept events for the current session, even if activeLoopID hasn't arrived yet.
+    const isCurrentSession = loop.sessionID === params.id
     const activeLoopID = params.id ? info()?.blueprint?.loopID : undefined
     const displayedLoopID = untrack(sessionLoop)?.id
-    if (loop.id !== activeLoopID && loop.id !== displayedLoopID) return
 
-    // Terminal: clear whichever reference matched
+    // Ignore events for other sessions when we have no matching reference.
+    if (!isCurrentSession && loop.id !== activeLoopID && loop.id !== displayedLoopID) return
+
+    // Terminal: clear whichever reference matched.
     if (isTerminalBlueprintLoopStatus(loop.status)) {
-      if (loop.id === activeLoopID) clearVisibleSessionLoop(params.id, loop.id)
-      else if (loop.id === displayedLoopID) mutateSessionLoop(null)
+      if (loop.id === activeLoopID || (isCurrentSession && loop.id === displayedLoopID)) {
+        clearVisibleSessionLoop(params.id, loop.id)
+      } else if (loop.id === displayedLoopID) {
+        mutateSessionLoop(null)
+      }
+      setOptimisticLoopID(null)
       return
     }
 
-    // Non-terminal: always update the display. Don't clear first — the
-    // session binding (activeLoopID) may arrive after the loop event,
-    // and clearing would cause a visible flicker.
+    // Non-terminal: update display and set optimistic ID.
     mutateSessionLoop(loop)
+    if (isCurrentSession) setOptimisticLoopID(loop.id)
   }
 
   const unsubBlueprintLoopUpdated = sdk.event.on("blueprint_loop.updated", (event) => {
@@ -364,11 +387,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return resolveBlueprintSlotDisplay({
       localSlot: localArmedLoop(),
       sessionLoop: sessionLoop(),
-      activeLoopID: params.id ? info()?.blueprint?.loopID : undefined,
+      activeLoopID: effectiveActiveLoopID(),
     })
   })
 
-  const canSubmit = createMemo(() => prompt.dirty() || working() || !!localArmedLoop())
+  const submitWorking = createMemo(() => {
+    if (working()) return true
+    const bp = displayedBlueprintLoop()
+    return !!(bp && bp.mode === "running")
+  })
+  const canSubmit = createMemo(() => prompt.dirty() || submitWorking() || !!localArmedLoop())
   const blueprintSubmitActive = createMemo(() => !!displayedBlueprintLoop() && !!localArmedLoop() && !working())
 
   createEffect(
@@ -377,6 +405,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       () => {
         cancelLongPress()
         setLocalArmedLoop(null)
+        setOptimisticLoopID(null)
       },
       { defer: true },
     ),
@@ -1448,7 +1477,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   inactive={!canSubmit()}
                   value={
                     <Switch>
-                      <Match when={working() && !prompt.dirty()}>
+                      <Match when={submitWorking() && !prompt.dirty()}>
                         <div class="flex items-center gap-2">
                           <span>Stop</span>
                           <span class="text-icon-base text-12-medium text-[10px]!">ESC</span>
@@ -1466,7 +1495,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   <IconButton
                     type="submit"
                     disabled={!canSubmit()}
-                    icon={working() && !prompt.dirty() ? "square" : "arrow-up"}
+                    icon={submitWorking() && !prompt.dirty() ? "square" : "arrow-up"}
                     variant="primary"
                     class="prompt-input-submit size-9 rounded-full!"
                   />

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -118,7 +118,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const status = createMemo(() => sync.data.session_status[params.id ?? ""] ?? idle)
-  const working = createMemo(() => status()?.type !== "idle")
+  const rawWorking = createMemo(() => status()?.type !== "idle")
+  const working = createMemo(() => rawWorking() || !!effectiveActiveLoopID())
   const [pendingPlanMode, setPendingPlanMode] = createSignal(false)
   const storedPlanMode = createMemo(() => (params.id ? (info()?.blueprint?.planMode ?? false) : pendingPlanMode()))
   const sessionScopeDirectory = createMemo(() => {

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -121,8 +121,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const working = createMemo(() => status()?.type !== "idle")
   const [pendingPlanMode, setPendingPlanMode] = createSignal(false)
   const storedPlanMode = createMemo(() => (params.id ? (info()?.blueprint?.planMode ?? false) : pendingPlanMode()))
-  const blueprintModeLocked = createMemo(() => !!localArmedLoop() || !!effectiveActiveLoopID())
-  const planMode = createMemo(() => !blueprintModeLocked() && storedPlanMode())
   const sessionScopeDirectory = createMemo(() => {
     const scope = info()?.scope
     if (!scope || typeof scope !== "object") return undefined
@@ -184,6 +182,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       sessionLoop: sessionLoop(),
     }),
   )
+  const blueprintModeLocked = createMemo(() => !!localArmedLoop() || !!effectiveActiveLoopID())
+  const planMode = createMemo(() => !blueprintModeLocked() && storedPlanMode())
 
   const getBlueprintSlotStatusLabel = (status: string) => {
     switch (status) {

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -118,8 +118,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const status = createMemo(() => sync.data.session_status[params.id ?? ""] ?? idle)
-  const rawWorking = createMemo(() => status()?.type !== "idle")
-  const working = createMemo(() => rawWorking() || !!effectiveActiveLoopID())
   const [pendingPlanMode, setPendingPlanMode] = createSignal(false)
   const storedPlanMode = createMemo(() => (params.id ? (info()?.blueprint?.planMode ?? false) : pendingPlanMode()))
   const sessionScopeDirectory = createMemo(() => {
@@ -183,6 +181,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       sessionLoop: sessionLoop(),
     }),
   )
+  const rawWorking = createMemo(() => status()?.type !== "idle")
+  const working = createMemo(() => rawWorking() || !!effectiveActiveLoopID())
   const blueprintModeLocked = createMemo(() => !!localArmedLoop() || !!effectiveActiveLoopID())
   const planMode = createMemo(() => !blueprintModeLocked() && storedPlanMode())
 

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -383,12 +383,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
   onCleanup(cancelLongPress)
 
+  let lastDisplayedLoop: BlueprintSlotDisplay | null = null
   const displayedBlueprintLoop = createMemo<BlueprintSlotDisplay | null>(() => {
-    return resolveBlueprintSlotDisplay({
+    const result = resolveBlueprintSlotDisplay({
       localSlot: localArmedLoop(),
       sessionLoop: sessionLoop(),
       activeLoopID: effectiveActiveLoopID(),
     })
+    if (result) {
+      lastDisplayedLoop = result
+      return result
+    }
+    // Hold the last non-null display while the effective loop is still
+    // known to be active — prevents one-frame slot disappearance during
+    // resource re-fetch or mutation→stabilize gaps.
+    return effectiveActiveLoopID() ? lastDisplayedLoop : null
   })
 
   const submitWorking = createMemo(() => {

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -394,7 +394,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const submitWorking = createMemo(() => {
     if (working()) return true
     const bp = displayedBlueprintLoop()
-    return !!(bp && bp.mode === "running")
+    return !!(bp && !isTerminalBlueprintLoopStatus(bp.mode))
   })
   const canSubmit = createMemo(() => prompt.dirty() || submitWorking() || !!localArmedLoop())
   const blueprintSubmitActive = createMemo(() => !!displayedBlueprintLoop() && !!localArmedLoop() && !working())

--- a/packages/app/src/components/prompt-input/blueprint-slot.test.ts
+++ b/packages/app/src/components/prompt-input/blueprint-slot.test.ts
@@ -4,17 +4,20 @@ import {
   blueprintRequestErrorMessage,
   isTerminalBlueprintLoopStatus,
   resolveBlueprintSlotDisplay,
+  resolveEffectiveBlueprintActiveLoopID,
   type BlueprintSlotDisplay,
 } from "./blueprint-slot"
 import type { BlueprintSlot } from "./types"
 
-function loop(status: BlueprintLoopInfo["status"] = "running") {
+function loop(status: BlueprintLoopInfo["status"] = "running", overrides?: Partial<BlueprintLoopInfo>) {
   return {
     id: "bll_active",
     noteID: "note_blueprint",
     title: "Active Blueprint",
     runMode: "current" as const,
     status: status as any,
+    sessionID: "ses_test",
+    ...overrides,
   }
 }
 
@@ -110,5 +113,135 @@ describe("prompt blueprint request errors", () => {
   test("uses nested data messages before falling back", () => {
     expect(blueprintRequestErrorMessage({ data: { message: "Loop not found" } })).toBe("Loop not found")
     expect(blueprintRequestErrorMessage({})).toBe("Request failed")
+  })
+})
+
+describe("resolveEffectiveBlueprintActiveLoopID", () => {
+  test("session active ID wins over optimistic ID", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: "bll_active",
+        optimisticLoopID: "bll_optimistic",
+      }),
+    ).toBe("bll_active")
+  })
+
+  test("session active ID wins over sessionLoop", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: "bll_active",
+        sessionLoop: { id: "bll_other", sessionID: "ses_test", status: "running" },
+      }),
+    ).toBe("bll_active")
+  })
+
+  test("non-terminal sessionLoop for current session bridges missing active ID", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: undefined,
+        sessionLoop: { id: "bll_bridge", sessionID: "ses_test", status: "running" },
+      }),
+    ).toBe("bll_bridge")
+  })
+
+  test("non-terminal sessionLoop for current session bridges null active ID", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: null,
+        sessionLoop: { id: "bll_bridge", sessionID: "ses_test", status: "waiting" },
+      }),
+    ).toBe("bll_bridge")
+  })
+
+  test("loop for another session does not bridge", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: undefined,
+        sessionLoop: { id: "bll_other", sessionID: "ses_other", status: "running" },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("terminal loop never bridges", () => {
+    const terminalStatuses: BlueprintLoopInfo["status"][] = ["completed", "failed", "cancelled"]
+    for (const status of terminalStatuses) {
+      expect(
+        resolveEffectiveBlueprintActiveLoopID({
+          sessionID: "ses_test",
+          sessionActiveLoopID: undefined,
+          sessionLoop: { id: "bll_done", sessionID: "ses_test", status },
+        }),
+      ).toBeUndefined()
+    }
+  })
+
+  test("optimistic loop ID matches sessionLoop when no active ID", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: undefined,
+        optimisticLoopID: "bll_opt",
+        sessionLoop: { id: "bll_opt", sessionID: "ses_test", status: "running" },
+      }),
+    ).toBe("bll_opt")
+  })
+
+  test("optimistic loop ID mismatching sessionLoop still bridges when sessionLoop belongs to current session", () => {
+    // The session loop for current session bridges regardless of optimistic ID.
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: undefined,
+        optimisticLoopID: "bll_mismatch",
+        sessionLoop: { id: "bll_other", sessionID: "ses_test", status: "running" },
+      }),
+    ).toBe("bll_other")
+  })
+
+  test("optimistic loop ID with terminal sessionLoop returns undefined", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: undefined,
+        optimisticLoopID: "bll_opt",
+        sessionLoop: { id: "bll_opt", sessionID: "ses_test", status: "completed" },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("undefined everything returns undefined", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: undefined,
+        sessionActiveLoopID: undefined,
+        optimisticLoopID: undefined,
+        sessionLoop: undefined,
+      }),
+    ).toBeUndefined()
+  })
+
+  test("null everything returns undefined", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: null,
+        sessionActiveLoopID: null,
+        optimisticLoopID: null,
+        sessionLoop: null,
+      }),
+    ).toBeUndefined()
+  })
+
+  test("no sessionLoop and no active ID returns undefined", () => {
+    expect(
+      resolveEffectiveBlueprintActiveLoopID({
+        sessionID: "ses_test",
+        sessionActiveLoopID: undefined,
+      }),
+    ).toBeUndefined()
   })
 })

--- a/packages/app/src/components/prompt-input/blueprint-slot.ts
+++ b/packages/app/src/components/prompt-input/blueprint-slot.ts
@@ -6,12 +6,48 @@ export type BlueprintSlotDisplay = {
   mode: string
 }
 
-type DisplayLoop = Pick<BlueprintLoopInfo, "id" | "noteID" | "title" | "runMode" | "status">
+export type BlueprintDisplayLoop = Pick<
+  BlueprintLoopInfo,
+  "id" | "noteID" | "title" | "runMode" | "status" | "sessionID"
+>
+
+type DisplayLoop = BlueprintDisplayLoop
 
 const TERMINAL_BLUEPRINT_LOOP_STATUSES = new Set(["completed", "failed", "cancelled"])
 
 export function isTerminalBlueprintLoopStatus(status?: string | null) {
   return !!status && TERMINAL_BLUEPRINT_LOOP_STATUSES.has(status)
+}
+
+export function resolveEffectiveBlueprintActiveLoopID(input: {
+  sessionID?: string | null
+  sessionActiveLoopID?: string | null
+  optimisticLoopID?: string | null
+  sessionLoop?: Pick<BlueprintDisplayLoop, "id" | "sessionID" | "status"> | null
+}): string | undefined {
+  // 1. Prefer sessionActiveLoopID when present.
+  if (input.sessionActiveLoopID) return input.sessionActiveLoopID
+
+  // 2. Bridge: sessionLoop is non-terminal and belongs to current session.
+  if (
+    input.sessionLoop &&
+    !isTerminalBlueprintLoopStatus(input.sessionLoop.status) &&
+    input.sessionLoop.sessionID === input.sessionID
+  ) {
+    return input.sessionLoop.id
+  }
+
+  // 3. Optimistic loop ID matches sessionLoop and sessionLoop is non-terminal.
+  if (
+    input.optimisticLoopID &&
+    input.sessionLoop &&
+    input.sessionLoop.id === input.optimisticLoopID &&
+    !isTerminalBlueprintLoopStatus(input.sessionLoop.status)
+  ) {
+    return input.sessionLoop.id
+  }
+
+  return undefined
 }
 
 export function resolveBlueprintSlotDisplay(input: {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -339,9 +339,9 @@ export function usePromptSubmit(input: PromptSubmitInput) {
     if (blueprintSlot && mode === "normal") {
       input.setBlueprintLoading(true)
       let createdLoopID: string | undefined
+      let loopID: string | undefined
       try {
         const userText = text.trim()
-        let loopID: string
         if (blueprintSlot.type === "pending") {
           const result = await sdk.client.blueprint.loop.create({
             blueprintLoopCreateInput: {
@@ -359,8 +359,21 @@ export function usePromptSubmit(input: PromptSubmitInput) {
           loopID = blueprintSlot.loopID
         }
 
+        // Optimistically bind the loop to current session so toolbar slot
+        // never disappears between create and the server-authored session.updated.
+        if (activeSession.id) {
+          sync.set(
+            produce((draft) => {
+              const session = draft.session.find((item) => item.id === activeSession.id)
+              if (session) {
+                session.blueprint = { ...session.blueprint, loopID, loopRole: "execution" as const, planMode: false }
+              }
+            }),
+          )
+        }
+
         clearInput()
-        await sdk.client.blueprint.loop.start({ id: loopID, userPrompt: userText || undefined })
+        await sdk.client.blueprint.loop.start({ id: loopID!, userPrompt: userText || undefined })
         closeStartProgress()
       } catch (err) {
         if (createdLoopID) {
@@ -373,6 +386,17 @@ export function usePromptSubmit(input: PromptSubmitInput) {
           description: errorMessage(err),
         })
         rollbackCreatedSession()
+        // Clear optimistic session binding on failure.
+        if (loopID && activeSession.id) {
+          sync.set(
+            produce((draft) => {
+              const session = draft.session.find((item) => item.id === activeSession.id)
+              if (session && session.blueprint?.loopID === loopID) {
+                session.blueprint = { ...session.blueprint, loopID: undefined }
+              }
+            }),
+          )
+        }
         restoreInput()
       } finally {
         input.setBlueprintLoading(false)

--- a/packages/app/src/components/session/session-progress-panel.tsx
+++ b/packages/app/src/components/session/session-progress-panel.tsx
@@ -41,6 +41,10 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
     completionTimer = undefined
   }
 
+  const blueprintLoopActive = createMemo(
+    () => !!sync.data.session.find((s) => s.id === props.sessionID)?.blueprint?.loopID,
+  )
+
   const dagNodes = createMemo(() => sync.data.dag[props.sessionID])
   const todos = createMemo(() => sync.data.todo[props.sessionID])
   const dagList = createMemo(() => dagNodes() ?? [])
@@ -79,7 +83,7 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
     clearCompletionTimer()
 
     if (current.status === "hidden") {
-      if (state.visible && !state.exiting) {
+      if (state.visible && !state.exiting && !blueprintLoopActive()) {
         setState("exiting", true)
         completionTimer = setTimeout(() => {
           setState({ expanded: false, visible: false, exiting: false })
@@ -91,8 +95,8 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
     }
     setState("visible", true)
 
-    // Complete → fade out after delay
-    if (current.status === "complete" && !state.expanded) {
+    // Complete → fade out after delay (but keep visible during blueprint loop)
+    if (current.status === "complete" && !state.expanded && !blueprintLoopActive()) {
       completionTimer = setTimeout(() => {
         setState("exiting", true)
         completionTimer = setTimeout(() => {
@@ -115,7 +119,7 @@ export function SessionProgressPanel(props: SessionProgressPanelProps) {
   const setExpanded = (expanded: boolean) => {
     clearCompletionTimer()
     setState("expanded", expanded)
-    if (!expanded && snapshot().status === "complete") {
+    if (!expanded && snapshot().status === "complete" && !blueprintLoopActive()) {
       completionTimer = setTimeout(() => {
         setState("exiting", true)
         completionTimer = setTimeout(() => {

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -34,6 +34,10 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
         const part = payload.properties.part
         return `message.part.updated:${directory}:${part.messageID}:${part.id}`
       }
+      if (payload.type === "blueprint_loop.updated") {
+        const loop = payload.properties.loop
+        return `blueprint_loop.updated:${directory}:${loop.id}`
+      }
     }
 
     const flush = () => {


### PR DESCRIPTION
## Summary
- Eliminates frontend UI flickering during BlueprintLoop execution by closing six race-condition gaps:
  - **D1**: Bridge function `resolveEffectiveBlueprintActiveLoopID` to produce a stable active loop ID
  - **D2**: Stabilize PromptInput with optimistic loop ID tracking and event acceptance for current session before server binding arrives
  - **D3**: Optimistically bind loop to session in submit path after `loop.create`, preventing toolbar slot disappearance
  - **D4**: Separate `submitWorking` from generic `working()` so submit button stays stable during continuation idle gaps
  - **D5**: Keep session progress island visible while BlueprintLoop is active
  - **D6**: Coalesce `blueprint_loop.updated` events in WebSocket flush window

## Test plan
- 59/59 unit tests pass (blueprint-slot 23, session-progress-summary 25, global-sync 11)
- All 10 typecheck packages pass
- Manual smoke test: run a multi-continuation BlueprintLoop and verify toolbar slot, submit button, and progress island remain stable

## Checklist
- [x] Typecheck passes
- [x] Tests pass
- [x] Formatting clean