### PR TITLE
Fix compaction turn display

### DIFF
--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -281,6 +281,30 @@ export namespace SessionInvoke {
     return undefined
   }
 
+  async function createAutoCompactionBoundary(input: { sessionID: string; lastUser: MessageV2.User }) {
+    const boundary = await Session.updateMessage({
+      id: Identifier.ascending("message"),
+      role: "user",
+      sessionID: input.sessionID,
+      time: { created: Date.now() },
+      agent: input.lastUser.agent,
+      model: input.lastUser.model,
+      summary: { title: "Compaction requested", diffs: [] },
+      metadata: {
+        synthetic: true,
+        compactionBoundary: true,
+        compactionParentID: input.lastUser.id,
+      },
+    })
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: boundary.id,
+      sessionID: input.sessionID,
+      type: "compaction",
+      auto: true,
+    })
+  }
+
   export const loop = fn(Identifier.schema("session"), async (sessionID) => {
     BlueprintContinuation.init()
     SessionManager.registerRuntime(sessionID)
@@ -763,13 +787,7 @@ export namespace SessionInvoke {
             soft: promptDecision.budget.soft,
             usable: promptDecision.budget.usable,
           })
-          await Session.updatePart({
-            id: Identifier.ascending("part"),
-            messageID: lastUser.id,
-            sessionID,
-            type: "compaction",
-            auto: true,
-          })
+          await createAutoCompactionBoundary({ sessionID, lastUser })
           continue
         }
 

--- a/packages/synergy/test/session/invoke-compaction.test.ts
+++ b/packages/synergy/test/session/invoke-compaction.test.ts
@@ -13,6 +13,8 @@ import { Cortex } from "../../src/cortex/manager"
 import { tmpdir } from "../fixture/fixture"
 import { Log } from "../../src/util/log"
 import { Config } from "../../src/config/config"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionCompaction } from "../../src/session/compaction"
 
 Log.init({ print: false })
 
@@ -49,6 +51,79 @@ function primaryAgent() {
     permission: PermissionNext.fromConfig({ "*": "allow" }),
     options: {},
   }
