### PR TITLE
fix: brand managed worktree names

### DIFF
--- a/packages/synergy/src/project/worktree.ts
+++ b/packages/synergy/src/project/worktree.ts
@@ -7,6 +7,7 @@ import { parse as parseJsonc } from "jsonc-parser"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import { Identifier } from "../id/id"
 import { Session } from "../session"
+import { isDefaultTitle } from "../session/title"
 import type { Scope } from "../scope"
 import { ScopeContext } from "../scope/context"
 import { fn } from "../util/fn"
@@ -228,6 +229,16 @@ export namespace Worktree {
       .replace(/^-+/, "")
       .replace(/-+$/, "")
     return result || randomName()
+  }
+
+  function purposeSlug(input?: string) {
+    const base = input ? slug(input) : "session"
+    const withoutBrand = base.replace(/^synergy(?:-+|$)/, "")
+    return withoutBrand || "session"
+  }
+
+  function worktreeName(segment: string) {
+    return `synergy-${segment}`
   }
 
   function hashID(input: string) {
@@ -499,11 +510,12 @@ export namespace Worktree {
 
   async function candidate(repoRoot: string, baseName?: string, sessionID?: string) {
     const root = worktreesRoot(repoRoot)
-    const base = slug(baseName || randomName())
+    const purpose = purposeSlug(baseName)
     const suffix = sessionID ? sessionID.replace(/^ses_/, "").slice(0, 6) : Date.now().toString(36).slice(-6)
     for (const attempt of Array.from({ length: 26 }, (_, i) => i)) {
-      const name = attempt === 0 ? `${base}-${suffix}` : `${base}-${suffix}-${attempt + 1}`
-      const branch = `synergy/${name}`
+      const segment = attempt === 0 ? `${purpose}-${suffix}` : `${purpose}-${suffix}-${attempt + 1}`
+      const name = worktreeName(segment)
+      const branch = `synergy/${segment}`
       const directory = path.join(root, name)
       if (await exists(directory)) continue
       const ref = `refs/heads/${branch}`
@@ -526,7 +538,7 @@ export namespace Worktree {
     await fs.mkdir(worktreesRoot(repoRoot), { recursive: true })
 
     const session = parsed.sessionID ? await Session.get(parsed.sessionID) : undefined
-    const titleName = session?.title && !session.title.startsWith("New Session") ? session.title : undefined
+    const titleName = session?.title && !isDefaultTitle(session.title) ? session.title : undefined
     const info = await candidate(repoRoot, parsed.name ?? titleName, parsed.sessionID)
     const base = await resolveBase({ baseRef: parsed.baseRef, baseRevision: parsed.baseRevision }, repoRoot)
 

--- a/packages/synergy/test/project/worktree.test.ts
+++ b/packages/synergy/test/project/worktree.test.ts
@@ -76,6 +76,10 @@ describe("git worktree integration", () => {
 
           expect(created.managed).toBe(true)
           expect(created.path).toStartWith(path.join(scope.worktree, ".synergy", "worktrees"))
+          expect(created.name).toStartWith("synergy-feature-one-")
+          expect(created.name).not.toContain("synergy-synergy")
+          expect(created.branch).toStartWith("synergy/feature-one-")
+          expect(created.branch).not.toContain("synergy/synergy")
           expect(await Bun.file(path.join(created.path, ".env.local")).text()).toBe("TOKEN=local")
           expect(await Bun.file(path.join(created.path, "setup.txt")).text()).toBe("setup")
 
@@ -117,10 +121,39 @@ describe("git worktree integration", () => {
           const session = await response.json()
           expect(session.workspace?.type).toBe("git_worktree")
           expect(session.workspace?.path).toStartWith(path.join(scope.worktree, ".synergy", "worktrees"))
+          expect(session.workspace?.name).toStartWith("synergy-route-worktree-")
+          expect(session.workspace?.branch).toStartWith("synergy/route-worktree-")
+          expect(session.workspace?.branch).not.toContain("synergy/synergy")
           expect(session.workspace?.originalCheckout).toBe(scope.worktree)
           expect(session.scope.directory).toBe(scope.worktree)
 
           await Worktree.remove({ sessionID: session.id, target: session.workspace.worktreeID, force: true })
+          await Session.remove(session.id)
+        })(),
+    })
+  })
+
+  test("workspace create falls back to branded session names for default titles", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: () =>
+        using(async () => {
+          const session = await Session.create()
+          const created = await Worktree.create({
+            sessionID: session.id,
+            bind: true,
+            baseRef: "current",
+          })
+
+          expect(created.name).toStartWith("synergy-session-")
+          expect(created.name).not.toContain("new-session")
+          expect(created.branch).toStartWith("synergy/session-")
+          expect(created.branch).not.toContain("new-session")
+
+          await Worktree.remove({ sessionID: session.id, target: created.id, force: true })
           await Session.remove(session.id)
         })(),
     })


### PR DESCRIPTION
## Summary
- Prefix managed worktree directory/display names with `synergy-` while keeping branches under `synergy/` without duplicating the brand.
- Stop using default timestamp session titles as the generated worktree purpose, falling back to `session` instead.
- Add worktree integration coverage for explicit names and default-title fallback naming.

## Tests
- `bun test test/project/worktree.test.ts`
- pre-push: `bun typecheck`
- pre-push: `bun run prettier --ignore-unknown --check .`