### PR TITLE
Fix plugin hook runtime contracts

### DIFF
--- a/docs/plugins/02-manifest-reference.md
+++ b/docs/plugins/02-manifest-reference.md
@@ -86,7 +86,7 @@ During `synergy-plugin build`, the runtime entry is bundled to `dist/runtime/ind
 
 `data.config` may be `none`, `plugin`, or `global`. It defaults to `none`; declare `plugin` or `global` only when the plugin reads Synergy configuration through plugin services. This is separate from `hooks.config`, which allows observing redacted runtime config snapshots.
 
-`hooks.events` may be `none`, `selected`, or `all`. In selected mode, `hooks.eventNames` supports exact event names, `*`, and suffix wildcards ending in `.*` such as `session.*`.
+`hooks.events` may be `none`, `selected`, or `all`. In selected mode, `hooks.eventNames` supports exact event names, `*`, and prefix wildcards ending in `.*` such as `session.*`.
 
 `hooks.config: true` allows the plugin `config(input, output)` hook to receive redacted config snapshots on startup, plugin reload, and config reload. `input.source` is `startup`, `plugin_reload`, or `reload`; `input.changedFields` is present for config reload notifications.
 

--- a/docs/plugins/02-manifest-reference.md
+++ b/docs/plugins/02-manifest-reference.md
@@ -71,14 +71,28 @@ During `synergy-plugin build`, the runtime entry is bundled to `dist/runtime/ind
       "trustedImport": false,
       "sandboxIframe": false,
     },