+}
+function testUser(input: {
+  id: string
+  sessionID: string
+  created: number
+  text?: string
+  summaryTitle?: string
+  metadata?: Record<string, unknown>
+  parts?: MessageV2.Part[]
+}): MessageV2.WithParts {
+  const info: MessageV2.User = {
+    id: input.id,
+    role: "user",
+    sessionID: input.sessionID,
+    agent: "synergy",
+    model: { providerID: "test-provider", modelID: "test-model" },
+    time: { created: input.created },
+    ...(input.summaryTitle ? { summary: { title: input.summaryTitle, diffs: [] } } : {}),
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  }
+  return {
+    info,
+    parts:
+      input.parts ??
+      (input.text
+        ? [
+            {
+              id: `${input.id}_text`,
+              sessionID: input.sessionID,
+              messageID: input.id,
+              type: "text",
+              text: input.text,
+            },
+          ]
+        : []),
+  }
+}
+
+function testAssistant(input: {
+  id: string
+  sessionID: string
+  parentID: string
+  created: number
+  completed?: number
+  summary?: boolean
+  finish?: string
+  parts?: MessageV2.Part[]
+}): MessageV2.WithParts {
+  const info: MessageV2.Assistant = {
+    id: input.id,
+    role: "assistant",
+    sessionID: input.sessionID,
+    parentID: input.parentID,
+    modelID: "test-model",
+    providerID: "test-provider",
+    mode: input.summary ? "compaction" : "synergy",
+    agent: input.summary ? "compaction" : "synergy",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: input.created, ...(input.completed !== undefined ? { completed: input.completed } : {}) },
+    ...(input.summary ? { summary: true } : {}),
+    ...(input.finish ? { finish: input.finish } : {}),
+  }
+  return { info, parts: input.parts ?? [] }
+}
+
+async function filterNewestFirst(messages: MessageV2.WithParts[]) {
+  return MessageV2.filterCompacted(
+    (async function* () {
+      for (let i = messages.length - 1; i >= 0; i--) yield messages[i]
+    })(),
+  )
 }
 
 describe.serial("SessionInvoke preflight compaction", () => {
@@ -97,6 +172,7 @@ describe.serial("SessionInvoke preflight compaction", () => {
       }))
       ;(Session.updatePart as any) = mock(async (input: Parameters<typeof Session.updatePart>[0]) => {
         if ("type" in input && input.type === "compaction") {
+          await originalUpdatePart(input as any)
           interceptedCompactionParts.push({
             messageID: input.messageID,
             sessionID: input.sessionID,
@@ -139,12 +215,25 @@ describe.serial("SessionInvoke preflight compaction", () => {
 
           await expect(SessionInvoke.loop.force(sessionID)).rejects.toBeInstanceOf(CompactionIntercept)
 
-          expect(interceptedCompactionParts).toEqual([
-            {
-              messageID: user.id,
-              sessionID,
+          expect(interceptedCompactionParts).toHaveLength(1)
+          const [compactionPart] = interceptedCompactionParts
+          expect(compactionPart.sessionID).toBe(sessionID)
+          expect(compactionPart.auto).toBe(true)
+          expect(compactionPart.messageID).not.toBe(user.id)
+
+          const boundary = await MessageV2.get({ sessionID, messageID: compactionPart.messageID })
+          expect(boundary.info?.role).toBe("user")
+          if (boundary.info?.role !== "user") throw new Error("expected compaction boundary user")
+          expect(boundary.info.summary?.title).toBe("Compaction requested")
+          expect(boundary.info.metadata?.synthetic).toBe(true)
+          expect(boundary.info.metadata?.compactionBoundary).toBe(true)
+          expect(boundary.info.metadata?.compactionParentID).toBe(user.id)
+          expect(boundary.parts).toEqual([
+            expect.objectContaining({
+              type: "compaction",
               auto: true,
-            },
+              messageID: compactionPart.messageID,
+            }),
           ])
           expect(processCalled).not.toHaveBeenCalled()
         },
@@ -489,5 +578,118 @@ describe.serial("SessionInvoke preflight compaction", () => {
       ;(Cortex.list as any) = originalCortexList
       ;(Cortex.getRunningTasks as any) = originalCortexGetRunningTasks
     }
+  })
+
+  test("filters compacted history from the synthetic auto-compaction boundary", async () => {
+    const sessionID = "ses_test"
+    const realUser = testUser({
+      id: "msg_real_user",
+      sessionID,
+      created: 1,
+      text: "Polish the account settings UI.",
+    })
+    const oldAssistant = testAssistant({
+      id: "msg_old_assistant",
+      sessionID,
+      parentID: realUser.info.id,
+      created: 2,
+      completed: 3,
+      finish: "tool-calls",
+      parts: [
+        {
+          id: "prt_old_text",
+          sessionID,
+          messageID: "msg_old_assistant",
+          type: "text",
+          text: "Large pre-compaction tool trajectory.",
+        },
+      ],
+    })
+    const boundary = testUser({
+      id: "msg_boundary",
+      sessionID,
+      created: 4,
+      summaryTitle: "Compaction requested",
+      metadata: {
+        synthetic: true,
+        compactionBoundary: true,
+        compactionParentID: realUser.info.id,
+      },
+      parts: [
+        {
+          id: "prt_boundary_compaction",
+          sessionID,
+          messageID: "msg_boundary",
+          type: "compaction",
+          auto: true,
+        },
+      ],
+    })
+    const summary = testAssistant({
+      id: "msg_summary",
+      sessionID,
+      parentID: boundary.info.id,
+      created: 5,
+      completed: 6,
+      summary: true,
+      finish: "stop",
+    })
+    const continuation = testUser({
+      id: "msg_continue",
+      sessionID,
+      created: 7,
+      summaryTitle: "Compaction complete",
+      parts: [
+        {
+          id: "prt_continue",
+          sessionID,
+          messageID: "msg_continue",
+          type: "text",
+          synthetic: true,
+          text: "Continue if you have next steps",
+        },
+      ],
+    })
+
+    const compacted = await filterNewestFirst([realUser, oldAssistant, boundary, summary, continuation])
+
+    expect(compacted.map((msg) => msg.info.id)).toEqual(["msg_boundary", "msg_summary", "msg_continue"])
+  })
+
+  test("resolves the compaction anchor from the real user before a synthetic boundary", () => {
+    const sessionID = "ses_test"
+    const realUser = testUser({
+      id: "msg_real_user",
+      sessionID,
+      created: 1,
+      text: "Polish the account settings UI.",
+    })
+    const boundary = testUser({
+      id: "msg_boundary",
+      sessionID,
+      created: 2,
+      summaryTitle: "Compaction requested",
+      metadata: {
+        synthetic: true,
+        compactionBoundary: true,
+        compactionParentID: realUser.info.id,
+      },
+      parts: [
+        {
+          id: "prt_boundary_compaction",
+          sessionID,
+          messageID: "msg_boundary",
+          type: "compaction",
+          auto: true,
+        },
+      ],
+    })
+
+    const anchor = SessionCompaction.resolveAnchor([realUser, boundary], boundary.info.id)
+
+    expect(anchor).toEqual({
+      text: "Polish the account settings UI.",
+      sourceMessageID: realUser.info.id,
+    })
   })
 })

--- a/packages/ui/src/components/compaction-card.css
+++ b/packages/ui/src/components/compaction-card.css
@@ -1,14 +1,20 @@
 [data-component="compaction-card"] {
   width: 100%;
   min-width: 0;
-  margin-top: 6px;
-  border: 1px solid var(--color-border-base);
+  margin-top: 4px;
+  border: 1px solid var(--color-border-subtle, var(--color-border-base));
   border-radius: var(--radius-md);
-  background: var(--surface-raised-base);
+  background: var(--surface-base, var(--surface-raised-base));
   overflow: hidden;
 }
 
-/* ── Collapsed header ── */
+[data-component="compaction-card"][data-status="running"] {
+  background: color-mix(
+    in srgb,
+    var(--surface-base, var(--surface-raised-base)) 92%,
+    var(--color-surface-info-weak) 8%
+  );
+}
 
 [data-slot="compaction-card-header"] {
   all: unset;
@@ -16,87 +22,132 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 10px 14px;
-  cursor: pointer;
+  gap: 12px;
+  padding: 9px 12px;
   box-sizing: border-box;
+  cursor: pointer;
   transition: background-color 0.15s ease;
-
-  &:hover {
-    background: var(--surface-raised-base-hover);
-  }
 }
 
-[data-slot="compaction-card-header-left"] {
+[data-slot="compaction-card-header"]:disabled {
+  cursor: default;
+}
+
+[data-slot="compaction-card-header"]:not(:disabled):hover {
+  background: var(--surface-raised-base-hover);
+}
+
+[data-slot="compaction-card-header"]:focus-visible {
+  outline: 2px solid var(--color-focus-ring, var(--color-border-focus));
+  outline-offset: -2px;
+}
+
+[data-slot="compaction-card-leading"] {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   min-width: 0;
 }
 
-[data-slot="compaction-card-header-left"] [data-slot="icon-svg"] {
-  color: var(--icon-info-base);
+[data-slot="compaction-card-icon"] {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-weak);
   flex-shrink: 0;
+}
+
+[data-status="running"] [data-slot="compaction-card-icon"] {
+  color: var(--icon-info-base);
+}
+
+[data-slot="compaction-card-copy"] {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+[data-slot="compaction-card-title-row"] {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 [data-slot="compaction-card-title"] {
   font-size: 0.8125rem;
+  line-height: 1.35;
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-base);
+  white-space: nowrap;
+}
+
+[data-slot="compaction-card-description"] {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--color-text-weak);
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 [data-slot="compaction-card-badge"] {
   font-size: 0.6875rem;
   font-weight: var(--font-weight-medium);
-  color: var(--color-text-on-warning-base);
-  background: var(--color-surface-warning-weak);
+  color: var(--color-text-weak);
+  background: var(--surface-raised-base);
+  border: 1px solid var(--color-border-subtle, var(--color-border-base));
   padding: 1px 6px;
   border-radius: var(--radius-full);
   white-space: nowrap;
   flex-shrink: 0;
 }
 
-[data-slot="compaction-card-header-right"] {
+[data-slot="compaction-card-meta"] {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
-  margin-left: 12px;
+  margin-left: 8px;
 }
 
 [data-slot="compaction-card-time"] {
   font-size: 0.75rem;
-  color: var(--color-text-weak);
+  color: var(--color-text-weaker, var(--color-text-weak));
   white-space: nowrap;
 }
 
-[data-slot="compaction-card-arrow"] [data-slot="icon-svg"] {
+[data-slot="compaction-card-arrow"] {
+  display: inline-flex;
   color: var(--icon-weak);
-  transition: transform 0.2s ease;
+  transition: transform 0.15s ease;
 }
 
-[data-expanded] [data-slot="compaction-card-arrow"] [data-slot="icon-svg"] {
+[data-expanded] [data-slot="compaction-card-arrow"] {
   transform: rotate(90deg);
 }
 
-/* ── Expanded content ── */
-
 [data-slot="compaction-card-content"] {
-  padding: 4px 14px 12px;
+  max-height: min(44vh, 32rem);
+  padding: 2px 12px 12px 40px;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
 }
-
-/* ── Warning banner ── */
 
 [data-slot="compaction-card-warning"] {
   display: flex;
   align-items: flex-start;
   gap: 6px;
-  padding: 8px 10px;
-  background: var(--color-surface-warning-weak);
-  border-radius: var(--radius-sm);
+  color: var(--color-text-on-warning-base);
+  font-size: 0.75rem;
+  line-height: 1.4;
 }
 
 [data-slot="compaction-card-warning"] [data-slot="icon-svg"] {
@@ -105,32 +156,23 @@
   margin-top: 1px;
 }
 
-[data-slot="compaction-card-warning-text"] {
-  font-size: 0.75rem;
-  line-height: 1.4;
-  color: var(--color-text-on-warning-base);
-}
-
-/* ── Summary markdown ── */
-
 [data-slot="compaction-card-summary"] {
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   line-height: 1.5;
   color: var(--color-text-base);
   -webkit-user-select: text;
   user-select: text;
 }
 
-[data-slot="compaction-card-summary"] {
-  & > *:first-child {
-    margin-top: 0;
-  }
-  & > *:last-child {
-    margin-bottom: 0;
-  }
+[data-slot="compaction-card-summary"] > *:first-child,
+[data-slot="compaction-card-section-item-text"] > *:first-child {
+  margin-top: 0;
 }
 
-/* ── Sections ── */
+[data-slot="compaction-card-summary"] > *:last-child,
+[data-slot="compaction-card-section-item-text"] > *:last-child {
+  margin-bottom: 0;
+}
 
 [data-slot="compaction-card-section"] {
   display: flex;
@@ -142,21 +184,19 @@
   font-size: 0.75rem;
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-weak);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   margin: 0;
   padding: 0;
 }
 
 [data-slot="compaction-card-section-item"] {
   display: flex;
-  gap: 6px;
-  padding: 4px 0;
+  gap: 7px;
+  padding: 2px 0;
 }
 
 [data-slot="compaction-card-bullet"] {
-  color: var(--color-text-weaker);
-  font-size: 0.875rem;
+  color: var(--color-text-weaker, var(--color-text-weak));
+  font-size: 0.8125rem;
   line-height: 1.5;
   flex-shrink: 0;
   user-select: none;
@@ -171,50 +211,24 @@
   user-select: text;
 }
 
-[data-slot="compaction-card-section-item-text"] {
-  & > *:first-child {
-    margin-top: 0;
-  }
-  & > *:last-child {
-    margin-bottom: 0;
-  }
-}
-
-/* ── Next step callout ── */
-
 [data-slot="compaction-card-next-step"] {
   display: flex;
-  align-items: flex-start;
-  gap: 6px;
-  padding: 8px 10px;
-  background: var(--color-surface-info-weak);
-  border-radius: var(--radius-sm);
-  margin-top: 2px;
-}
-
-[data-slot="compaction-card-next-step"] [data-slot="icon-svg"] {
-  color: var(--icon-info-base);
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-[data-slot="compaction-card-next-step-content"] {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+  padding-top: 2px;
+  color: var(--color-text-base);
 }
 
 [data-slot="compaction-card-next-step-label"] {
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-weak);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  white-space: nowrap;
 }
 
 [data-slot="compaction-card-next-step-text"] {
   font-size: 0.8125rem;
   line-height: 1.45;
   color: var(--color-text-base);
+  min-width: 0;
 }

--- a/packages/ui/src/components/compaction-card.tsx
+++ b/packages/ui/src/components/compaction-card.tsx
@@ -1,6 +1,6 @@
 import { Show, For, createMemo, createSignal, type Component } from "solid-js"
 import { DateTime } from "luxon"
-import type { MessagePartProps } from "./message-part"
+import type { Message as MessageType, Part as PartType } from "@ericsanchezok/synergy-sdk/client"
 import { Markdown } from "./markdown"
 import { Icon } from "./icon"
 import { getSemanticIcon } from "./semantic-icon"
@@ -23,92 +23,127 @@ interface CompactionRecoveryPayload {
   validated: boolean
 }
 
-function asCompactionRecovery(part: MessagePartProps["part"]): CompactionRecoveryPayload | null {
-  if ((part as unknown as CompactionRecoveryPayload).type !== "compaction_recovery") return null
+export interface CompactionCardProps {
+  part?: PartType
+  message: MessageType
+  defaultOpen?: boolean
+}
+
+function asCompactionRecovery(part: PartType | undefined): CompactionRecoveryPayload | undefined {
+  if (!part) return undefined
+  if ((part as unknown as CompactionRecoveryPayload).type !== "compaction_recovery") return undefined
   return part as unknown as CompactionRecoveryPayload
 }
 
-const CompactionCard: Component<MessagePartProps> = (props) => {
-  const match = createMemo(() => asCompactionRecovery(props.part))
+const CompactionCard: Component<CompactionCardProps> = (props) => {
+  const recovery = createMemo(() => asCompactionRecovery(props.part))
+  const complete = createMemo(() => recovery()?.validated === true)
+  const sections = createMemo(() => recovery()?.sections ?? [])
+  const summary = createMemo(() => recovery()?.summary?.trim() ?? "")
+  const showSummaryFallback = createMemo(() => sections().length === 0 && !!summary())
 
   const [expanded, setExpanded] = createSignal(props.defaultOpen ?? false)
 
-  const timestamp = createMemo(() => {
-    const ms = props.message.time.created
-    return DateTime.fromMillis(ms).toFormat("HH:mm")
-  })
-
+  const timestamp = createMemo(() => DateTime.fromMillis(props.message.time.created).toFormat("HH:mm"))
+  const title = createMemo(() => (complete() ? "Context compressed" : "Compressing context…"))
+  const description = createMemo(() => (complete() ? "Summary ready" : "Preparing a compact continuation summary"))
+  const canExpand = createMemo(() => complete() && (sections().length > 0 || !!summary() || !!recovery()?.nextStep))
   const expandIcon = createMemo(() =>
     expanded() ? getSemanticIcon("navigation.collapse") : getSemanticIcon("navigation.expand"),
   )
 
+  const toggle = () => {
+    if (!canExpand()) return
+    setExpanded((value) => !value)
+  }
+
   return (
-    <Show when={match()}>
-      {(p) => (
-        <div data-component="compaction-card" data-expanded={expanded() ? "" : undefined}>
-          <button type="button" data-slot="compaction-card-header" onClick={() => setExpanded((v) => !v)}>
-            <div data-slot="compaction-card-header-left">
-              <Icon name={getSemanticIcon("settings.compaction")} size="small" />
-              <span data-slot="compaction-card-title">Session Compacted</span>
-              <Show when={(p().pendingDagCount ?? 0) > 0}>
-                <span data-slot="compaction-card-badge">{p().pendingDagCount} pending</span>
+    <div
+      data-component="compaction-card"
+      data-status={complete() ? "complete" : "running"}
+      data-expanded={expanded() ? "" : undefined}
+    >
+      <button
+        type="button"
+        data-slot="compaction-card-header"
+        disabled={!canExpand()}
+        aria-expanded={canExpand() ? expanded() : undefined}
+        onClick={toggle}
+      >
+        <div data-slot="compaction-card-leading">
+          <div data-slot="compaction-card-icon" aria-hidden="true">
+            <Icon name={getSemanticIcon("settings.compaction")} size="small" />
+          </div>
+          <div data-slot="compaction-card-copy">
+            <div data-slot="compaction-card-title-row">
+              <span data-slot="compaction-card-title">{title()}</span>
+              <Show when={(recovery()?.pendingDagCount ?? 0) > 0}>
+                <span data-slot="compaction-card-badge">{recovery()!.pendingDagCount} pending</span>
               </Show>
             </div>
-            <div data-slot="compaction-card-header-right">
-              <span data-slot="compaction-card-time">{timestamp()}</span>
-              <div data-slot="compaction-card-arrow">
-                <Icon name={expandIcon()} size="small" />
-              </div>
-            </div>
-          </button>
-
-          <Show when={expanded()}>
-            <div data-slot="compaction-card-content">
-              <Show when={p().mechanical}>
-                <div data-slot="compaction-card-warning">
-                  <Icon name="alert-triangle" size="small" />
-                  <span data-slot="compaction-card-warning-text">
-                    This summary was mechanically generated due to context limits. Some detail may be missing.
-                  </span>
-                </div>
-              </Show>
-
-              <div data-slot="compaction-card-summary">
-                <Markdown text={p().summary} />
-              </div>
-
-              <For each={p().sections}>
-                {(section) => (
-                  <div data-slot="compaction-card-section">
-                    <h4 data-slot="compaction-card-section-heading">{section.heading}</h4>
-                    <For each={section.items}>
-                      {(item) => (
-                        <div data-slot="compaction-card-section-item">
-                          <span data-slot="compaction-card-bullet">•</span>
-                          <div data-slot="compaction-card-section-item-text">
-                            <Markdown text={item} />
-                          </div>
-                        </div>
-                      )}
-                    </For>
-                  </div>
-                )}
-              </For>
-
-              <Show when={p().nextStep}>
-                <div data-slot="compaction-card-next-step">
-                  <Icon name={getSemanticIcon("action.info")} size="small" />
-                  <div data-slot="compaction-card-next-step-content">
-                    <span data-slot="compaction-card-next-step-label">Next step</span>
-                    <span data-slot="compaction-card-next-step-text">{p().nextStep}</span>
-                  </div>
-                </div>
-              </Show>
-            </div>
+            <span data-slot="compaction-card-description">{description()}</span>
+          </div>
+        </div>
+        <div data-slot="compaction-card-meta">
+          <span data-slot="compaction-card-time">{timestamp()}</span>
+          <Show when={canExpand()}>
+            <span data-slot="compaction-card-arrow" aria-hidden="true">
+              <Icon name={expandIcon()} size="small" />
+            </span>
           </Show>
         </div>
-      )}
-    </Show>
+      </button>
+
+      <Show when={expanded() && recovery()}>
+        {(p) => (
+          <div data-slot="compaction-card-content">
+            <Show when={p().mechanical}>
+              <div data-slot="compaction-card-warning">
+                <Icon name="alert-triangle" size="small" />
+                <span data-slot="compaction-card-warning-text">
+                  This summary was mechanically generated due to context limits. Some detail may be missing.
+                </span>
+              </div>
+            </Show>
+
+            <Show when={showSummaryFallback()}>
+              <div data-slot="compaction-card-summary">
+                <Markdown text={summary()} />
+              </div>
+            </Show>
+
+            <For each={sections()}>
+              {(section) => (
+                <section data-slot="compaction-card-section">
+                  <h4 data-slot="compaction-card-section-heading">{section.heading}</h4>
+                  <For each={section.items}>
+                    {(item) => (
+                      <div data-slot="compaction-card-section-item">
+                        <span data-slot="compaction-card-bullet" aria-hidden="true">
+                          •
+                        </span>
+                        <div data-slot="compaction-card-section-item-text">
+                          <Markdown text={item} />
+                        </div>
+                      </div>
+                    )}
+                  </For>
+                </section>
+              )}
+            </For>
+
+            <Show when={p().nextStep}>
+              {(nextStep) => (
+                <div data-slot="compaction-card-next-step">
+                  <span data-slot="compaction-card-next-step-label">Next step</span>
+                  <span data-slot="compaction-card-next-step-text">{nextStep()}</span>
+                </div>
+              )}
+            </Show>
+          </div>
+        )}
+      </Show>
+    </div>
   )
 }
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -50,7 +50,7 @@ import { createAutoScroll, createTypewriter, createAnimatedNumber } from "../hoo
 import { getApprovalAudit } from "../utils/approval-audit"
 import { getSemanticIcon } from "./semantic-icon"
 import { isToolCardHidden } from "./tool-result-presentation"
-import { shouldCollapseUserMessage, visibleUserMessageText } from "./user-message-utils"
+import { hasVisibleUserMessageContent, shouldCollapseUserMessage, visibleUserMessageText } from "./user-message-utils"
 import { CompactionCard } from "./compaction-card"
 
 export type UserMessageVariant = "default" | "turn-bubble"
@@ -1534,6 +1534,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
     }),
   )
 
+  const hasVisibleContent = createMemo(() => hasVisibleUserMessageContent(props.parts))
   const inlineFiles = createMemo(() =>
     files().filter((f) => {
       if (isNoteAttachment(f) || isSessionAttachment(f)) return false
@@ -1583,7 +1584,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
           </Show>
         </div>
       </Show>
-      <Show when={isTurnBubble() && (timestamp() || text())}>
+      <Show when={isTurnBubble() && hasVisibleContent()}>
         <div data-slot="user-message-meta">
           <Show when={timestamp()}>{(value) => <span data-slot="user-message-time">{value()}</span>}</Show>
           <Show when={text()}>

--- a/packages/ui/src/components/session-turn-timeline.test.ts
+++ b/packages/ui/src/components/session-turn-timeline.test.ts
@@ -27,6 +27,7 @@ mock.module("./accordion", () => {
 mock.module("./attachment-card", () => ({ AttachmentGallery: Empty }))
 mock.module("./button", () => ({ Button: Empty }))
 mock.module("./diff-changes", () => ({ DiffChanges: Empty }))
+mock.module("./compaction-card", () => ({ CompactionCard: Empty }))
 mock.module("./error-card", () => ({ ErrorCard: Empty }))
 mock.module("./file-icon", () => ({ FileIcon: Empty }))
 mock.module("./icon", () => ({ Icon: Empty }))
@@ -41,7 +42,10 @@ const {
   collectAssistantMessagesForTurn,
   collectMessagesForTurnDisplay,
   collectSessionTurnTimelineItems,
+  collectUserCompactionTimelineItems,
   isGuidedContextUserMessage,
+  shouldShowTurnDiffs,
+  shouldShowTurnUserChrome,
   providerPreludeElapsedLabel,
   providerPreludeText,
   shouldShowProviderPrelude,
@@ -87,6 +91,28 @@ function completedAssistant(id: string): AssistantMessage {
     ...assistant(id),
     time: { created: 1, completed: 2 },
   } as AssistantMessage
+}
+
+function compactionAssistant(id: string, parentID = "user"): AssistantMessage {
+  return {
+    ...assistantFor(id, parentID),
+    mode: "compaction",
+    agent: "compaction",
+    summary: true,
+  } as AssistantMessage
+}
+
+function compactionRecoveryPart(id: string, messageID: string): PartType {
+  return {
+    id,
+    sessionID: "session",
+    messageID,
+    type: "compaction_recovery",
+    summary: "## Current work\n- Keep the UI stable",
+    sections: [{ heading: "Current work", items: ["Keep the UI stable"] }],
+    mechanical: false,
+    validated: true,
+  } as PartType
 }
 
 function textPart(id: string, messageID: string, text = "Hello"): PartType {
@@ -226,6 +252,48 @@ describe("session turn assistant collection", () => {
         firstUser.id,
       ).map((message) => message.id),
     ).toEqual([firstAssistant.id])
+  })
+
+  test("stops the previous turn at a synthetic compaction boundary", async () => {
+    await import("./special-user-message")
+    const firstUser = user("msg_001_user")
+    const firstAssistant = assistantFor("msg_002_assistant", firstUser.id)
+    const boundary = user("msg_003_boundary", { synthetic: true, compactionBoundary: true })
+    const compaction = compactionAssistant("msg_004_compaction", boundary.id)
+
+    expect(
+      collectAssistantMessagesForTurn(
+        [firstUser, firstAssistant, boundary, compaction] as MessageType[],
+        firstUser.id,
+      ).map((message) => message.id),
+    ).toEqual([firstAssistant.id])
+    expect(
+      collectAssistantMessagesForTurn(
+        [firstUser, firstAssistant, boundary, compaction] as MessageType[],
+        boundary.id,
+      ).map((message) => message.id),
+    ).toEqual([compaction.id])
+  })
+
+  test("hides synthetic compaction chrome while keeping the recovery card", () => {
+    const compactionUser = user("msg_compaction", { synthetic: true })
+    const recovery = compactionRecoveryPart("recovery", compactionUser.id)
+    const parts = [
+      { ...textPart("synthetic-continue", compactionUser.id, "Continue if you have next steps"), synthetic: true },
+      recovery,
+    ] as PartType[]
+
+    const cardItems = collectUserCompactionTimelineItems(compactionUser, parts)
+
+    expect(cardItems).toHaveLength(1)
+    expect(cardItems[0]).toMatchObject({ kind: "compaction", part: recovery })
+    expect(shouldShowTurnUserChrome(compactionUser, parts, true)).toBe(false)
+    expect(
+      shouldShowTurnDiffs(
+        { metadata: compactionUser.metadata, summary: { diffs: [{ file: "file.ts", additions: 1, deletions: 0 }] } },
+        { hasCompactionEvent: true },
+      ),
+    ).toBe(false)
   })
 })
 
@@ -395,6 +463,31 @@ describe("session turn timeline", () => {
     expect(items.map((item) => item.kind)).toEqual(["tool-attachments", "part"])
     expect(items[0]).toMatchObject({ kind: "tool-attachments", files: [image] })
     expect(items[1]).toMatchObject({ kind: "part", part: { type: "text" } })
+  })
+
+  test("renders compaction assistants as one event card while hiding streaming text", () => {
+    const message = compactionAssistant("assistant-compaction")
+    const streamingItems = collectSessionTurnTimelineItems(
+      [message],
+      { [message.id]: [textPart("text-stream", message.id, "Raw compaction tokens")] },
+      true,
+    )
+
+    expect(streamingItems).toHaveLength(1)
+    expect(streamingItems[0]).toMatchObject({ kind: "compaction", part: undefined })
+    expect(timelineVisualKind(streamingItems[0])).toBe("compaction")
+    expect(timelineItemStableKey(streamingItems[0])).toBe("compaction:assistant-compaction")
+
+    const recovery = compactionRecoveryPart("recovery", message.id)
+    const completedItems = collectSessionTurnTimelineItems(
+      [message],
+      { [message.id]: [textPart("text-stream", message.id, "Raw compaction tokens"), recovery] },
+      false,
+    )
+
+    expect(completedItems).toHaveLength(1)
+    expect(completedItems[0]).toMatchObject({ kind: "compaction", part: recovery })
+    expect(timelineItemStableKey(completedItems[0])).toBe("compaction:assistant-compaction")
   })
 
   test("keeps tool-call prelude text as text display", () => {

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -35,6 +35,8 @@ import { Button } from "./button"
 import { createStore } from "solid-js/store"
 import { createAutoScroll } from "../hooks"
 import { getSpecialUserMessageRenderer, hasSpecialUserMessageRenderer } from "./special-user-message"
+import { CompactionCard } from "./compaction-card"
+import { hasVisibleUserMessageContent } from "./user-message-utils"
 
 function same<T>(a: readonly T[] | undefined, b: readonly T[] | undefined) {
   if (a === b) return true
@@ -47,7 +49,7 @@ export type SessionTurnTimelineItem =
   | {
       kind: "part"
       message: AssistantMessage
-      part: TextPart | ToolPart | AttachmentPart
+      part: TextPart | ToolPart | AttachmentPart | PartType
     }
   | {
       kind: "reasoning"
@@ -65,6 +67,11 @@ export type SessionTurnTimelineItem =
       part: ToolPart
       files: AttachmentPart[]
     }
+  | {
+      kind: "compaction"
+      message: MessageType
+      part?: PartType
+    }
 
 export type SessionTurnTimelineVisualKind =
   | "text"
@@ -73,6 +80,7 @@ export type SessionTurnTimelineVisualKind =
   | "attachment"
   | "media-pending"
   | "tool-attachments"
+  | "compaction"
 
 const DEFAULT_PROVIDER_PRELUDE_TEXT = "Awaiting response…"
 
@@ -95,6 +103,45 @@ function visibleAttachmentParts(files: AttachmentPart[] | undefined): Attachment
   return (files ?? []).filter((file) => !resolveAttachmentPresentation(file).hidden)
 }
 
+function isCompactionAssistant(message: AssistantMessage): boolean {
+  return message.mode === "compaction" || message.agent === "compaction"
+}
+
+export function isCompactionBoundaryUser(message: Pick<UserMessage, "metadata">): boolean {
+  return message.metadata?.compactionBoundary === true
+}
+
+export function collectUserCompactionTimelineItems(
+  message: UserMessage,
+  parts: readonly PartType[],
+): SessionTurnTimelineItem[] {
+  const compactionRecovery = parts.find((part) => part.type === "compaction_recovery")
+  if (!compactionRecovery) return []
+  return [{ kind: "compaction", message, part: compactionRecovery }]
+}
+
+export function shouldShowTurnDiffs(
+  message: Pick<UserMessage, "metadata" | "summary"> | undefined,
+  options: { hasCompactionEvent?: boolean } = {},
+): boolean {
+  if (!message) return false
+  if (isCompactionBoundaryUser(message) || options.hasCompactionEvent) return false
+  return (message.summary?.diffs?.length ?? 0) > 0
+}
+
+export function shouldShowTurnUserChrome(
+  message: Pick<UserMessage, "metadata"> | undefined,
+  parts: readonly PartType[] | undefined,
+  hasCompactionEvent: boolean,
+): boolean {
+  if (!message) return false
+  if (isCompactionBoundaryUser(message)) return false
+  if (!hasCompactionEvent) return true
+  if (message.metadata?.synthetic === true) return false
+
+  return hasVisibleUserMessageContent(parts)
+}
+
 export function timelineKindForPart(part: PartType, working: boolean): SessionTurnTimelineItem["kind"] | undefined {
   if (part.type === "text") return part.text.trim() ? "part" : undefined
   if (part.type === "attachment") return resolveAttachmentPresentation(part).hidden ? undefined : "part"
@@ -110,13 +157,16 @@ export function timelineKindForPart(part: PartType, working: boolean): SessionTu
 }
 
 export function timelineVisualKind(item: SessionTurnTimelineItem): SessionTurnTimelineVisualKind {
+  if (item.kind === "compaction") return "compaction"
   if (item.kind !== "part") return item.kind
   if (item.part.type === "tool") return "tool"
   if (item.part.type === "attachment") return "attachment"
+  if (item.part.type === "compaction_recovery") return "compaction"
   return "text"
 }
 
 export function timelineItemStableKey(item: SessionTurnTimelineItem): string {
+  if (item.kind === "compaction") return `compaction:${item.message.id}`
   return `${timelineVisualKind(item)}:${item.message.id}:${item.part.id}`
 }
 
@@ -129,7 +179,13 @@ export function collectSessionTurnTimelineItems(
 
   for (const message of messages) {
     const parts = partsByMessage[message.id] ?? []
-    const hasCompactionRecovery = parts.some((p) => p.type === "compaction_recovery")
+    const compactionRecovery = parts.find((part) => part.type === "compaction_recovery")
+    if (isCompactionAssistant(message)) {
+      items.push({ kind: "compaction", message, part: compactionRecovery })
+      continue
+    }
+
+    const hasCompactionRecovery = !!compactionRecovery
     for (const part of parts) {
       const kind = timelineKindForPart(part, working)
       if (!kind) continue
@@ -232,6 +288,9 @@ export function shouldShowProviderPrelude(input: {
 }
 
 function TimelineItemDisplay(props: { item: SessionTurnTimelineItem; serverUrl: string }) {
+  if (props.item.kind === "compaction") {
+    return <CompactionCard part={props.item.part} message={props.item.message} />
+  }
   if (props.item.kind === "part" || props.item.kind === "reasoning") {
     return <Part part={props.item.part} message={props.item.message} />
   }
@@ -438,10 +497,11 @@ export function SessionTurn(
     return false
   })
 
-  const hasDiffs = createMemo(() => message()?.summary?.diffs?.length)
   const timelineItems = createMemo(
     () => {
       const result: SessionTurnDisplayItem[] = []
+      const msg = message()
+      if (msg) result.push(...collectUserCompactionTimelineItems(msg, parts()))
       for (const item of displayMessages()) {
         if (item.role === "user") {
           result.push({
@@ -458,6 +518,11 @@ export function SessionTurn(
     emptyDisplayItems,
     { equals: same },
   )
+  const hasCompactionEvent = createMemo(() =>
+    timelineItems().some((item) => isAssistantTimelineDisplayItem(item) && timelineVisualKind(item) === "compaction"),
+  )
+  const showUserChrome = createMemo(() => shouldShowTurnUserChrome(message(), parts(), hasCompactionEvent()))
+  const hasDiffs = createMemo(() => shouldShowTurnDiffs(message(), { hasCompactionEvent: hasCompactionEvent() }))
   const latestAssistantTimelineItems = createMemo(() => {
     const latest = lastAssistantMessage()
     if (!latest) return []
@@ -565,18 +630,20 @@ export function SessionTurn(
                     <Part part={shellModePart()!} message={msg()} defaultOpen />
                   </Match>
                   <Match when={true}>
-                    {/* Mailbox source annotation */}
-                    <Show when={(msg() as UserMessage).metadata?.mailbox && !specialUserMessageRenderer()}>
-                      <MailboxSourceBadge message={msg() as UserMessage} />
-                    </Show>
-                    {/* User message */}
-                    <Show
-                      when={specialUserMessageRenderer()}
-                      fallback={<Message message={msg()} parts={parts()} userVariant="turn-bubble" />}
-                    >
-                      {(SpecialUserMessage) => (
-                        <Dynamic component={SpecialUserMessage()} message={msg()} parts={parts()} />
-                      )}
+                    <Show when={showUserChrome()}>
+                      {/* Mailbox source annotation */}
+                      <Show when={(msg() as UserMessage).metadata?.mailbox && !specialUserMessageRenderer()}>
+                        <MailboxSourceBadge message={msg() as UserMessage} />
+                      </Show>
+                      {/* User message */}
+                      <Show
+                        when={specialUserMessageRenderer()}
+                        fallback={<Message message={msg()} parts={parts()} userVariant="turn-bubble" />}
+                      >
+                        {(SpecialUserMessage) => (
+                          <Dynamic component={SpecialUserMessage()} message={msg()} parts={parts()} />
+                        )}
+                      </Show>
                     </Show>
                     <Show when={hasTimelineItems() || showProviderPrelude() || (!working() && hasDiffs())}>
                       <div data-slot="session-turn-timeline">

--- a/packages/ui/src/components/special-user-message.tsx
+++ b/packages/ui/src/components/special-user-message.tsx
@@ -76,6 +76,14 @@ function PlanModeUserRequestMessage(props: SpecialUserMessageProps): JSX.Element
   ) as unknown as JSX.Element
 }
 
+function HiddenSpecialMessage(): JSX.Element {
+  return h("div", {
+    "data-component": "special-user-message",
+    "data-kind": "hidden",
+    hidden: true,
+  }) as unknown as JSX.Element
+}
+
 function BlueprintControlMessage(props: SpecialUserMessageProps): JSX.Element {
   const [detailsOpen, setDetailsOpen] = createSignal(false)
   let detailsTrigger: HTMLButtonElement | undefined
@@ -218,6 +226,14 @@ function BlueprintControlMessage(props: SpecialUserMessageProps): JSX.Element {
     ],
   ) as unknown as JSX.Element
 }
+
+registerSpecialUserMessageRenderer({
+  id: "compaction-boundary",
+  match(message) {
+    return message.metadata?.compactionBoundary === true
+  },
+  component: HiddenSpecialMessage,
+})
 
 registerSpecialUserMessageRenderer({
   id: "plan-mode-user-request",

--- a/packages/ui/src/components/user-message-utils.test.ts
+++ b/packages/ui/src/components/user-message-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { Part as PartType } from "@ericsanchezok/synergy-sdk"
 import {
   USER_MESSAGE_COLLAPSE_LENGTH,
+  hasVisibleUserMessageContent,
   USER_MESSAGE_COLLAPSE_LINES,
   shouldCollapseUserMessage,
   userMessageLineCount,
@@ -29,5 +30,18 @@ describe("user message display helpers", () => {
     ] as PartType[]
 
     expect(visibleUserMessageText(parts)).toBe("visible user message")
+  })
+
+  test("does not treat synthetic-only text as visible user content", () => {
+    expect(hasVisibleUserMessageContent(undefined)).toBe(false)
+    expect(
+      hasVisibleUserMessageContent([
+        { type: "text", text: "Continue if you have next steps", synthetic: true },
+      ] as PartType[]),
+    ).toBe(false)
+    expect(hasVisibleUserMessageContent([{ type: "text", text: "visible user message" }] as PartType[])).toBe(true)
+    expect(
+      hasVisibleUserMessageContent([{ type: "attachment", filename: "image.png", mime: "image/png" }] as PartType[]),
+    ).toBe(true)
   })
 })

--- a/packages/ui/src/components/user-message-utils.ts
+++ b/packages/ui/src/components/user-message-utils.ts
@@ -16,3 +16,8 @@ export function visibleUserMessageText(parts: readonly PartType[] | undefined) {
   const textPart = parts?.find((p) => p.type === "text" && !(p as TextPart).synthetic) as TextPart | undefined
   return textPart?.text || ""
 }
+
+export function hasVisibleUserMessageContent(parts: readonly PartType[] | undefined) {
+  if (visibleUserMessageText(parts)) return true
+  return parts?.some((part) => part.type === "attachment") ?? false
+}


### PR DESCRIPTION
## Summary
- Isolate auto-compaction onto a synthetic boundary turn so compacted history no longer attaches to the original user request.
- Render compaction recovery as a dedicated timeline card while hiding synthetic user chrome and diff accordions for compaction turns.
- Polish the compaction card running/complete states and make expanded summaries scrollable without the extra icon ring.

## Verification
- cd packages/ui && bun test src/components/session-turn-timeline.test.ts src/components/user-message-utils.test.ts test/css-token-integrity.test.ts
- bun run typecheck
- pre-push hook: typecheck + prettier --check .