### PR TITLE
refactor(app): derive session timeline from root message fields

### DIFF
--- a/packages/app/src/components/session/commands.tsx
+++ b/packages/app/src/components/session/commands.tsx
@@ -208,7 +208,11 @@ export function useSessionCommands(params: {
         }
         const message = visibleUserMessages().at(-1)
         if (!message) return
-        await sdk.client.session.rollback({ sessionID, numTurns: 1 })
+        // Roll back using the last visibleRoot's id as cutMessageID
+        await sdk.client.session.rollback({
+          sessionID,
+          cutMessageID: message.id,
+        })
         const parts = sync.data.part[message.id]
         if (parts) {
           const restored = extractPromptDraft({ message, parts, directory: sdk.directory })
@@ -232,6 +236,31 @@ export function useSessionCommands(params: {
         await sdk.client.session.unrollback({ sessionID })
         prompt.resetDraft()
         setActiveMessage(userMessages().at(-1))
+      },
+    },
+    {
+      id: "session.rewind_to_here",
+      title: "Rewind to here",
+      description: "Rewind session to the active message",
+      category: "Session",
+      disabled: !routeParams.id || !activeMessage(),
+      onSelect: async () => {
+        const sessionID = routeParams.id
+        const message = activeMessage()
+        if (!sessionID || !message) return
+        if (status()?.type !== "idle") {
+          await sdk.client.session.abort({ sessionID }).catch(() => {})
+        }
+        await sdk.client.session.rollback({
+          sessionID,
+          cutMessageID: message.id,
+        })
+        const parts = sync.data.part[message.id]
+        if (parts) {
+          const restored = extractPromptDraft({ message, parts, directory: sdk.directory })
+          prompt.set(restored.prompt, inlineLength(restored.prompt))
+          prompt.context.set(restored.context)
+        }
       },
     },
     {

--- a/packages/app/src/components/session/conversation.tsx
+++ b/packages/app/src/components/session/conversation.tsx
@@ -39,6 +39,8 @@ export function SessionConversation(props: {
   scrollToMessage: (msg: UserMessage, behavior?: ScrollBehavior) => void
   anchor: (id: string) => string
   terminalHeight: Accessor<number>
+  onRewind?: (message: UserMessage) => void
+  rollbackActive?: boolean
 }) {
   const workspaceOpen = createMemo(() => props.workspaceOpen?.() ?? false)
   return (
@@ -144,6 +146,8 @@ export function SessionConversation(props: {
                 sessionID={props.sessionID}
                 messageID={msg.id}
                 lastUserMessageID={props.lastUserMessage()?.id}
+                onRewind={() => props.onRewind?.(msg as UserMessage)}
+                rollbackActive={props.rollbackActive}
                 classes={{
                   root: "min-w-0 w-full relative",
                   content: "flex flex-col justify-between !overflow-visible",

--- a/packages/app/src/components/session/conversation.tsx
+++ b/packages/app/src/components/session/conversation.tsx
@@ -5,16 +5,18 @@ import { SessionTurn } from "@ericsanchezok/synergy-ui/session-turn"
 import { MailboxMessage } from "@ericsanchezok/synergy-ui/mailbox-message"
 import { CommandResultOutput } from "@ericsanchezok/synergy-ui/command-result-output"
 import type { createAutoScroll } from "@ericsanchezok/synergy-ui/hooks"
-import type { UserMessage, AssistantMessage, Message } from "@ericsanchezok/synergy-sdk"
+import type { UserMessage, AssistantMessage, Message, SessionInboxItem } from "@ericsanchezok/synergy-sdk"
 import { SessionTimeline } from "./session-timeline"
 import { ConversationViewport } from "./conversation-viewport"
 import { navMark } from "@/utils/perf"
 import { BrowserViewEffects } from "@/components/workspace/browser/browser-view-effects"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
 
 export function SessionConversation(props: {
   sessionID: string
   paramsDir: string
   timeline: Accessor<Message[]>
+  pendingTimeline?: Accessor<SessionInboxItem[]>
   visibleUserMessages: Accessor<UserMessage[]>
   lastUserMessage: Accessor<UserMessage | undefined>
   activeMessage: Accessor<UserMessage | undefined>
@@ -160,6 +162,31 @@ export function SessionConversation(props: {
           )
         }}
       </For>
+      <Show when={props.pendingTimeline?.()?.length}>
+        <div class="w-full flex flex-col items-start gap-2 opacity-50">
+          <For each={props.pendingTimeline?.() ?? []}>
+            {(item) => {
+              const isTask = () => item.mode === "task"
+              const label = () =>
+                item.message?.parts?.[0]?.type === "text"
+                  ? (item.message!.parts[0] as { text: string }).text
+                  : (item.summary?.title ?? "Pending…")
+              return (
+                <div
+                  data-slot="pending-timeline-item"
+                  data-mode={item.mode}
+                  class="flex items-center gap-2 px-3 py-2 rounded-lg bg-background-weak text-text-weak text-sm"
+                >
+                  <Icon name="clock" size="small" />
+                  <Show when={isTask()} fallback={<span class="text-xs">{label()}</span>}>
+                    <span class="text-xs">{label()}</span>
+                  </Show>
+                </div>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
     </ConversationViewport>
   )
 }

--- a/packages/app/src/components/session/dialog-rewind-confirm.css
+++ b/packages/app/src/components/session/dialog-rewind-confirm.css
@@ -1,0 +1,74 @@
+.rewind-confirm-dialog {
+  [data-slot="dialog-body"] {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
+.rewind-confirm-counts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rewind-confirm-count-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-small);
+  color: var(--text-base);
+}
+
+.rewind-confirm-file-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 24px;
+}
+
+.rewind-confirm-file-item {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--background-weak);
+  font-size: var(--font-size-x-small);
+  color: var(--text-weak);
+  font-family: var(--font-family-mono);
+}
+
+.rewind-confirm-file-more {
+  font-size: var(--font-size-x-small);
+  color: var(--text-subtle);
+  padding: 1px 4px;
+}
+
+.rewind-confirm-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-small);
+  color: var(--text-base);
+  cursor: pointer;
+
+  input[type="checkbox"] {
+    accent-color: var(--accent-base);
+  }
+}
+
+.rewind-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.rewind-confirm-button[data-tone="danger"] {
+  --button-background: var(--danger-background, var(--red-600));
+  --button-color: var(--danger-color, white);
+}
+
+.rewind-confirm-spinner {
+  width: 14px;
+  height: 14px;
+  margin-right: 4px;
+}

--- a/packages/app/src/components/session/dialog-rewind-confirm.tsx
+++ b/packages/app/src/components/session/dialog-rewind-confirm.tsx
@@ -1,0 +1,190 @@
+import { createMemo, createSignal, Show } from "solid-js"
+import type { UserMessage, Part as PartType } from "@ericsanchezok/synergy-sdk"
+import { Button } from "@ericsanchezok/synergy-ui/button"
+import { Dialog } from "@ericsanchezok/synergy-ui/dialog"
+import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
+
+interface DialogRewindConfirmProps {
+  /** The target user message to rewind to (cut = this message and everything after) */
+  cutMessage: UserMessage
+  /** All messages in the session ordered by id */
+  allMessages: { id: string; role: string }[]
+  /** Parts records keyed by message id */
+  partsByMessage: Record<string, PartType[] | undefined>
+  filesByMessage: Record<string, string[] | undefined>
+  onRewind: (cutMessageID: string, restoreFiles: boolean) => Promise<void>
+}
+
+function activeMessageIndex(messages: { id: string }[], cutId: string) {
+  return messages.findIndex((m) => m.id >= cutId)
+}
+
+function computeCounts(props: {
+  allMessages: { id: string; role: string }[]
+  cutId: string
+  partsByMessage: Record<string, PartType[] | undefined>
+  filesByMessage: Record<string, string[] | undefined>
+}) {
+  const { allMessages, cutId, partsByMessage, filesByMessage } = props
+  const idx = activeMessageIndex(allMessages, cutId)
+  if (idx < 0)
+    return { droppedUserMessages: 0, assistantReplies: 0, affectedFiles: 0, affectedFileNames: [] as string[] }
+
+  const dropped = allMessages.slice(idx)
+  const droppedUser = dropped.filter((m) => m.role === "user")
+  const assistantReplies = dropped.filter((m) => m.role === "assistant").length
+
+  const affectedFileSet = new Set<string>()
+  for (const m of dropped) {
+    const parts = partsByMessage[m.id]
+    if (parts) {
+      for (const p of parts) {
+        if (p.type === "patch" && "files" in p && Array.isArray((p as { files: string[] }).files)) {
+          for (const f of (p as { files: string[] }).files) affectedFileSet.add(f)
+        }
+      }
+    }
+    const msgFiles = filesByMessage[m.id]
+    if (msgFiles) for (const f of msgFiles) affectedFileSet.add(f)
+  }
+
+  return {
+    droppedUserMessages: droppedUser.length,
+    assistantReplies,
+    affectedFiles: affectedFileSet.size,
+    affectedFileNames: Array.from(affectedFileSet).slice(0, 10),
+  }
+}
+
+export function DialogRewindConfirm(props: DialogRewindConfirmProps) {
+  const dialog = useDialog()
+  const [pending, setPending] = createSignal(false)
+  const [restoreFiles, setRestoreFiles] = createSignal(true)
+
+  const summary = createMemo(() => (props.cutMessage as { summary?: { title?: string } }).summary?.title)
+
+  const counts = createMemo(() =>
+    computeCounts({
+      allMessages: props.allMessages,
+      cutId: props.cutMessage.id,
+      partsByMessage: props.partsByMessage,
+      filesByMessage: props.filesByMessage,
+    }),
+  )
+
+  const handleRewind = async () => {
+    if (pending()) return
+    setPending(true)
+    try {
+      await props.onRewind(props.cutMessage.id, restoreFiles())
+      dialog.close()
+    } catch (error) {
+      showToast({
+        type: "error",
+        title: "Rewind failed",
+        description: error instanceof Error ? error.message : "Request failed",
+      })
+      setPending(false)
+    }
+  }
+
+  return (
+    <Dialog
+      title="Rewind to here"
+      description={
+        summary() ? `Rewind before 「${summary()}」?` : "Rewind before this message? Messages after it will be hidden."
+      }
+      class="rewind-confirm-dialog"
+      action={
+        <button
+          type="button"
+          data-slot="dialog-close-button"
+          data-component="icon-button"
+          data-variant="ghost"
+          disabled={pending()}
+          onClick={() => {
+            if (!pending()) dialog.close()
+          }}
+        >
+          <Icon name="x" size="small" />
+        </button>
+      }
+    >
+      <div class="rewind-confirm-counts">
+        <Show when={counts().droppedUserMessages > 0}>
+          <div class="rewind-confirm-count-row">
+            <Icon name="message-square" size="small" />
+            <span>
+              {counts().droppedUserMessages} user {counts().droppedUserMessages === 1 ? "message" : "messages"}
+            </span>
+          </div>
+        </Show>
+        <Show when={counts().assistantReplies > 0}>
+          <div class="rewind-confirm-count-row">
+            <Icon name="bot" size="small" />
+            <span>
+              {counts().assistantReplies} {counts().assistantReplies === 1 ? "reply" : "replies"}
+            </span>
+          </div>
+        </Show>
+        <Show when={counts().affectedFiles > 0}>
+          <div class="rewind-confirm-count-row">
+            <Icon name="file" size="small" />
+            <span>
+              {counts().affectedFiles} affected {counts().affectedFiles === 1 ? "file" : "files"}
+            </span>
+          </div>
+          <Show when={counts().affectedFileNames.length > 0}>
+            <div class="rewind-confirm-file-list">
+              {counts().affectedFileNames.map((f) => (
+                <span class="rewind-confirm-file-item">{f}</span>
+              ))}
+              <Show when={counts().affectedFiles > counts().affectedFileNames.length}>
+                <span class="rewind-confirm-file-more">
+                  +{counts().affectedFiles - counts().affectedFileNames.length} more
+                </span>
+              </Show>
+            </div>
+          </Show>
+        </Show>
+      </div>
+
+      <label class="rewind-confirm-checkbox-label">
+        <input
+          type="checkbox"
+          checked={restoreFiles()}
+          onChange={(e) => setRestoreFiles(e.currentTarget.checked)}
+          disabled={pending()}
+        />
+        <span>Restore files</span>
+      </label>
+
+      <div data-slot="dialog-actions" class="rewind-confirm-actions">
+        <Button type="button" variant="ghost" size="large" disabled={pending()} onClick={() => dialog.close()}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="large"
+          class="rewind-confirm-button"
+          data-tone="danger"
+          disabled={pending()}
+          onClick={() => void handleRewind()}
+        >
+          {pending() ? (
+            <>
+              <Spinner class="rewind-confirm-spinner" />
+              {"Rewinding\u2026"}
+            </>
+          ) : (
+            "Rewind"
+          )}
+        </Button>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/session/prompt-dock.tsx
+++ b/packages/app/src/components/session/prompt-dock.tsx
@@ -44,6 +44,7 @@ export function PromptDock(props: {
   scopeName: Accessor<string>
   branch: Accessor<string | undefined>
   lastModified: Accessor<string | null | undefined>
+  rollbackActive?: boolean
 }) {
   const nav = useNavigate()
   return (
@@ -167,7 +168,12 @@ export function PromptDock(props: {
                     hideAgentSelector={!props.meta().showInputBar}
                   />
                   <Show when={props.sessionID}>
-                    <SessionInbox sessionID={props.sessionID!} sync={props.sync} sdk={props.sdk} />
+                    <SessionInbox
+                      sessionID={props.sessionID!}
+                      sync={props.sync}
+                      sdk={props.sdk}
+                      freezeHint={props.rollbackActive}
+                    />
                   </Show>
                 </div>
               </>

--- a/packages/app/src/components/session/rollback-banner.css
+++ b/packages/app/src/components/session/rollback-banner.css
@@ -1,0 +1,54 @@
+[data-component="rollback-banner"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  margin: 0 16px 8px;
+  border-radius: 8px;
+  background: var(--background-base);
+  border: 1px solid var(--border-weak);
+  font-size: var(--font-size-small);
+  color: var(--text-base);
+  animation: fadeDown 0.2s ease-out both;
+}
+
+@keyframes fadeDown {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+[data-slot="rollback-banner-content"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+[data-slot="rollback-banner-text"] {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-slot="rollback-banner-actions"] {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.rollback-banner-dismiss {
+  opacity: 0.5;
+  transition: opacity var(--motion-duration-fast) var(--motion-ease-standard);
+
+  &:hover {
+    opacity: 1;
+  }
+}

--- a/packages/app/src/components/session/rollback-banner.tsx
+++ b/packages/app/src/components/session/rollback-banner.tsx
@@ -1,0 +1,121 @@
+import { Show } from "solid-js"
+import { Button } from "@ericsanchezok/synergy-ui/button"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
+import type { SessionRollbackSummary } from "@ericsanchezok/synergy-sdk/client"
+import type { useSDK } from "@/context/sdk"
+
+interface RollbackBannerProps {
+  sessionID: string
+  rollback: SessionRollbackSummary
+  sdk: ReturnType<typeof useSDK>
+  onDismiss: () => void
+}
+
+export function RollbackBanner(props: RollbackBannerProps) {
+  const { rollback } = props
+  const numTurns = rollback.numTurns ?? 0
+  const numMessages = rollback.droppedMessageIDs?.length ?? 0
+  const numFiles = rollback.patchPartIDs?.length ?? 0
+
+  const handleRedo = async () => {
+    if (!rollback.canUnrollback) {
+      showToast({
+        type: "info",
+        title: "Cannot redo",
+        description: "A new task has been started. The rollback can no longer be redone.",
+        duration: 4000,
+      })
+      return
+    }
+
+    try {
+      await props.sdk.client.session.unrollback({ sessionID: props.sessionID })
+      showToast({
+        type: "success",
+        title: "Redo complete",
+        description: `Restored ${numMessages} message${numMessages === 1 ? "" : "s"}`,
+      })
+      props.onDismiss()
+    } catch (err) {
+      if (err instanceof Error && err.message?.includes("new session messages")) {
+        showToast({
+          type: "warning",
+          title: "Cannot redo",
+          description: "New messages have been added. This rollback can no longer be redone.",
+        })
+      } else {
+        showToast({
+          type: "error",
+          title: "Redo failed",
+          description: err instanceof Error ? err.message : "Request failed",
+        })
+      }
+    }
+  }
+
+  const handleRestoreFiles = async () => {
+    if (numFiles === 0) return
+    try {
+      const result = await props.sdk.client.session.files.restore({
+        sessionID: props.sessionID,
+        rollbackID: rollback.id,
+      })
+      const count = result.data?.restoredFiles?.length ?? 0
+      showToast({
+        type: "success",
+        title: "Files restored",
+        description: `${count} file${count === 1 ? "" : "s"} restored`,
+      })
+    } catch (err) {
+      showToast({
+        type: "error",
+        title: "Failed to restore files",
+        description: err instanceof Error ? err.message : "Request failed",
+      })
+    }
+  }
+
+  return (
+    <div data-component="rollback-banner">
+      <div data-slot="rollback-banner-content">
+        <Icon name="undo-2" size="small" />
+        <span data-slot="rollback-banner-text">
+          Rewound {numMessages} message{numMessages === 1 ? "" : "s"} ({numTurns} turn{numTurns === 1 ? "" : "s"})
+        </span>
+      </div>
+      <div data-slot="rollback-banner-actions">
+        <Button
+          type="button"
+          variant="ghost"
+          size="small"
+          data-tone={rollback.canUnrollback ? "neutral" : "disabled"}
+          disabled={!rollback.canUnrollback}
+          title={
+            rollback.canUnrollback
+              ? "Restore the rewound messages"
+              : "New messages have been added; cannot redo this rollback"
+          }
+          onClick={() => void handleRedo()}
+        >
+          Redo
+        </Button>
+        <Show when={numFiles > 0}>
+          <Button type="button" variant="ghost" size="small" onClick={() => void handleRestoreFiles()}>
+            Restore files ({numFiles})
+          </Button>
+        </Show>
+        <Button
+          type="button"
+          variant="ghost"
+          size="small"
+          class="rollback-banner-dismiss"
+          onClick={props.onDismiss}
+          aria-label="Dismiss"
+        >
+          <Icon name="x" size="small" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/session/session-inbox.tsx
+++ b/packages/app/src/components/session/session-inbox.tsx
@@ -16,6 +16,7 @@ type SessionInboxProps = {
   sessionID: string
   sync: ReturnType<typeof useSync>
   sdk: ReturnType<typeof useSDK>
+  freezeHint?: boolean
 }
 
 function labelByMode(item: SessionInboxItem): string {
@@ -209,6 +210,19 @@ export function SessionInbox(props: SessionInboxProps) {
 
   const remove = async (item: SessionInboxItem) => {
     await props.sdk.client.session.inboxRemove({ sessionID: props.sessionID, itemID: item.id })
+    showToast({
+      type: "info",
+      title: "Removed queued message",
+      description: "The message has been removed from the inbox.",
+      actions: [
+        {
+          label: "Restore",
+          onClick: () => {
+            void props.sdk.client.session.inboxGuide({ sessionID: props.sessionID, itemID: item.id }).catch(() => {})
+          },
+        },
+      ],
+    })
   }
   const confirmRemove = (item: SessionInboxItem) => {
     confirm.show({
@@ -256,6 +270,9 @@ export function SessionInbox(props: SessionInboxProps) {
           </Match>
           <Match when={true}>
             <div class="session-inbox-list">
+              <Show when={props.freezeHint}>
+                <div class="px-1 py-1 text-11-medium text-text-subtle">Inbox frozen while rewinding</div>
+              </Show>
               <div class="session-inbox-queue-note">
                 <span>{note()}</span>
                 <Show when={actionableItems().length > 1}>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -260,6 +260,7 @@ function SessionPageContent() {
   // ── Root message derivation layer ───────────────────────────────────
   // Replaces old isSessionIdentityAnchor / isGuidedContextUserMessage / synthetic metadata
   // heuristics with orthogonal isRoot/visible/rootID/origin fields.
+  /** @deprecated Use inline empty arrays or nullish coalescing. */
   const emptyUserMessages: UserMessage[] = []
   const rootMessages = createMemo(
     () =>
@@ -321,6 +322,7 @@ function SessionPageContent() {
     return msgs.filter((message) => message.id >= firstID)
   }, emptyUserMessages)
 
+  /** @deprecated Use inline empty arrays or nullish coalescing. */
   const emptyTimeline: Message[] = []
   const isActionCommandMessage = (message: Message) => {
     const metadata = message.metadata as

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -51,6 +51,8 @@ import {
 } from "@/components/session/worktree-session"
 import { WorktreeTransitionContent } from "@/components/session/worktree-transition-dialog"
 import { worktreeTransition, clearWorktreeTransition } from "@/components/session/worktree-progress-signals"
+import { RollbackBanner } from "@/components/session/rollback-banner"
+import { DialogRewindConfirm } from "@/components/session/dialog-rewind-confirm"
 
 const handoff = {
   prompt: "",
@@ -193,6 +195,9 @@ function SessionPageContent() {
   const reviewCount = createMemo(() => info()?.summary?.files ?? 0)
   const hasReview = createMemo(() => reviewCount() > 0)
   const rollback = createMemo(() => info()?.history?.rollback)
+  const rollbackActive = createMemo(() => rollback() !== undefined)
+  const [rollbackDismissed, setRollbackDismissed] = createSignal(false)
+  const showRollbackBanner = createMemo(() => rollback() !== undefined && !rollbackDismissed())
   const hiddenMessageIDs = createMemo(() => {
     const rb = rollback()
     if (!rb) return new Set<string>()
@@ -211,6 +216,32 @@ function SessionPageContent() {
     if (isHomeScope(sdk.scopeKey) && (messages()?.length ?? 0) === 0) return true
     return false
   })
+  const openRewindConfirm = (message: UserMessage) => {
+    const targetMsg = message
+    const sessionID = params.id
+    dialog.push(() => (
+      <DialogRewindConfirm
+        cutMessage={targetMsg}
+        allMessages={messages().filter((m) => m.role === "user" || m.role === "assistant")}
+        partsByMessage={sync.data.part}
+        filesByMessage={{}}
+        onRewind={async (cutMessageID, restoreFiles) => {
+          if (!sessionID) return
+          if (status().type !== "idle") {
+            await sdk.client.session.abort({ sessionID }).catch(() => {})
+          }
+          await sdk.client.session.rollback({ sessionID, cutMessageID })
+          if (restoreFiles) {
+            const rb = rollback()
+            if (rb) {
+              await sdk.client.session.files.restore({ sessionID, rollbackID: rb.id }).catch(() => {})
+            }
+          }
+          setActiveMessage(userMessages().findLast((x) => x.id < cutMessageID))
+        }}
+      />
+    ))
+  }
   const messagesReady = createMemo(() => {
     const id = params.id
     if (!id) return true
@@ -906,6 +937,14 @@ function SessionPageContent() {
                 )}
               </Show>
               <SessionTopBar />
+              <Show when={showRollbackBanner()}>
+                <RollbackBanner
+                  sessionID={params.id!}
+                  rollback={rollback()!}
+                  sdk={sdk}
+                  onDismiss={() => setRollbackDismissed(true)}
+                />
+              </Show>
               <div class="flex-1 min-h-0 min-w-0 overflow-hidden">
                 <Switch>
                   <Match when={!isNewSession()}>
@@ -986,6 +1025,8 @@ function SessionPageContent() {
                           anchor={anchor}
                           terminalHeight={bottomSurface().opened() ? bottomSurface().size : () => 0}
                           workspaceOpen={sideOpen}
+                          onRewind={openRewindConfirm}
+                          rollbackActive={rollbackActive()}
                         />
                       </Show>
                     </Show>
@@ -1022,6 +1063,7 @@ function SessionPageContent() {
               branch={branch}
               lastModified={lastModified}
               workspaceOpen={sideOpen}
+              rollbackActive={rollbackActive()}
             />
             <Show when={isDesktop() && showTabs() && !sideOpen()}>
               <ResizeHandle

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,6 +1,5 @@
 import { Show, Match, Switch, createMemo, createEffect, createSignal, on, onCleanup } from "solid-js"
 import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
-import { isGuidedContextUserMessage } from "@ericsanchezok/synergy-ui/session-turn"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLocal } from "@/context/local"
 import { useFile, type SelectedLineRange } from "@/context/file"
@@ -194,7 +193,13 @@ function SessionPageContent() {
   const reviewCount = createMemo(() => info()?.summary?.files ?? 0)
   const hasReview = createMemo(() => reviewCount() > 0)
   const rollback = createMemo(() => info()?.history?.rollback)
-  const hiddenMessageIDs = createMemo(() => new Set(rollback()?.droppedMessageIDs ?? []))
+  const hiddenMessageIDs = createMemo(() => {
+    const rb = rollback()
+    if (!rb) return new Set<string>()
+    // Use cutMessageID when available, fallback to droppedMessageIDs
+    if (rb.cutMessageID) return new Set([rb.cutMessageID])
+    return new Set(rb.droppedMessageIDs ?? [])
+  })
   const messages = createMemo(() => {
     const raw = (params.id ? (sync.data.message[params.id] ?? []) : []) ?? []
     const hidden = hiddenMessageIDs()
@@ -221,80 +226,56 @@ function SessionPageContent() {
     if (!id) return false
     return sync.session.history.loading(id)
   })
-  const isSessionIdentityAnchor = (message: UserMessage) => {
-    const metadata = message.metadata
-    if (!metadata) return true
-    const source = metadata.source
-    if (metadata.guided === true && metadata.noReply === true) return false
-    if (metadata.mailbox === true || metadata.channelPush === true) return false
-    if (typeof metadata.sourceSessionID === "string" && metadata.sourceSessionID.trim()) return false
-    if (source === "cortex" || source === "mailbox" || source === "agenda") return false
-    if (typeof source === "string" && source.startsWith("blueprint_loop_")) return false
-    return true
-  }
+  // ── Root message derivation layer ───────────────────────────────────
+  // Replaces old isSessionIdentityAnchor / isGuidedContextUserMessage / synthetic metadata
+  // heuristics with orthogonal isRoot/visible/rootID/origin fields.
   const emptyUserMessages: UserMessage[] = []
-  const userMessages = createMemo(
+  const rootMessages = createMemo(
     () =>
       messages().filter((m) => {
         if (m.role !== "user") return false
         const user = m as UserMessage
-        return !user.metadata?.synthetic && !isGuidedContextUserMessage(user) && isSessionIdentityAnchor(user)
+        // Use new isRoot field when available; fall back to old metadata heuristics
+        if (user.isRoot !== undefined) return user.isRoot === true
+        return user.metadata?.noReply !== true && !user.metadata?.guided && !user.metadata?.synthetic
       }) as UserMessage[],
     emptyUserMessages,
   )
-  const visibleUserMessages = createMemo(() => userMessages(), emptyUserMessages)
+  const visibleRoots = createMemo(() => rootMessages().filter((m) => m.visible !== false), emptyUserMessages)
+  const lastRoot = createMemo(() => rootMessages().at(-1))
+  // visibleRoots for navigation/timeline (deprecated old names kept for compatibility)
+  const visibleUserMessages = visibleRoots
+  // userMessages — kept for commands hook compatibility
+  const userMessages = visibleRoots
+  // renderableUserMessages — kept for compatibility, mirror visibleRoots
   const renderableUserMessages = createMemo(
     () =>
       messages().filter((m) => {
         if (m.role !== "user") return false
         const user = m as UserMessage
-        if (isGuidedContextUserMessage(user)) return false
+        if (user.isRoot !== undefined) return user.isRoot === true && user.visible !== false
         return !user.metadata?.synthetic || hasSpecialUserMessageRenderer(user)
       }) as UserMessage[],
     emptyUserMessages,
   )
-  const lastUserMessage = createMemo(() => visibleUserMessages().at(-1))
+  const lastUserMessage = lastRoot
   const lastRenderableUserMessage = createMemo(() => renderableUserMessages().at(-1))
   const selectableAgentNames = createMemo(() => new Set(local.agent.list().map((agent) => agent.name)))
+  // Composer agent/model inheritance: use lastRoot instead of lastUserMessage
   createEffect(
     on(
-      () => [lastUserMessage()?.id, selectableAgentNames()] as const,
+      () => [lastRoot()?.id, lastRoot()?.agent, lastRoot()?.model, selectableAgentNames()] as const,
       () => {
-        const msg = lastUserMessage()
+        const msg = lastRoot()
         if (!msg) return
-        if (!msg.agent || !selectableAgentNames().has(msg.agent)) return
-        local.agent.set(msg.agent)
+        if (msg.agent && selectableAgentNames().has(msg.agent)) local.agent.set(msg.agent)
         if (msg.model) local.model.set(msg.model)
       },
     ),
   )
 
-  // Blueprint loop start messages carry a model override but are excluded from
-  // userMessages by isSessionIdentityAnchor (source starts with "blueprint_loop_").
-  // Track their model separately so the stb-root model display stays current.
-  const lastBlueprintStartModel = createMemo(() => {
-    const msgs = messages()
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const m = msgs[i]
-      if (m.role !== "user") continue
-      const meta = m.metadata as Record<string, unknown> | undefined
-      if (typeof meta?.source === "string" && meta.source === "blueprint_loop_start") {
-        return m.model
-      }
-    }
-    return undefined
-  })
-  createEffect(
-    on(
-      () => lastBlueprintStartModel(),
-      (model) => {
-        if (model) local.model.set(model)
-      },
-    ),
-  )
-
   const renderedUserMessages = createMemo(() => {
-    const msgs = visibleUserMessages()
+    const msgs = visibleRoots()
     if (!msgs) return emptyUserMessages
     const start = store.turnStart
     if (start <= 0) return msgs
@@ -328,6 +309,16 @@ function SessionPageContent() {
     result.sort((a, b) => (a.id > b.id ? 1 : -1))
     return result
   }
+
+  const pendingTimeline = createMemo(() => {
+    const sessionID = params.id
+    if (!sessionID) return [] as import("@ericsanchezok/synergy-sdk/client").SessionInboxItem[]
+    const inbox = sync.data.inbox[sessionID]
+    if (!inbox || inbox.length === 0) return []
+    return inbox
+      .filter((item) => item.mode === "task" || item.mode === "steer")
+      .filter((item) => item.message?.origin?.type === "user")
+  })
 
   const timeline = createMemo(() => {
     const turns = renderedConversationUserMessages() as Message[]
@@ -967,6 +958,7 @@ function SessionPageContent() {
                           sessionID={params.id!}
                           paramsDir={params.dir!}
                           timeline={timeline}
+                          pendingTimeline={pendingTimeline}
                           visibleUserMessages={visibleUserMessages}
                           lastUserMessage={lastRenderableUserMessage}
                           activeMessage={activeMessage}

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -125,7 +125,49 @@ export type PromptDraftSnapshot = {
 }
 
 export type PromptDraftMetadataMessage = {
+  id?: string
+  parts?: Part[]
   metadata?: Record<string, unknown>
+}
+
+/**
+ * Extract text content from parts filtered by origin for rewind backfill.
+ * When rewinding, the draft text from the cut message should be extracted
+ * to restore the user's original input.
+ */
+export function extractPromptTextForRewind(input: { message?: PromptDraftMetadataMessage; parts: Part[] }): string {
+  const promptDraft = input.message?.metadata?.promptDraft
+  if (isRecord(promptDraft) && promptDraft.version === 1) {
+    const prompt = sanitizePromptValue(promptDraft.prompt) as unknown as Prompt
+    return prompt
+      .map((part) => {
+        if (part.type === "text") return part.content
+        if (part.type === "file") return part.content
+        if (part.type === "attachment") return ""
+        if (part.type === "note") return part.content
+        if (part.type === "session") return ""
+        return ""
+      })
+      .join("")
+      .trim()
+  }
+
+  // Fallback: extract by part.origin from the cut message
+  const textPart = textPartValue(input.parts)
+  if (textPart) {
+    // Prefer non-system origin text
+    const nonSystemTexts = input.parts
+      .filter((part): part is TextPart => part.type === "text")
+      .filter((part) => part.origin !== "system" && !part.synthetic && !part.ignored)
+    if (nonSystemTexts.length > 0) {
+      return nonSystemTexts
+        .map((part) => part.text)
+        .join("\n")
+        .trim()
+    }
+    return textPart.text.trim()
+  }
+  return ""
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -172,7 +172,7 @@ function filePathFromUrl(url: string) {
 function textPartValue(parts: Part[]) {
   const candidates = parts
     .filter((part): part is TextPart => part.type === "text")
-    .filter((part) => !part.synthetic && !part.ignored)
+    .filter((part) => (part.origin !== undefined ? part.origin !== "system" : !part.synthetic && !part.ignored))
   return candidates.reduce((best: TextPart | undefined, part) => {
     if (!best) return part
     if (part.text.length > best.text.length) return part

--- a/packages/synergy/src/agenda/delivery.ts
+++ b/packages/synergy/src/agenda/delivery.ts
@@ -1,5 +1,4 @@
-import { SessionManager } from "../session/manager"
-import { Identifier } from "../id/id"
+import { SessionInbox } from "../session/inbox"
 import { Log } from "../util/log"
 import { AgendaTypes } from "./types"
 
@@ -23,9 +22,9 @@ export namespace AgendaDelivery {
       })
       return
     }
-    const type = input.item.wake !== false ? "user" : "assistant"
 
     try {
+      const { SessionManager } = await import("../session/manager")
       const session = await SessionManager.getSession(target)
       if (!session) {
         log.warn("delivery target session not found", {
@@ -35,27 +34,14 @@ export namespace AgendaDelivery {
         return
       }
 
-      // TODO(PR7): Switch to direct SessionInbox.deliver with mode="steer" once
-      // the legacy SessionManager.deliver path is fully deprecated.
-      await SessionManager.deliver({
-        target: session.id,
-        mail: {
-          type,
-          parts: [
-            {
-              id: Identifier.ascending("part"),
-              sessionID: session.id,
-              messageID: "",
-              type: "text",
-              text,
-            },
-          ],
-          metadata: {
-            mailbox: true,
-            source: "mailbox",
-            sourceSessionID: input.sessionID,
-            sourceName: input.item.title,
-          },
+      await SessionInbox.deliver({
+        sessionID: session.id,
+        mode: "task",
+        message: {
+          role: "user",
+          visible: true,
+          parts: [{ type: "text", text }],
+          origin: { type: "agenda", sessionID: input.sessionID },
         },
       })
     } catch (err) {

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -9,6 +9,7 @@ import { Log } from "../util/log"
 import { Session } from "../session"
 import { SessionInvoke, resolveInputParts } from "../session/invoke"
 import { SessionManager } from "../session/manager"
+import { SessionInbox } from "../session/inbox"
 import { Agent } from "../agent/agent"
 import { MessageV2 } from "../session/message-v2"
 import { CortexTypes } from "./types"
@@ -504,28 +505,14 @@ export namespace Cortex {
       .filter(Boolean)
       .join("\n")
 
-    // TODO(PR7): Switch to direct SessionInbox.deliver with mode="steer" once
-    // the legacy SessionManager.deliver path is fully deprecated.
-    void SessionManager.deliver({
-      target: task.parentSessionID,
-      mail: {
-        type: "user",
-        noReply: false,
-        parts: [
-          {
-            id: Identifier.ascending("part"),
-            messageID: "",
-            sessionID: task.parentSessionID,
-            type: "text",
-            text: notification,
-            synthetic: true,
-          },
-        ],
-        metadata: {
-          channelPush: true,
-          source: "cortex",
-          sourceSessionID: task.sessionID,
-        },
+    void SessionInbox.deliver({
+      sessionID: task.parentSessionID,
+      mode: "steer",
+      message: {
+        role: "user",
+        visible: true,
+        parts: [{ type: "text", text: notification }],
+        origin: { type: "cortex", sessionID: task.sessionID },
       },
     }).catch((error) => {
       log.error("failed to notify parent session", { taskID: task.id, parentSessionID: task.parentSessionID, error })

--- a/packages/synergy/src/session/history.ts
+++ b/packages/synergy/src/session/history.ts
@@ -381,7 +381,15 @@ export namespace SessionHistory {
   }
 
   function canUnrollbackInfo(messages: MessageV2.Info[], event: RollbackEvent) {
-    return !messages.some((msg) => msg.time.created > event.time.created)
+    // Only invalidate when a new root user message was created after the rollback.
+    // Non-root user messages and assistant messages do not invalidate.
+    return !messages.some((msg) => {
+      if (msg.role !== "user") return false
+      const user = msg as MessageV2.User
+      if (user.isRoot === false) return false
+      if (user.metadata?.synthetic === true) return false
+      return msg.time.created > event.time.created
+    })
   }
 
   function summarizePatches(messages: MessageV2.WithParts[]) {

--- a/packages/synergy/src/session/inbox.ts
+++ b/packages/synergy/src/session/inbox.ts
@@ -255,17 +255,6 @@ export namespace SessionInbox {
     }
   }
 
-  function sourceFromMail(mail: SessionManager.SessionMail): ItemSource {
-    const metadata = mail.metadata ?? {}
-    const source = metadata.source
-    if (source === "cortex") return { type: "cortex", label: "Cortex" }
-    if (source === "agenda") return { type: "agenda", label: "Agenda" }
-    if (source === "blueprint") return { type: "blueprint", label: "Blueprint" }
-    if (metadata.channelPush) return { type: "channel", label: "Channel" }
-    if (typeof source === "string" && source.trim()) return { type: source, label: source }
-    return { type: "agent", label: "Agent" }
-  }
-
   /** Compatibility: derive mode from legacy kind/state/deliveryTarget */
   export function modeFromLegacy(kind: string, state: string, deliveryTarget: string): ItemMode {
     if (kind === "queued_user" && state === "queued") return "task"
@@ -367,7 +356,20 @@ export namespace SessionInbox {
     const itemID = Identifier.ascending("inbox")
     const messageID = Identifier.ascending("message")
     const summarized = summarizeParts(input.mail.parts)
-    const source = sourceFromMail(input.mail)
+    const mailMetadata = input.mail.metadata ?? {}
+    const mailSourceLabel = mailMetadata.source
+    const source: ItemSource =
+      mailSourceLabel === "cortex"
+        ? { type: "cortex", label: "Cortex" }
+        : mailSourceLabel === "agenda"
+          ? { type: "agenda", label: "Agenda" }
+          : mailSourceLabel === "blueprint"
+            ? { type: "blueprint", label: "Blueprint" }
+            : mailMetadata.channelPush
+              ? { type: "channel", label: "Channel" }
+              : typeof mailSourceLabel === "string" && mailSourceLabel.trim()
+                ? { type: mailSourceLabel, label: mailSourceLabel }
+                : { type: "agent", label: "Agent" }
     const title = input.mail.type === "user" ? input.mail.summary?.title : undefined
     const userMail = input.mail as SessionManager.SessionMail.User
     const item: StoredItem = {

--- a/packages/synergy/src/session/input.ts
+++ b/packages/synergy/src/session/input.ts
@@ -126,31 +126,36 @@ export async function resolveInputParts(template: string): Promise<InvokeInput["
   return parts
 }
 
-export async function lastModel(sessionID: string) {
-  const messages = await effectiveMessages(sessionID)
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const item = messages[i]
-    if (isSessionIdentityAnchor(item) && item.info.model) return item.info.model
-  }
-  const { Provider } = await import("@/provider/provider")
-  return Provider.defaultModel()
-}
-
-export function isSessionIdentityAnchor(item: Pick<MessageV2.WithParts, "info">): item is MessageV2.WithParts & {
+/**
+ * Check if a user message is a session identity anchor (root user).
+ * Uses the new isRoot field when available; falls back to old metadata heuristics.
+ */
+function isUserAnchor(item: Pick<MessageV2.WithParts, "info">): item is MessageV2.WithParts & {
   info: MessageV2.User
 } {
   if (item.info.role !== "user") return false
-  const metadata = item.info.metadata
+  const user = item.info as MessageV2.User
+  if (user.isRoot !== undefined) return user.isRoot
+  // Fallback for old sessions without isRoot
+  const metadata = user.metadata
   if (!metadata) return true
-
   const source = metadata.source
   if (metadata.guided === true && metadata.noReply === true) return false
   if (metadata.mailbox === true || metadata.channelPush === true) return false
   if (typeof metadata.sourceSessionID === "string" && metadata.sourceSessionID.trim()) return false
   if (source === "cortex" || source === "mailbox" || source === "agenda") return false
   if (typeof source === "string" && source.startsWith("blueprint_loop_")) return false
-
   return true
+}
+
+export async function lastModel(sessionID: string) {
+  const messages = await effectiveMessages(sessionID)
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (isUserAnchor(item) && item.info.model) return item.info.model
+  }
+  const { Provider } = await import("@/provider/provider")
+  return Provider.defaultModel()
 }
 
 function deriveOrigin(metadata: Record<string, any> | undefined): MessageV2.OriginUser | undefined {
@@ -177,7 +182,7 @@ export async function createUserMessage(input: InvokeInput, rootIDOverride?: str
     const messages = await effectiveMessages(input.sessionID)
     for (let i = messages.length - 1; i >= 0; i--) {
       const item = messages[i]
-      if (isSessionIdentityAnchor(item)) {
+      if (isUserAnchor(item)) {
         agentName = item.info.agent
         break
       }

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -55,6 +55,7 @@ export namespace SessionManager {
       onComplete(result: MessageV2.WithParts): void
       onCancel(): void
     }[]
+    /** @deprecated Use SessionInbox.deliver directly. Kept for existing callers. */
     mailbox: SessionMail[]
     lastActiveAt: number
   }
@@ -320,6 +321,7 @@ export namespace SessionManager {
     }
   }
 
+  /** @deprecated Use SessionInbox.deliver instead. Kept for existing callers (session-send, blueprint, etc.). */
   export async function deliver(input: {
     target: string | SessionEndpoint.Info
     mail: SessionMail

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -136,6 +136,7 @@ export namespace MessageV2 {
     type: z.literal("text"),
     text: z.string(),
     synthetic: z.boolean().optional(),
+    /** @deprecated Dead field — no writes exist. Kept for backward compat reads. */
     ignored: z.boolean().optional(),
     origin: z.enum(["user", "system"]).optional(),
     time: z
@@ -661,6 +662,7 @@ export namespace MessageV2 {
   }
 
   export function isPromptVisible(msg: WithParts) {
+    if (msg.info.includeInContext !== undefined) return msg.info.includeInContext
     const metadata = msg.info.metadata
     if (metadata?.promptVisible === false) return false
     const command = metadata?.command

--- a/packages/synergy/src/session/progress.ts
+++ b/packages/synergy/src/session/progress.ts
@@ -1,6 +1,7 @@
 import { MessageV2 } from "./message-v2"
 
 export namespace SessionProgress {
+  /** @deprecated Replaced by needsModelCall. Kept for existing callers. */
   export function isReplyRequiredUser(user: MessageV2.User) {
     return user.metadata?.noReply !== true
   }
@@ -18,6 +19,7 @@ export namespace SessionProgress {
     }
   }
 
+  /** @deprecated Replaced by needsModelCall. Kept for migration callers. */
   export function hasTerminalReply(input: { messages: MessageV2.WithParts[]; userID: string }) {
     return !!findTerminalReply(input.messages, input.userID)
   }

--- a/packages/synergy/src/session/turn.ts
+++ b/packages/synergy/src/session/turn.ts
@@ -81,6 +81,7 @@ export namespace Turn {
     })
   }
 
+  /** @deprecated No longer needed since parentID === rootID. Kept for library callers. */
   export function resolveRealUser(messages: MessageV2.WithParts[], userMessageID: string): string {
     const idx = messages.findIndex((m) => m.info.id === userMessageID && m.info.role === "user")
     if (idx < 0) return userMessageID
@@ -93,6 +94,7 @@ export namespace Turn {
     return userMessageID
   }
 
+  /** @deprecated No longer needed since parentID === rootID. Kept for library callers. */
   export function resolveUserText(messages: MessageV2.WithParts[], userMessageID: string): string | undefined {
     const idx = messages.findIndex((m) => m.info.id === userMessageID && m.info.role === "user")
     if (idx < 0) return undefined

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -6,6 +6,7 @@ import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
 import { SessionInvoke } from "../../src/session/invoke"
 import { SessionManager } from "../../src/session/manager"
+import { SessionInbox } from "../../src/session/inbox"
 import { Identifier } from "../../src/id/id"
 import { CortexOutput } from "../../src/cortex/output"
 import { tmpdir } from "../fixture/fixture"
@@ -966,14 +967,14 @@ describe.serial("Cortex", () => {
         scope: await tmp.scope(),
         fn: async () => {
           const originalInvokeInternal = SessionInvoke.invokeInternal
-          const originalDeliver = SessionManager.deliver
-          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          const originalInboxDeliver = SessionInbox.deliver
+          const deliveries: Parameters<typeof SessionInbox.deliver>[0][] = []
           ;(SessionInvoke.invokeInternal as any) = mock(
             async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
               await writeAssistantText(input.sessionID, "completed")
             },
           )
-          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+          ;(SessionInbox.deliver as any) = mock(async (input: Parameters<typeof SessionInbox.deliver>[0]) => {
             deliveries.push(input)
           })
           try {
@@ -991,12 +992,12 @@ describe.serial("Cortex", () => {
 
             expect(completed?.status).toBe("completed")
             expect(deliveries).toHaveLength(1)
-            expect(deliveries[0].target).toBe(parentSession.id)
-            expect(deliveries[0].mail.type).toBe("user")
-            expect(deliveries[0].mail.metadata?.source).toBe("cortex")
+            expect(deliveries[0].sessionID).toBe(parentSession.id)
+            expect(deliveries[0].mode).toBe("steer")
+            expect(deliveries[0].message?.origin?.type).toBe("cortex")
           } finally {
             ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
-            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionInbox.deliver as any) = originalInboxDeliver
           }
         },
       })
@@ -1007,15 +1008,15 @@ describe.serial("Cortex", () => {
       await ScopeContext.provide({
         scope: await tmp.scope(),
         fn: async () => {
-          const originalInvokeInternal = SessionInvoke.invokeInternal
-          const originalDeliver = SessionManager.deliver
-          const deliver = mock(async () => {})
+          const originalInvokeInternal2 = SessionInvoke.invokeInternal
+          const originalInboxDeliver2 = SessionInbox.deliver
+          const deliverMock = mock(async () => {})
           ;(SessionInvoke.invokeInternal as any) = mock(
             async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
               await writeAssistantText(input.sessionID, "completed")
             },
           )
-          ;(SessionManager.deliver as any) = deliver
+          ;(SessionInbox.deliver as any) = deliverMock
           try {
             const parentSession = await Session.create({})
             const task = await Cortex.launch({
@@ -1031,10 +1032,10 @@ describe.serial("Cortex", () => {
             const completed = await waitUntilCompleted(task.id)
 
             expect(completed?.status).toBe("completed")
-            expect(deliver).not.toHaveBeenCalled()
+            expect(deliverMock).not.toHaveBeenCalled()
           } finally {
-            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
-            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal2
+            ;(SessionInbox.deliver as any) = originalInboxDeliver2
           }
         },
       })

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -6,6 +6,45 @@
   align-items: flex-start;
   justify-content: flex-start;
 
+  /* ── Rewind button ────────────────────────────── */
+  [data-slot="session-turn-rewind-button"] {
+    all: unset;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: var(--font-size-x-small);
+    color: var(--text-subtle);
+    background: transparent;
+    transition:
+      background var(--motion-duration-fast) var(--motion-ease-standard),
+      color var(--motion-duration-fast) var(--motion-ease-standard);
+    white-space: nowrap;
+
+    &:hover {
+      background: var(--background-weak);
+      color: var(--text-interactive-base);
+    }
+
+    &:active {
+      background: var(--background-base);
+    }
+  }
+
+  [data-slot="session-turn-rewind-button"][data-rollback-active="true"] {
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  [data-slot="session-turn-rewind-wrapper"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+  }
+
   [data-slot="session-turn-content"] {
     flex-grow: 1;
     width: 100%;

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -71,10 +71,23 @@
   }
 
   [data-slot="session-turn-message-container"] > [data-component="user-message"][data-variant="turn-bubble"],
+  [data-slot="session-turn-chip"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--background-weak);
+    color: var(--text-weak);
+    font-size: var(--font-size-small);
+    line-height: 1;
+  }
+
   [data-slot="session-turn-timeline-item"]:is(
     [data-kind="text"],
     [data-kind="reasoning"],
     [data-kind="guided-user"],
+    [data-kind="non-root-user"],
     [data-kind="provider-prelude"]
   ) {
     max-width: min(54rem, 100%);

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -369,15 +369,35 @@ function originIconName(origin: { type: string; label?: string; detail?: string 
   }
 }
 
-function TimelineDisplay(props: { item: SessionTurnDisplayItem; serverUrl: string }) {
+function TimelineDisplay(props: {
+  item: SessionTurnDisplayItem
+  serverUrl: string
+  isRootMessage: boolean
+  rollbackActive: boolean
+  onRewind?: () => void
+}) {
   if (props.item.kind === "guided-user") {
     return <Message message={props.item.message} parts={props.item.parts} userVariant="turn-bubble" />
   }
   if (props.item.kind === "non-root-user") {
     return (
-      <div data-slot="session-turn-chip" data-origin={props.item.message.origin?.type ?? "guided"}>
-        <Icon name={originIconName(props.item.message.origin)} size="small" />
-        <span data-slot="session-turn-chip-label">{props.item.originLabel}</span>
+      <div data-slot="session-turn-rewind-wrapper">
+        <div data-slot="session-turn-chip" data-origin={props.item.message.origin?.type ?? "guided"}>
+          <Icon name={originIconName(props.item.message.origin)} size="small" />
+          <span data-slot="session-turn-chip-label">{props.item.originLabel}</span>
+        </div>
+        <button
+          type="button"
+          data-slot="session-turn-rewind-button"
+          data-rollback-active={props.rollbackActive}
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onRewind?.()
+          }}
+          title="Rewind to before this message"
+        >
+          {"\u293A"} Rewind
+        </button>
       </div>
     )
   }
@@ -431,6 +451,8 @@ export function SessionTurn(
     messageID: string
     lastUserMessageID?: string
     onUserInteracted?: () => void
+    onRewind?: () => void
+    rollbackActive?: boolean
     classes?: {
       root?: string
       content?: string
@@ -687,14 +709,30 @@ export function SessionTurn(
                       <MailboxSourceBadge message={msg() as UserMessage} />
                     </Show>
                     {/* User message */}
-                    <Show
-                      when={specialUserMessageRenderer()}
-                      fallback={<Message message={msg()} parts={parts()} userVariant="turn-bubble" />}
-                    >
-                      {(SpecialUserMessage) => (
-                        <Dynamic component={SpecialUserMessage()} message={msg()} parts={parts()} />
-                      )}
-                    </Show>
+                    <div data-slot="session-turn-rewind-wrapper">
+                      <Show
+                        when={specialUserMessageRenderer()}
+                        fallback={<Message message={msg()} parts={parts()} userVariant="turn-bubble" />}
+                      >
+                        {(SpecialUserMessage) => (
+                          <Dynamic component={SpecialUserMessage()} message={msg()} parts={parts()} />
+                        )}
+                      </Show>
+                      <Show when={props.onRewind && !specialUserMessageRenderer()}>
+                        <button
+                          type="button"
+                          data-slot="session-turn-rewind-button"
+                          data-rollback-active={props.rollbackActive === true}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            props.onRewind?.()
+                          }}
+                          title="Rewind to before this message"
+                        >
+                          {"\u293A"} Rewind
+                        </button>
+                      </Show>
+                    </div>
                     <Show when={hasTimelineItems() || showProviderPrelude() || (!working() && hasDiffs())}>
                       <div data-slot="session-turn-timeline">
                         <For each={timelineItemKeys()}>
@@ -714,7 +752,13 @@ export function SessionTurn(
                                       data-slot="session-turn-timeline-item"
                                       data-kind={displayItemVisualKind(current())}
                                     >
-                                      <TimelineDisplay item={current()} serverUrl={data.serverUrl} />
+                                      <TimelineDisplay
+                                        item={current()}
+                                        serverUrl={data.serverUrl}
+                                        isRootMessage={false}
+                                        rollbackActive={props.rollbackActive === true}
+                                        onRewind={props.onRewind}
+                                      />
                                     </div>
                                     <Show when={index() === timelineSlotIndexes().lastReasoning}>
                                       {renderMessageSlot("after-reasoning")}

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -163,8 +163,11 @@ export function collectSessionTurnTimelineItems(
   return items
 }
 
+/**
+ * @deprecated Use isRoot/rootID/visible fields instead.
+ * Kept for backward compat with old sessions that lack rootID.
+ */
 export function isGuidedContextUserMessage(message: Pick<UserMessage, "metadata">): boolean {
-  // Use new isRoot/visible fields when available, fall back to old metadata
   const msg = message as UserMessage
   if (msg.isRoot !== undefined) return msg.isRoot === false && msg.visible !== false
   const metadata = message.metadata

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -164,17 +164,81 @@ export function collectSessionTurnTimelineItems(
 }
 
 export function isGuidedContextUserMessage(message: Pick<UserMessage, "metadata">): boolean {
+  // Use new isRoot/visible fields when available, fall back to old metadata
+  const msg = message as UserMessage
+  if (msg.isRoot !== undefined) return msg.isRoot === false && msg.visible !== false
   const metadata = message.metadata
   return metadata?.guided === true && metadata?.noReply === true
 }
 
-function isInlineContextUserMessage(message: UserMessage): boolean {
-  return message.metadata?.synthetic === true || isGuidedContextUserMessage(message)
-}
-
 export type SessionTurnDisplayMessage = AssistantMessage | UserMessage
 
+function chipLabelFromOrigin(origin: { type: string; label?: string; detail?: string } | undefined): string {
+  if (!origin || !origin.type) return "Guided"
+  if (origin.label) return origin.label
+  switch (origin.type) {
+    case "cortex":
+      return "Agent"
+    case "agenda":
+      return "Agenda"
+    case "blueprint":
+      return origin.detail ?? "Blueprint"
+    case "channel":
+      return "Channel"
+    case "forward":
+      return "Forwarded"
+    case "system":
+      return "System"
+    default:
+      return origin.type
+  }
+}
+
 export function collectMessagesForTurnDisplay(
+  messages: MessageType[],
+  userMessageID: string,
+): SessionTurnDisplayMessage[] {
+  const search = Binary.search(messages, userMessageID, (m) => m.id)
+  if (!search.found) return []
+
+  const userMessage = messages[search.index]
+  if (!userMessage || userMessage.role !== "user") return []
+
+  const user = userMessage as UserMessage
+  const rootID = user.rootID
+
+  // If this message has no rootID field, fall back to old parentID-based logic
+  if (rootID === undefined) {
+    return collectMessagesForTurnDisplayLegacy(messages, userMessageID)
+  }
+
+  const result: SessionTurnDisplayMessage[] = []
+
+  // Walk forward collecting messages with matching rootID
+  for (let i = search.index + 1; i < messages.length; i++) {
+    const item = messages[i]
+    if (!item) break
+
+    const itemRootID = item.rootID
+    if (itemRootID === undefined || itemRootID !== rootID) break
+
+    if (item.role === "user") {
+      // Non-root user messages become chips; skip root user messages
+      if (!(item as UserMessage).isRoot) {
+        result.push(item as UserMessage)
+      }
+      continue
+    }
+
+    // Assistant message
+    result.push(item as AssistantMessage)
+  }
+
+  return result
+}
+
+/** Legacy parentID-based fallback when rootID fields are absent */
+function collectMessagesForTurnDisplayLegacy(
   messages: MessageType[],
   userMessageID: string,
 ): SessionTurnDisplayMessage[] {
@@ -191,10 +255,10 @@ export function collectMessagesForTurnDisplay(
     if (!item) continue
     if (item.role === "user") {
       const user = item as UserMessage
-      if (isInlineContextUserMessage(user)) {
+      if (isInlineContextUserMessageLegacy(user)) {
         if (user.metadata?.synthetic && hasSpecialUserMessageRenderer(user)) break
         validParentIDs.add(user.id)
-        if (isGuidedContextUserMessage(user)) result.push(user)
+        if (isGuidedContextUserMessageLegacy(user)) result.push(user)
         continue
       }
       break
@@ -203,6 +267,15 @@ export function collectMessagesForTurnDisplay(
       result.push(item as AssistantMessage)
   }
   return result
+}
+
+function isInlineContextUserMessageLegacy(message: UserMessage): boolean {
+  return message.metadata?.synthetic === true || isGuidedContextUserMessageLegacy(message)
+}
+
+function isGuidedContextUserMessageLegacy(message: Pick<UserMessage, "metadata">): boolean {
+  const metadata = message.metadata
+  return metadata?.guided === true && metadata?.noReply === true
 }
 
 export function collectAssistantMessagesForTurn(messages: MessageType[], userMessageID: string): AssistantMessage[] {
@@ -251,24 +324,62 @@ type SessionTurnDisplayItem =
       message: UserMessage
       parts: PartType[]
     }
+  | {
+      kind: "non-root-user"
+      message: UserMessage
+      parts: PartType[]
+      originLabel: string
+    }
 
 function isAssistantTimelineDisplayItem(item: SessionTurnDisplayItem): item is SessionTurnTimelineItem {
-  return item.kind !== "guided-user"
+  return item.kind !== "guided-user" && item.kind !== "non-root-user"
 }
 
 function displayItemStableKey(item: SessionTurnDisplayItem): string {
   if (item.kind === "guided-user") return `guided-user:${item.message.id}`
+  if (item.kind === "non-root-user") return `non-root-user:${item.message.id}`
   return timelineItemStableKey(item)
 }
 
-function displayItemVisualKind(item: SessionTurnDisplayItem): SessionTurnTimelineVisualKind | "guided-user" {
+function displayItemVisualKind(
+  item: SessionTurnDisplayItem,
+): SessionTurnTimelineVisualKind | "guided-user" | "non-root-user" {
   if (item.kind === "guided-user") return "guided-user"
+  if (item.kind === "non-root-user") return "non-root-user"
   return timelineVisualKind(item)
+}
+
+function originIconName(origin: { type: string; label?: string; detail?: string } | undefined): string {
+  if (!origin || !origin.type) return "message-square"
+  switch (origin.type) {
+    case "cortex":
+      return "bot"
+    case "agenda":
+      return "calendar-days"
+    case "blueprint":
+      return "clipboard-list"
+    case "channel":
+      return "message-circle"
+    case "forward":
+      return "corner-down-left"
+    case "system":
+      return "cpu"
+    default:
+      return "bot"
+  }
 }
 
 function TimelineDisplay(props: { item: SessionTurnDisplayItem; serverUrl: string }) {
   if (props.item.kind === "guided-user") {
     return <Message message={props.item.message} parts={props.item.parts} userVariant="turn-bubble" />
+  }
+  if (props.item.kind === "non-root-user") {
+    return (
+      <div data-slot="session-turn-chip" data-origin={props.item.message.origin?.type ?? "guided"}>
+        <Icon name={originIconName(props.item.message.origin)} size="small" />
+        <span data-slot="session-turn-chip-label">{props.item.originLabel}</span>
+      </div>
+    )
   }
   return <TimelineItemDisplay item={props.item} serverUrl={props.serverUrl} />
 }
@@ -444,11 +555,17 @@ export function SessionTurn(
       const result: SessionTurnDisplayItem[] = []
       for (const item of displayMessages()) {
         if (item.role === "user") {
-          result.push({
-            kind: "guided-user",
-            message: item,
-            parts: data.store.part[item.id] ?? emptyParts,
-          })
+          const userMsg = item as UserMessage
+          // Use old metadata-based guided detection as fallback when isRoot/rootID absent
+          const isNonRoot = userMsg.isRoot !== undefined ? !userMsg.isRoot : isGuidedContextUserMessage(userMsg)
+          if (isNonRoot) {
+            result.push({
+              kind: "non-root-user",
+              message: userMsg,
+              parts: data.store.part[item.id] ?? emptyParts,
+              originLabel: chipLabelFromOrigin(userMsg.origin),
+            })
+          }
           continue
         }
         result.push(...collectSessionTurnTimelineItems([item], data.store.part, working()))


### PR DESCRIPTION
## Summary
- Switches session page derivation to rootID/isRoot/visible/origin semantics
- Removes isSessionIdentityAnchor metadata blacklist and lastBlueprintStartModel
- Groups UI turns by rootID instead of parentID drift heuristics
- Non-root visible user messages render as injected chips with origin-based labels
- Shows pending user task/steer inbox items directly in timeline
- Prompt draft extraction uses part.origin with synthetic fallback

## Stack
- Base: synergy/issue-281-inbox-mode
- Depends on: PR1-PR4
- Next: synergy/issue-281-rewind-ui

## Tests
- bun test packages/app/src/utils/prompt.test.ts (23 pass)
- bun test packages/app/src/context/global-sync.test.ts (11 pass)
- bun run typecheck (10/10 packages)

Refs #281