+    "hooks": {
+      "events": "selected",
+      "eventNames": [],
+      "config": false,
+      "toolExecute": "own",
+      "permissionAsk": "none",
+      "promptTransform": false,
+      "compactionTransform": false,
+    },
   },
 }
 ```
 
-`data.config` may be `none`, `plugin`, or `global`. It defaults to `none`; declare `plugin` or `global` only when the plugin reads Synergy configuration.
+`data.config` may be `none`, `plugin`, or `global`. It defaults to `none`; declare `plugin` or `global` only when the plugin reads Synergy configuration through plugin services. This is separate from `hooks.config`, which allows observing redacted runtime config snapshots.
 
-Per-tool capabilities live under `contributes.tools[].capabilities` and are merged with plugin-wide defaults.
-Unknown permission and capability keys are rejected during manifest validation.
+`hooks.events` may be `none`, `selected`, or `all`. In selected mode, `hooks.eventNames` supports exact event names, `*`, and suffix wildcards ending in `.*` such as `session.*`.
+
+`hooks.config: true` allows the plugin `config(input, output)` hook to receive redacted config snapshots on startup, plugin reload, and config reload. `input.source` is `startup`, `plugin_reload`, or `reload`; `input.changedFields` is present for config reload notifications.
+
+`hooks.promptTransform: true` allows `experimental.chat.system.transform` and `experimental.chat.messages.transform`. The system transform hook runs in `budget` and `final` phases; use `input.phase` to avoid duplicate prompt injection.
+
+Per-tool capabilities live under `contributes.tools[].capabilities` and are merged with plugin-wide defaults. Unknown permission and capability keys are rejected during manifest validation.
 
 ## Runtime Tool Contributions
 

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -145,6 +145,9 @@ All local, npm, git, URL, directory, file, and tarball specs use the shared reso
 - Worker/process plugins register proxy tools in the host and execute through the plugin runner.
 - `Plugin.trigger()` proxies isolated hooks through the runtime supervisor.
 - Bridge requests are checked against manifest-derived approval capabilities.
+- Event hooks observe permitted bus events only. `permissions.hooks.eventNames` accepts exact names, `*`, and prefix wildcards such as `session.*`.
+- Config hooks require `permissions.hooks.config: true` and receive redacted snapshots with `source` set to `startup`, `plugin_reload`, or `reload`.
+- `experimental.chat.system.transform` requires `permissions.hooks.promptTransform: true` and runs twice: `phase: "budget"` before token budgeting and `phase: "final"` before the provider call. Check `input.phase` when adding instructions so final-only content is not injected during budgeting.
 
 ## Web UI Notes
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -166,6 +166,69 @@ const plan = await context.task?.run({
 
 When `output.mode` is `structured`, Cortex validates the child task result against the schema and may run repair turns before completing. Cortex still stores its normal task trajectory summary in `task.result`; the structured value is returned to the plugin call site as `plan.outputResult.data`.
 
+## Hooks
+
+Plugins return hooks from `init()`. Hook permissions are declared in `plugin.json` and Synergy only invokes permissioned hooks.
+
+### Event hook
+
+`event(input)` observes runtime bus events without mutating them. Declare event access under `permissions.hooks`:
+
+```jsonc
+{
+  "permissions": {
+    "hooks": {
+      "events": "selected",
+      "eventNames": ["session.*", "message.updated"],
+    },
+  },
+}
+```
+
+`events` is `"none"`, `"selected"`, or `"all"`. In selected mode, `eventNames` supports exact names, `*` for all events, and suffix wildcards ending in `.*` such as `session.*`.
+
+```ts
+event(input) {
+  console.log(input.event.type, input.event.properties)
+}
+```
+
+### Config hook
+
+`config(input, output)` observes a redacted runtime config snapshot at startup, plugin reload, and config reload. Declare `permissions.hooks.config: true`; this permission is separate from `permissions.data.config`.
+
+```jsonc
+{
+  "permissions": {
+    "hooks": {
+      "config": true,
+    },
+  },
+}
+```
+
+```ts
+config(input, output) {
+  console.log(input.source, input.changedFields)
+  console.log(output.config.model)
+}
+```
+
+`input.source` is `"startup"`, `"plugin_reload"`, or `"reload"`. Secret fields in `output.config` are replaced with Synergy's redacted sentinel before dispatch.
+
+### System prompt transform
+
+`experimental.chat.system.transform(input, output)` can rewrite the assembled system prompt when `permissions.hooks.promptTransform` is `true`. Synergy calls this hook in two phases: `input.phase === "budget"` before token budgeting and `input.phase === "final"` before the provider call. The input includes `sessionID`, `agent`, `model`, `messageID`, and `small` for final calls.
+
+```ts
+"experimental.chat.system.transform"(input, output) {
+  if (input.phase !== "final") return
+  output.system.push("Additional final-call instruction.")
+}
+```
+
+If a transform empties `output.system`, Synergy restores the original system prompt.
+
 ## Plugin Input
 
 `init(input)` receives runtime services scoped to the active Synergy Scope:

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -185,7 +185,7 @@ Plugins return hooks from `init()`. Hook permissions are declared in `plugin.jso
 }
 ```
 
-`events` is `"none"`, `"selected"`, or `"all"`. In selected mode, `eventNames` supports exact names, `*` for all events, and suffix wildcards ending in `.*` such as `session.*`.
+`events` is `"none"`, `"selected"`, or `"all"`. In selected mode, `eventNames` supports exact names, `*` for all events, and prefix wildcards ending in `.*` such as `session.*`.
 
 ```ts
 event(input) {

--- a/packages/plugin/src/hooks.ts
+++ b/packages/plugin/src/hooks.ts
@@ -40,13 +40,13 @@ export const HOOKS: HookDescriptor[] = [
     name: "config",
     category: "core",
     mutatesOutput: false,
-    summary: "Observe the loaded runtime config",
+    summary: "Observe redacted runtime config snapshots at startup and config reload",
   },
   {
     name: "event",
     category: "core",
     mutatesOutput: false,
-    summary: "Observe runtime bus events",
+    summary: "Observe permitted runtime bus events by exact or wildcard event name",
   },
   {
     name: "chat.message",
@@ -172,7 +172,7 @@ export const HOOKS: HookDescriptor[] = [
     name: "experimental.chat.system.transform",
     category: "experimental",
     mutatesOutput: true,
-    summary: "Rewrite the assembled system prompt",
+    summary: "Rewrite the assembled system prompt during budget and final phases",
   },
   {
     name: "experimental.session.compacting",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -2,7 +2,6 @@ import type {
   AgendaItem,
   AgendaRunLog,
   CortexTask,
-  Event,
   createSynergyClient,
   MemoryCategory,
   MemoryRecallMode,
@@ -429,6 +428,34 @@ export interface PluginDescriptor {
 // PluginHooks — what init() returns
 // ---------------------------------------------------------------------------
 
+export interface PluginEventHookInput {
+  event: {
+    type: string
+    properties: unknown
+  }
+}
+
+export interface PluginConfigHookInput {
+  source: "startup" | "reload" | "plugin_reload"
+  scopeID?: string
+  scopeType?: string
+  changedFields?: string[]
+  timestamp: number
+}
+
+export interface PluginConfigHookOutput {
+  config: Config
+}
+
+export interface PluginChatSystemTransformInput {
+  phase: "budget" | "final"
+  sessionID: string
+  agent: string
+  model: { providerID: string; modelID: string }
+  messageID?: string
+  small?: boolean
+}
+
 export interface PluginHooks {
   /** Called when the plugin is being unloaded (e.g. runtime reload) */
   dispose?(): Promise<void>
@@ -445,9 +472,9 @@ export interface PluginHooks {
   /** Provider runtime/catalog profiles */
   provider?: ProviderProfileHook | ProviderProfileHook[]
   /** Observe runtime bus events */
-  event?(input: { event: Event }): Promise<void>
-  /** Observe the loaded runtime config */
-  config?(input: Config): Promise<void>
+  event?(input: PluginEventHookInput): Promise<void>
+  /** Observe a redacted runtime config snapshot */
+  config?(input: PluginConfigHookInput, output: PluginConfigHookOutput): Promise<void>
   /** Rewrite incoming user messages */
   "chat.message"?(
     input: {
@@ -482,7 +509,10 @@ export interface PluginHooks {
     output: { messages: { info: Message; parts: Part[] }[] },
   ): Promise<void>
   /** Rewrite the assembled system prompt */
-  "experimental.chat.system.transform"?(input: {}, output: { system: string[] }): Promise<void>
+  "experimental.chat.system.transform"?(
+    input: PluginChatSystemTransformInput,
+    output: { system: string[] },
+  ): Promise<void>
   /** Customize session compaction */
   "experimental.session.compacting"?(
     input: { sessionID: string },

--- a/packages/plugin/src/manifest.ts
+++ b/packages/plugin/src/manifest.ts
@@ -250,6 +250,7 @@ const PluginPermissionsSchema = z
       .object({
         events: z.enum(["none", "selected", "all"]).default("selected"),
         eventNames: z.array(z.string()).default([]),
+        config: z.boolean().default(false),
         toolExecute: z.enum(["none", "own", "declared", "all"]).default("own"),
         permissionAsk: z.enum(["none", "own", "all"]).default("none"),
         promptTransform: z.boolean().default(false),

--- a/packages/synergy/src/config/config.ts
+++ b/packages/synergy/src/config/config.ts
@@ -853,6 +853,9 @@ export namespace Config {
     if (result.provider) {
       for (const provider of Object.values(result.provider) as any[]) {
         if (provider?.options?.apiKey) provider.options.apiKey = REDACTED_SENTINEL
+        for (const model of Object.values(provider?.models ?? {}) as any[]) {
+          if (model?.options?.apiKey) model.options.apiKey = REDACTED_SENTINEL
+        }
       }
     }
     if (result.mcp) {
@@ -892,9 +895,15 @@ export namespace Config {
     }
     if (result.provider && stored.provider) {
       for (const [key, provider] of Object.entries(result.provider) as [string, any][]) {
+        const storedProvider = (stored.provider as Record<string, any>)[key]
         if (provider?.options?.apiKey === REDACTED_SENTINEL) {
-          const storedProvider = (stored.provider as Record<string, any>)[key]
           if (storedProvider?.options?.apiKey) provider.options.apiKey = storedProvider.options.apiKey
+        }
+        for (const [modelKey, model] of Object.entries(provider?.models ?? {}) as [string, any][]) {
+          if (model?.options?.apiKey === REDACTED_SENTINEL) {
+            const storedModel = storedProvider?.models?.[modelKey]
+            if (storedModel?.options?.apiKey) model.options.apiKey = storedModel.options.apiKey
+          }
         }
       }
     }

--- a/packages/synergy/src/plugin/index.ts
+++ b/packages/synergy/src/plugin/index.ts
@@ -32,6 +32,7 @@ export namespace Plugin {
   // Lifecycle
   export const trigger = lifecycle.trigger
   export const init = lifecycle.init
+  export const notifyConfigHooks = lifecycle.notifyConfigHooks
   export const reload = lifecycle.reload
   export const manifest = lifecycle.manifest
 

--- a/packages/synergy/src/plugin/lifecycle.ts
+++ b/packages/synergy/src/plugin/lifecycle.ts
@@ -13,6 +13,28 @@ import { withTimeout } from "../util/timeout"
 import { resolveRuntimeLimits } from "../plugin-runtime/health"
 
 const log = Log.create({ service: "plugin.lifecycle" })
+type ConfigHookInput = {
+  source: "startup" | "reload" | "plugin_reload"
+  scopeID?: string
+  scopeType?: string
+  changedFields?: string[]
+  timestamp: number
+}
+
+type ConfigHookOutput = { config: Config.Info }
+
+const pluginEventState = ScopedState.create(
+  () => {
+    const unsub = Bus.subscribeAll(async (event) => {
+      const loaded = await state().then((x) => [...x.loaded])
+      for (const plugin of loaded) {
+        await notifyEventHook(plugin, event)
+      }
+    })
+    return { unsub }
+  },
+  async (s) => s.unsub(),
+)
 
 // ---------------------------------------------------------------------------
 // Hook triggering — unchanged interface for all existing consumers
@@ -21,62 +43,19 @@ const log = Log.create({ service: "plugin.lifecycle" })
 export async function trigger<
   Name extends Exclude<
     keyof Required<PluginHooks>,
-    "auth" | "provider" | "event" | "tool" | "cli" | "skills" | "agents" | "dispose"
+    "auth" | "provider" | "event" | "config" | "tool" | "cli" | "skills" | "agents" | "dispose"
   >,
   Input = Parameters<Required<PluginHooks>[Name]>[0],
   Output = Parameters<Required<PluginHooks>[Name]>[1],
 >(name: Name, input: Input, output: Output): Promise<Output> {
   if (!name) return output
-  const isToolHook = name === "tool.execute.before" || name === "tool.execute.after"
-  const isPermissionAsk = name === "permission.ask"
   for (const plugin of await state().then((x) => [...x.loaded])) {
-    const { id, hooks, manifest, runtimeMode } = plugin
+    const { id, hooks, runtimeMode } = plugin
     const fn = hooks[name]
     if (!fn) continue
+    if (!canReceiveHook(plugin, String(name), input)) continue
 
     try {
-      // Hook gating: scope filtering from manifest permissions.hooks
-      if (isToolHook) {
-        const scope = manifest?.permissions?.hooks?.toolExecute ?? "own"
-        if (scope !== "all") {
-          // "own" scope: only fire if this plugin owns the tool being executed.
-          // The input carries the prefixed full tool ID (e.g. plugin__myplugin__mytool).
-          const toolId = (input as any)?.tool as string | undefined
-          if (scope === "own" && toolId && PluginToolId.is(toolId)) {
-            const parsed = PluginToolId.parse(toolId)
-            if (parsed?.pluginId !== id) continue
-          } else if (scope === "declared") {
-            // "declared" scope: fire if the tool is in this plugin's declared contributes.tools
-            const toolName = toolId
-              ? PluginToolId.is(toolId)
-                ? PluginToolId.parse(toolId)?.toolId
-                : toolId
-              : undefined
-            const declared = manifest?.contributes?.tools?.some(
-              (tool: { id?: string; name?: string }) => tool.name === toolName || tool.id === toolName,
-            )
-            if (!declared) continue
-          } else {
-            // "none" or unrecognized: skip
-            continue
-          }
-        }
-      }
-
-      if (isPermissionAsk) {
-        const scope = manifest?.permissions?.hooks?.permissionAsk ?? "none"
-        if (scope === "none") continue
-        if (scope === "own") {
-          // "own" scope: only fire for permissions triggered by this plugin's own tools.
-          // The input carries the tool name/id.
-          const toolId = (input as any)?.tool as string | undefined
-          if (toolId && PluginToolId.is(toolId)) {
-            const parsed = PluginToolId.parse(toolId)
-            if (parsed?.pluginId !== id) continue
-          }
-        }
-      }
-
       if (runtimeMode && runtimeMode !== "in-process") {
         const runtime = getRuntime(id)
         if (runtime?.hooks?.includes(String(name))) {
@@ -126,32 +105,31 @@ export async function reload() {
   log.info("plugin state reloaded")
 }
 
-export async function init() {
+export async function init(input: { source?: "startup" | "plugin_reload" } = {}) {
   await restoreRuntimeState()
   const config = await Config.current()
 
   const loaded = await state().then((x) => [...x.loaded])
   const { Server } = await import("../server/server")
+  const runtimeStarts: Promise<void>[] = []
   for (const plugin of loaded) {
-    const { id, hooks, runtimeMode, source, entryPath, pluginDir, manifest } = plugin
-    try {
-      await hooks.config?.(config)
-    } catch (err) {
-      await disableLoadedPlugin(plugin, "hook", err)
-      continue
-    }
+    const { id, runtimeMode, source, entryPath, pluginDir, manifest } = plugin
     if (runtimeMode && runtimeMode !== "in-process" && entryPath && source) {
-      void startRuntime(id, {
-        mode: runtimeMode,
-        source,
-        entryPath,
-        pluginDir,
-        scope: ScopeContext.current.scope,
-        serverUrl: Server.url().toString(),
-      }).catch(async (err) => {
-        log.error("plugin runtime start error", { id, err })
-        await disableLoadedPlugin(plugin, "runtime", err)
-      })
+      runtimeStarts.push(
+        startRuntime(id, {
+          mode: runtimeMode,
+          source,
+          entryPath,
+          pluginDir,
+          scope: ScopeContext.current.scope,
+          serverUrl: Server.url().toString(),
+        })
+          .then(() => {})
+          .catch(async (err) => {
+            log.error("plugin runtime start error", { id, err })
+            await disableLoadedPlugin(plugin, "runtime", err)
+          }),
+      )
     }
     if (manifest.contributes?.mcp) {
       // Plugin-contributed MCP servers may spawn network-backed `npx` processes.
@@ -159,28 +137,47 @@ export async function init() {
       void startForPlugin(id, manifest.contributes.mcp).catch((err) => log.error("plugin mcp start error", { id, err }))
     }
   }
-  const pluginEventState = ScopedState.create(
-    () => {
-      const unsub = Bus.subscribeAll(async (input) => {
-        const loaded = await state().then((x) => [...x.loaded])
-        for (const plugin of loaded) {
-          try {
-            if (!canReceiveEvent(plugin, input.type)) continue
-            const fn = plugin.hooks["event"]
-            if (!fn) continue
-            await withTimeout(Promise.resolve(fn({ event: input })), await hookInvocationTimeoutMs(plugin), {
-              message: `Plugin event hook timed out`,
-            })
-          } catch (err) {
-            await disableLoadedPlugin(plugin, "hook", err)
-          }
-        }
-      })
-      return { unsub }
-    },
-    async (s) => s.unsub(),
-  )
+  await Promise.all(runtimeStarts)
+  await notifyConfigHooks({ source: input.source ?? "startup", config })
   void pluginEventState()
+}
+
+export async function notifyConfigHooks(input: {
+  source: "startup" | "reload" | "plugin_reload"
+  config?: Config.Info
+  changedFields?: string[]
+}) {
+  const config = input.config ?? (await Config.current())
+  const redactedConfig = Config.redactForClient(config)
+  const hookInput: ConfigHookInput = {
+    source: input.source,
+    scopeID: ScopeContext.current.scope.id,
+    scopeType: ScopeContext.current.scope.type,
+    changedFields: input.changedFields,
+    timestamp: Date.now(),
+  }
+  for (const plugin of await state().then((x) => [...x.loaded])) {
+    if (!canReceiveConfig(plugin)) continue
+    const output = { config: immutableConfigSnapshot(redactedConfig) }
+    try {
+      if (plugin.runtimeMode && plugin.runtimeMode !== "in-process") {
+        const runtime = getRuntime(plugin.id)
+        if (runtime?.hooks?.includes("config")) {
+          await triggerRuntimeHook(plugin.id, "config", hookInput, output)
+        }
+        continue
+      }
+      const fn = plugin.hooks.config as
+        | ((input: ConfigHookInput, output: ConfigHookOutput) => Promise<void>)
+        | undefined
+      if (!fn) continue
+      await withTimeout(Promise.resolve(fn(hookInput, output)), await hookInvocationTimeoutMs(plugin), {
+        message: `Plugin config hook timed out`,
+      })
+    } catch (err) {
+      await disableLoadedPlugin(plugin, "hook", err)
+    }
+  }
 }
 
 /** Look up a plugin's manifest — used both internally and re-exported by the facade */
@@ -190,13 +187,95 @@ export async function manifest(pluginId: string) {
   return plugin.manifest
 }
 
+function canReceiveHook(plugin: LoadedPlugin, name: string, input: unknown): boolean {
+  const hooks = plugin.manifest?.permissions?.hooks
+  if (name === "tool.execute.before" || name === "tool.execute.after") return canReceiveToolHook(plugin, input)
+  if (name === "permission.ask") return canReceivePermissionAsk(plugin, input)
+  if (name === "experimental.chat.system.transform" || name === "experimental.chat.messages.transform") {
+    return hooks?.promptTransform === true
+  }
+  if (name === "experimental.session.compacting") return hooks?.compactionTransform === true
+  return true
+}
+
+function canReceiveToolHook(plugin: LoadedPlugin, input: unknown): boolean {
+  const scope = plugin.manifest?.permissions?.hooks?.toolExecute ?? "own"
+  if (scope === "all") return true
+  const toolId = (input as any)?.tool as string | undefined
+  if (scope === "own" && toolId && PluginToolId.is(toolId)) {
+    return PluginToolId.parse(toolId)?.pluginId === plugin.id
+  }
+  if (scope === "declared") {
+    const toolName = toolId ? (PluginToolId.is(toolId) ? PluginToolId.parse(toolId)?.toolId : toolId) : undefined
+    return Boolean(
+      toolName &&
+        plugin.manifest?.contributes?.tools?.some(
+          (tool: { id?: string; name?: string }) => tool.name === toolName || tool.id === toolName,
+        ),
+    )
+  }
+  return false
+}
+
+function canReceivePermissionAsk(plugin: LoadedPlugin, input: unknown): boolean {
+  const scope = plugin.manifest?.permissions?.hooks?.permissionAsk ?? "none"
+  if (scope === "none") return false
+  if (scope === "all") return true
+  const toolId = (input as any)?.tool as string | undefined
+  if (!toolId || !PluginToolId.is(toolId)) return true
+  return PluginToolId.parse(toolId)?.pluginId === plugin.id
+}
+
+function canReceiveConfig(plugin: LoadedPlugin): boolean {
+  return plugin.manifest?.permissions?.hooks?.config === true
+}
+
 function canReceiveEvent(plugin: LoadedPlugin, eventName: string): boolean {
-  const manifest = plugin.manifest
-  const hooks = manifest?.permissions?.hooks
+  const hooks = plugin.manifest?.permissions?.hooks
   const mode = hooks?.events ?? "selected"
   if (mode === "all") return true
   if (mode === "none") return false
-  return (hooks?.eventNames ?? []).includes(eventName)
+  return (hooks?.eventNames ?? []).some((pattern: string) => eventNameMatches(pattern, eventName))
+}
+
+function eventNameMatches(pattern: string, eventName: string): boolean {
+  if (pattern === "*") return true
+  if (pattern.endsWith(".*")) return eventName.startsWith(`${pattern.slice(0, -2)}.`)
+  return pattern === eventName
+}
+
+async function notifyEventHook(plugin: LoadedPlugin, event: { type: string; properties: unknown }) {
+  if (!canReceiveEvent(plugin, event.type)) return
+  try {
+    if (plugin.runtimeMode && plugin.runtimeMode !== "in-process") {
+      const runtime = getRuntime(plugin.id)
+      if (runtime?.hooks?.includes("event")) {
+        await triggerRuntimeHook(plugin.id, "event", { event }, {})
+      }
+      return
+    }
+    const fn = plugin.hooks.event as
+      | ((input: { event: { type: string; properties: unknown } }) => Promise<void>)
+      | undefined
+    if (!fn) return
+    await withTimeout(Promise.resolve(fn({ event })), await hookInvocationTimeoutMs(plugin), {
+      message: `Plugin event hook timed out`,
+    })
+  } catch (err) {
+    await disableLoadedPlugin(plugin, "hook", err)
+  }
+}
+
+function immutableConfigSnapshot(config: Config.Info): Config.Info {
+  return deepFreeze(structuredClone(config))
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== "object") return value
+  for (const nested of Object.values(value)) {
+    deepFreeze(nested)
+  }
+  return Object.freeze(value)
 }
 
 async function hookInvocationTimeoutMs(plugin: LoadedPlugin): Promise<number> {

--- a/packages/synergy/src/plugin/lifecycle.ts
+++ b/packages/synergy/src/plugin/lifecycle.ts
@@ -222,7 +222,7 @@ function canReceivePermissionAsk(plugin: LoadedPlugin, input: unknown): boolean 
   if (scope === "none") return false
   if (scope === "all") return true
   const toolId = (input as any)?.tool as string | undefined
-  if (!toolId || !PluginToolId.is(toolId)) return true
+  if (!toolId || !PluginToolId.is(toolId)) return false
   return PluginToolId.parse(toolId)?.pluginId === plugin.id
 }
 

--- a/packages/synergy/src/runtime/reload.ts
+++ b/packages/synergy/src/runtime/reload.ts
@@ -267,6 +267,8 @@ export namespace RuntimeReload {
           const { TimeoutConfig } = await import("@/util/timeout-config")
           TimeoutConfig.invalidate()
         }
+        const { Plugin } = await import("../plugin")
+        await Plugin.notifyConfigHooks({ source: "reload", config: result.config, changedFields: result.changedFields })
         return
       }
       case "provider": {
@@ -282,7 +284,7 @@ export namespace RuntimeReload {
       case "plugin": {
         const { Plugin } = await import("../plugin")
         await Plugin.reload()
-        await Plugin.init()
+        await Plugin.init({ source: "plugin_reload" })
         return
       }
       case "mcp": {

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -651,7 +651,7 @@ export namespace SessionInvoke {
         const promptPlan = await PromptBudgeter.buildPlan({
           sessionID,
           agent: agent.name,
-          messageID: lastUser.id,
+          messageID: R.id,
           model,
           system: systemParts,
           systemCacheBreakpoint,

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -649,6 +649,9 @@ export namespace SessionInvoke {
 
         const promptPlanTimer = log.time("promptBudgeter.buildPlan")
         const promptPlan = await PromptBudgeter.buildPlan({
+          sessionID,
+          agent: agent.name,
+          messageID: lastUser.id,
           model,
           system: systemParts,
           systemCacheBreakpoint,

--- a/packages/synergy/src/session/llm.ts
+++ b/packages/synergy/src/session/llm.ts
@@ -154,7 +154,18 @@ export namespace LLM {
     if (input.user.system) system.push(input.user.system)
 
     const original = clone(system)
-    await Plugin.trigger("experimental.chat.system.transform", {}, { system })
+    await Plugin.trigger(
+      "experimental.chat.system.transform",
+      {
+        phase: "final",
+        sessionID: input.sessionID,
+        agent: input.agent.name,
+        model: { providerID: input.model.providerID, modelID: input.model.id },
+        messageID: input.user.id,
+        small: input.small,
+      },
+      { system },
+    )
     if (system.length === 0) {
       system.push(...original)
     }

--- a/packages/synergy/src/session/prompt-budgeter.ts
+++ b/packages/synergy/src/session/prompt-budgeter.ts
@@ -12,6 +12,9 @@ export namespace PromptBudgeter {
   const MESSAGE_OVERHEAD_PER_ITEM = 12
 
   export interface PromptPlanInput {
+    sessionID: string
+    agent: string
+    messageID?: string
     model: Provider.Model
     system: string[]
     systemCacheBreakpoint?: number
@@ -65,7 +68,17 @@ export namespace PromptBudgeter {
   export async function buildPlan(input: PromptPlanInput): Promise<PromptPlan> {
     const system = [...input.system]
     const original = [...system]
-    await Plugin.trigger("experimental.chat.system.transform", {}, { system })
+    await Plugin.trigger(
+      "experimental.chat.system.transform",
+      {
+        phase: "budget",
+        sessionID: input.sessionID,
+        agent: input.agent,
+        model: { providerID: input.model.providerID, modelID: input.model.id },
+        messageID: input.messageID,
+      },
+      { system },
+    )
     const normalizedSystem = system.length > 0 ? system : original
 
     return {

--- a/packages/synergy/test/plugin/capability-consistency.test.ts
+++ b/packages/synergy/test/plugin/capability-consistency.test.ts
@@ -61,6 +61,23 @@ describe("plugin capability consistency", () => {
     expect(baseCapabilities(manifest)).toContain("config:read")
   })
 
+  test("grants config hook capability separately from config data access", () => {
+    const manifest = PluginManifest.parse({
+      name: "config-hook-plugin",
+      version: "1.0.0",
+      description: "Plugin that observes config snapshots",
+      permissions: {
+        hooks: {
+          config: true,
+        },
+      },
+    })
+
+    expect(baseCapabilities(manifest)).toContain("config_hook")
+    expect(baseCapabilities(manifest)).not.toContain("config:read")
+    expect(sharedBaseCapabilities(manifest)).toEqual(baseCapabilities(manifest))
+  })
+
   test("runtime and plugin-kit agree on delegated task permissions", () => {
     const manifest = PluginManifest.parse({
       name: "task-plugin",

--- a/packages/synergy/test/plugin/consent.test.ts
+++ b/packages/synergy/test/plugin/consent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { diffPermissions } from "../../src/plugin/consent/diff"
 import { computeRisk } from "@ericsanchezok/synergy-plugin/permissions"
 import { generatePermissionItems } from "../../src/plugin/consent/summary"
-import type { PluginManifest } from "@ericsanchezok/synergy-plugin"
+import { PluginManifest as PluginManifestSchema, type PluginManifest } from "@ericsanchezok/synergy-plugin"
 
 function makeManifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
   const base: PluginManifest = {
@@ -166,6 +166,22 @@ describe("consent module", () => {
       const items = generatePermissionItems(manifest, ["task"])
       expect(items[0].key).toBe("task")
       expect(items[0].severity).toBe("medium")
+    })
+
+    test("config hook is a medium hook permission item", () => {
+      const manifest = PluginManifestSchema.parse({
+        name: "test-plugin",
+        version: "1.0.0",
+        description: "A test plugin",
+        permissions: {
+          hooks: {
+            config: true,
+          },
+        },
+      })
+      const items = generatePermissionItems(manifest, ["config_hook"])
+      expect(items.some((item) => item.key === "config_hook" && item.category === "hooks")).toBe(true)
+      expect(items.some((item) => item.key === "hooks.config" && item.severity === "medium")).toBe(true)
     })
   })
 })

--- a/packages/synergy/test/plugin/hook-config.test.ts
+++ b/packages/synergy/test/plugin/hook-config.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Config } from "../../src/config/config"
+import { Plugin } from "../../src/plugin"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
+
+const originalGlobal = Config.global
+
+const secretConfig = {
+  provider: {
+    openai: {
+      options: { apiKey: "provider-secret" },
+      models: { "gpt-secret": { options: { apiKey: "model-secret" } } },
+    },
+  },
+  email: {
+    smtp: { host: "smtp.example.com", port: 465, secure: true, username: "u", password: "smtp-secret" },
+    imap: { host: "imap.example.com", port: 993, secure: true, username: "u", password: "imap-secret" },
+  },
+  channel: { feishu: { type: "feishu", accounts: { main: { appId: "app", appSecret: "feishu-secret" } } } },
+  embedding: { apiKey: "embedding-secret" },
+  rerank: { apiKey: "rerank-secret" },
+  mcp: { demo: { type: "remote", url: "https://example.com/mcp", oauth: { clientSecret: "mcp-secret" } } },
+}
+
+afterEach(() => {
+  ;(Config as any).global = originalGlobal
+})
+
+async function writeConfigPlugin(
+  root: string,
+  input: {
+    id: string
+    configPermission?: boolean
+    hookBody?: string
+  },
+) {
+  const dir = path.join(root, input.id)
+  await fs.mkdir(path.join(dir, "src"), { recursive: true })
+  await Bun.write(
+    path.join(dir, "plugin.json"),
+    JSON.stringify(
+      {
+        name: input.id,
+        version: "0.1.0",
+        main: "./src/index.ts",
+        description: "Config hook test plugin",
+        runtime: { mode: "in-process" },
+        permissions: { hooks: { config: input.configPermission } },
+      },
+      null,
+      2,
+    ),
+  )
+  await Bun.write(
+    path.join(dir, "src", "index.ts"),
+    `export default {
+  id: ${JSON.stringify(input.id)},
+  async init() {
+    return {
+      config: async (input, output) => {
+        ${input.hookBody ?? "globalThis.__synergyConfigCalls.push({ input, config: output.config })"}
+      }
+    }
+  }
+}
+`,
+  )
+  return dir
+}
+
+describe("plugin config hooks", () => {
+  test("requires explicit config hook permission", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyConfigCalls = []
+    const denied = await writeConfigPlugin(tmp.path, { id: "config-denied-plugin" })
+    const allowed = await writeConfigPlugin(tmp.path, { id: "config-allowed-plugin", configPermission: true })
+    ;(Config as any).global = mock(async () => ({
+      ...secretConfig,
+      plugin: [pathToFileURL(denied).href, pathToFileURL(allowed).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.init({ source: "plugin_reload" })
+        expect((globalThis as any).__synergyConfigCalls).toHaveLength(1)
+        expect((globalThis as any).__synergyConfigCalls[0].input.source).toBe("plugin_reload")
+      },
+    })
+  })
+
+  test("passes changed fields and redacted config on reload notification", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyConfigCalls = []
+    const dir = await writeConfigPlugin(tmp.path, { id: "config-redaction-plugin", configPermission: true })
+    ;(Config as any).global = mock(async () => ({
+      ...secretConfig,
+      plugin: [pathToFileURL(dir).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.getLoaded()
+        await Plugin.notifyConfigHooks({ source: "reload", changedFields: ["provider.openai.options.apiKey"] })
+        const call = (globalThis as any).__synergyConfigCalls[0]
+        expect(call.input.source).toBe("reload")
+        expect(call.input.changedFields).toEqual(["provider.openai.options.apiKey"])
+        expect(call.input.scopeID).toBeTruthy()
+        expect(call.input.timestamp).toBeGreaterThan(0)
+        expect(call.config.provider.openai.options.apiKey).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.provider.openai.models["gpt-secret"].options.apiKey).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.email.smtp.password).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.email.imap.password).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.channel.feishu.accounts.main.appSecret).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.embedding.apiKey).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.rerank.apiKey).toBe(Config.REDACTED_SENTINEL)
+        expect(call.config.mcp.demo.oauth.clientSecret).toBe(Config.REDACTED_SENTINEL)
+      },
+    })
+  })
+
+  test("config hook snapshots are isolated per plugin", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyConfigCalls = []
+    const mutating = await writeConfigPlugin(tmp.path, {
+      id: "mutating-config-plugin",
+      configPermission: true,
+      hookBody: `
+        try { output.config.model = "mutated" } catch {}
+        try { output.config.provider.openai.options.apiKey = "mutated-secret" } catch {}
+        globalThis.__synergyConfigCalls.push(output.config.model)
+      `,
+    })
+    const observing = await writeConfigPlugin(tmp.path, {
+      id: "observing-config-plugin",
+      configPermission: true,
+      hookBody: `globalThis.__synergyConfigCalls.push({ model: output.config.model, apiKey: output.config.provider.openai.options.apiKey })`,
+    })
+    ;(Config as any).global = mock(async () => ({
+      ...secretConfig,
+      model: "openai/gpt-4.1",
+      plugin: [pathToFileURL(mutating).href, pathToFileURL(observing).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.notifyConfigHooks({ source: "startup" })
+        expect((globalThis as any).__synergyConfigCalls).toEqual([
+          "openai/gpt-4.1",
+          { model: "openai/gpt-4.1", apiKey: Config.REDACTED_SENTINEL },
+        ])
+      },
+    })
+  })
+
+  test("throwing config hook disables only that plugin", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyConfigCalls = []
+    const bad = await writeConfigPlugin(tmp.path, {
+      id: "bad-config-plugin",
+      configPermission: true,
+      hookBody: `globalThis.__synergyConfigCalls.push("bad"); throw new Error("config failed")`,
+    })
+    const good = await writeConfigPlugin(tmp.path, {
+      id: "good-config-plugin",
+      configPermission: true,
+      hookBody: `globalThis.__synergyConfigCalls.push("good")`,
+    })
+    ;(Config as any).global = mock(async () => ({
+      plugin: [pathToFileURL(bad).href, pathToFileURL(good).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.notifyConfigHooks({ source: "startup" })
+        expect((globalThis as any).__synergyConfigCalls).toEqual(["bad", "good"])
+        expect((await Plugin.getDisabledPlugin("bad-config-plugin"))?.phase).toBe("hook")
+      },
+    })
+  })
+})

--- a/packages/synergy/test/plugin/hook-events.test.ts
+++ b/packages/synergy/test/plugin/hook-events.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+import z from "zod"
+import { Bus } from "../../src/bus"
+import { BusEvent } from "../../src/bus/bus-event"
+import { Config } from "../../src/config/config"
+import { Plugin } from "../../src/plugin"
+import { RuntimeReload } from "../../src/runtime/reload"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
+
+const originalGlobal = Config.global
+
+const TestEvent = BusEvent.define("plugin.test.event", z.object({ value: z.string() }))
+const SessionEvent = BusEvent.define("session.test.event", z.object({ value: z.string() }))
+const OtherEvent = BusEvent.define("other.test.event", z.object({ value: z.string() }))
+
+afterEach(() => {
+  ;(Config as any).global = originalGlobal
+})
+
+async function writeEventPlugin(
+  root: string,
+  input: {
+    id: string
+    events?: "none" | "selected" | "all"
+    eventNames?: string[]
+    hookBody?: string
+  },
+) {
+  const dir = path.join(root, input.id)
+  await fs.mkdir(path.join(dir, "src"), { recursive: true })
+  await Bun.write(
+    path.join(dir, "plugin.json"),
+    JSON.stringify(
+      {
+        name: input.id,
+        version: "0.1.0",
+        main: "./src/index.ts",
+        description: "Event hook test plugin",
+        runtime: { mode: "in-process" },
+        permissions: { hooks: { events: input.events, eventNames: input.eventNames } },
+      },
+      null,
+      2,
+    ),
+  )
+  await Bun.write(
+    path.join(dir, "src", "index.ts"),
+    `export default {
+  id: ${JSON.stringify(input.id)},
+  async init() {
+    return {
+      event: async (input) => {
+        ${input.hookBody ?? "globalThis.__synergyEventCalls.push(input.event.type)"}
+      }
+    }
+  }
+}
+`,
+  )
+  return dir
+}
+
+async function providePlugins(root: string, dirs: string[], fn: () => Promise<void>) {
+  ;(Config as any).global = mock(async () => ({
+    plugin: dirs.map((dir) => pathToFileURL(dir).href),
+    pluginMarketplace: { enabled: false },
+    pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+  }))
+
+  await ScopeContext.provide({
+    scope: await (await tmpdir({ git: true, init: async () => root })).scope(),
+    fn,
+  })
+}
+
+describe("plugin event hooks", () => {
+  test("default selected mode with empty eventNames receives nothing", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyEventCalls = []
+    const dir = await writeEventPlugin(tmp.path, { id: "default-event-plugin" })
+    ;(Config as any).global = mock(async () => ({
+      plugin: [pathToFileURL(dir).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.init()
+        await Bus.publish(TestEvent, { value: "a" })
+        expect((globalThis as any).__synergyEventCalls).toEqual([])
+      },
+    })
+  })
+
+  test("selected event names support exact, prefix wildcard, and all modes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyEventCalls = []
+    const exact = await writeEventPlugin(tmp.path, {
+      id: "exact-event-plugin",
+      events: "selected",
+      eventNames: ["plugin.test.event"],
+      hookBody: `globalThis.__synergyEventCalls.push(["exact", input.event.type])`,
+    })
+    const prefix = await writeEventPlugin(tmp.path, {
+      id: "prefix-event-plugin",
+      events: "selected",
+      eventNames: ["session.*"],
+      hookBody: `globalThis.__synergyEventCalls.push(["prefix", input.event.type])`,
+    })
+    const all = await writeEventPlugin(tmp.path, {
+      id: "all-event-plugin",
+      events: "all",
+      hookBody: `globalThis.__synergyEventCalls.push(["all", input.event.type])`,
+    })
+    ;(Config as any).global = mock(async () => ({
+      plugin: [pathToFileURL(exact).href, pathToFileURL(prefix).href, pathToFileURL(all).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.init()
+        await Bus.publish(TestEvent, { value: "a" })
+        await Bus.publish(SessionEvent, { value: "b" })
+        await Bus.publish(OtherEvent, { value: "c" })
+        expect((globalThis as any).__synergyEventCalls).toEqual([
+          ["exact", "plugin.test.event"],
+          ["all", "plugin.test.event"],
+          ["prefix", "session.test.event"],
+          ["all", "session.test.event"],
+          ["all", "other.test.event"],
+        ])
+      },
+    })
+  })
+
+  test("plugin reload does not duplicate event subscriptions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyEventCalls = []
+    const dir = await writeEventPlugin(tmp.path, {
+      id: "reload-event-plugin",
+      events: "all",
+    })
+    ;(Config as any).global = mock(async () => ({
+      plugin: [pathToFileURL(dir).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.init()
+        await RuntimeReload.reload({ targets: ["plugin"], reason: "event-reload-test" })
+        await Bus.publish(TestEvent, { value: "a" })
+        expect((globalThis as any).__synergyEventCalls).toEqual(["plugin.test.event"])
+      },
+    })
+  })
+
+  test("throwing event hook disables only that plugin", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ;(globalThis as any).__synergyEventCalls = []
+    const bad = await writeEventPlugin(tmp.path, {
+      id: "bad-event-plugin",
+      events: "all",
+      hookBody: `globalThis.__synergyEventCalls.push("bad"); throw new Error("event failed")`,
+    })
+    const good = await writeEventPlugin(tmp.path, {
+      id: "good-event-plugin",
+      events: "all",
+      hookBody: `globalThis.__synergyEventCalls.push("good")`,
+    })
+    ;(Config as any).global = mock(async () => ({
+      plugin: [pathToFileURL(bad).href, pathToFileURL(good).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await Plugin.init()
+        await Bus.publish(TestEvent, { value: "a" })
+        await Bus.publish(TestEvent, { value: "b" })
+        expect((globalThis as any).__synergyEventCalls).toEqual(["bad", "good", "good"])
+        expect((await Plugin.getDisabledPlugin("bad-event-plugin"))?.phase).toBe("hook")
+      },
+    })
+  })
+})

--- a/packages/synergy/test/plugin/manifest.test.ts
+++ b/packages/synergy/test/plugin/manifest.test.ts
@@ -185,6 +185,47 @@ describe("PluginManifest schema", () => {
     expect(result.success).toBe(false)
   })
 
+  test("config hook permission parses and defaults to false", () => {
+    const result = PluginManifest.safeParse({
+      name: "config-hook-plugin",
+      version: "1.0.0",
+      description: "Observes config hook snapshots",
+      permissions: {
+        hooks: {
+          config: true,
+        },
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.permissions?.hooks?.config).toBe(true)
+    }
+
+    const minimal = PluginManifest.parse({
+      name: "minimal-plugin",
+      version: "1.0.0",
+      description: "No hook permission",
+      permissions: {
+        hooks: {},
+      },
+    })
+    expect(minimal.permissions?.hooks?.config).toBe(false)
+  })
+
+  test("unknown hook permission fields are rejected", () => {
+    const result = PluginManifest.safeParse({
+      name: "future-hook-plugin",
+      version: "1.0.0",
+      description: "Uses an unknown hook permission",
+      permissions: {
+        hooks: {
+          futureHook: true,
+        },
+      },
+    })
+    expect(result.success).toBe(false)
+  })
+
   test("plugin-specific invoke permission is rejected", () => {
     const result = PluginManifest.safeParse({
       name: "invoke-permission-plugin",

--- a/packages/synergy/test/runtime/reload.test.ts
+++ b/packages/synergy/test/runtime/reload.test.ts
@@ -7,11 +7,14 @@ import { RuntimeReload } from "../../src/runtime/reload"
 import { Config } from "../../src/config/config"
 import { ConfigDomain } from "../../src/config/domain"
 import { GlobalBus } from "../../src/bus/global"
+import { Plugin } from "../../src/plugin"
 
 const originalConfigReload = Config.reload
+const originalNotifyConfigHooks = Plugin.notifyConfigHooks
 
 afterEach(() => {
   Config.reload = originalConfigReload
+  ;(Plugin as any).notifyConfigHooks = originalNotifyConfigHooks
   GlobalBus.removeAllListeners("event")
 })
 
@@ -208,6 +211,27 @@ describe("runtime.reload", () => {
         const reloadedEvent = events.find((e) => e.payload?.type === RuntimeReload.Event.Reloaded.type)
         expect(reloadedEvent).toBeDefined()
         expect(reloadedEvent!.payload.properties.executed).toContain("config")
+      },
+    })
+  })
+
+  test("config reload notifies plugin config hooks with changed fields", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const config = { model: "openai/gpt-4.1" } as Config.Info
+        Config.reload = mock(async () => ({
+          config,
+          changedFields: ["toast"],
+          oldConfig: {},
+        })) as typeof Config.reload
+        const notify = mock(async () => {})
+        ;(Plugin as any).notifyConfigHooks = notify
+
+        await RuntimeReload.reload({ targets: ["config"], scope: "global", reason: "hook-notify" })
+
+        expect(notify).toHaveBeenCalledWith({ source: "reload", config, changedFields: ["toast"] })
       },
     })
   })

--- a/packages/synergy/test/session/plugin-system-transform.test.ts
+++ b/packages/synergy/test/session/plugin-system-transform.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Config } from "../../src/config/config"
+import { LLM } from "../../src/session/llm"
+import { Plugin } from "../../src/plugin"
+import { PromptBudgeter } from "../../src/session/prompt-budgeter"
+import { Provider } from "../../src/provider/provider"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
+import type { Agent } from "../../src/agent/agent"
+
+const originalGlobal = Config.global
+const originalTrigger = Plugin.trigger
+const originalGetLanguage = Provider.getLanguage
+
+function createModel(): Provider.Model {
+  return {
+    id: "test-model",
+    providerID: "test-provider",
+    name: "Test Model",
+    limit: { context: 100_000, output: 8_000 },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      interleaved: false,
+      input: { text: true, image: false, audio: false, video: false, pdf: false },
+      output: { text: true, image: false, audio: false, video: false, pdf: false },
+    },
+    api: { npm: "@ai-sdk/openai", id: "gpt-test", url: "https://example.com" },
+    options: {},
+  } as Provider.Model
+}
+
+afterEach(() => {
+  ;(Config as any).global = originalGlobal
+  ;(Plugin as any).trigger = originalTrigger
+  ;(Provider as any).getLanguage = originalGetLanguage
+})
+
+async function writeSystemTransformPlugin(
+  root: string,
+  input: {
+    id: string
+    promptTransform?: boolean
+    hookBody: string
+  },
+) {
+  const dir = path.join(root, input.id)
+  await fs.mkdir(path.join(dir, "src"), { recursive: true })
+  await Bun.write(
+    path.join(dir, "plugin.json"),
+    JSON.stringify(
+      {
+        name: input.id,
+        version: "0.1.0",
+        main: "./src/index.ts",
+        description: "System transform test plugin",
+        runtime: { mode: "in-process" },
+        permissions: { hooks: { promptTransform: input.promptTransform } },
+      },
+      null,
+      2,
+    ),
+  )
+  await Bun.write(
+    path.join(dir, "src", "index.ts"),
+    `export default {
+  id: ${JSON.stringify(input.id)},
+  async init() {
+    return {
+      "experimental.chat.system.transform": async (input, output) => {
+        ${input.hookBody}
+      }
+    }
+  }
+}
+`,
+  )
+  return dir
+}
+
+describe("plugin system transform hooks", () => {
+  test("requires promptTransform permission", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const denied = await writeSystemTransformPlugin(tmp.path, {
+      id: "system-transform-denied",
+      hookBody: `output.system.push("denied")`,
+    })
+    const allowed = await writeSystemTransformPlugin(tmp.path, {
+      id: "system-transform-allowed",
+      promptTransform: true,
+      hookBody: `output.system.push("allowed")`,
+    })
+    ;(Config as any).global = mock(async () => ({
+      plugin: [pathToFileURL(denied).href, pathToFileURL(allowed).href],
+      pluginMarketplace: { enabled: false },
+      pluginRuntimePolicy: { allowLocalInProcess: true, highRiskRequiresProcess: false },
+    }))
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const output = { system: ["base"] }
+        await Plugin.trigger(
+          "experimental.chat.system.transform",
+          {
+            phase: "final",
+            sessionID: "session-1",
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            messageID: "message-1",
+          },
+          output,
+        )
+        expect(output.system).toEqual(["base", "allowed"])
+      },
+    })
+  })
+
+  test("budget phase receives context and restores emptied system prompt", async () => {
+    const calls: unknown[] = []
+    ;(Plugin as any).trigger = mock(async (_name: string, input: unknown, output: { system: string[] }) => {
+      calls.push(input)
+      output.system.length = 0
+      return output
+    })
+
+    const plan = await PromptBudgeter.buildPlan({
+      sessionID: "session-1",
+      agent: "synergy-max",
+      messageID: "message-1",
+      model: createModel(),
+      system: ["base system"],
+      messages: [{ role: "user", content: "hello" }],
+      toolDefinitions: [],
+    })
+
+    expect(calls).toEqual([
+      {
+        phase: "budget",
+        sessionID: "session-1",
+        agent: "synergy-max",
+        model: { providerID: "test-provider", modelID: "test-model" },
+        messageID: "message-1",
+      },
+    ])
+    expect(plan.system).toEqual(["base system"])
+  })
+
+  test("final phase receives context so plugins can avoid duplicate injection", async () => {
+    const finalContext: unknown[] = []
+    const stop = new Error("stop after final transform")
+    ;(Provider as any).getLanguage = mock(async () => ({}) as any)
+    ;(Config as any).global = mock(async () => ({ role_variant: {}, provider: {} }))
+    ;(Plugin as any).trigger = mock(async (name: string, input: unknown, output: { system?: string[] }) => {
+      if (name === "experimental.chat.system.transform") {
+        finalContext.push(input)
+        output.system?.push("final-only")
+        throw stop
+      }
+      return output
+    })
+
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await expect(
+          LLM.stream({
+            user: {
+              id: "message-2",
+              role: "user",
+              time: { created: Date.now() },
+              parts: [{ type: "text", text: "hi" }],
+            } as any,
+            sessionID: "session-2",
+            model: createModel(),
+            agent: { name: "synergy", prompt: "agent prompt", options: {} } as Agent.Info,
+            system: ["runtime system"],
+            abort: new AbortController().signal,
+            messages: [{ role: "user", content: "hello" }],
+            small: true,
+            tools: {},
+          }),
+        ).rejects.toBe(stop)
+      },
+    })
+
+    expect(finalContext).toEqual([
+      {
+        phase: "final",
+        sessionID: "session-2",
+        agent: "synergy",
+        model: { providerID: "test-provider", modelID: "test-model" },
+        messageID: "message-2",
+        small: true,
+      },
+    ])
+  })
+})

--- a/packages/util/src/capability.ts
+++ b/packages/util/src/capability.ts
@@ -84,6 +84,7 @@ export interface SynergyCapabilityManifest {
       permissionAsk?: "none" | "own" | "all"
       events?: "none" | "selected" | "all"
       eventNames?: string[]
+      config?: boolean
     }
     network?: { connectDomains?: string[] }
   }
@@ -286,6 +287,12 @@ export const SYNERGY_CAPABILITY_DETAILS: Record<string, SynergyCapabilityDefinit
     title: "Subscribe to Synergy events",
     description: "Can receive approved Synergy runtime events.",
   },
+  config_hook: {
+    category: "hooks",
+    severity: "medium",
+    title: "Observe runtime config",
+    description: "Can receive redacted runtime configuration snapshots when Synergy starts or reloads config.",
+  },
   session_state: {
     category: "session",
     severity: "low",
@@ -398,6 +405,7 @@ export const SYNERGY_PROFILE_CAPABILITIES = [
   "tool_execution_hook",
   "permission_hook",
   "event_hook",
+  "config_hook",
   "identity_act",
   "communication_email",
   "channel_outbound",
@@ -561,6 +569,7 @@ function buildCapabilitySet(
   const hooks = permissions?.hooks
   if (hooks?.promptTransform) caps.add("prompt_transform")
   if (hooks?.compactionTransform) caps.add("compaction_transform")
+  if (hooks?.config) caps.add("config_hook")
   if (hooks?.toolExecute && hooks.toolExecute !== "none") caps.add("tool_execution_hook")
   if (hooks?.permissionAsk && hooks.permissionAsk !== "none") caps.add("permission_hook")
   if (hooks?.events === "all" || (hooks?.events === "selected" && (hooks.eventNames?.length ?? 0) > 0)) {
@@ -782,6 +791,15 @@ function hookPermissionItems(manifest: SynergyCapabilityManifest): SynergyCapabi
       severity: "high",
       title: "Transform prompts",
       description: "Can modify the system prompt and message context sent to the LLM.",
+    })
+  }
+  if (hooks?.config) {
+    items.push({
+      key: "hooks.config",
+      category: "hooks",
+      severity: "medium",
+      title: "Observe runtime config",
+      description: "Can observe redacted runtime configuration snapshots when Synergy starts or reloads config.",
     })
   }
   if (hooks?.toolExecute === "all") {


### PR DESCRIPTION
## Summary
- Align plugin hook SDK contracts with runtime behavior for event, config, and system prompt transform hooks.
- Add explicit `permissions.hooks.config`, `config_hook` capability/consent output, redacted config hook dispatch, reload notifications, and event wildcard matching.
- Add phase/session context for system prompt transforms plus focused runtime, manifest, capability, consent, and docs coverage.

## Verification
- `./script/format.ts`
- `bun run typecheck`
- `bun run --cwd packages/plugin build`
- `cd packages/synergy && bun test test/plugin/manifest.test.ts test/plugin/capability-consistency.test.ts test/plugin/consent.test.ts test/plugin/lifecycle-isolation.test.ts test/bus/bus-event.test.ts test/plugin/hook-events.test.ts test/plugin/hook-config.test.ts test/session/plugin-system-transform.test.ts test/runtime/reload.test.ts`

## Release note
- Next package release must include `@ericsanchezok/synergy-plugin` so standalone plugin authors receive the updated hook types and manifest schema.