### PR TITLE
fix(plugin): regenerate bun.lock after sdk dependency move

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -142,10 +142,10 @@
       "name": "@ericsanchezok/synergy-plugin",
       "version": "1.1.26",
       "dependencies": {
+        "@ericsanchezok/synergy-sdk": "workspace:*",
         "@ericsanchezok/synergy-util": "workspace:*",
       },
       "devDependencies": {
-        "@ericsanchezok/synergy-sdk": "workspace:*",
         "@tsconfig/node22": "catalog:",
         "@types/node": "catalog:",
         "@typescript/native-preview": "catalog:",


### PR DESCRIPTION
## Summary

- Commit `07d09996` moved `@ericsanchezok/synergy-sdk` from `devDependencies` to `dependencies` in `packages/plugin/package.json`
- The `bun.lock` was not regenerated, causing the CI format check to fail (prettier formats the lockfile)
- Running `bun install` regenerates `bun.lock` correctly — this PR commits that change