### PR TITLE
fix(session): stop calibration at compaction boundary

### DIFF
--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -1765,7 +1765,10 @@ export namespace SessionInvoke {
       const info = msgs[i].info
       if (info.role !== "assistant") continue
       const assistant = info as MessageV2.Assistant
-      if (assistant.summary) continue
+      if (assistant.summary) {
+        if (assistant.finish) break
+        continue
+      }
       const tokens = assistant.tokens
       if (ModelLimit.actualInput(tokens) > 0) {
         calibrationIdx = i

--- a/packages/synergy/test/session/invoke-compaction.test.ts
+++ b/packages/synergy/test/session/invoke-compaction.test.ts
@@ -22,7 +22,36 @@ class CompactionIntercept extends Error {
   }
 }
 
-describe("SessionInvoke preflight compaction", () => {
+function testModel() {
+  return {
+    id: "test-model",
+    providerID: "test-provider",
+    name: "Test Model",
+    limit: { context: 100_000, output: 8_192 },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      input: { text: true, image: false, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+    },
+    api: { npm: "@ai-sdk/openai" },
+    options: {},
+  }
+}
+
+function primaryAgent() {
+  return {
+    name: "synergy",
+    mode: "primary",
+    permission: PermissionNext.fromConfig({ "*": "allow" }),
+    options: {},
+  }
+}
+
+describe.serial("SessionInvoke preflight compaction", () => {
   test("injects a compaction part before main inference when prompt budget is exceeded", async () => {
     await using tmp = await tmpdir({ git: true })
 
@@ -42,29 +71,8 @@ describe("SessionInvoke preflight compaction", () => {
     const interceptedCompactionParts: Array<{ messageID: string; sessionID: string; auto: boolean }> = []
 
     try {
-      ;(Provider.getModel as any) = mock(async () => ({
-        id: "test-model",
-        providerID: "test-provider",
-        name: "Test Model",
-        limit: { context: 100_000, output: 8_192 },
-        cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-        capabilities: {
-          toolcall: true,
-          attachment: false,
-          reasoning: false,
-          temperature: true,
-          input: { text: true, image: false, audio: false, video: false },
-          output: { text: true, image: false, audio: false, video: false },
-        },
-        api: { npm: "@ai-sdk/openai" },
-        options: {},
-      }))
-      ;(Agent.get as any) = mock(async () => ({
-        name: "synergy",
-        mode: "primary",
-        permission: PermissionNext.fromConfig({ "*": "allow" }),
-        options: {},
-      }))
+      ;(Provider.getModel as any) = mock(async () => testModel())
+      ;(Agent.get as any) = mock(async () => primaryAgent())
       ;(Config.current as any) = mock(async () => ({
         ...(await originalConfigCurrent()),
         compaction: { auto: true, maxHistoryImages: 8 },
@@ -174,29 +182,8 @@ describe("SessionInvoke preflight compaction", () => {
     let processCount = 0
 
     try {
-      ;(Provider.getModel as any) = mock(async () => ({
-        id: "test-model",
-        providerID: "test-provider",
-        name: "Test Model",
-        limit: { context: 100_000, output: 8_192 },
-        cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-        capabilities: {
-          toolcall: true,
-          attachment: false,
-          reasoning: false,
-          temperature: true,
-          input: { text: true, image: false, audio: false, video: false },
-          output: { text: true, image: false, audio: false, video: false },
-        },
-        api: { npm: "@ai-sdk/openai" },
-        options: {},
-      }))
-      ;(Agent.get as any) = mock(async () => ({
-        name: "synergy",
-        mode: "primary",
-        permission: PermissionNext.fromConfig({ "*": "allow" }),
-        options: {},
-      }))
+      ;(Provider.getModel as any) = mock(async () => testModel())
+      ;(Agent.get as any) = mock(async () => primaryAgent())
       ;(Config.current as any) = mock(async () => ({
         ...(await originalConfigCurrent()),
         compaction: { auto: true, maxHistoryImages: 8 },
@@ -281,6 +268,224 @@ describe("SessionInvoke preflight compaction", () => {
       ;(PromptBudgeter.buildPlan as any) = originalBuildPlan
       ;(PromptBudgeter.decide as any) = originalDecide
       ;(SessionProcessor.create as any) = originalProcessorCreate
+      ;(Cortex.list as any) = originalCortexList
+      ;(Cortex.getRunningTasks as any) = originalCortexGetRunningTasks
+    }
+  })
+
+  test("does not reuse token calibration across a completed compaction boundary", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const originalGetModel = Provider.getModel
+    const originalGetAgent = Agent.get
+    const originalConfigCurrent = Config.current
+    const originalDefinitions = ToolResolver.definitions
+    const originalResolveWithAvailability = ToolResolver.resolveWithAvailability
+    const originalBuildPlan = PromptBudgeter.buildPlan
+    const originalDecide = PromptBudgeter.decide
+    const originalProcessorCreate = SessionProcessor.create
+    const originalUpdatePart = Session.updatePart
+    const originalCortexList = Cortex.list
+    const originalCortexGetRunningTasks = Cortex.getRunningTasks
+
+    const decideOptions: Array<Parameters<typeof PromptBudgeter.decide>[3]> = []
+    const interceptedCompactionParts: Array<{ messageID: string; sessionID: string; auto: boolean }> = []
+    let processCount = 0
+
+    try {
+      ;(Provider.getModel as any) = mock(async () => testModel())
+      ;(Agent.get as any) = mock(async () => primaryAgent())
+      ;(Config.current as any) = mock(async () => ({
+        ...(await originalConfigCurrent()),
+        compaction: { auto: true, maxHistoryImages: 8 },
+      }))
+      ;(ToolResolver.definitions as any) = mock(async () => [])
+      ;(ToolResolver.resolveWithAvailability as any) = mock(async () => ({ tools: {}, activeToolIDs: [] }))
+      ;(PromptBudgeter.buildPlan as any) = mock(async () => ({
+        system: ["stub system"],
+        messages: [{ role: "user", content: "stub message" }],
+        toolDefinitions: [],
+      }))
+      ;(PromptBudgeter.decide as any) = mock(
+        async (
+          _plan: Parameters<typeof PromptBudgeter.decide>[0],
+          _limits: Parameters<typeof PromptBudgeter.decide>[1],
+          _modelID: Parameters<typeof PromptBudgeter.decide>[2],
+          options: Parameters<typeof PromptBudgeter.decide>[3],
+        ) => {
+          decideOptions.push(options)
+          const shouldCompact = !!options?.calibration
+          return {
+            budget: { context: 100_000, usable: 100_000, threshold: 0.85, soft: 85_000 },
+            measure: {
+              system: 10,
+              messages: shouldCompact ? 90_000 : 10,
+              tools: 0,
+              total: shouldCompact ? 90_000 : 20,
+            },
+            shouldCompact,
+          }
+        },
+      )
+      ;(SessionProcessor.create as any) = mock((input: Parameters<typeof SessionProcessor.create>[0]) => ({
+        message: input.assistantMessage,
+        partFromToolCall: () => undefined,
+        trackExecution: () => {},
+        process: mock(async () => {
+          processCount++
+          input.assistantMessage.finish = "stop"
+          input.assistantMessage.time.completed = Date.now()
+          await Session.updateMessage(input.assistantMessage)
+          return "stop" as const
+        }),
+      }))
+      ;(Cortex.list as any) = mock(() => [])
+      ;(Cortex.getRunningTasks as any) = mock(() => [])
+
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const sessionID = session.id
+          const created = Date.now()
+
+          const user = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "user",
+            sessionID,
+            agent: "synergy",
+            model: {
+              providerID: "test-provider",
+              modelID: "test-model",
+            },
+            time: {
+              created,
+            },
+          })
+
+          await originalUpdatePart({
+            id: Identifier.ascending("part"),
+            messageID: user.id,
+            sessionID,
+            type: "text",
+            text: "Analyze the status bar content.",
+          })
+          await originalUpdatePart({
+            id: Identifier.ascending("part"),
+            messageID: user.id,
+            sessionID,
+            type: "compaction",
+            auto: true,
+          })
+
+          await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "assistant",
+            parentID: user.id,
+            sessionID,
+            modelID: "test-model",
+            providerID: "test-provider",
+            mode: "synergy",
+            agent: "synergy",
+            path: {
+              cwd: tmp.path,
+              root: tmp.path,
+            },
+            cost: 0,
+            tokens: {
+              input: 91_000,
+              output: 6_000,
+              reasoning: 1_000,
+              cache: { read: 0, write: 0 },
+            },
+            finish: "stop",
+            time: {
+              created: created + 1,
+              completed: created + 2,
+            },
+          })
+
+          await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "assistant",
+            parentID: user.id,
+            sessionID,
+            modelID: "test-model",
+            providerID: "test-provider",
+            mode: "compaction",
+            agent: "compaction",
+            summary: true,
+            path: {
+              cwd: tmp.path,
+              root: tmp.path,
+            },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            finish: "stop",
+            time: {
+              created: created + 3,
+              completed: created + 4,
+            },
+          })
+
+          const continueUser = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "user",
+            sessionID,
+            agent: "synergy",
+            model: {
+              providerID: "test-provider",
+              modelID: "test-model",
+            },
+            summary: { title: "Compaction complete", diffs: [] },
+            time: {
+              created: created + 5,
+            },
+          })
+
+          await originalUpdatePart({
+            id: Identifier.ascending("part"),
+            messageID: continueUser.id,
+            sessionID,
+            type: "text",
+            synthetic: true,
+            text: "Continue if you have next steps",
+          })
+          ;(Session.updatePart as any) = mock(async (input: Parameters<typeof Session.updatePart>[0]) => {
+            if ("type" in input && input.type === "compaction") {
+              interceptedCompactionParts.push({
+                messageID: input.messageID,
+                sessionID: input.sessionID,
+                auto: input.auto,
+              })
+              throw new CompactionIntercept()
+            }
+            return await originalUpdatePart(input as any)
+          })
+
+          await SessionInvoke.loop.force(sessionID)
+
+          expect(decideOptions).toHaveLength(1)
+          expect(decideOptions[0]?.calibration).toBeUndefined()
+          expect(interceptedCompactionParts).toEqual([])
+          expect(processCount).toBe(1)
+        },
+      })
+    } finally {
+      ;(Provider.getModel as any) = originalGetModel
+      ;(Agent.get as any) = originalGetAgent
+      ;(Config.current as any) = originalConfigCurrent
+      ;(ToolResolver.definitions as any) = originalDefinitions
+      ;(ToolResolver.resolveWithAvailability as any) = originalResolveWithAvailability
+      ;(PromptBudgeter.buildPlan as any) = originalBuildPlan
+      ;(PromptBudgeter.decide as any) = originalDecide
+      ;(SessionProcessor.create as any) = originalProcessorCreate
+      ;(Session.updatePart as any) = originalUpdatePart
       ;(Cortex.list as any) = originalCortexList
       ;(Cortex.getRunningTasks as any) = originalCortexGetRunningTasks
     }


### PR DESCRIPTION
## Summary
- stop prompt-budget calibration from crossing completed compaction summaries
- add regression coverage for synthetic continue after auto compaction
- keep the fix backend-only with no schema or UI changes

## Tests
- bun test test/session/invoke-compaction.test.ts
- bun run typecheck
- pre-push typecheck and prettier check