### PR TITLE
refactor(session): switch to root-based loop and compaction

### DIFF
--- a/packages/app/src/components/session/commands.tsx
+++ b/packages/app/src/components/session/commands.tsx
@@ -208,7 +208,11 @@ export function useSessionCommands(params: {
         }
         const message = visibleUserMessages().at(-1)
         if (!message) return
-        await sdk.client.session.rollback({ sessionID, numTurns: 1 })
+        // Roll back using the last visibleRoot's id as cutMessageID
+        await sdk.client.session.rollback({
+          sessionID,
+          cutMessageID: message.id,
+        })
         const parts = sync.data.part[message.id]
         if (parts) {
           const restored = extractPromptDraft({ message, parts, directory: sdk.directory })
@@ -232,6 +236,31 @@ export function useSessionCommands(params: {
         await sdk.client.session.unrollback({ sessionID })
         prompt.resetDraft()
         setActiveMessage(userMessages().at(-1))
+      },
+    },
+    {
+      id: "session.rewind_to_here",
+      title: "Rewind to here",
+      description: "Rewind session to the active message",
+      category: "Session",
+      disabled: !routeParams.id || !activeMessage(),
+      onSelect: async () => {
+        const sessionID = routeParams.id
+        const message = activeMessage()
+        if (!sessionID || !message) return
+        if (status()?.type !== "idle") {
+          await sdk.client.session.abort({ sessionID }).catch(() => {})
+        }
+        await sdk.client.session.rollback({
+          sessionID,
+          cutMessageID: message.id,
+        })
+        const parts = sync.data.part[message.id]
+        if (parts) {
+          const restored = extractPromptDraft({ message, parts, directory: sdk.directory })
+          prompt.set(restored.prompt, inlineLength(restored.prompt))
+          prompt.context.set(restored.context)
+        }
       },
     },
     {

--- a/packages/app/src/components/session/conversation.tsx
+++ b/packages/app/src/components/session/conversation.tsx
@@ -39,6 +39,8 @@ export function SessionConversation(props: {
   scrollToMessage: (msg: UserMessage, behavior?: ScrollBehavior) => void
   anchor: (id: string) => string
   terminalHeight: Accessor<number>
+  onRewind?: (message: UserMessage) => void
+  rollbackActive?: boolean
 }) {
   const workspaceOpen = createMemo(() => props.workspaceOpen?.() ?? false)
   return (
@@ -144,6 +146,8 @@ export function SessionConversation(props: {
                 sessionID={props.sessionID}
                 messageID={msg.id}
                 lastUserMessageID={props.lastUserMessage()?.id}
+                onRewind={() => props.onRewind?.(msg as UserMessage)}
+                rollbackActive={props.rollbackActive}
                 classes={{
                   root: "min-w-0 w-full relative",
                   content: "flex flex-col justify-between !overflow-visible",

--- a/packages/app/src/components/session/conversation.tsx
+++ b/packages/app/src/components/session/conversation.tsx
@@ -5,16 +5,18 @@ import { SessionTurn } from "@ericsanchezok/synergy-ui/session-turn"
 import { MailboxMessage } from "@ericsanchezok/synergy-ui/mailbox-message"
 import { CommandResultOutput } from "@ericsanchezok/synergy-ui/command-result-output"
 import type { createAutoScroll } from "@ericsanchezok/synergy-ui/hooks"
-import type { UserMessage, AssistantMessage, Message } from "@ericsanchezok/synergy-sdk"
+import type { UserMessage, AssistantMessage, Message, SessionInboxItem } from "@ericsanchezok/synergy-sdk"
 import { SessionTimeline } from "./session-timeline"
 import { ConversationViewport } from "./conversation-viewport"
 import { navMark } from "@/utils/perf"
 import { BrowserViewEffects } from "@/components/workspace/browser/browser-view-effects"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
 
 export function SessionConversation(props: {
   sessionID: string
   paramsDir: string
   timeline: Accessor<Message[]>
+  pendingTimeline?: Accessor<SessionInboxItem[]>
   visibleUserMessages: Accessor<UserMessage[]>
   lastUserMessage: Accessor<UserMessage | undefined>
   activeMessage: Accessor<UserMessage | undefined>
@@ -160,6 +162,31 @@ export function SessionConversation(props: {
           )
         }}
       </For>
+      <Show when={props.pendingTimeline?.()?.length}>
+        <div class="w-full flex flex-col items-start gap-2 opacity-50">
+          <For each={props.pendingTimeline?.() ?? []}>
+            {(item) => {
+              const isTask = () => item.mode === "task"
+              const label = () =>
+                item.message?.parts?.[0]?.type === "text"
+                  ? (item.message!.parts[0] as { text: string }).text
+                  : (item.summary?.title ?? "Pending…")
+              return (
+                <div
+                  data-slot="pending-timeline-item"
+                  data-mode={item.mode}
+                  class="flex items-center gap-2 px-3 py-2 rounded-lg bg-background-weak text-text-weak text-sm"
+                >
+                  <Icon name="clock" size="small" />
+                  <Show when={isTask()} fallback={<span class="text-xs">{label()}</span>}>
+                    <span class="text-xs">{label()}</span>
+                  </Show>
+                </div>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
     </ConversationViewport>
   )
 }

--- a/packages/app/src/components/session/dialog-rewind-confirm.css
+++ b/packages/app/src/components/session/dialog-rewind-confirm.css
@@ -1,0 +1,74 @@
+.rewind-confirm-dialog {
+  [data-slot="dialog-body"] {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
+.rewind-confirm-counts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rewind-confirm-count-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-small);
+  color: var(--text-base);
+}
+
+.rewind-confirm-file-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 24px;
+}
+
+.rewind-confirm-file-item {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--background-weak);
+  font-size: var(--font-size-x-small);
+  color: var(--text-weak);
+  font-family: var(--font-family-mono);
+}
+
+.rewind-confirm-file-more {
+  font-size: var(--font-size-x-small);
+  color: var(--text-subtle);
+  padding: 1px 4px;
+}
+
+.rewind-confirm-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-small);
+  color: var(--text-base);
+  cursor: pointer;
+
+  input[type="checkbox"] {
+    accent-color: var(--accent-base);
+  }
+}
+
+.rewind-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.rewind-confirm-button[data-tone="danger"] {
+  --button-background: var(--danger-background, var(--red-600));
+  --button-color: var(--danger-color, white);
+}
+
+.rewind-confirm-spinner {
+  width: 14px;
+  height: 14px;
+  margin-right: 4px;
+}

--- a/packages/app/src/components/session/dialog-rewind-confirm.tsx
+++ b/packages/app/src/components/session/dialog-rewind-confirm.tsx
@@ -1,0 +1,190 @@
+import { createMemo, createSignal, Show } from "solid-js"
+import type { UserMessage, Part as PartType } from "@ericsanchezok/synergy-sdk"
+import { Button } from "@ericsanchezok/synergy-ui/button"
+import { Dialog } from "@ericsanchezok/synergy-ui/dialog"
+import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
+
+interface DialogRewindConfirmProps {
+  /** The target user message to rewind to (cut = this message and everything after) */
+  cutMessage: UserMessage
+  /** All messages in the session ordered by id */
+  allMessages: { id: string; role: string }[]
+  /** Parts records keyed by message id */
+  partsByMessage: Record<string, PartType[] | undefined>
+  filesByMessage: Record<string, string[] | undefined>
+  onRewind: (cutMessageID: string, restoreFiles: boolean) => Promise<void>
+}
+
+function activeMessageIndex(messages: { id: string }[], cutId: string) {
+  return messages.findIndex((m) => m.id >= cutId)
+}
+
+function computeCounts(props: {
+  allMessages: { id: string; role: string }[]
+  cutId: string
+  partsByMessage: Record<string, PartType[] | undefined>
+  filesByMessage: Record<string, string[] | undefined>
+}) {
+  const { allMessages, cutId, partsByMessage, filesByMessage } = props
+  const idx = activeMessageIndex(allMessages, cutId)
+  if (idx < 0)
+    return { droppedUserMessages: 0, assistantReplies: 0, affectedFiles: 0, affectedFileNames: [] as string[] }
+
+  const dropped = allMessages.slice(idx)
+  const droppedUser = dropped.filter((m) => m.role === "user")
+  const assistantReplies = dropped.filter((m) => m.role === "assistant").length
+
+  const affectedFileSet = new Set<string>()
+  for (const m of dropped) {
+    const parts = partsByMessage[m.id]
+    if (parts) {
+      for (const p of parts) {
+        if (p.type === "patch" && "files" in p && Array.isArray((p as { files: string[] }).files)) {
+          for (const f of (p as { files: string[] }).files) affectedFileSet.add(f)
+        }
+      }
+    }
+    const msgFiles = filesByMessage[m.id]
+    if (msgFiles) for (const f of msgFiles) affectedFileSet.add(f)
+  }
+
+  return {
+    droppedUserMessages: droppedUser.length,
+    assistantReplies,
+    affectedFiles: affectedFileSet.size,
+    affectedFileNames: Array.from(affectedFileSet).slice(0, 10),
+  }
+}
+
+export function DialogRewindConfirm(props: DialogRewindConfirmProps) {
+  const dialog = useDialog()
+  const [pending, setPending] = createSignal(false)
+  const [restoreFiles, setRestoreFiles] = createSignal(true)
+
+  const summary = createMemo(() => (props.cutMessage as { summary?: { title?: string } }).summary?.title)
+
+  const counts = createMemo(() =>
+    computeCounts({
+      allMessages: props.allMessages,
+      cutId: props.cutMessage.id,
+      partsByMessage: props.partsByMessage,
+      filesByMessage: props.filesByMessage,
+    }),
+  )
+
+  const handleRewind = async () => {
+    if (pending()) return
+    setPending(true)
+    try {
+      await props.onRewind(props.cutMessage.id, restoreFiles())
+      dialog.close()
+    } catch (error) {
+      showToast({
+        type: "error",
+        title: "Rewind failed",
+        description: error instanceof Error ? error.message : "Request failed",
+      })
+      setPending(false)
+    }
+  }
+
+  return (
+    <Dialog
+      title="Rewind to here"
+      description={
+        summary() ? `Rewind before 「${summary()}」?` : "Rewind before this message? Messages after it will be hidden."
+      }
+      class="rewind-confirm-dialog"
+      action={
+        <button
+          type="button"
+          data-slot="dialog-close-button"
+          data-component="icon-button"
+          data-variant="ghost"
+          disabled={pending()}
+          onClick={() => {
+            if (!pending()) dialog.close()
+          }}
+        >
+          <Icon name="x" size="small" />
+        </button>
+      }
+    >
+      <div class="rewind-confirm-counts">
+        <Show when={counts().droppedUserMessages > 0}>
+          <div class="rewind-confirm-count-row">
+            <Icon name="message-square" size="small" />
+            <span>
+              {counts().droppedUserMessages} user {counts().droppedUserMessages === 1 ? "message" : "messages"}
+            </span>
+          </div>
+        </Show>
+        <Show when={counts().assistantReplies > 0}>
+          <div class="rewind-confirm-count-row">
+            <Icon name="bot" size="small" />
+            <span>
+              {counts().assistantReplies} {counts().assistantReplies === 1 ? "reply" : "replies"}
+            </span>
+          </div>
+        </Show>
+        <Show when={counts().affectedFiles > 0}>
+          <div class="rewind-confirm-count-row">
+            <Icon name="file" size="small" />
+            <span>
+              {counts().affectedFiles} affected {counts().affectedFiles === 1 ? "file" : "files"}
+            </span>
+          </div>
+          <Show when={counts().affectedFileNames.length > 0}>
+            <div class="rewind-confirm-file-list">
+              {counts().affectedFileNames.map((f) => (
+                <span class="rewind-confirm-file-item">{f}</span>
+              ))}
+              <Show when={counts().affectedFiles > counts().affectedFileNames.length}>
+                <span class="rewind-confirm-file-more">
+                  +{counts().affectedFiles - counts().affectedFileNames.length} more
+                </span>
+              </Show>
+            </div>
+          </Show>
+        </Show>
+      </div>
+
+      <label class="rewind-confirm-checkbox-label">
+        <input
+          type="checkbox"
+          checked={restoreFiles()}
+          onChange={(e) => setRestoreFiles(e.currentTarget.checked)}
+          disabled={pending()}
+        />
+        <span>Restore files</span>
+      </label>
+
+      <div data-slot="dialog-actions" class="rewind-confirm-actions">
+        <Button type="button" variant="ghost" size="large" disabled={pending()} onClick={() => dialog.close()}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="large"
+          class="rewind-confirm-button"
+          data-tone="danger"
+          disabled={pending()}
+          onClick={() => void handleRewind()}
+        >
+          {pending() ? (
+            <>
+              <Spinner class="rewind-confirm-spinner" />
+              {"Rewinding\u2026"}
+            </>
+          ) : (
+            "Rewind"
+          )}
+        </Button>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -44,6 +44,7 @@ export function PromptDock(props: {
   scopeName: Accessor<string>
   branch: Accessor<string | undefined>
   lastModified: Accessor<string | null | undefined>
+  rollbackActive?: boolean
 }) {
   const nav = useNavigate()
   return (
@@ -167,7 +168,12 @@ export function PromptDock(props: {
                     hideAgentSelector={!props.meta().showInputBar}
                   />
                   <Show when={props.sessionID}>
-                    <SessionInbox sessionID={props.sessionID!} sync={props.sync} sdk={props.sdk} />
+                    <SessionInbox
+                      sessionID={props.sessionID!}
+                      sync={props.sync}
+                      sdk={props.sdk}
+                      freezeHint={props.rollbackActive}
+                    />
                   </Show>
                 </div>
               </>

--- a/packages/app/src/components/session/rollback-banner.css
+++ b/packages/app/src/components/session/rollback-banner.css
@@ -1,0 +1,54 @@
+[data-component="rollback-banner"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  margin: 0 16px 8px;
+  border-radius: 8px;
+  background: var(--background-base);
+  border: 1px solid var(--border-weak);
+  font-size: var(--font-size-small);
+  color: var(--text-base);
+  animation: fadeDown 0.2s ease-out both;
+}
+
+@keyframes fadeDown {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+[data-slot="rollback-banner-content"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+[data-slot="rollback-banner-text"] {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-slot="rollback-banner-actions"] {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.rollback-banner-dismiss {
+  opacity: 0.5;
+  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard);
+
+  &:hover {
+    opacity: 1;
+  }
+}

--- a/packages/app/src/components/session/rollback-banner.tsx
+++ b/packages/app/src/components/session/rollback-banner.tsx
@@ -1,0 +1,121 @@
+import { Show } from "solid-js"
+import { Button } from "@ericsanchezok/synergy-ui/button"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
+import type { SessionRollbackSummary } from "@ericsanchezok/synergy-sdk/client"
+import type { useSDK } from "@/context/sdk"
+
+interface RollbackBannerProps {
+  sessionID: string
+  rollback: SessionRollbackSummary
+  sdk: ReturnType<typeof useSDK>
+  onDismiss: () => void
+}
+
+export function RollbackBanner(props: RollbackBannerProps) {
+  const { rollback } = props
+  const numTurns = rollback.numTurns ?? 0
+  const numMessages = rollback.droppedMessageIDs?.length ?? 0
+  const numFiles = rollback.patchPartIDs?.length ?? 0
+
+  const handleRedo = async () => {
+    if (!rollback.canUnrollback) {
+      showToast({
+        type: "info",
+        title: "Cannot redo",
+        description: "A new task has been started. The rollback can no longer be redone.",
+        duration: 4000,
+      })
+      return
+    }
+
+    try {
+      await props.sdk.client.session.unrollback({ sessionID: props.sessionID })
+      showToast({
+        type: "success",
+        title: "Redo complete",
+        description: `Restored ${numMessages} message${numMessages === 1 ? "" : "s"}`,
+      })
+      props.onDismiss()
+    } catch (err) {
+      if (err instanceof Error && err.message?.includes("new session messages")) {
+        showToast({
+          type: "warning",
+          title: "Cannot redo",
+          description: "New messages have been added. This rollback can no longer be redone.",
+        })
+      } else {
+        showToast({
+          type: "error",
+          title: "Redo failed",
+          description: err instanceof Error ? err.message : "Request failed",
+        })
+      }
+    }
+  }
+
+  const handleRestoreFiles = async () => {
+    if (numFiles === 0) return
+    try {
+      const result = await props.sdk.client.session.files.restore({
+        sessionID: props.sessionID,
+        rollbackID: rollback.id,
+      })
+      const count = result.data?.restoredFiles?.length ?? 0
+      showToast({
+        type: "success",
+        title: "Files restored",
+        description: `${count} file${count === 1 ? "" : "s"} restored`,
+      })
+    } catch (err) {
+      showToast({
+        type: "error",
+        title: "Failed to restore files",
+        description: err instanceof Error ? err.message : "Request failed",
+      })
+    }
+  }
+
+  return (
+    <div data-component="rollback-banner">
+      <div data-slot="rollback-banner-content">
+        <Icon name="undo-2" size="small" />
+        <span data-slot="rollback-banner-text">
+          Rewound {numMessages} message{numMessages === 1 ? "" : "s"} ({numTurns} turn{numTurns === 1 ? "" : "s"})
+        </span>
+      </div>
+      <div data-slot="rollback-banner-actions">
+        <Button
+          type="button"
+          variant="ghost"
+          size="small"
+          data-tone={rollback.canUnrollback ? "neutral" : "disabled"}
+          disabled={!rollback.canUnrollback}
+          title={
+            rollback.canUnrollback
+              ? "Restore the rewound messages"
+              : "New messages have been added; cannot redo this rollback"
+          }
+          onClick={() => void handleRedo()}
+        >
+          Redo
+        </Button>
+        <Show when={numFiles > 0}>
+          <Button type="button" variant="ghost" size="small" onClick={() => void handleRestoreFiles()}>
+            Restore files ({numFiles})
+          </Button>
+        </Show>
+        <Button
+          type="button"
+          variant="ghost"
+          size="small"
+          class="rollback-banner-dismiss"
+          onClick={props.onDismiss}
+          aria-label="Dismiss"
+        >
+          <Icon name="x" size="small" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/session/session-inbox-utils.ts
+++ b/packages/app/src/components/session/session-inbox-utils.ts
@@ -1,11 +1,22 @@
 import type { SessionInboxItem } from "@ericsanchezok/synergy-sdk/client"
 
+function modeRank(mode: SessionInboxItem["mode"]): number {
+  if (mode === "steer") return 0
+  if (mode === "task") return 1
+  if (mode === "context") return 2
+  return 3
+}
+
 export function sortInboxItems(items: SessionInboxItem[]) {
   const deliveryRank: Record<SessionInboxItem["deliveryTarget"], number> = {
     next_model_call: 0,
     after_turn: 1,
   }
   return items.slice().sort((a, b) => {
+    // Primary sort by mode (steer first, then task, then context)
+    const modeDiff = modeRank(a.mode) - modeRank(b.mode)
+    if (modeDiff !== 0) return modeDiff
+    // Fallback by deliveryTarget
     const delivery = deliveryRank[a.deliveryTarget] - deliveryRank[b.deliveryTarget]
     if (delivery !== 0) return delivery
     const order = a.orderKey.localeCompare(b.orderKey)
@@ -28,5 +39,5 @@ export function deriveSessionInboxView(items: SessionInboxItem[] | undefined): S
 }
 
 export function isInboxItemInteractive(item: SessionInboxItem) {
-  return item.kind === "queued_user"
+  return item.mode === "task" || item.kind === "queued_user"
 }

--- a/packages/app/src/components/session/session-inbox.test.ts
+++ b/packages/app/src/components/session/session-inbox.test.ts
@@ -14,6 +14,8 @@ function item(
     kind,
     state: kind === "guiding" ? "guiding" : "queued",
     deliveryTarget,
+    mode: kind === "guiding" ? "steer" : kind === "agent_update" ? "steer" : ("task" as const),
+    messageID: `msg_${id}`,
     summary: { title: id },
     source: { type: "test" },
     time: { created: 1 },

--- a/packages/app/src/components/session/session-inbox.tsx
+++ b/packages/app/src/components/session/session-inbox.tsx
@@ -18,17 +18,32 @@ type SessionInboxProps = {
   sdk: ReturnType<typeof useSDK>
 }
 
-const labelByKind: Record<SessionInboxItem["kind"], string> = {
-  queued_user: "Queued by you",
-  guiding: "Guiding current run",
-  agent_update: "Agent updates",
+function labelByMode(item: SessionInboxItem): string {
+  if (item.mode) {
+    if (item.mode === "task") return "Queued by you"
+    if (item.mode === "steer") return "Guiding current run"
+    if (item.mode === "context") return "Context update"
+  }
+  // Legacy fallback by kind
+  if (item.kind === "queued_user") return "Queued by you"
+  if (item.kind === "guiding") return "Guiding current run"
+  if (item.kind === "agent_update") return "Agent updates"
+  return "Update"
 }
 
-function timingLabel(item: SessionInboxItem) {
+function timingLabel(item: SessionInboxItem): string {
+  if (item.mode === "task") return "After turn"
+  if (item.mode === "steer") return "Next call"
+  if (item.mode === "context") return "Context"
+  // Legacy fallback by deliveryTarget
   return item.deliveryTarget === "next_model_call" ? "Next call" : "After turn"
 }
 
 function deliveryDescription(item: SessionInboxItem) {
+  if (item.mode === "task") return "Sends after this turn; multiple queued items share one reply cycle."
+  if (item.mode === "steer") return "Joins the current run before its next model request."
+  if (item.mode === "context") return "Joined to the ongoing model call as context."
+  // Legacy fallback by deliveryTarget
   if (item.deliveryTarget === "next_model_call") return "Joins the current run before its next model request."
   return "Sends after this turn; multiple queued items share one reply cycle."
 }
@@ -38,9 +53,16 @@ function itemCountLabel(count: number) {
 }
 
 function queueNote(items: SessionInboxItem[]) {
-  const nextCall = items.filter((item) => item.deliveryTarget === "next_model_call").length
-  const afterTurn = items.filter((item) => item.deliveryTarget === "after_turn").length
+  const steers = items.filter((item) => item.mode === "steer").length
+  const tasks = items.filter((item) => item.mode === "task").length
+  const nextCall = items.filter((item) => item.mode !== "task" || item.deliveryTarget === "next_model_call").length
+  const afterTurn = items.filter((item) => item.mode === "task" || item.deliveryTarget === "after_turn").length
 
+  if (steers > 0 && tasks > 0) return `${steers} next call · ${tasks} after turn`
+  if (steers > 1) return `${steers} items join the next model call`
+  if (steers === 1) return "Joins the current run's next model call"
+  if (tasks > 1) return `${tasks} items send together in one reply`
+  if (tasks === 1) return "Sends automatically after this turn"
   if (nextCall > 0 && afterTurn > 0) return `${nextCall} next call · ${afterTurn} after turn`
   if (nextCall > 1) return `${nextCall} items join the next model call`
   if (nextCall === 1) return "Joins the current run's next model call"
@@ -59,7 +81,7 @@ function detailText(item: SessionInboxItem) {
 function InboxDetail(props: { item: SessionInboxItem }) {
   return (
     <div class="session-inbox-detail">
-      <div class="text-12-medium text-text-strong">{labelByKind[props.item.kind]}</div>
+      <div class="text-12-medium text-text-strong">{labelByMode(props.item)}</div>
       <Markdown
         text={detailText(props.item)}
         cacheKey={`session-inbox-detail-${props.item.id}`}
@@ -93,7 +115,7 @@ function InboxRow(props: {
       <Tooltip placement="left" class="session-inbox-row-tooltip" value={<InboxDetail item={props.item} />}>
         <div class="session-inbox-row-main">
           <div class="session-inbox-row-meta">
-            <span class="session-inbox-row-label">{labelByKind[props.item.kind]}</span>
+            <span class="session-inbox-row-label">{labelByMode(props.item)}</span>
             <span class="session-inbox-row-status" data-target={props.item.deliveryTarget}>
               {timingLabel(props.item)}
             </span>

--- a/packages/app/src/components/session/session-inbox.tsx
+++ b/packages/app/src/components/session/session-inbox.tsx
@@ -16,6 +16,7 @@ type SessionInboxProps = {
   sessionID: string
   sync: ReturnType<typeof useSync>
   sdk: ReturnType<typeof useSDK>
+  freezeHint?: boolean
 }
 
 function labelByMode(item: SessionInboxItem): string {
@@ -209,6 +210,19 @@ export function SessionInbox(props: SessionInboxProps) {
 
   const remove = async (item: SessionInboxItem) => {
     await props.sdk.client.session.inboxRemove({ sessionID: props.sessionID, itemID: item.id })
+    showToast({
+      type: "info",
+      title: "Removed queued message",
+      description: "The message has been removed from the inbox.",
+      actions: [
+        {
+          label: "Restore",
+          onClick: () => {
+            void props.sdk.client.session.inboxGuide({ sessionID: props.sessionID, itemID: item.id }).catch(() => {})
+          },
+        },
+      ],
+    })
   }
   const confirmRemove = (item: SessionInboxItem) => {
     confirm.show({
@@ -256,6 +270,9 @@ export function SessionInbox(props: SessionInboxProps) {
           </Match>
           <Match when={true}>
             <div class="session-inbox-list">
+              <Show when={props.freezeHint}>
+                <div class="px-1 py-1 text-11-medium text-text-subtle">Inbox frozen while rewinding</div>
+              </Show>
               <div class="session-inbox-queue-note">
                 <span>{note()}</span>
                 <Show when={actionableItems().length > 1}>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -260,6 +260,7 @@ function SessionPageContent() {
   // ── Root message derivation layer ───────────────────────────────────
   // Replaces old isSessionIdentityAnchor / isGuidedContextUserMessage / synthetic metadata
   // heuristics with orthogonal isRoot/visible/rootID/origin fields.
+  /** @deprecated Use inline empty arrays or nullish coalescing. */
   const emptyUserMessages: UserMessage[] = []
   const rootMessages = createMemo(
     () =>
@@ -321,6 +322,7 @@ function SessionPageContent() {
     return msgs.filter((message) => message.id >= firstID)
   }, emptyUserMessages)
 
+  /** @deprecated Use inline empty arrays or nullish coalescing. */
   const emptyTimeline: Message[] = []
   const isActionCommandMessage = (message: Message) => {
     const metadata = message.metadata as

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -51,6 +51,8 @@ import {
 } from "@/components/session/worktree-session"
 import { WorktreeTransitionContent } from "@/components/session/worktree-transition-dialog"
 import { worktreeTransition, clearWorktreeTransition } from "@/components/session/worktree-progress-signals"
+import { RollbackBanner } from "@/components/session/rollback-banner"
+import { DialogRewindConfirm } from "@/components/session/dialog-rewind-confirm"
 
 const handoff = {
   prompt: "",
@@ -193,6 +195,9 @@ function SessionPageContent() {
   const reviewCount = createMemo(() => info()?.summary?.files ?? 0)
   const hasReview = createMemo(() => reviewCount() > 0)
   const rollback = createMemo(() => info()?.history?.rollback)
+  const rollbackActive = createMemo(() => rollback() !== undefined)
+  const [rollbackDismissed, setRollbackDismissed] = createSignal(false)
+  const showRollbackBanner = createMemo(() => rollback() !== undefined && !rollbackDismissed())
   const hiddenMessageIDs = createMemo(() => {
     const rb = rollback()
     if (!rb) return new Set<string>()
@@ -211,6 +216,32 @@ function SessionPageContent() {
     if (isHomeScope(sdk.scopeKey) && (messages()?.length ?? 0) === 0) return true
     return false
   })
+  const openRewindConfirm = (message: UserMessage) => {
+    const targetMsg = message
+    const sessionID = params.id
+    dialog.push(() => (
+      <DialogRewindConfirm
+        cutMessage={targetMsg}
+        allMessages={messages().filter((m) => m.role === "user" || m.role === "assistant")}
+        partsByMessage={sync.data.part}
+        filesByMessage={{}}
+        onRewind={async (cutMessageID, restoreFiles) => {
+          if (!sessionID) return
+          if (status().type !== "idle") {
+            await sdk.client.session.abort({ sessionID }).catch(() => {})
+          }
+          await sdk.client.session.rollback({ sessionID, cutMessageID })
+          if (restoreFiles) {
+            const rb = rollback()
+            if (rb) {
+              await sdk.client.session.files.restore({ sessionID, rollbackID: rb.id }).catch(() => {})
+            }
+          }
+          setActiveMessage(userMessages().findLast((x) => x.id < cutMessageID))
+        }}
+      />
+    ))
+  }
   const messagesReady = createMemo(() => {
     const id = params.id
     if (!id) return true
@@ -906,6 +937,14 @@ function SessionPageContent() {
                 )}
               </Show>
               <SessionTopBar />
+              <Show when={showRollbackBanner()}>
+                <RollbackBanner
+                  sessionID={params.id!}
+                  rollback={rollback()!}
+                  sdk={sdk}
+                  onDismiss={() => setRollbackDismissed(true)}
+                />
+              </Show>
               <div class="flex-1 min-h-0 min-w-0 overflow-hidden">
                 <Switch>
                   <Match when={!isNewSession()}>
@@ -986,6 +1025,8 @@ function SessionPageContent() {
                           anchor={anchor}
                           terminalHeight={bottomSurface().opened() ? bottomSurface().size : () => 0}
                           workspaceOpen={sideOpen}
+                          onRewind={openRewindConfirm}
+                          rollbackActive={rollbackActive()}
                         />
                       </Show>
                     </Show>
@@ -1022,6 +1063,7 @@ function SessionPageContent() {
               branch={branch}
               lastModified={lastModified}
               workspaceOpen={sideOpen}
+              rollbackActive={rollbackActive()}
             />
             <Show when={isDesktop() && showTabs() && !sideOpen()}>
               <ResizeHandle

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,6 +1,5 @@
 import { Show, Match, Switch, createMemo, createEffect, createSignal, on, onCleanup } from "solid-js"
 import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
-import { isGuidedContextUserMessage } from "@ericsanchezok/synergy-ui/session-turn"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLocal } from "@/context/local"
 import { useFile, type SelectedLineRange } from "@/context/file"
@@ -194,7 +193,13 @@ function SessionPageContent() {
   const reviewCount = createMemo(() => info()?.summary?.files ?? 0)
   const hasReview = createMemo(() => reviewCount() > 0)
   const rollback = createMemo(() => info()?.history?.rollback)
-  const hiddenMessageIDs = createMemo(() => new Set(rollback()?.droppedMessageIDs ?? []))
+  const hiddenMessageIDs = createMemo(() => {
+    const rb = rollback()
+    if (!rb) return new Set<string>()
+    // Use cutMessageID when available, fallback to droppedMessageIDs
+    if (rb.cutMessageID) return new Set([rb.cutMessageID])
+    return new Set(rb.droppedMessageIDs ?? [])
+  })
   const messages = createMemo(() => {
     const raw = (params.id ? (sync.data.message[params.id] ?? []) : []) ?? []
     const hidden = hiddenMessageIDs()
@@ -221,80 +226,56 @@ function SessionPageContent() {
     if (!id) return false
     return sync.session.history.loading(id)
   })
-  const isSessionIdentityAnchor = (message: UserMessage) => {
-    const metadata = message.metadata
-    if (!metadata) return true
-    const source = metadata.source
-    if (metadata.guided === true && metadata.noReply === true) return false
-    if (metadata.mailbox === true || metadata.channelPush === true) return false
-    if (typeof metadata.sourceSessionID === "string" && metadata.sourceSessionID.trim()) return false
-    if (source === "cortex" || source === "mailbox" || source === "agenda") return false
-    if (typeof source === "string" && source.startsWith("blueprint_loop_")) return false
-    return true
-  }
+  // ── Root message derivation layer ───────────────────────────────────
+  // Replaces old isSessionIdentityAnchor / isGuidedContextUserMessage / synthetic metadata
+  // heuristics with orthogonal isRoot/visible/rootID/origin fields.
   const emptyUserMessages: UserMessage[] = []
-  const userMessages = createMemo(
+  const rootMessages = createMemo(
     () =>
       messages().filter((m) => {
         if (m.role !== "user") return false
         const user = m as UserMessage
-        return !user.metadata?.synthetic && !isGuidedContextUserMessage(user) && isSessionIdentityAnchor(user)
+        // Use new isRoot field when available; fall back to old metadata heuristics
+        if (user.isRoot !== undefined) return user.isRoot === true
+        return user.metadata?.noReply !== true && !user.metadata?.guided && !user.metadata?.synthetic
       }) as UserMessage[],
     emptyUserMessages,
   )
-  const visibleUserMessages = createMemo(() => userMessages(), emptyUserMessages)
+  const visibleRoots = createMemo(() => rootMessages().filter((m) => m.visible !== false), emptyUserMessages)
+  const lastRoot = createMemo(() => rootMessages().at(-1))
+  // visibleRoots for navigation/timeline (deprecated old names kept for compatibility)
+  const visibleUserMessages = visibleRoots
+  // userMessages — kept for commands hook compatibility
+  const userMessages = visibleRoots
+  // renderableUserMessages — kept for compatibility, mirror visibleRoots
   const renderableUserMessages = createMemo(
     () =>
       messages().filter((m) => {
         if (m.role !== "user") return false
         const user = m as UserMessage
-        if (isGuidedContextUserMessage(user)) return false
+        if (user.isRoot !== undefined) return user.isRoot === true && user.visible !== false
         return !user.metadata?.synthetic || hasSpecialUserMessageRenderer(user)
       }) as UserMessage[],
     emptyUserMessages,
   )
-  const lastUserMessage = createMemo(() => visibleUserMessages().at(-1))
+  const lastUserMessage = lastRoot
   const lastRenderableUserMessage = createMemo(() => renderableUserMessages().at(-1))
   const selectableAgentNames = createMemo(() => new Set(local.agent.list().map((agent) => agent.name)))
+  // Composer agent/model inheritance: use lastRoot instead of lastUserMessage
   createEffect(
     on(
-      () => [lastUserMessage()?.id, selectableAgentNames()] as const,
+      () => [lastRoot()?.id, lastRoot()?.agent, lastRoot()?.model, selectableAgentNames()] as const,
       () => {
-        const msg = lastUserMessage()
+        const msg = lastRoot()
         if (!msg) return
-        if (!msg.agent || !selectableAgentNames().has(msg.agent)) return
-        local.agent.set(msg.agent)
+        if (msg.agent && selectableAgentNames().has(msg.agent)) local.agent.set(msg.agent)
         if (msg.model) local.model.set(msg.model)
       },
     ),
   )
 
-  // Blueprint loop start messages carry a model override but are excluded from
-  // userMessages by isSessionIdentityAnchor (source starts with "blueprint_loop_").
-  // Track their model separately so the stb-root model display stays current.
-  const lastBlueprintStartModel = createMemo(() => {
-    const msgs = messages()
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const m = msgs[i]
-      if (m.role !== "user") continue
-      const meta = m.metadata as Record<string, unknown> | undefined
-      if (typeof meta?.source === "string" && meta.source === "blueprint_loop_start") {
-        return m.model
-      }
-    }
-    return undefined
-  })
-  createEffect(
-    on(
-      () => lastBlueprintStartModel(),
-      (model) => {
-        if (model) local.model.set(model)
-      },
-    ),
-  )
-
   const renderedUserMessages = createMemo(() => {
-    const msgs = visibleUserMessages()
+    const msgs = visibleRoots()
     if (!msgs) return emptyUserMessages
     const start = store.turnStart
     if (start <= 0) return msgs
@@ -328,6 +309,16 @@ function SessionPageContent() {
     result.sort((a, b) => (a.id > b.id ? 1 : -1))
     return result
   }
+
+  const pendingTimeline = createMemo(() => {
+    const sessionID = params.id
+    if (!sessionID) return [] as import("@ericsanchezok/synergy-sdk/client").SessionInboxItem[]
+    const inbox = sync.data.inbox[sessionID]
+    if (!inbox || inbox.length === 0) return []
+    return inbox
+      .filter((item) => item.mode === "task" || item.mode === "steer")
+      .filter((item) => item.message?.origin?.type === "user")
+  })
 
   const timeline = createMemo(() => {
     const turns = renderedConversationUserMessages() as Message[]
@@ -967,6 +958,7 @@ function SessionPageContent() {
                           sessionID={params.id!}
                           paramsDir={params.dir!}
                           timeline={timeline}
+                          pendingTimeline={pendingTimeline}
                           visibleUserMessages={visibleUserMessages}
                           lastUserMessage={lastRenderableUserMessage}
                           activeMessage={activeMessage}

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -125,7 +125,49 @@ export type PromptDraftSnapshot = {
 }
 
 export type PromptDraftMetadataMessage = {
+  id?: string
+  parts?: Part[]
   metadata?: Record<string, unknown>
+}
+
+/**
+ * Extract text content from parts filtered by origin for rewind backfill.
+ * When rewinding, the draft text from the cut message should be extracted
+ * to restore the user's original input.
+ */
+export function extractPromptTextForRewind(input: { message?: PromptDraftMetadataMessage; parts: Part[] }): string {
+  const promptDraft = input.message?.metadata?.promptDraft
+  if (isRecord(promptDraft) && promptDraft.version === 1) {
+    const prompt = sanitizePromptValue(promptDraft.prompt) as unknown as Prompt
+    return prompt
+      .map((part) => {
+        if (part.type === "text") return part.content
+        if (part.type === "file") return part.content
+        if (part.type === "attachment") return ""
+        if (part.type === "note") return part.content
+        if (part.type === "session") return ""
+        return ""
+      })
+      .join("")
+      .trim()
+  }
+
+  // Fallback: extract by part.origin from the cut message
+  const textPart = textPartValue(input.parts)
+  if (textPart) {
+    // Prefer non-system origin text
+    const nonSystemTexts = input.parts
+      .filter((part): part is TextPart => part.type === "text")
+      .filter((part) => part.origin !== "system" && !part.synthetic && !part.ignored)
+    if (nonSystemTexts.length > 0) {
+      return nonSystemTexts
+        .map((part) => part.text)
+        .join("\n")
+        .trim()
+    }
+    return textPart.text.trim()
+  }
+  return ""
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -172,7 +172,7 @@ function filePathFromUrl(url: string) {
 function textPartValue(parts: Part[]) {
   const candidates = parts
     .filter((part): part is TextPart => part.type === "text")
-    .filter((part) => !part.synthetic && !part.ignored)
+    .filter((part) => (part.origin !== undefined ? part.origin !== "system" : !part.synthetic && !part.ignored))
   return candidates.reduce((best: TextPart | undefined, part) => {
     if (!best) return part
     if (part.text.length > best.text.length) return part

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3416,61 +3416,6 @@ export type SessionWorkspaceSelection =
       baseRevision?: string
     }
 
-export type SessionInboxItemSource = {
-  type: string
-  label?: string
-  [key: string]: unknown | string | undefined
-}
-
-export type SessionInboxItem = {
-  id: string
-  sessionID: string
-  kind: "queued_user" | "guiding" | "agent_update"
-  state: "queued" | "guiding"
-  deliveryTarget: "after_turn" | "next_model_call"
-  summary: {
-    title: string
-    preview?: string
-  }
-  detail?: {
-    text?: string
-    attachments?: Array<string>
-  }
-  source: SessionInboxItemSource
-  time: {
-    created: number
-    updated?: number
-  }
-  orderKey: string
-  messageID?: string
-}
-
-export type SessionInputResult =
-  | {
-      status: "started"
-      messageID: string
-    }
-  | {
-      status: "queued"
-      item: SessionInboxItem
-    }
-
-export type TextPartInput = {
-  id?: string
-  type: "text"
-  text: string
-  synthetic?: boolean
-  ignored?: boolean
-  origin?: "user" | "system"
-  time?: {
-    start: number
-    end?: number
-  }
-  metadata?: {
-    [key: string]: unknown
-  }
-}
-
 export type AttachmentSourceText = {
   value: string
   start: number
@@ -3536,6 +3481,111 @@ export type AttachmentModelPolicy =
       mode: "none"
     }
 
+export type OriginUser = {
+  type: string
+  sessionID?: string
+  label?: string
+  detail?: string
+}
+
+export type SessionInboxItemSource = {
+  type: string
+  label?: string
+  [key: string]: unknown | string | undefined
+}
+
+export type SessionInboxItem = {
+  id: string
+  sessionID: string
+  kind: "queued_user" | "guiding" | "agent_update"
+  state: "queued" | "guiding"
+  deliveryTarget: "after_turn" | "next_model_call"
+  mode: "task" | "steer" | "context"
+  message?: {
+    role?: "user" | "assistant"
+    parts: Array<
+      | {
+          id?: string
+          type: "text"
+          text: string
+          synthetic?: boolean
+          ignored?: boolean
+          origin?: "user" | "system"
+          time?: {
+            start: number
+            end?: number
+          }
+          metadata?: {
+            [key: string]: unknown
+          }
+        }
+      | {
+          id?: string
+          type: "attachment"
+          mime: string
+          filename?: string
+          url: string
+          localPath?: string
+          source?: AttachmentSource
+          presentation?: AttachmentPresentation
+          model?: AttachmentModelPolicy
+          metadata?: {
+            [key: string]: unknown
+          }
+        }
+    >
+    agent?: string
+    model?: {
+      providerID: string
+      modelID: string
+    }
+    origin?: OriginUser
+    visible?: boolean
+  }
+  summaryPreview?: string
+  summary: {
+    title: string
+    preview?: string
+  }
+  detail?: {
+    text?: string
+    attachments?: Array<string>
+  }
+  source: SessionInboxItemSource
+  time: {
+    created: number
+    updated?: number
+  }
+  orderKey: string
+  messageID: string
+}
+
+export type SessionInputResult =
+  | {
+      status: "started"
+      messageID: string
+    }
+  | {
+      status: "queued"
+      item: SessionInboxItem
+    }
+
+export type TextPartInput = {
+  id?: string
+  type: "text"
+  text: string
+  synthetic?: boolean
+  ignored?: boolean
+  origin?: "user" | "system"
+  time?: {
+    start: number
+    end?: number
+  }
+  metadata?: {
+    [key: string]: unknown
+  }
+}
+
 export type AttachmentPartInput = {
   id?: string
   type: "attachment"
@@ -3549,13 +3599,6 @@ export type AttachmentPartInput = {
   metadata?: {
     [key: string]: unknown
   }
-}
-
-export type OriginUser = {
-  type: string
-  sessionID?: string
-  label?: string
-  detail?: string
 }
 
 export type UserMessage = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -24606,169 +24606,6 @@
           }
         ]
       },
-      "SessionInboxItemSource": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          }
-        },
-        "required": ["type"],
-        "additionalProperties": {}
-      },
-      "SessionInboxItem": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^inb.*"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
-          },
-          "kind": {
-            "type": "string",
-            "enum": ["queued_user", "guiding", "agent_update"]
-          },
-          "state": {
-            "type": "string",
-            "enum": ["queued", "guiding"]
-          },
-          "deliveryTarget": {
-            "type": "string",
-            "enum": ["after_turn", "next_model_call"]
-          },
-          "summary": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "preview": {
-                "type": "string"
-              }
-            },
-            "required": ["title"]
-          },
-          "detail": {
-            "type": "object",
-            "properties": {
-              "text": {
-                "type": "string"
-              },
-              "attachments": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "source": {
-            "$ref": "#/components/schemas/SessionInboxItemSource"
-          },
-          "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              },
-              "updated": {
-                "type": "number"
-              }
-            },
-            "required": ["created"]
-          },
-          "orderKey": {
-            "type": "string"
-          },
-          "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
-          }
-        },
-        "required": ["id", "sessionID", "kind", "state", "deliveryTarget", "summary", "source", "time", "orderKey"]
-      },
-      "SessionInputResult": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "status": {
-                "type": "string",
-                "const": "started"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              }
-            },
-            "required": ["status", "messageID"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "status": {
-                "type": "string",
-                "const": "queued"
-              },
-              "item": {
-                "$ref": "#/components/schemas/SessionInboxItem"
-              }
-            },
-            "required": ["status", "item"]
-          }
-        ]
-      },
-      "TextPartInput": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "const": "text"
-          },
-          "text": {
-            "type": "string"
-          },
-          "synthetic": {
-            "type": "boolean"
-          },
-          "ignored": {
-            "type": "boolean"
-          },
-          "origin": {
-            "type": "string",
-            "enum": ["user", "system"]
-          },
-          "time": {
-            "type": "object",
-            "properties": {
-              "start": {
-                "type": "number"
-              },
-              "end": {
-                "type": "number"
-              }
-            },
-            "required": ["start"]
-          },
-          "metadata": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {}
-          }
-        },
-        "required": ["type", "text"]
-      },
       "AttachmentSourceText": {
         "type": "object",
         "properties": {
@@ -24965,6 +24802,332 @@
           }
         ]
       },
+      "OriginUser": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          }
+        },
+        "required": ["type"]
+      },
+      "SessionInboxItemSource": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": {}
+      },
+      "SessionInboxItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^inb.*"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses.*"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["queued_user", "guiding", "agent_update"]
+          },
+          "state": {
+            "type": "string",
+            "enum": ["queued", "guiding"]
+          },
+          "deliveryTarget": {
+            "type": "string",
+            "enum": ["after_turn", "next_model_call"]
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["task", "steer", "context"]
+          },
+          "message": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "default": "user",
+                "type": "string",
+                "enum": ["user", "assistant"]
+              },
+              "parts": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "text"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "synthetic": {
+                          "type": "boolean"
+                        },
+                        "ignored": {
+                          "type": "boolean"
+                        },
+                        "origin": {
+                          "type": "string",
+                          "enum": ["user", "system"]
+                        },
+                        "time": {
+                          "type": "object",
+                          "properties": {
+                            "start": {
+                              "type": "number"
+                            },
+                            "end": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["start"]
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": ["type", "text"]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "attachment"
+                        },
+                        "mime": {
+                          "type": "string"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "localPath": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "$ref": "#/components/schemas/AttachmentSource"
+                        },
+                        "presentation": {
+                          "$ref": "#/components/schemas/AttachmentPresentation"
+                        },
+                        "model": {
+                          "$ref": "#/components/schemas/AttachmentModelPolicy"
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": ["type", "mime", "url"]
+                    }
+                  ]
+                }
+              },
+              "agent": {
+                "type": "string"
+              },
+              "model": {
+                "type": "object",
+                "properties": {
+                  "providerID": {
+                    "type": "string"
+                  },
+                  "modelID": {
+                    "type": "string"
+                  }
+                },
+                "required": ["providerID", "modelID"]
+              },
+              "origin": {
+                "$ref": "#/components/schemas/OriginUser"
+              },
+              "visible": {
+                "default": true,
+                "type": "boolean"
+              }
+            },
+            "required": ["parts"]
+          },
+          "summaryPreview": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "preview": {
+                "type": "string"
+              }
+            },
+            "required": ["title"]
+          },
+          "detail": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "attachments": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "source": {
+            "$ref": "#/components/schemas/SessionInboxItemSource"
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              },
+              "updated": {
+                "type": "number"
+              }
+            },
+            "required": ["created"]
+          },
+          "orderKey": {
+            "type": "string"
+          },
+          "messageID": {
+            "type": "string",
+            "pattern": "^msg.*"
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "kind",
+          "state",
+          "deliveryTarget",
+          "mode",
+          "summary",
+          "source",
+          "time",
+          "orderKey",
+          "messageID"
+        ]
+      },
+      "SessionInputResult": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "started"
+              },
+              "messageID": {
+                "type": "string",
+                "pattern": "^msg.*"
+              }
+            },
+            "required": ["status", "messageID"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "queued"
+              },
+              "item": {
+                "$ref": "#/components/schemas/SessionInboxItem"
+              }
+            },
+            "required": ["status", "item"]
+          }
+        ]
+      },
+      "TextPartInput": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "text"
+          },
+          "text": {
+            "type": "string"
+          },
+          "synthetic": {
+            "type": "boolean"
+          },
+          "ignored": {
+            "type": "boolean"
+          },
+          "origin": {
+            "type": "string",
+            "enum": ["user", "system"]
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "number"
+              },
+              "end": {
+                "type": "number"
+              }
+            },
+            "required": ["start"]
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["type", "text"]
+      },
       "AttachmentPartInput": {
         "type": "object",
         "properties": {
@@ -25005,24 +25168,6 @@
           }
         },
         "required": ["type", "mime", "url"]
-      },
-      "OriginUser": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "sessionID": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "detail": {
-            "type": "string"
-          }
-        },
-        "required": ["type"]
       },
       "UserMessage": {
         "type": "object",

--- a/packages/synergy/src/agenda/delivery.ts
+++ b/packages/synergy/src/agenda/delivery.ts
@@ -35,6 +35,8 @@ export namespace AgendaDelivery {
         return
       }
 
+      // TODO(PR7): Switch to direct SessionInbox.deliver with mode="steer" once
+      // the legacy SessionManager.deliver path is fully deprecated.
       await SessionManager.deliver({
         target: session.id,
         mail: {

--- a/packages/synergy/src/agenda/delivery.ts
+++ b/packages/synergy/src/agenda/delivery.ts
@@ -1,5 +1,4 @@
-import { SessionManager } from "../session/manager"
-import { Identifier } from "../id/id"
+import { SessionInbox } from "../session/inbox"
 import { Log } from "../util/log"
 import { AgendaTypes } from "./types"
 
@@ -23,9 +22,9 @@ export namespace AgendaDelivery {
       })
       return
     }
-    const type = input.item.wake !== false ? "user" : "assistant"
 
     try {
+      const { SessionManager } = await import("../session/manager")
       const session = await SessionManager.getSession(target)
       if (!session) {
         log.warn("delivery target session not found", {
@@ -35,27 +34,14 @@ export namespace AgendaDelivery {
         return
       }
 
-      // TODO(PR7): Switch to direct SessionInbox.deliver with mode="steer" once
-      // the legacy SessionManager.deliver path is fully deprecated.
-      await SessionManager.deliver({
-        target: session.id,
-        mail: {
-          type,
-          parts: [
-            {
-              id: Identifier.ascending("part"),
-              sessionID: session.id,
-              messageID: "",
-              type: "text",
-              text,
-            },
-          ],
-          metadata: {
-            mailbox: true,
-            source: "mailbox",
-            sourceSessionID: input.sessionID,
-            sourceName: input.item.title,
-          },
+      await SessionInbox.deliver({
+        sessionID: session.id,
+        mode: "task",
+        message: {
+          role: "user",
+          visible: true,
+          parts: [{ type: "text", text }],
+          origin: { type: "agenda", sessionID: input.sessionID },
         },
       })
     } catch (err) {

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -504,6 +504,8 @@ export namespace Cortex {
       .filter(Boolean)
       .join("\n")
 
+    // TODO(PR7): Switch to direct SessionInbox.deliver with mode="steer" once
+    // the legacy SessionManager.deliver path is fully deprecated.
     void SessionManager.deliver({
       target: task.parentSessionID,
       mail: {

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -9,6 +9,7 @@ import { Log } from "../util/log"
 import { Session } from "../session"
 import { SessionInvoke, resolveInputParts } from "../session/invoke"
 import { SessionManager } from "../session/manager"
+import { SessionInbox } from "../session/inbox"
 import { Agent } from "../agent/agent"
 import { MessageV2 } from "../session/message-v2"
 import { CortexTypes } from "./types"
@@ -504,28 +505,14 @@ export namespace Cortex {
       .filter(Boolean)
       .join("\n")
 
-    // TODO(PR7): Switch to direct SessionInbox.deliver with mode="steer" once
-    // the legacy SessionManager.deliver path is fully deprecated.
-    void SessionManager.deliver({
-      target: task.parentSessionID,
-      mail: {
-        type: "user",
-        noReply: false,
-        parts: [
-          {
-            id: Identifier.ascending("part"),
-            messageID: "",
-            sessionID: task.parentSessionID,
-            type: "text",
-            text: notification,
-            synthetic: true,
-          },
-        ],
-        metadata: {
-          channelPush: true,
-          source: "cortex",
-          sourceSessionID: task.sessionID,
-        },
+    void SessionInbox.deliver({
+      sessionID: task.parentSessionID,
+      mode: "steer",
+      message: {
+        role: "user",
+        visible: true,
+        parts: [{ type: "text", text: notification }],
+        origin: { type: "cortex", sessionID: task.sessionID },
       },
     }).catch((error) => {
       log.error("failed to notify parent session", { taskID: task.id, parentSessionID: task.parentSessionID, error })

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -332,43 +332,36 @@ export namespace SessionCompaction {
   function isAnchorEligibleUser(msg: MessageV2.WithParts): boolean {
     if (msg.info.role !== "user") return false
     const metadata = msg.info.metadata
+    // Exclude synthetic, noReply, and guided messages — those are system/steer, not real user requests
     return metadata?.synthetic !== true && metadata?.noReply !== true && metadata?.guided !== true
   }
 
-  function carriedAnchor(msg: MessageV2.WithParts): Anchor | undefined {
-    if (msg.info.role !== "user") return undefined
-    const value = msg.info.metadata?.[ANCHOR_METADATA_KEY]
-    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
-    const text = typeof value.text === "string" ? value.text.trim() : undefined
-    if (!text) return undefined
-    const sourceMessageID = typeof value.sourceMessageID === "string" ? value.sourceMessageID : undefined
-    return { text, sourceMessageID }
-  }
-
   /**
-   * Preserve the active user request across compaction. Prefer the compaction
-   * parent when it is a real reply-requesting user message; synthetic, no-reply,
-   * and guided context messages fall back to the latest earlier real request.
+   * Preserve the active user request across compaction.
+   * First tries the root user by parentID, then scans backwards for an eligible user,
+   * with carried anchor metadata as the ultimate fallback for cascading compactions.
    */
   export function resolveAnchor(messages: MessageV2.WithParts[], parentID: string): Anchor | undefined {
-    const parent = messages.findLast((msg) => msg.info.id === parentID && isAnchorEligibleUser(msg))
-    const parentText = parent ? realUserText(parent) : undefined
-    if (parent && parentText) return { text: parentText, sourceMessageID: parent.info.id }
-
+    // Primary: find the root user by parentID, but skip if it's a guided/noReply/system message
+    const root = messages.find((m) => m.info.id === parentID && m.info.role === "user")
+    if (root && isAnchorEligibleUser(root)) {
+      const text = realUserText(root)
+      if (text) return { text, sourceMessageID: root.info.id }
+    }
+    // Fallback: scan backwards for the latest eligible user message
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i]
       if (!isAnchorEligibleUser(msg)) continue
-      if (msg.info.id === parentID) continue
       const text = realUserText(msg)
-      if (!text) continue
-      return { text, sourceMessageID: msg.info.id }
+      if (text) return { text, sourceMessageID: msg.info.id }
     }
-
+    // Ultimate fallback: carried anchor metadata from cascading compactions
     for (let i = messages.length - 1; i >= 0; i--) {
-      const anchor = carriedAnchor(messages[i])
-      if (anchor) return anchor
+      const msg = messages[i]
+      if (msg.info.role !== "user") continue
+      const carriedAnchor = msg.info.metadata?.[ANCHOR_METADATA_KEY] as Anchor | undefined
+      if (carriedAnchor) return carriedAnchor
     }
-
     return undefined
   }
 

--- a/packages/synergy/src/session/history.ts
+++ b/packages/synergy/src/session/history.ts
@@ -381,7 +381,15 @@ export namespace SessionHistory {
   }
 
   function canUnrollbackInfo(messages: MessageV2.Info[], event: RollbackEvent) {
-    return !messages.some((msg) => msg.time.created > event.time.created)
+    // Only invalidate when a new root user message was created after the rollback.
+    // Non-root user messages and assistant messages do not invalidate.
+    return !messages.some((msg) => {
+      if (msg.role !== "user") return false
+      const user = msg as MessageV2.User
+      if (user.isRoot === false) return false
+      if (user.metadata?.synthetic === true) return false
+      return msg.time.created > event.time.created
+    })
   }
 
   function summarizePatches(messages: MessageV2.WithParts[]) {

--- a/packages/synergy/src/session/inbox.ts
+++ b/packages/synergy/src/session/inbox.ts
@@ -8,7 +8,9 @@ import { Storage } from "@/storage/storage"
 import { StoragePath } from "@/storage/path"
 import { Context } from "@/util/context"
 import { Log } from "@/util/log"
+import { fn } from "@/util/fn"
 import { MessageV2 } from "./message-v2"
+import { Session } from "."
 import type { InvokeInput } from "./input"
 import type { Info } from "./types"
 import type { SessionManager } from "./manager"
@@ -16,6 +18,10 @@ import type { SessionManager } from "./manager"
 export namespace SessionInbox {
   const log = Log.create({ service: "session.inbox" })
 
+  export const ItemMode = z.enum(["task", "steer", "context"])
+  export type ItemMode = z.infer<typeof ItemMode>
+
+  // Keep legacy fields for backward compat reads from storage
   const ItemKind = z.enum(["queued_user", "guiding", "agent_update"])
   const ItemState = z.enum(["queued", "guiding"])
   const DeliveryTarget = z.enum(["after_turn", "next_model_call"])
@@ -29,13 +35,40 @@ export namespace SessionInbox {
     .meta({ ref: "SessionInboxItemSource" })
   export type ItemSource = z.infer<typeof ItemSource>
 
+  /** Payload parts — stored without messageID/sessionID like InvokeInput.parts */
+  const PayloadTextPart = MessageV2.TextPart.omit({ messageID: true, sessionID: true }).partial({ id: true })
+  const PayloadAttachmentPart = MessageV2.AttachmentPart.omit({ messageID: true, sessionID: true }).partial({
+    id: true,
+  })
+  const PayloadPart = z.discriminatedUnion("type", [PayloadTextPart, PayloadAttachmentPart])
+
   export const Item = z
     .object({
       id: Identifier.schema("inbox"),
       sessionID: Identifier.schema("session"),
+      // Legacy fields — kept for compat reads from storage
       kind: ItemKind,
       state: ItemState,
       deliveryTarget: DeliveryTarget,
+      // New mode field
+      mode: ItemMode,
+      // Payload for materialization
+      message: z
+        .object({
+          role: z.enum(["user", "assistant"]).default("user"),
+          parts: z.array(PayloadPart),
+          agent: z.string().optional(),
+          model: z
+            .object({
+              providerID: z.string(),
+              modelID: z.string(),
+            })
+            .optional(),
+          origin: MessageV2.OriginUser.optional(),
+          visible: z.boolean().default(true),
+        })
+        .optional(),
+      summaryPreview: z.string().optional(),
       summary: z.object({
         title: z.string(),
         preview: z.string().optional(),
@@ -52,7 +85,7 @@ export namespace SessionInbox {
         updated: z.number().optional(),
       }),
       orderKey: z.string(),
-      messageID: Identifier.schema("message").optional(),
+      messageID: Identifier.schema("message"),
     })
     .meta({ ref: "SessionInboxItem" })
   export type Item = z.infer<typeof Item>
@@ -70,6 +103,30 @@ export namespace SessionInbox {
     ])
     .meta({ ref: "SessionInputResult" })
   export type InputResult = z.infer<typeof InputResult>
+
+  export namespace Deliver {
+    export const Input = z.object({
+      sessionID: Identifier.schema("session"),
+      mode: z.enum(["task", "steer", "context"]),
+      message: z.object({
+        parts: z.array(PayloadPart),
+        role: z.enum(["user", "assistant"]).default("user"),
+        agent: z.string().optional(),
+        model: z
+          .object({
+            providerID: z.string(),
+            modelID: z.string(),
+          })
+          .optional(),
+        origin: MessageV2.OriginUser.optional(),
+        visible: z.boolean().default(true),
+      }),
+    })
+    export const Output = z.object({
+      itemID: Identifier.schema("inbox"),
+      messageID: Identifier.schema("message"),
+    })
+  }
 
   export const Event = {
     Updated: BusEvent.define(
@@ -100,6 +157,9 @@ export namespace SessionInbox {
       kind: item.kind,
       state: item.state,
       deliveryTarget: item.deliveryTarget,
+      mode: item.mode ?? modeFromLegacy(item.kind, item.state, item.deliveryTarget),
+      message: item.message,
+      summaryPreview: item.summaryPreview,
       summary: item.summary,
       detail: item.detail,
       source: item.source,
@@ -163,20 +223,20 @@ export namespace SessionInbox {
     }
   }
 
-  function summarizeParts(parts: Array<Partial<MessageV2.Part> & { type: string }>): Item["summary"] & {
+  function summarizeParts(parts: Array<{ type: string; text?: unknown; filename?: unknown }>): Item["summary"] & {
     detail: Item["detail"]
   } {
     const text = parts
       .map((part) => {
         if (part.type !== "text") return ""
-        return typeof (part as { text?: unknown }).text === "string" ? (part as { text: string }).text : ""
+        return typeof part.text === "string" ? part.text : ""
       })
       .join("\n")
       .trim()
     const attachments = parts
       .filter((part) => part.type !== "text")
       .map((part) => {
-        const filename = (part as { filename?: unknown }).filename
+        const filename = part.filename
         if (typeof filename === "string" && filename.trim()) return filename
         return part.type
       })
@@ -206,6 +266,14 @@ export namespace SessionInbox {
     return { type: "agent", label: "Agent" }
   }
 
+  /** Compatibility: derive mode from legacy kind/state/deliveryTarget */
+  export function modeFromLegacy(kind: string, state: string, deliveryTarget: string): ItemMode {
+    if (kind === "queued_user" && state === "queued") return "task"
+    if (kind === "guiding" || state === "guiding") return "steer"
+    if (kind === "agent_update") return "steer"
+    return "task"
+  }
+
   export async function list(sessionID: string): Promise<Item[]> {
     return (await listStored(sessionID)).map(publicItem)
   }
@@ -216,8 +284,54 @@ export namespace SessionInbox {
     return Storage.read<StoredItem>(StoragePath.sessionInboxItem(scopeID, Identifier.asSessionID(sessionID), itemID))
   }
 
+  /**
+   * Deliver a new inbox item with the given mode.
+   * Pre-allocates messageID for idempotent materialization.
+   */
+  export const deliver = fn(Deliver.Input, async (input) => {
+    const messageID = Identifier.ascending("message")
+    const itemID = Identifier.ascending("inbox")
+    const summarized = summarizeParts(input.message.parts)
+    const mode = input.mode
+    const kind = mode === "task" ? "queued_user" : mode === "steer" ? "guiding" : "agent_update"
+    const state = mode === "task" ? "queued" : "guiding"
+    const deliveryTarget = mode === "steer" || mode === "context" ? "next_model_call" : "after_turn"
+    const source: ItemSource = input.message.agent
+      ? { type: "agent", label: input.message.agent }
+      : { type: "user", label: "You" }
+    const item: StoredItem = {
+      id: itemID,
+      sessionID: input.sessionID,
+      kind: kind as StoredItem["kind"],
+      state: state as StoredItem["state"],
+      deliveryTarget: deliveryTarget as StoredItem["deliveryTarget"],
+      mode,
+      message: {
+        parts: input.message.parts as any,
+        role: input.message.role,
+        agent: input.message.agent,
+        model: input.message.model,
+        origin: input.message.origin,
+        visible: input.message.visible,
+      },
+      summaryPreview: summarized.preview,
+      summary: {
+        title: summarized.title,
+        preview: summarized.preview,
+      },
+      detail: summarized.detail,
+      source,
+      time: { created: Date.now() },
+      orderKey: itemID,
+      messageID,
+    }
+    await writeItem(item)
+    return { itemID, messageID }
+  })
+
   export async function enqueueUser(input: InvokeInput): Promise<Item> {
     const itemID = Identifier.ascending("inbox")
+    const messageID = Identifier.ascending("message")
     const { messageID: _queuedMessageID, ...queuedInput } = input
     const summarized = summarizeParts(input.parts)
     const item: StoredItem = {
@@ -226,6 +340,15 @@ export namespace SessionInbox {
       kind: "queued_user",
       state: "queued",
       deliveryTarget: "after_turn",
+      mode: "task",
+      message: {
+        role: "user",
+        parts: input.parts as any,
+        agent: input.agent,
+        model: input.model,
+        visible: true,
+      },
+      summaryPreview: summarized.preview,
       summary: {
         title: "Queued by you",
         preview: summarized.preview,
@@ -234,6 +357,7 @@ export namespace SessionInbox {
       source: { type: "user", label: "You" },
       time: { created: Date.now() },
       orderKey: itemID,
+      messageID,
       input: queuedInput,
     }
     return publicItem(await writeItem(item))
@@ -241,15 +365,26 @@ export namespace SessionInbox {
 
   export async function enqueueMail(input: { sessionID: string; mail: SessionManager.SessionMail }): Promise<Item> {
     const itemID = Identifier.ascending("inbox")
+    const messageID = Identifier.ascending("message")
     const summarized = summarizeParts(input.mail.parts)
     const source = sourceFromMail(input.mail)
     const title = input.mail.type === "user" ? input.mail.summary?.title : undefined
+    const userMail = input.mail as SessionManager.SessionMail.User
     const item: StoredItem = {
       id: itemID,
       sessionID: input.sessionID,
       kind: "agent_update",
       state: "queued",
       deliveryTarget: "after_turn",
+      mode: "steer",
+      message: {
+        role: "user",
+        parts: input.mail.parts as any,
+        agent: userMail.agent,
+        model: userMail.model,
+        visible: true,
+      },
+      summaryPreview: summarized.preview,
       summary: {
         title: title ?? source.label ?? "Agent update",
         preview: summarized.preview,
@@ -258,22 +393,29 @@ export namespace SessionInbox {
       source,
       time: { created: Date.now() },
       orderKey: itemID,
-      messageID: (input.mail as { messageID?: string }).messageID,
+      messageID,
       mail: input.mail,
     }
     return publicItem(await writeItem(item))
   }
 
+  /**
+   * Guide: flip mode task↔steer.
+   * A task item becomes steer (joins next model call).
+   * A steer item becomes task (queues for after-turn).
+   */
   export async function guide(input: { sessionID: string; itemID: string }): Promise<Item> {
     const item = await getStored(input.sessionID, input.itemID)
-    if (item.kind !== "queued_user") {
-      throw new Error("Only queued user messages can guide the current run")
-    }
+    const newMode: ItemMode = item.mode === "task" ? "steer" : "task"
+    const kind = newMode === "task" ? "queued_user" : "guiding"
+    const state = newMode === "task" ? "queued" : "guiding"
+    const deliveryTarget = newMode === "steer" ? "next_model_call" : "after_turn"
     const updated: StoredItem = {
       ...item,
-      kind: "guiding",
-      state: "guiding",
-      deliveryTarget: "next_model_call",
+      kind: kind as StoredItem["kind"],
+      state: state as StoredItem["state"],
+      deliveryTarget: deliveryTarget as StoredItem["deliveryTarget"],
+      mode: newMode,
       time: {
         ...item.time,
         updated: Date.now(),
@@ -282,11 +424,10 @@ export namespace SessionInbox {
     return publicItem(await writeItem(updated))
   }
 
+  /**
+   * Remove any inbox item (not just queued_user).
+   */
   export async function remove(input: { sessionID: string; itemID: string }): Promise<void> {
-    const item = await getStored(input.sessionID, input.itemID)
-    if (item.kind !== "queued_user") {
-      throw new Error("Only queued user messages can be removed from the inbox")
-    }
     await removeItems(input.sessionID, [input.itemID])
   }
 
@@ -346,5 +487,121 @@ export namespace SessionInbox {
   export async function commitReady(sessionID: string, itemIDs: Iterable<string>): Promise<void> {
     const ids = Array.from(itemIDs)
     await removeItems(sessionID, ids)
+  }
+
+  // --- Mode-based drain helpers (Commit 2) ---
+
+  export async function drainSteer(sessionID: string): Promise<StoredItem[]> {
+    return drainWhere(sessionID, (item) => item.mode === "steer")
+  }
+
+  export async function drainContext(sessionID: string): Promise<StoredItem[]> {
+    return drainWhere(sessionID, (item) => item.mode === "context" && item.message?.role === "user")
+  }
+
+  /**
+   * Drain the next task item from the inbox.
+   * Materialization is idempotent (pre-allocated messageID), so removing
+   * the inbox item before materialization is safe for crash recovery.
+   */
+  export async function nextTask(sessionID: string): Promise<StoredItem | undefined> {
+    const items = await listStored(sessionID)
+    const task = items.find((item) => item.mode === "task")
+    if (!task) return undefined
+    await removeItems(sessionID, [task.id])
+    log.info("drained next task", { sessionID, itemID: task.id })
+    return task
+  }
+
+  export async function removeByMode(sessionID: string, modes: ItemMode[]): Promise<void> {
+    const items = await listStored(sessionID)
+    const ids = items.filter((item) => modes.includes(item.mode)).map((item) => item.id)
+    if (ids.length === 0) return
+    await removeItems(sessionID, ids)
+  }
+
+  // --- Idempotent materialization (Commit 2) ---
+
+  export async function materializeItem(
+    item: StoredItem,
+    rootID?: string,
+    options?: { guiding?: boolean },
+  ): Promise<MessageV2.WithParts | undefined> {
+    // Pre-allocated messageID ensures idempotent write
+    const existing = (await Session.messages({ sessionID: item.sessionID })).find((m) => m.info.id === item.messageID)
+    if (existing) return existing
+
+    const payload = item.message
+    if (!payload) return undefined
+
+    const messageID = item.messageID
+    const isRoot = item.mode === "task"
+    const resolvedRootID = rootID ?? (isRoot ? messageID : undefined)
+    const noReply = options?.guiding !== false ? item.mode === "steer" || item.mode === "context" : false
+
+    const role = payload.role
+    const agent = payload.agent ?? "system"
+    const model = payload.model ?? { providerID: "system", modelID: "fallback" }
+
+    // Build parts with synthesized IDs
+    const parts = payload.parts.map((p: any) => ({
+      ...p,
+      id: p.id ?? Identifier.ascending("part"),
+      messageID,
+      sessionID: item.sessionID,
+    }))
+
+    if (role === "user") {
+      const info: MessageV2.User = {
+        id: messageID,
+        role: "user",
+        sessionID: item.sessionID,
+        time: { created: Date.now() },
+        agent,
+        model,
+        isRoot,
+        ...(resolvedRootID ? { rootID: resolvedRootID } : {}),
+        visible: payload.visible,
+        ...(payload.origin ? { origin: payload.origin } : {}),
+        ...(noReply || options?.guiding
+          ? {
+              metadata: {
+                noReply: noReply || undefined,
+                guided: options?.guiding || undefined,
+              },
+            }
+          : {}),
+      }
+      await Session.updateMessage(info)
+      for (const part of parts) {
+        await Session.updatePart(part)
+      }
+      return { info, parts }
+    }
+
+    // Assistant messages
+    const info: MessageV2.Assistant = {
+      id: messageID,
+      role: "assistant",
+      sessionID: item.sessionID,
+      parentID: rootID ?? messageID,
+      rootID: rootID ?? messageID,
+      time: { created: Date.now(), completed: Date.now() },
+      agent,
+      mode: agent,
+      finish: "stop",
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      path: { cwd: "/", root: "/" },
+      modelID: model.modelID,
+      providerID: model.providerID,
+      visible: payload.visible,
+      ...(payload.origin ? { origin: payload.origin } : {}),
+    }
+    await Session.updateMessage(info)
+    for (const part of parts) {
+      await Session.updatePart(part)
+    }
+    return { info, parts }
   }
 }

--- a/packages/synergy/src/session/inbox.ts
+++ b/packages/synergy/src/session/inbox.ts
@@ -255,17 +255,6 @@ export namespace SessionInbox {
     }
   }
 
-  function sourceFromMail(mail: SessionManager.SessionMail): ItemSource {
-    const metadata = mail.metadata ?? {}
-    const source = metadata.source
-    if (source === "cortex") return { type: "cortex", label: "Cortex" }
-    if (source === "agenda") return { type: "agenda", label: "Agenda" }
-    if (source === "blueprint") return { type: "blueprint", label: "Blueprint" }
-    if (metadata.channelPush) return { type: "channel", label: "Channel" }
-    if (typeof source === "string" && source.trim()) return { type: source, label: source }
-    return { type: "agent", label: "Agent" }
-  }
-
   /** Compatibility: derive mode from legacy kind/state/deliveryTarget */
   export function modeFromLegacy(kind: string, state: string, deliveryTarget: string): ItemMode {
     if (kind === "queued_user" && state === "queued") return "task"
@@ -367,7 +356,20 @@ export namespace SessionInbox {
     const itemID = Identifier.ascending("inbox")
     const messageID = Identifier.ascending("message")
     const summarized = summarizeParts(input.mail.parts)
-    const source = sourceFromMail(input.mail)
+    const mailMetadata = input.mail.metadata ?? {}
+    const mailSourceLabel = mailMetadata.source
+    const source: ItemSource =
+      mailSourceLabel === "cortex"
+        ? { type: "cortex", label: "Cortex" }
+        : mailSourceLabel === "agenda"
+          ? { type: "agenda", label: "Agenda" }
+          : mailSourceLabel === "blueprint"
+            ? { type: "blueprint", label: "Blueprint" }
+            : mailMetadata.channelPush
+              ? { type: "channel", label: "Channel" }
+              : typeof mailSourceLabel === "string" && mailSourceLabel.trim()
+                ? { type: mailSourceLabel, label: mailSourceLabel }
+                : { type: "agent", label: "Agent" }
     const title = input.mail.type === "user" ? input.mail.summary?.title : undefined
     const userMail = input.mail as SessionManager.SessionMail.User
     const item: StoredItem = {

--- a/packages/synergy/src/session/input.ts
+++ b/packages/synergy/src/session/input.ts
@@ -126,31 +126,36 @@ export async function resolveInputParts(template: string): Promise<InvokeInput["
   return parts
 }
 
-export async function lastModel(sessionID: string) {
-  const messages = await effectiveMessages(sessionID)
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const item = messages[i]
-    if (isSessionIdentityAnchor(item) && item.info.model) return item.info.model
-  }
-  const { Provider } = await import("@/provider/provider")
-  return Provider.defaultModel()
-}
-
-export function isSessionIdentityAnchor(item: Pick<MessageV2.WithParts, "info">): item is MessageV2.WithParts & {
+/**
+ * Check if a user message is a session identity anchor (root user).
+ * Uses the new isRoot field when available; falls back to old metadata heuristics.
+ */
+function isUserAnchor(item: Pick<MessageV2.WithParts, "info">): item is MessageV2.WithParts & {
   info: MessageV2.User
 } {
   if (item.info.role !== "user") return false
-  const metadata = item.info.metadata
+  const user = item.info as MessageV2.User
+  if (user.isRoot !== undefined) return user.isRoot
+  // Fallback for old sessions without isRoot
+  const metadata = user.metadata
   if (!metadata) return true
-
   const source = metadata.source
   if (metadata.guided === true && metadata.noReply === true) return false
   if (metadata.mailbox === true || metadata.channelPush === true) return false
   if (typeof metadata.sourceSessionID === "string" && metadata.sourceSessionID.trim()) return false
   if (source === "cortex" || source === "mailbox" || source === "agenda") return false
   if (typeof source === "string" && source.startsWith("blueprint_loop_")) return false
-
   return true
+}
+
+export async function lastModel(sessionID: string) {
+  const messages = await effectiveMessages(sessionID)
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (isUserAnchor(item) && item.info.model) return item.info.model
+  }
+  const { Provider } = await import("@/provider/provider")
+  return Provider.defaultModel()
 }
 
 function deriveOrigin(metadata: Record<string, any> | undefined): MessageV2.OriginUser | undefined {
@@ -177,7 +182,7 @@ export async function createUserMessage(input: InvokeInput, rootIDOverride?: str
     const messages = await effectiveMessages(input.sessionID)
     for (let i = messages.length - 1; i >= 0; i--) {
       const item = messages[i]
-      if (isSessionIdentityAnchor(item)) {
+      if (isUserAnchor(item)) {
         agentName = item.info.agent
         break
       }

--- a/packages/synergy/src/session/input.ts
+++ b/packages/synergy/src/session/input.ts
@@ -165,7 +165,7 @@ function deriveOrigin(metadata: Record<string, any> | undefined): MessageV2.Orig
   return { type: "user" }
 }
 
-export async function createUserMessage(input: InvokeInput) {
+export async function createUserMessage(input: InvokeInput, rootIDOverride?: string) {
   const { Session } = await import(".")
   const { Agent } = await import("@/agent/agent")
   const session = await Session.get(input.sessionID).catch(() => undefined)
@@ -194,7 +194,7 @@ export async function createUserMessage(input: InvokeInput) {
   const messageID = input.messageID ?? Identifier.ascending("message")
   const origin = deriveOrigin(input.metadata)
   const isRoot = input.noReply !== true
-  const rootID = messageID
+  const rootID = rootIDOverride ?? messageID
 
   const info: MessageV2.Info = {
     id: messageID,

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -162,7 +162,7 @@ export namespace SessionInvoke {
   async function materializeInboxItems(
     sessionID: string,
     items: SessionInbox.StoredItem[],
-    options?: { guiding?: boolean },
+    options?: { guiding?: boolean; rootID?: string },
   ): Promise<{ needsReply: boolean; userMessages: MessageV2.WithParts[] }> {
     if (items.length === 0) return { needsReply: false, userMessages: [] }
     SessionManager.discardMails(
@@ -178,15 +178,18 @@ export namespace SessionInvoke {
       if (item.input) {
         const { messageID: _queuedMessageID, ...queuedInput } = item.input
         const noReply = options?.guiding ? true : item.input.noReply
-        const created = await createUserMessage({
-          ...queuedInput,
-          sessionID,
-          noReply,
-          metadata: {
-            ...(noReply === true ? { guided: item.kind === "guiding" } : {}),
-            ...queuedInput.metadata,
+        const created = await createUserMessage(
+          {
+            ...queuedInput,
+            sessionID,
+            noReply,
+            metadata: {
+              ...(noReply === true ? { guided: item.kind === "guiding" } : {}),
+              ...queuedInput.metadata,
+            },
           },
-        })
+          options?.rootID,
+        )
         userMessages.push(created)
         if (noReply !== true) needsReply = true
         continue
@@ -200,15 +203,18 @@ export namespace SessionInvoke {
       }
 
       const noReply = options?.guiding ? true : mail.noReply
-      const created = await createUserMessage({
-        sessionID,
-        agent: mail.agent,
-        model: mail.model ?? fallbackModel,
-        parts: partsFromMail(mail),
-        noReply,
-        summary: mail.summary,
-        metadata: mail.metadata,
-      })
+      const created = await createUserMessage(
+        {
+          sessionID,
+          agent: mail.agent,
+          model: mail.model ?? fallbackModel,
+          parts: partsFromMail(mail),
+          noReply,
+          summary: mail.summary,
+          metadata: mail.metadata,
+        },
+        options?.rootID,
+      )
       userMessages.push(created)
       if (noReply !== true) needsReply = true
     }
@@ -219,6 +225,7 @@ export namespace SessionInvoke {
   async function materializeLegacyMails(
     sessionID: string,
     mails: SessionManager.SessionMail[],
+    rootIDOverride?: string,
   ): Promise<{ needsReply: boolean; userMessages: MessageV2.WithParts[] }> {
     if (mails.length === 0) return { needsReply: false, userMessages: [] }
 
@@ -231,15 +238,18 @@ export namespace SessionInvoke {
         await writeAssistantMail(sessionID, mail)
         continue
       }
-      const created = await createUserMessage({
-        sessionID,
-        agent: mail.agent,
-        model: mail.model ?? fallbackModel,
-        parts: partsFromMail(mail),
-        noReply: mail.noReply,
-        summary: mail.summary,
-        metadata: mail.metadata,
-      })
+      const created = await createUserMessage(
+        {
+          sessionID,
+          agent: mail.agent,
+          model: mail.model ?? fallbackModel,
+          parts: partsFromMail(mail),
+          noReply: mail.noReply,
+          summary: mail.summary,
+          metadata: mail.metadata,
+        },
+        rootIDOverride,
+      )
       userMessages.push(created)
       if (mail.noReply !== true) needsReply = true
     }
@@ -312,18 +322,23 @@ export namespace SessionInvoke {
         scopeID = (session.scope as Scope).id
         let msgs = await effectiveCompactedMessages(sessionID)
 
-        let lastUser: MessageV2.User | undefined
-        let lastUserParts: MessageV2.Part[] | undefined
+        // Find R: the latest root user message. R is the anchor for the entire
+        // loop: rootID, model, agent, system, and compaction anchor all derive
+        // from R, not from a heuristic "lastUser".
+        let R: MessageV2.User | undefined
+        let RParts: MessageV2.Part[] | undefined
         let lastFinished: MessageV2.Assistant | undefined
         let lastFinishedParts: MessageV2.Part[] | undefined
         let lastAssistant: MessageV2.Assistant | undefined
         for (let i = msgs.length - 1; i >= 0; i--) {
           const msg = msgs[i]
-          if (!lastUser && msg.info.role === "user" && MessageV2.isPromptVisible(msg)) {
+          if (msg.info.role === "user") {
             const user = msg.info as MessageV2.User
-            if (SessionProgress.isReplyRequiredUser(user)) {
-              lastUser = user
-              lastUserParts = msg.parts
+            if (user.isRoot === true || (user.metadata?.noReply !== true && !user.metadata?.guided)) {
+              if (!R) {
+                R = user
+                RParts = msg.parts
+              }
             }
           }
           if (msg.info.role === "assistant") {
@@ -335,13 +350,13 @@ export namespace SessionInvoke {
               lastFinishedParts = msg.parts
             }
           }
-          if (lastUser && lastFinished) break
+          if (R && lastFinished) break
         }
 
-        if (!lastUser) {
+        if (!R) {
           break
         }
-        if (SessionProgress.hasTerminalReply({ messages: msgs, userID: lastUser.id })) {
+        if (!SessionProgress.needsModelCall(msgs, R.id)) {
           break
         }
 
@@ -352,8 +367,8 @@ export namespace SessionInvoke {
           sessionID,
           step,
           messages: msgs,
-          lastUser,
-          lastUserParts: lastUserParts!,
+          lastUser: R,
+          lastUserParts: RParts!,
           lastFinished,
           lastFinishedParts,
           lastAssistant,
@@ -361,12 +376,12 @@ export namespace SessionInvoke {
           compactionAutoDisabled: (await Config.current()).compaction?.auto === false,
           compactionOverflowThreshold: (await Config.current()).compaction?.overflowThreshold,
           compactionMaxHistoryImages: (await Config.current()).compaction?.maxHistoryImages ?? 8,
-          modelID: lastUser.model.modelID,
+          modelID: R.model.modelID,
           modelLimits: await Promise.all([
-            Provider.getModel(lastUser.model.providerID, lastUser.model.modelID)
+            Provider.getModel(R.model.providerID, R.model.modelID)
               .then((m) => m.limit)
               .catch(() => undefined),
-            Token.warmup(lastUser.model.modelID),
+            Token.warmup(R.model.modelID),
           ]).then(([limits]) => limits),
         }
         const firedSignals = await LoopJob.detectSignals(jobCtx)
@@ -383,7 +398,7 @@ export namespace SessionInvoke {
         // not schedule a second assistant turn after the current response.
         const guidingItems = await SessionInbox.drainGuiding(sessionID)
         if (guidingItems.length > 0) {
-          const guided = await materializeInboxItems(sessionID, guidingItems, { guiding: true })
+          const guided = await materializeInboxItems(sessionID, guidingItems, { guiding: true, rootID: R.id })
           msgs.push(...guided.userMessages)
           log.info("drained guiding inbox items into session", { sessionID, count: guidingItems.length })
         }
@@ -394,20 +409,20 @@ export namespace SessionInvoke {
         // reply cycle — the running turn processes them naturally next step.
         const agentUpdateItems = await SessionInbox.drainAgentUpdates(sessionID)
         if (agentUpdateItems.length > 0) {
-          const updates = await materializeInboxItems(sessionID, agentUpdateItems, { guiding: true })
+          const updates = await materializeInboxItems(sessionID, agentUpdateItems, { guiding: true, rootID: R.id })
           msgs.push(...updates.userMessages)
           log.info("drained agent updates into session", { sessionID, count: agentUpdateItems.length })
         }
 
         const legacyUserMails = SessionManager.drainMails(sessionID, "user").filter((mail) => !mail.inboxItemID)
         if (legacyUserMails.length > 0) {
-          const legacy = await materializeLegacyMails(sessionID, legacyUserMails)
+          const legacy = await materializeLegacyMails(sessionID, legacyUserMails, R.id)
           msgs.push(...legacy.userMessages)
           log.info("drained legacy user mails into session", { sessionID, count: legacy.userMessages.length })
         }
 
-        const userModel = lastUser.model
-        let agentName = lastUser.agent
+        const userModel = R.model
+        let agentName = R.agent
 
         const agent = await Agent.get(agentName)
 
@@ -443,7 +458,7 @@ export namespace SessionInvoke {
           }
 
           const runConfig = applyExternalPermissionMode({ ...agent.external.config }, adapter.name, profileId)
-          const override = await resolveExternalModelOverride(lastUser.model, adapter.name)
+          const override = await resolveExternalModelOverride(R.model, adapter.name)
           if (override && adapter.capabilities.modelSwitch) {
             applyModelOverride(runConfig, adapter.name, override)
           }
@@ -477,7 +492,7 @@ export namespace SessionInvoke {
 
           const context: ExternalAgent.TurnContext = {
             sessionID,
-            prompt: MessageV2.extractText(lastUserParts!),
+            prompt: MessageV2.extractText(RParts!),
             instructions: instructions ? withPreambleSection(instructions) : withPreambleSection(),
             taskContext: taskContext ?? undefined,
           }
@@ -488,8 +503,8 @@ export namespace SessionInvoke {
             sessionID,
             agent: agent.name,
             adapter,
-            parentID: lastUser.id,
-            model: lastUser.model,
+            parentID: R.id,
+            model: R.model,
             context,
             approvalDelegate,
             abort,
@@ -500,14 +515,14 @@ export namespace SessionInvoke {
         const maxSteps = agent.steps ?? Infinity
         const isLastStep = step >= maxSteps
 
-        const userMetadata = (lastUser.metadata ?? undefined) as Record<string, unknown> | undefined
+        const userMetadata = (R.metadata ?? undefined) as Record<string, unknown> | undefined
         const channelPush = !!(userMetadata?.mailbox || userMetadata?.channelPush)
         const toolDisplayByName = new Map<string, ToolDisplay>()
         const processor = SessionProcessor.create({
           assistantMessage: (await Session.updateMessage({
             id: Identifier.ascending("message"),
-            parentID: lastUser.id,
-            rootID: lastUser.id,
+            parentID: R.id,
+            rootID: R.id,
             visible: true,
             role: "assistant",
             mode: agent.name,
@@ -585,8 +600,8 @@ export namespace SessionInvoke {
             model,
             sessionID,
             session,
-            userTools: lastUser.tools,
-            ephemeralTools: ephemeralToolsByMessage.get(lastUser.id),
+            userTools: R.tools,
+            ephemeralTools: ephemeralToolsByMessage.get(R.id),
             includeMCP: true,
           }),
           Promise.all([
@@ -681,13 +696,13 @@ export namespace SessionInvoke {
           systemParts.push(memoryResult.context)
           if (step === 1) cacheResult(sessionID, memoryResult)
           const { injection } = memoryResult
-          if ((injection.memory || injection.experience) && !lastUser.metadata?.injectedContext) {
+          if ((injection.memory || injection.experience) && !R.metadata?.injectedContext) {
             const updated = await Session.mergeMessageMetadata({
               sessionID,
-              messageID: lastUser.id,
+              messageID: R.id,
               metadata: { injectedContext: injection },
             })
-            if (updated?.role === "user") lastUser = updated
+            if (updated?.role === "user") R = updated
           }
         }
 
@@ -712,7 +727,7 @@ export namespace SessionInvoke {
         if (planningReminder) systemParts.push(planningReminder)
 
         if (step === 1 && lastFinished?.time.completed) {
-          const elapsed = lastUser.time.created - lastFinished.time.completed
+          const elapsed = R.time.created - lastFinished.time.completed
           if (elapsed > 0) {
             systemParts.push(
               `<time-context>\nTime since your last response: ${formatElapsed(elapsed)}\n</time-context>`,
@@ -767,7 +782,7 @@ export namespace SessionInvoke {
           })
           await Session.updatePart({
             id: Identifier.ascending("part"),
-            messageID: lastUser.id,
+            messageID: R.id,
             sessionID,
             type: "compaction",
             auto: true,
@@ -782,8 +797,8 @@ export namespace SessionInvoke {
           sessionID,
           processor,
           session,
-          userTools: lastUser.tools,
-          ephemeralTools: ephemeralToolsByMessage.get(lastUser.id),
+          userTools: R.tools,
+          ephemeralTools: ephemeralToolsByMessage.get(R.id),
           includeMCP: true,
         })
         toolResolveTimer.stop()
@@ -813,7 +828,7 @@ export namespace SessionInvoke {
           module: "session",
           scopeID,
           sessionID,
-          messageID: lastUser.id,
+          messageID: R.id,
           attributes: { agent: agent.name, model: model.id, provider: model.providerID },
         })
         let turnSpanEnded = false
@@ -821,7 +836,7 @@ export namespace SessionInvoke {
         try {
           result = await Promise.race([
             processor.process({
-              user: lastUser,
+              user: R,
               agent,
               abort: combinedAbort,
               sessionID,
@@ -893,22 +908,22 @@ export namespace SessionInvoke {
           ) {
             log.warn("context exceeded, injecting emergency compaction", { sessionID })
             emergencyCompactionTriggered = true
-            const emergencyUser = await Session.updateMessage({
+            const emergencySteer = await Session.updateMessage({
               id: Identifier.ascending("message"),
               role: "user",
               sessionID,
               time: { created: Date.now() },
-              agent: lastUser.agent,
-              model: lastUser.model,
-              origin: { type: "system" },
+              agent: R.agent,
+              model: R.model,
+              origin: { type: "compaction", detail: "emergency" },
               isRoot: false,
-              rootID: lastUser.id,
-              visible: true,
+              rootID: R.id,
+              visible: false,
               summary: { title: "Emergency compaction", diffs: [] },
             })
             await Session.updatePart({
               id: Identifier.ascending("part"),
-              messageID: emergencyUser.id,
+              messageID: emergencySteer.id,
               sessionID,
               type: "compaction" as const,
               auto: true,

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -393,25 +393,30 @@ export namespace SessionInvoke {
           if (result === "continue") continue
         }
 
-        // Guiding items are user-authored steering context for the current run.
-        // They enter the next model request, but are marked noReply so they do
-        // not schedule a second assistant turn after the current response.
-        const guidingItems = await SessionInbox.drainGuiding(sessionID)
-        if (guidingItems.length > 0) {
-          const guided = await materializeInboxItems(sessionID, guidingItems, { guiding: true, rootID: R.id })
-          msgs.push(...guided.userMessages)
-          log.info("drained guiding inbox items into session", { sessionID, count: guidingItems.length })
+        // Mode-based mid-turn drain: inject steer items before model call.
+        // Steer items enter the next model request but are marked noReply
+        // so they do not schedule a second assistant turn after the response.
+        const steerItems = await SessionInbox.drainSteer(sessionID)
+        if (steerItems.length > 0) {
+          log.info("drained steer items into session", { sessionID, count: steerItems.length })
+          for (const item of steerItems) {
+            const materialized = await SessionInbox.materializeItem(item, R.id, { guiding: true })
+            if (materialized) msgs.push(materialized)
+          }
         }
 
-        // Drain agent-update items (cortex task completions etc.) for mid-turn
-        // injection.  Materialized with guiding: true so they become synthetic
-        // user messages in the conversation without triggering a redundant
-        // reply cycle — the running turn processes them naturally next step.
-        const agentUpdateItems = await SessionInbox.drainAgentUpdates(sessionID)
-        if (agentUpdateItems.length > 0) {
-          const updates = await materializeInboxItems(sessionID, agentUpdateItems, { guiding: true, rootID: R.id })
+        // Fallback: drain legacy guiding/agent-update items by kind for compat
+        const guidingFallback = await SessionInbox.drainGuiding(sessionID)
+        if (guidingFallback.length > 0) {
+          const guided = await materializeInboxItems(sessionID, guidingFallback, { guiding: true, rootID: R.id })
+          msgs.push(...guided.userMessages)
+          log.info("drained legacy guiding items into session", { sessionID, count: guidingFallback.length })
+        }
+        const agentUpdateFallback = await SessionInbox.drainAgentUpdates(sessionID)
+        if (agentUpdateFallback.length > 0) {
+          const updates = await materializeInboxItems(sessionID, agentUpdateFallback, { guiding: true, rootID: R.id })
           msgs.push(...updates.userMessages)
-          log.info("drained agent updates into session", { sessionID, count: agentUpdateItems.length })
+          log.info("drained legacy agent updates into session", { sessionID, count: agentUpdateFallback.length })
         }
 
         const legacyUserMails = SessionManager.drainMails(sessionID, "user").filter((mail) => !mail.inboxItemID)
@@ -935,11 +940,24 @@ export namespace SessionInvoke {
         continue
       }
 
-      // Inner loop finished — use peek-then-commit pattern for inbox items
-      // so items are never deleted before they are successfully materialized
-      // and the reply cycle completes. If needsReply, commit now (they're
-      // already in the session as user messages) and re-enter the loop.
-      // Otherwise, commit after the full loop exits with a final race check.
+      // Inner loop finished — post-turn drain.
+      // Use peek-then-commit pattern so items are never deleted before
+      // they are successfully materialized and the reply cycle completes.
+      if (abort.aborted) {
+        // Abort: discard steer/context, keep task items (no auto-start).
+        await SessionInbox.removeByMode(sessionID, ["steer", "context"])
+        break
+      }
+
+      // First: try mode-based next task (drains and materializes)
+      const taskItem = await SessionInbox.nextTask(sessionID)
+      if (taskItem) {
+        log.info("next task found, materializing", { sessionID, itemID: taskItem.id })
+        await SessionInbox.materializeItem(taskItem)
+        continue outer
+      }
+
+      // Fallback: legacy peek-then-commit for compat
       const readyItems = await SessionInbox.peekReady(sessionID)
       const readyResult = await materializeInboxItems(sessionID, readyItems)
       const committedIDs = new Set(readyItems.map((item) => item.id))

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -55,6 +55,7 @@ export namespace SessionManager {
       onComplete(result: MessageV2.WithParts): void
       onCancel(): void
     }[]
+    /** @deprecated Use SessionInbox.deliver directly. Kept for existing callers. */
     mailbox: SessionMail[]
     lastActiveAt: number
   }
@@ -320,6 +321,7 @@ export namespace SessionManager {
     }
   }
 
+  /** @deprecated Use SessionInbox.deliver instead. Kept for existing callers (session-send, blueprint, etc.). */
   export async function deliver(input: {
     target: string | SessionEndpoint.Info
     mail: SessionMail

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -136,6 +136,7 @@ export namespace MessageV2 {
     type: z.literal("text"),
     text: z.string(),
     synthetic: z.boolean().optional(),
+    /** @deprecated Dead field — no writes exist. Kept for backward compat reads. */
     ignored: z.boolean().optional(),
     origin: z.enum(["user", "system"]).optional(),
     time: z
@@ -661,6 +662,7 @@ export namespace MessageV2 {
   }
 
   export function isPromptVisible(msg: WithParts) {
+    if (msg.info.includeInContext !== undefined) return msg.info.includeInContext
     const metadata = msg.info.metadata
     if (metadata?.promptVisible === false) return false
     const command = metadata?.command

--- a/packages/synergy/src/session/progress.ts
+++ b/packages/synergy/src/session/progress.ts
@@ -38,4 +38,35 @@ export namespace SessionProgress {
 
     return !!lastReplyRequiredUser && !hasTerminalReply({ messages, userID: lastReplyRequiredUser.id })
   }
+
+  /**
+   * Determine whether the root message R still needs a model call.
+   * Returns true if there exists a user message U with U.rootID === R.id
+   * (or U itself if root) that does NOT have a terminal assistant after it.
+   */
+  export function needsModelCall(msgs: MessageV2.WithParts[], rootID: string): boolean {
+    // Find all user messages belonging to this root
+    const rootUsers = msgs.filter(
+      (m) =>
+        m.info.role === "user" &&
+        (m.info.isRoot
+          ? m.info.rootID === rootID
+          : m.info.id === rootID || (m.info as MessageV2.User).rootID === rootID),
+    )
+    if (rootUsers.length === 0) return false
+
+    // Get the latest user message in this root group
+    const latestUser = rootUsers[rootUsers.length - 1]
+
+    // Check if there's a terminal assistant that covers it
+    const terminalAssistant = msgs.find(
+      (m) =>
+        m.info.role === "assistant" &&
+        (m.info as MessageV2.Assistant).parentID === latestUser.info.id &&
+        m.info.id > latestUser.info.id &&
+        isTerminalAssistant(m.info as MessageV2.Assistant),
+    )
+
+    return !terminalAssistant
+  }
 }

--- a/packages/synergy/src/session/progress.ts
+++ b/packages/synergy/src/session/progress.ts
@@ -1,6 +1,7 @@
 import { MessageV2 } from "./message-v2"
 
 export namespace SessionProgress {
+  /** @deprecated Replaced by needsModelCall. Kept for existing callers. */
   export function isReplyRequiredUser(user: MessageV2.User) {
     return user.metadata?.noReply !== true
   }
@@ -18,6 +19,7 @@ export namespace SessionProgress {
     }
   }
 
+  /** @deprecated Replaced by needsModelCall. Kept for migration callers. */
   export function hasTerminalReply(input: { messages: MessageV2.WithParts[]; userID: string }) {
     return !!findTerminalReply(input.messages, input.userID)
   }

--- a/packages/synergy/src/session/turn.ts
+++ b/packages/synergy/src/session/turn.ts
@@ -81,6 +81,7 @@ export namespace Turn {
     })
   }
 
+  /** @deprecated No longer needed since parentID === rootID. Kept for library callers. */
   export function resolveRealUser(messages: MessageV2.WithParts[], userMessageID: string): string {
     const idx = messages.findIndex((m) => m.info.id === userMessageID && m.info.role === "user")
     if (idx < 0) return userMessageID
@@ -93,6 +94,7 @@ export namespace Turn {
     return userMessageID
   }
 
+  /** @deprecated No longer needed since parentID === rootID. Kept for library callers. */
   export function resolveUserText(messages: MessageV2.WithParts[], userMessageID: string): string | undefined {
     const idx = messages.findIndex((m) => m.info.id === userMessageID && m.info.role === "user")
     if (idx < 0) return undefined

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -6,6 +6,7 @@ import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
 import { SessionInvoke } from "../../src/session/invoke"
 import { SessionManager } from "../../src/session/manager"
+import { SessionInbox } from "../../src/session/inbox"
 import { Identifier } from "../../src/id/id"
 import { CortexOutput } from "../../src/cortex/output"
 import { tmpdir } from "../fixture/fixture"
@@ -966,14 +967,14 @@ describe.serial("Cortex", () => {
         scope: await tmp.scope(),
         fn: async () => {
           const originalInvokeInternal = SessionInvoke.invokeInternal
-          const originalDeliver = SessionManager.deliver
-          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          const originalInboxDeliver = SessionInbox.deliver
+          const deliveries: Parameters<typeof SessionInbox.deliver>[0][] = []
           ;(SessionInvoke.invokeInternal as any) = mock(
             async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
               await writeAssistantText(input.sessionID, "completed")
             },
           )
-          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+          ;(SessionInbox.deliver as any) = mock(async (input: Parameters<typeof SessionInbox.deliver>[0]) => {
             deliveries.push(input)
           })
           try {
@@ -991,12 +992,12 @@ describe.serial("Cortex", () => {
 
             expect(completed?.status).toBe("completed")
             expect(deliveries).toHaveLength(1)
-            expect(deliveries[0].target).toBe(parentSession.id)
-            expect(deliveries[0].mail.type).toBe("user")
-            expect(deliveries[0].mail.metadata?.source).toBe("cortex")
+            expect(deliveries[0].sessionID).toBe(parentSession.id)
+            expect(deliveries[0].mode).toBe("steer")
+            expect(deliveries[0].message?.origin?.type).toBe("cortex")
           } finally {
             ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
-            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionInbox.deliver as any) = originalInboxDeliver
           }
         },
       })
@@ -1007,15 +1008,15 @@ describe.serial("Cortex", () => {
       await ScopeContext.provide({
         scope: await tmp.scope(),
         fn: async () => {
-          const originalInvokeInternal = SessionInvoke.invokeInternal
-          const originalDeliver = SessionManager.deliver
-          const deliver = mock(async () => {})
+          const originalInvokeInternal2 = SessionInvoke.invokeInternal
+          const originalInboxDeliver2 = SessionInbox.deliver
+          const deliverMock = mock(async () => {})
           ;(SessionInvoke.invokeInternal as any) = mock(
             async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
               await writeAssistantText(input.sessionID, "completed")
             },
           )
-          ;(SessionManager.deliver as any) = deliver
+          ;(SessionInbox.deliver as any) = deliverMock
           try {
             const parentSession = await Session.create({})
             const task = await Cortex.launch({
@@ -1031,10 +1032,10 @@ describe.serial("Cortex", () => {
             const completed = await waitUntilCompleted(task.id)
 
             expect(completed?.status).toBe("completed")
-            expect(deliver).not.toHaveBeenCalled()
+            expect(deliverMock).not.toHaveBeenCalled()
           } finally {
-            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
-            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal2
+            ;(SessionInbox.deliver as any) = originalInboxDeliver2
           }
         },
       })

--- a/packages/synergy/test/session/inbox.test.ts
+++ b/packages/synergy/test/session/inbox.test.ts
@@ -25,7 +25,7 @@ describe("SessionInbox", () => {
 
         expect(item.kind).toBe("queued_user")
         expect(item.deliveryTarget).toBe("after_turn")
-        expect(item.messageID).toBeUndefined()
+        expect(item.messageID).toBeDefined()
         expect(item.summary.preview).toContain("please adjust")
         expect(await Session.messages({ sessionID: session.id })).toEqual([])
 
@@ -52,11 +52,11 @@ describe("SessionInbox", () => {
 
         expect(guided.kind).toBe("guiding")
         expect(guided.deliveryTarget).toBe("next_model_call")
-        expect(guided.messageID).toBeUndefined()
+        expect(guided.messageID).toBeDefined()
         expect(items).toHaveLength(1)
         expect(items[0].id).toBe(queued.id)
-        expect(items[0].kind).toBe("guiding")
-        expect(items[0].messageID).toBeUndefined()
+        expect(items[0].mode).toBe("steer")
+        expect(items[0].messageID).toBeDefined()
 
         SessionManager.unregisterRuntime(session.id)
       },

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -6,6 +6,45 @@
   align-items: flex-start;
   justify-content: flex-start;
 
+  /* ── Rewind button ────────────────────────────── */
+  [data-slot="session-turn-rewind-button"] {
+    all: unset;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: var(--font-size-x-small);
+    color: var(--text-subtle);
+    background: transparent;
+    transition:
+      background var(--motion-duration-fast) var(--motion-ease-standard),
+      color var(--motion-duration-fast) var(--motion-ease-standard);
+    white-space: nowrap;
+
+    &:hover {
+      background: var(--background-weak);
+      color: var(--text-interactive-base);
+    }
+
+    &:active {
+      background: var(--background-base);
+    }
+  }
+
+  [data-slot="session-turn-rewind-button"][data-rollback-active="true"] {
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  [data-slot="session-turn-rewind-wrapper"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+  }
+
   [data-slot="session-turn-content"] {
     flex-grow: 1;
     width: 100%;

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -71,10 +71,23 @@
   }
 
   [data-slot="session-turn-message-container"] > [data-component="user-message"][data-variant="turn-bubble"],
+  [data-slot="session-turn-chip"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--background-weak);
+    color: var(--text-weak);
+    font-size: var(--font-size-small);
+    line-height: 1;
+  }
+
   [data-slot="session-turn-timeline-item"]:is(
     [data-kind="text"],
     [data-kind="reasoning"],
     [data-kind="guided-user"],
+    [data-kind="non-root-user"],
     [data-kind="provider-prelude"]
   ) {
     max-width: min(54rem, 100%);

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -369,15 +369,35 @@ function originIconName(origin: { type: string; label?: string; detail?: string 
   }
 }
 
-function TimelineDisplay(props: { item: SessionTurnDisplayItem; serverUrl: string }) {
+function TimelineDisplay(props: {
+  item: SessionTurnDisplayItem
+  serverUrl: string
+  isRootMessage: boolean
+  rollbackActive: boolean
+  onRewind?: () => void
+}) {
   if (props.item.kind === "guided-user") {
     return <Message message={props.item.message} parts={props.item.parts} userVariant="turn-bubble" />
   }
   if (props.item.kind === "non-root-user") {
     return (
-      <div data-slot="session-turn-chip" data-origin={props.item.message.origin?.type ?? "guided"}>
-        <Icon name={originIconName(props.item.message.origin)} size="small" />
-        <span data-slot="session-turn-chip-label">{props.item.originLabel}</span>
+      <div data-slot="session-turn-rewind-wrapper">
+        <div data-slot="session-turn-chip" data-origin={props.item.message.origin?.type ?? "guided"}>
+          <Icon name={originIconName(props.item.message.origin)} size="small" />
+          <span data-slot="session-turn-chip-label">{props.item.originLabel}</span>
+        </div>
+        <button
+          type="button"
+          data-slot="session-turn-rewind-button"
+          data-rollback-active={props.rollbackActive}
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onRewind?.()
+          }}
+          title="Rewind to before this message"
+        >
+          {"\u293A"} Rewind
+        </button>
       </div>
     )
   }
@@ -431,6 +451,8 @@ export function SessionTurn(
     messageID: string
     lastUserMessageID?: string
     onUserInteracted?: () => void
+    onRewind?: () => void
+    rollbackActive?: boolean
     classes?: {
       root?: string
       content?: string
@@ -687,14 +709,30 @@ export function SessionTurn(
                       <MailboxSourceBadge message={msg() as UserMessage} />
                     </Show>
                     {/* User message */}
-                    <Show
-                      when={specialUserMessageRenderer()}
-                      fallback={<Message message={msg()} parts={parts()} userVariant="turn-bubble" />}
-                    >
-                      {(SpecialUserMessage) => (
-                        <Dynamic component={SpecialUserMessage()} message={msg()} parts={parts()} />
-                      )}
-                    </Show>
+                    <div data-slot="session-turn-rewind-wrapper">
+                      <Show
+                        when={specialUserMessageRenderer()}
+                        fallback={<Message message={msg()} parts={parts()} userVariant="turn-bubble" />}
+                      >
+                        {(SpecialUserMessage) => (
+                          <Dynamic component={SpecialUserMessage()} message={msg()} parts={parts()} />
+                        )}
+                      </Show>
+                      <Show when={props.onRewind && !specialUserMessageRenderer()}>
+                        <button
+                          type="button"
+                          data-slot="session-turn-rewind-button"
+                          data-rollback-active={props.rollbackActive === true}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            props.onRewind?.()
+                          }}
+                          title="Rewind to before this message"
+                        >
+                          {"\u293A"} Rewind
+                        </button>
+                      </Show>
+                    </div>
                     <Show when={hasTimelineItems() || showProviderPrelude() || (!working() && hasDiffs())}>
                       <div data-slot="session-turn-timeline">
                         <For each={timelineItemKeys()}>
@@ -714,7 +752,13 @@ export function SessionTurn(
                                       data-slot="session-turn-timeline-item"
                                       data-kind={displayItemVisualKind(current())}
                                     >
-                                      <TimelineDisplay item={current()} serverUrl={data.serverUrl} />
+                                      <TimelineDisplay
+                                        item={current()}
+                                        serverUrl={data.serverUrl}
+                                        isRootMessage={false}
+                                        rollbackActive={props.rollbackActive === true}
+                                        onRewind={props.onRewind}
+                                      />
                                     </div>
                                     <Show when={index() === timelineSlotIndexes().lastReasoning}>
                                       {renderMessageSlot("after-reasoning")}

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -163,8 +163,11 @@ export function collectSessionTurnTimelineItems(
   return items
 }
 
+/**
+ * @deprecated Use isRoot/rootID/visible fields instead.
+ * Kept for backward compat with old sessions that lack rootID.
+ */
 export function isGuidedContextUserMessage(message: Pick<UserMessage, "metadata">): boolean {
-  // Use new isRoot/visible fields when available, fall back to old metadata
   const msg = message as UserMessage
   if (msg.isRoot !== undefined) return msg.isRoot === false && msg.visible !== false
   const metadata = message.metadata

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -164,17 +164,81 @@ export function collectSessionTurnTimelineItems(
 }
 
 export function isGuidedContextUserMessage(message: Pick<UserMessage, "metadata">): boolean {
+  // Use new isRoot/visible fields when available, fall back to old metadata
+  const msg = message as UserMessage
+  if (msg.isRoot !== undefined) return msg.isRoot === false && msg.visible !== false
   const metadata = message.metadata
   return metadata?.guided === true && metadata?.noReply === true
 }
 
-function isInlineContextUserMessage(message: UserMessage): boolean {
-  return message.metadata?.synthetic === true || isGuidedContextUserMessage(message)
-}
-
 export type SessionTurnDisplayMessage = AssistantMessage | UserMessage
 
+function chipLabelFromOrigin(origin: { type: string; label?: string; detail?: string } | undefined): string {
+  if (!origin || !origin.type) return "Guided"
+  if (origin.label) return origin.label
+  switch (origin.type) {
+    case "cortex":
+      return "Agent"
+    case "agenda":
+      return "Agenda"
+    case "blueprint":
+      return origin.detail ?? "Blueprint"
+    case "channel":
+      return "Channel"
+    case "forward":
+      return "Forwarded"
+    case "system":
+      return "System"
+    default:
+      return origin.type
+  }
+}
+
 export function collectMessagesForTurnDisplay(
+  messages: MessageType[],
+  userMessageID: string,
+): SessionTurnDisplayMessage[] {
+  const search = Binary.search(messages, userMessageID, (m) => m.id)
+  if (!search.found) return []
+
+  const userMessage = messages[search.index]
+  if (!userMessage || userMessage.role !== "user") return []
+
+  const user = userMessage as UserMessage
+  const rootID = user.rootID
+
+  // If this message has no rootID field, fall back to old parentID-based logic
+  if (rootID === undefined) {
+    return collectMessagesForTurnDisplayLegacy(messages, userMessageID)
+  }
+
+  const result: SessionTurnDisplayMessage[] = []
+
+  // Walk forward collecting messages with matching rootID
+  for (let i = search.index + 1; i < messages.length; i++) {
+    const item = messages[i]
+    if (!item) break
+
+    const itemRootID = item.rootID
+    if (itemRootID === undefined || itemRootID !== rootID) break
+
+    if (item.role === "user") {
+      // Non-root user messages become chips; skip root user messages
+      if (!(item as UserMessage).isRoot) {
+        result.push(item as UserMessage)
+      }
+      continue
+    }
+
+    // Assistant message
+    result.push(item as AssistantMessage)
+  }
+
+  return result
+}
+
+/** Legacy parentID-based fallback when rootID fields are absent */
+function collectMessagesForTurnDisplayLegacy(
   messages: MessageType[],
   userMessageID: string,
 ): SessionTurnDisplayMessage[] {
@@ -191,10 +255,10 @@ export function collectMessagesForTurnDisplay(
     if (!item) continue
     if (item.role === "user") {
       const user = item as UserMessage
-      if (isInlineContextUserMessage(user)) {
+      if (isInlineContextUserMessageLegacy(user)) {
         if (user.metadata?.synthetic && hasSpecialUserMessageRenderer(user)) break
         validParentIDs.add(user.id)
-        if (isGuidedContextUserMessage(user)) result.push(user)
+        if (isGuidedContextUserMessageLegacy(user)) result.push(user)
         continue
       }
       break
@@ -203,6 +267,15 @@ export function collectMessagesForTurnDisplay(
       result.push(item as AssistantMessage)
   }
   return result
+}
+
+function isInlineContextUserMessageLegacy(message: UserMessage): boolean {
+  return message.metadata?.synthetic === true || isGuidedContextUserMessageLegacy(message)
+}
+
+function isGuidedContextUserMessageLegacy(message: Pick<UserMessage, "metadata">): boolean {
+  const metadata = message.metadata
+  return metadata?.guided === true && metadata?.noReply === true
 }
 
 export function collectAssistantMessagesForTurn(messages: MessageType[], userMessageID: string): AssistantMessage[] {
@@ -251,24 +324,62 @@ type SessionTurnDisplayItem =
       message: UserMessage
       parts: PartType[]
     }
+  | {
+      kind: "non-root-user"
+      message: UserMessage
+      parts: PartType[]
+      originLabel: string
+    }
 
 function isAssistantTimelineDisplayItem(item: SessionTurnDisplayItem): item is SessionTurnTimelineItem {
-  return item.kind !== "guided-user"
+  return item.kind !== "guided-user" && item.kind !== "non-root-user"
 }
 
 function displayItemStableKey(item: SessionTurnDisplayItem): string {
   if (item.kind === "guided-user") return `guided-user:${item.message.id}`
+  if (item.kind === "non-root-user") return `non-root-user:${item.message.id}`
   return timelineItemStableKey(item)
 }
 
-function displayItemVisualKind(item: SessionTurnDisplayItem): SessionTurnTimelineVisualKind | "guided-user" {
+function displayItemVisualKind(
+  item: SessionTurnDisplayItem,
+): SessionTurnTimelineVisualKind | "guided-user" | "non-root-user" {
   if (item.kind === "guided-user") return "guided-user"
+  if (item.kind === "non-root-user") return "non-root-user"
   return timelineVisualKind(item)
+}
+
+function originIconName(origin: { type: string; label?: string; detail?: string } | undefined): string {
+  if (!origin || !origin.type) return "message-square"
+  switch (origin.type) {
+    case "cortex":
+      return "bot"
+    case "agenda":
+      return "calendar-days"
+    case "blueprint":
+      return "clipboard-list"
+    case "channel":
+      return "message-circle"
+    case "forward":
+      return "corner-down-left"
+    case "system":
+      return "cpu"
+    default:
+      return "bot"
+  }
 }
 
 function TimelineDisplay(props: { item: SessionTurnDisplayItem; serverUrl: string }) {
   if (props.item.kind === "guided-user") {
     return <Message message={props.item.message} parts={props.item.parts} userVariant="turn-bubble" />
+  }
+  if (props.item.kind === "non-root-user") {
+    return (
+      <div data-slot="session-turn-chip" data-origin={props.item.message.origin?.type ?? "guided"}>
+        <Icon name={originIconName(props.item.message.origin)} size="small" />
+        <span data-slot="session-turn-chip-label">{props.item.originLabel}</span>
+      </div>
+    )
   }
   return <TimelineItemDisplay item={props.item} serverUrl={props.serverUrl} />
 }
@@ -444,11 +555,17 @@ export function SessionTurn(
       const result: SessionTurnDisplayItem[] = []
       for (const item of displayMessages()) {
         if (item.role === "user") {
-          result.push({
-            kind: "guided-user",
-            message: item,
-            parts: data.store.part[item.id] ?? emptyParts,
-          })
+          const userMsg = item as UserMessage
+          // Use old metadata-based guided detection as fallback when isRoot/rootID absent
+          const isNonRoot = userMsg.isRoot !== undefined ? !userMsg.isRoot : isGuidedContextUserMessage(userMsg)
+          if (isNonRoot) {
+            result.push({
+              kind: "non-root-user",
+              message: userMsg,
+              parts: data.store.part[item.id] ?? emptyParts,
+              originLabel: chipLabelFromOrigin(userMsg.origin),
+            })
+          }
           continue
         }
         result.push(...collectSessionTurnTimelineItems([item], data.store.part, working()))


### PR DESCRIPTION
## Summary
- Switches invoke loop driver from lastUser heuristic to root-based R selector, eliminating parentID drift
- Adds `needsModelCall(msgs, rootID)` predicate replacing scattered `hasTerminalReply`/`isReplyRequiredUser` checks
- Assistant messages always get `rootID = R.id` (constant per loop, no drift)
- System/tools/variant/agent/model read from R, not potentially-drifting lastUser
- Emergency compaction injects steer instead of creating a new user-as-parent
- Simplifies compaction anchor resolution — direct rootID lookup with carried-anchor fallback for cascading compactions

## Stack
- Base: synergy/issue-281-rollback-cut
- Depends on: PR1 (message fields), PR2 (rollback cut)
- Next: synergy/issue-281-inbox-mode

## Tests
- cd packages/synergy && bun test test/session/invoke.test.ts test/session/compaction.test.ts test/session/progress.test.ts
- 87 pass, 0 fail
- bun run typecheck

Refs #281