### PR TITLE
fix(session): allow repeat auto-compaction after fulfilled compaction

### DIFF
--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -36,15 +36,46 @@ export namespace SessionCompaction {
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 
+  /**
+   * Check whether a compaction request for the given parent user message has
+   * already been fulfilled — i.e., there exists a completed summary assistant
+   * message targeting that parent. Used by both the proactive budget trigger
+   * and the compact signal to distinguish "compaction already pending" from
+   * "compaction already completed and should not block another."
+   */
+  export function hasFulfilledCompaction(messages: MessageV2.WithParts[], parentID: string): boolean {
+    return messages.some((m) => {
+      if (m.info.role !== "assistant") return false
+      const a = m.info as MessageV2.Assistant
+      return a.summary === true && !!a.finish && a.parentID === parentID
+    })
+  }
+
   /** Detect whether a processor error was caused by exceeding the model's context window. */
   export function isContextExceeded(error: unknown): boolean {
     if (!error || typeof error !== "object") return false
     const obj = error as { name?: string; data?: { message?: string; statusCode?: number; responseBody?: string } }
-    if (obj.name !== "APIError") return false
-    // Check the primary error message and the raw response body, since
-    // ProviderTransform.error() may rewrite the message and drop keywords.
-    const texts = [obj.data?.message ?? "", obj.data?.responseBody ?? ""].map((s) => s.toLowerCase())
-    return texts.some(
+
+    const texts: string[] = [obj.data?.message ?? "", obj.data?.responseBody ?? ""]
+
+    // Provider streaming errors (e.g. SSE error events from OpenAI Codex) may
+    // arrive as a plain Error instead of APICallError, and fromError() stores
+    // them as NamedError.Unknown with the JSON-stringified error payload in
+    // the message field. Try to extract nested keywords so emergency compaction
+    // can still recognize them.
+    if (typeof obj.data?.message === "string") {
+      try {
+        const nested = JSON.parse(obj.data.message)
+        for (const key of ["code", "type", "message"]) {
+          if (typeof nested?.error?.[key] === "string") texts.push(nested.error[key])
+        }
+        if (typeof nested?.error === "string") texts.push(nested.error)
+      } catch {}
+    }
+
+    const lower = texts.filter(Boolean).map((s) => s.toLowerCase())
+    if (lower.length === 0) return false
+    return lower.some(
       (msg) =>
         msg.includes("context_length_exceeded") ||
         msg.includes("context length") ||

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -36,19 +36,42 @@ export namespace SessionCompaction {
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 
-  /**
-   * Check whether a compaction request for the given parent user message has
-   * already been fulfilled — i.e., there exists a completed summary assistant
-   * message targeting that parent. Used by both the proactive budget trigger
-   * and the compact signal to distinguish "compaction already pending" from
-   * "compaction already completed and should not block another."
-   */
-  export function hasFulfilledCompaction(messages: MessageV2.WithParts[], parentID: string): boolean {
-    return messages.some((m) => {
-      if (m.info.role !== "assistant") return false
-      const a = m.info as MessageV2.Assistant
-      return a.summary === true && !!a.finish && a.parentID === parentID
-    })
+  function completedSummaries(messages: MessageV2.WithParts[], parentID: string): MessageV2.Assistant[] {
+    return messages
+      .map((m) => m.info)
+      .filter(
+        (info): info is MessageV2.Assistant =>
+          info.role === "assistant" && info.summary === true && !!info.finish && info.parentID === parentID,
+      )
+  }
+
+  function summaryRequestID(summary: MessageV2.Assistant): string | undefined {
+    const value = summary.metadata?.compactionRequestPartID
+    return typeof value === "string" ? value : undefined
+  }
+
+  export function pendingCompactionRequest(
+    messages: MessageV2.WithParts[],
+    parentID: string,
+    parts: MessageV2.Part[],
+  ): MessageV2.CompactionPart | undefined {
+    const requests = parts.filter((part): part is MessageV2.CompactionPart => part.type === "compaction")
+    if (requests.length === 0) return undefined
+
+    const requestIDs = new Set(requests.map((part) => part.id))
+    const fulfilled = new Set<string>()
+    for (const summary of completedSummaries(messages, parentID)) {
+      const requestID = summaryRequestID(summary)
+      if (requestID) {
+        if (requestIDs.has(requestID)) fulfilled.add(requestID)
+        continue
+      }
+
+      const legacyRequest = requests.find((part) => !fulfilled.has(part.id))
+      if (legacyRequest) fulfilled.add(legacyRequest.id)
+    }
+
+    return requests.findLast((part) => !fulfilled.has(part.id))
   }
 
   /** Detect whether a processor error was caused by exceeding the model's context window. */
@@ -355,6 +378,7 @@ export namespace SessionCompaction {
 
   export async function process(input: {
     parentID: string
+    requestPartID: string
     messages: MessageV2.WithParts[]
     sessionID: string
     abort: AbortSignal
@@ -396,6 +420,9 @@ export namespace SessionCompaction {
       providerID: model.providerID,
       time: {
         created: Date.now(),
+      },
+      metadata: {
+        compactionRequestPartID: input.requestPartID,
       },
     })) as MessageV2.Assistant
     const processor = SessionProcessor.create({
@@ -549,10 +576,12 @@ export namespace SessionCompaction {
       return []
     },
     async execute(ctx) {
-      const part = ctx.lastUserParts.find((p): p is MessageV2.CompactionPart => p.type === "compaction")!
+      const part = pendingCompactionRequest(ctx.messages, ctx.lastUser.id, ctx.lastUserParts)
+      if (!part) return "pass"
       const result = await process({
         messages: ctx.messages,
         parentID: ctx.lastUser.id,
+        requestPartID: part.id,
         abort: ctx.abort,
         sessionID: ctx.sessionID,
         auto: part.auto,

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -22,6 +22,10 @@ import type { ModelMessage } from "ai"
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
 
+  export interface CompactionCompletion {
+    requestPartID?: string
+  }
+
   export const Event = {
     Compacted: BusEvent.define(
       "session.compacted",
@@ -36,13 +40,20 @@ export namespace SessionCompaction {
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 
-  function completedSummaries(messages: MessageV2.WithParts[], parentID: string): MessageV2.Assistant[] {
+  export function completedCompactionHistory(
+    messages: MessageV2.WithParts[],
+    parentID: string,
+  ): CompactionCompletion[] {
     return messages
       .map((m) => m.info)
       .filter(
         (info): info is MessageV2.Assistant =>
           info.role === "assistant" && info.summary === true && !!info.finish && info.parentID === parentID,
       )
+      .map((summary) => {
+        const requestPartID = summaryRequestID(summary)
+        return requestPartID ? { requestPartID } : {}
+      })
   }
 
   function summaryRequestID(summary: MessageV2.Assistant): string | undefined {
@@ -55,13 +66,20 @@ export namespace SessionCompaction {
     parentID: string,
     parts: MessageV2.Part[],
   ): MessageV2.CompactionPart | undefined {
+    return pendingCompactionRequestFromHistory(completedCompactionHistory(messages, parentID), parts)
+  }
+
+  export function pendingCompactionRequestFromHistory(
+    history: CompactionCompletion[],
+    parts: MessageV2.Part[],
+  ): MessageV2.CompactionPart | undefined {
     const requests = parts.filter((part): part is MessageV2.CompactionPart => part.type === "compaction")
     if (requests.length === 0) return undefined
 
     const requestIDs = new Set(requests.map((part) => part.id))
     const fulfilled = new Set<string>()
-    for (const summary of completedSummaries(messages, parentID)) {
-      const requestID = summaryRequestID(summary)
+    for (const completion of history) {
+      const requestID = completion.requestPartID
       if (requestID) {
         if (requestIDs.has(requestID)) fulfilled.add(requestID)
         continue
@@ -576,7 +594,8 @@ export namespace SessionCompaction {
       return []
     },
     async execute(ctx) {
-      const part = pendingCompactionRequest(ctx.messages, ctx.lastUser.id, ctx.lastUserParts)
+      const history = ctx.compactionHistory ?? completedCompactionHistory(ctx.messages, ctx.lastUser.id)
+      const part = pendingCompactionRequestFromHistory(history, ctx.lastUserParts)
       if (!part) return "pass"
       const result = await process({
         messages: ctx.messages,

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -895,19 +895,8 @@ export namespace SessionInvoke {
     }
   }
 
-  /**
-   * Returns true when a compaction part is present on the root user message BUT
-   * the compaction has already been fulfilled (completed summary exists). When
-   * fulfilled, the part acts as a boundary marker for filterCompacted() but
-   * should NOT block future proactive compaction requests.
-   *
-   * False means either no compaction part is present, or the part is still
-   * pending (unfulfilled) — in both cases the proactive trigger can proceed.
-   */
   function compactionPending(jobCtx: LoopJob.Context): boolean {
-    const hasCompactionPart = jobCtx.lastUserParts.some((part) => part.type === "compaction")
-    if (!hasCompactionPart) return false
-    return !SessionCompaction.hasFulfilledCompaction(jobCtx.messages, jobCtx.lastUser.id)
+    return !!SessionCompaction.pendingCompactionRequest(jobCtx.messages, jobCtx.lastUser.id, jobCtx.lastUserParts)
   }
 
   // --- Helpers ---

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -659,11 +659,7 @@ export namespace SessionInvoke {
         })
         promptDecideTimer.stop()
 
-        if (
-          !jobCtx.compactionAutoDisabled &&
-          !jobCtx.lastUserParts.some((part) => part.type === "compaction") &&
-          promptDecision.shouldCompact
-        ) {
+        if (!jobCtx.compactionAutoDisabled && !compactionPending(jobCtx) && promptDecision.shouldCompact) {
           log.info("prompt budget exceeded, injecting compaction", {
             sessionID,
             total: promptDecision.measure.total,
@@ -897,6 +893,21 @@ export namespace SessionInvoke {
       const msg = messages[index]
       if (msg.info.role === "assistant") return msg
     }
+  }
+
+  /**
+   * Returns true when a compaction part is present on the root user message BUT
+   * the compaction has already been fulfilled (completed summary exists). When
+   * fulfilled, the part acts as a boundary marker for filterCompacted() but
+   * should NOT block future proactive compaction requests.
+   *
+   * False means either no compaction part is present, or the part is still
+   * pending (unfulfilled) — in both cases the proactive trigger can proceed.
+   */
+  function compactionPending(jobCtx: LoopJob.Context): boolean {
+    const hasCompactionPart = jobCtx.lastUserParts.some((part) => part.type === "compaction")
+    if (!hasCompactionPart) return false
+    return !SessionCompaction.hasFulfilledCompaction(jobCtx.messages, jobCtx.lastUser.id)
   }
 
   // --- Helpers ---

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -202,7 +202,8 @@ export namespace SessionInvoke {
         if (abort.aborted) break
         session = await Session.get(sessionID)
         scopeID = (session.scope as Scope).id
-        let msgs = await effectiveCompactedMessages(sessionID)
+        const allMessages = await Session.messages({ sessionID })
+        let msgs = await effectiveCompactedMessages(allMessages)
 
         // Find R: the latest root user message. R is the anchor for the entire
         // loop: rootID, model, agent, system, and compaction anchor all derive
@@ -264,6 +265,7 @@ export namespace SessionInvoke {
           sessionID,
           step,
           messages: msgs,
+          compactionHistory: SessionCompaction.completedCompactionHistory(allMessages, R.id),
           lastUser: R,
           lastUserParts: RParts!,
           lastFinished,
@@ -896,7 +898,9 @@ export namespace SessionInvoke {
   }
 
   function compactionPending(jobCtx: LoopJob.Context): boolean {
-    return !!SessionCompaction.pendingCompactionRequest(jobCtx.messages, jobCtx.lastUser.id, jobCtx.lastUserParts)
+    const history =
+      jobCtx.compactionHistory ?? SessionCompaction.completedCompactionHistory(jobCtx.messages, jobCtx.lastUser.id)
+    return !!SessionCompaction.pendingCompactionRequestFromHistory(history, jobCtx.lastUserParts)
   }
 
   // --- Helpers ---
@@ -1535,7 +1539,8 @@ export namespace SessionInvoke {
       if (!session) continue
       if (session.agenda) continue
 
-      const messages = await effectiveCompactedMessages(sessionID)
+      const allMessages = await Session.messages({ sessionID })
+      const messages = await effectiveCompactedMessages(allMessages)
       const pendingReply = SessionProgress.pendingReply(messages)
 
       if (session.pendingReply !== pendingReply) {
@@ -1562,8 +1567,7 @@ export namespace SessionInvoke {
     }
   }
 
-  async function effectiveCompactedMessages(sessionID: string) {
-    const messages = await Session.messages({ sessionID })
+  async function effectiveCompactedMessages(messages: MessageV2.WithParts[]) {
     return MessageV2.filterCompacted(newestFirst(messages))
   }
 

--- a/packages/synergy/src/session/loop-job.ts
+++ b/packages/synergy/src/session/loop-job.ts
@@ -1,4 +1,5 @@
 import { MessageV2 } from "./message-v2"
+import type { SessionCompaction } from "./compaction"
 import type { Info } from "./types"
 import { Log } from "../util/log"
 
@@ -12,6 +13,7 @@ export namespace LoopJob {
     sessionID: string
     step: number
     messages: MessageV2.WithParts[]
+    compactionHistory?: SessionCompaction.CompactionCompletion[]
     lastUser: MessageV2.User
     lastUserParts: MessageV2.Part[]
     lastFinished?: MessageV2.Assistant

--- a/packages/synergy/src/session/loop-signals.ts
+++ b/packages/synergy/src/session/loop-signals.ts
@@ -3,6 +3,7 @@ import { LoopJob } from "./loop-job"
 import { Session } from "."
 import { Identifier } from "../id/id"
 import { MessageV2 } from "./message-v2"
+import { SessionCompaction } from "./compaction"
 import { Log } from "@/util/log"
 import { ScopeContext } from "../scope/context"
 const log = Log.create({ service: "session.loop-signals" })
@@ -29,12 +30,7 @@ LoopJob.defineSignal({
     // in the window after compaction runs. Fire only while the request is still
     // pending — i.e. no completed compaction summary for R exists yet — otherwise
     // the loop would re-compact endlessly instead of resuming the task.
-    const fulfilled = ctx.messages.some((m) => {
-      if (m.info.role !== "assistant") return false
-      const a = m.info as MessageV2.Assistant
-      return a.summary === true && !!a.finish && a.parentID === ctx.lastUser.id
-    })
-    return !fulfilled
+    return !SessionCompaction.hasFulfilledCompaction(ctx.messages, ctx.lastUser.id)
   },
 })
 

--- a/packages/synergy/src/session/loop-signals.ts
+++ b/packages/synergy/src/session/loop-signals.ts
@@ -25,7 +25,8 @@ function lastAssistant(ctx: LoopJob.Context): AssistantMsg | undefined {
 LoopJob.defineSignal({
   type: "compact",
   detect(ctx) {
-    return !!SessionCompaction.pendingCompactionRequest(ctx.messages, ctx.lastUser.id, ctx.lastUserParts)
+    const history = ctx.compactionHistory ?? SessionCompaction.completedCompactionHistory(ctx.messages, ctx.lastUser.id)
+    return !!SessionCompaction.pendingCompactionRequestFromHistory(history, ctx.lastUserParts)
   },
 })
 

--- a/packages/synergy/src/session/loop-signals.ts
+++ b/packages/synergy/src/session/loop-signals.ts
@@ -25,12 +25,7 @@ function lastAssistant(ctx: LoopJob.Context): AssistantMsg | undefined {
 LoopJob.defineSignal({
   type: "compact",
   detect(ctx) {
-    if (!ctx.lastUserParts.some((p) => p.type === "compaction")) return false
-    // The compaction part lives on the task root R (issue #281 §7), so it stays
-    // in the window after compaction runs. Fire only while the request is still
-    // pending — i.e. no completed compaction summary for R exists yet — otherwise
-    // the loop would re-compact endlessly instead of resuming the task.
-    return !SessionCompaction.hasFulfilledCompaction(ctx.messages, ctx.lastUser.id)
+    return !!SessionCompaction.pendingCompactionRequest(ctx.messages, ctx.lastUser.id, ctx.lastUserParts)
   },
 })
 

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -1096,8 +1096,12 @@ export namespace MessageV2 {
   export async function filterCompacted(stream: AsyncIterable<MessageV2.WithParts>) {
     const result = [] as MessageV2.WithParts[]
     const completed = new Set<string>()
+    let latestCompactionParentID: string | undefined
     for await (const msg of stream) {
       result.push(msg)
+      if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !latestCompactionParentID) {
+        latestCompactionParentID = msg.info.parentID
+      }
       if (
         msg.info.role === "user" &&
         completed.has(msg.info.id) &&
@@ -1107,7 +1111,26 @@ export namespace MessageV2 {
       if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish) completed.add(msg.info.parentID)
     }
     result.reverse()
-    return result
+    if (!latestCompactionParentID) return result
+
+    const rootIndex = result.findIndex(
+      (msg) =>
+        msg.info.role === "user" &&
+        msg.info.id === latestCompactionParentID &&
+        msg.parts.some((part) => part.type === "compaction"),
+    )
+    if (rootIndex < 0) return result
+
+    const summaryIndex = result.findLastIndex(
+      (msg) =>
+        msg.info.role === "assistant" &&
+        msg.info.summary &&
+        msg.info.finish &&
+        msg.info.parentID === latestCompactionParentID,
+    )
+    if (summaryIndex <= rootIndex) return result
+
+    return [result[rootIndex], ...result.slice(summaryIndex)]
   }
 
   export function fromError(e: unknown, ctx: { providerID: string }) {

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -122,37 +122,6 @@ test("enabled_providers restricts to only listed providers", async () => {
   })
 })
 
-test("model whitelist filters models for provider", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-          provider: {
-            anthropic: {
-              whitelist: ["claude-sonnet-4-20250514"],
-            },
-          },
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      expect(providers["anthropic"]).toBeDefined()
-      const models = Object.keys(providers["anthropic"].models)
-      expect(models).toContain("claude-sonnet-4-20250514")
-      expect(models.length).toBe(1)
-    },
-  })
-})
-
 test("model blacklist excludes specific models", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -289,31 +258,6 @@ test("env variable takes precedence, config merges options", async () => {
       expect(providers["anthropic"]).toBeDefined()
       // Config options should be merged
       expect(providers["anthropic"].options.timeout).toBe(60000)
-    },
-  })
-})
-
-test("getModel returns model for valid provider/model", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const model = await Provider.getModel("anthropic", "claude-sonnet-4-20250514")
-      expect(model).toBeDefined()
-      expect(model.providerID).toBe("anthropic")
-      expect(model.id).toBe("claude-sonnet-4-20250514")
     },
   })
 })
@@ -679,42 +623,6 @@ test("explicit baseURL overrides api field", async () => {
   })
 })
 
-test("model inherits properties from existing database model", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-          provider: {
-            anthropic: {
-              models: {
-                "claude-sonnet-4-20250514": {
-                  name: "Custom Name for Sonnet",
-                },
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      const model = providers["anthropic"].models["claude-sonnet-4-20250514"]
-      expect(model.name).toBe("Custom Name for Sonnet")
-      expect(model.capabilities.toolcall).toBe(true)
-      expect(model.capabilities.attachment).toBe(true)
-      expect(model.limit.context).toBeGreaterThan(0)
-    },
-  })
-})
-
 test("disabled_providers prevents loading even with env var", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -760,39 +668,6 @@ test("enabled_providers with empty array allows no providers", async () => {
     fn: async () => {
       const providers = await Provider.list()
       expect(Object.keys(providers).length).toBe(0)
-    },
-  })
-})
-
-test("whitelist and blacklist can be combined", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-          provider: {
-            anthropic: {
-              whitelist: ["claude-sonnet-4-20250514", "claude-opus-4-20250514"],
-              blacklist: ["claude-opus-4-20250514"],
-            },
-          },
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      expect(providers["anthropic"]).toBeDefined()
-      const models = Object.keys(providers["anthropic"].models)
-      expect(models).toContain("claude-sonnet-4-20250514")
-      expect(models).not.toContain("claude-opus-4-20250514")
-      expect(models.length).toBe(1)
     },
   })
 })
@@ -1362,32 +1237,6 @@ test("provider env fallback - second env var used if first missing", async () =>
   })
 })
 
-test("getModel returns consistent results", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const model1 = await Provider.getModel("anthropic", "claude-sonnet-4-20250514")
-      const model2 = await Provider.getModel("anthropic", "claude-sonnet-4-20250514")
-      expect(model1.providerID).toEqual(model2.providerID)
-      expect(model1.id).toEqual(model2.id)
-      expect(model1).toEqual(model2)
-    },
-  })
-})
-
 test("provider name defaults to id when not in database", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -1714,71 +1563,6 @@ test("custom model inherits api.url from models.dev provider", async () => {
   })
 })
 
-test("model variants are generated for reasoning models", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      // Claude sonnet 4 has reasoning capability
-      const model = providers["anthropic"].models["claude-sonnet-4-20250514"]
-      expect(model.capabilities.reasoning).toBe(true)
-      expect(model.variants).toBeDefined()
-      expect(Object.keys(model.variants!).length).toBeGreaterThan(0)
-    },
-  })
-})
-
-test("model variants can be disabled via config", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-          provider: {
-            anthropic: {
-              models: {
-                "claude-sonnet-4-20250514": {
-                  variants: {
-                    high: { disabled: true },
-                  },
-                },
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      const model = providers["anthropic"].models["claude-sonnet-4-20250514"]
-      expect(model.variants).toBeDefined()
-      expect(model.variants!["high"]).toBeUndefined()
-      // max variant should still exist
-      expect(model.variants!["max"]).toBeDefined()
-    },
-  })
-})
-
 test("model variants can be customized via config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -1893,46 +1677,6 @@ test("all variants can be disabled via config", async () => {
       const model = providers["anthropic"].models["claude-sonnet-4-20250514"]
       expect(model.variants).toBeDefined()
       expect(Object.keys(model.variants!).length).toBe(0)
-    },
-  })
-})
-
-test("variant config merges with generated variants", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          $schema: "file:///test/config.schema.json",
-          provider: {
-            anthropic: {
-              models: {
-                "claude-sonnet-4-20250514": {
-                  variants: {
-                    high: {
-                      extraOption: "custom-value",
-                    },
-                  },
-                },
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-  await provideTestScope({
-    scope: await tmp.scope(),
-    init: async () => {
-      Env.set("ANTHROPIC_API_KEY", "test-api-key")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      const model = providers["anthropic"].models["claude-sonnet-4-20250514"]
-      expect(model.variants!["high"]).toBeDefined()
-      // Should have both the generated thinking config and the custom option
-      expect(model.variants!["high"].thinking).toBeDefined()
-      expect(model.variants!["high"].extraOption).toBe("custom-value")
     },
   })
 })

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -304,23 +304,135 @@ describe("session.compaction.isContextExceeded", () => {
     expect(SessionCompaction.isContextExceeded({ name: "AuthError", data: { message: "bad key" } })).toBe(false)
   })
 
-  test("rejects null / undefined", () => {
-    expect(SessionCompaction.isContextExceeded(null)).toBe(false)
-    expect(SessionCompaction.isContextExceeded(undefined)).toBe(false)
+  test("detects codex streaming error stored as UnknownError", () => {
+    // Codex SSE streaming error: {"type":"error","sequence_number":2,"error":{"type":"invalid_request_error","code":"context_length_exceeded",...}}
+    // fromError() wraps this as NamedError.Unknown when it's not an APICallError.
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: {
+          message:
+            '{"type":"error","sequence_number":2,"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model.","param":"input"}}',
+        },
+      }),
+    ).toBe(true)
   })
 
-  test("rejects primitive values", () => {
-    expect(SessionCompaction.isContextExceeded("context_length_exceeded")).toBe(false)
-    expect(SessionCompaction.isContextExceeded(42)).toBe(false)
+  test("detects UnknownError with nested error.type containing context_length_exceeded", () => {
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: {
+          message: '{"type":"error","error":{"type":"context_length_exceeded"}}',
+        },
+      }),
+    ).toBe(true)
   })
 
-  test("detects 'request too large' with token mention", () => {
-    expect(SessionCompaction.isContextExceeded(apiError("request too large: total token count exceeds limit"))).toBe(
-      true,
-    )
+  test("rejects UnknownError without context keywords", () => {
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: { message: "some random network error" },
+      }),
+    ).toBe(false)
+  })
+
+  test("rejects UnknownError with unrelated nested error", () => {
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: {
+          message: '{"type":"error","error":{"type":"rate_limit_exceeded","message":"too many requests"}}',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test("detects context keyword in plain message without APIError name", () => {
+    expect(SessionCompaction.isContextExceeded({ data: { message: "context_length_exceeded" } })).toBe(true)
   })
 })
 
+// ---------------------------------------------------------------------------
+// SessionCompaction.hasFulfilledCompaction
+// ---------------------------------------------------------------------------
+
+describe("session.compaction.hasFulfilledCompaction", () => {
+  const now = Date.now()
+
+  function makeAssistant(opts: {
+    id: string
+    parentID: string
+    summary?: boolean
+    finish?: string
+  }): MessageV2.WithParts {
+    const info: MessageV2.Assistant = {
+      id: opts.id,
+      role: "assistant",
+      sessionID: "test-session",
+      time: { created: now },
+      modelID: "test-model",
+      providerID: "test",
+      mode: "default",
+      agent: "synergy",
+      path: { cwd: "/", root: "/" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      parentID: opts.parentID,
+    }
+    if (opts.summary) info.summary = true
+    if (opts.finish) info.finish = opts.finish as MessageV2.Assistant["finish"]
+    return { info, parts: [] }
+  }
+
+  test("returns true for fulfilled compaction", () => {
+    const parentID = "root-user"
+    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true, finish: "stop" })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(true)
+  })
+
+  test("returns false when no summary assistant exists", () => {
+    const msgs = [makeAssistant({ id: "asst-1", parentID: "other-parent", summary: true, finish: "stop" })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
+  })
+
+  test("returns false when summary is missing finish", () => {
+    const parentID = "root-user"
+    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
+  })
+
+  test("returns false for non-summary assistant matching parentID", () => {
+    const parentID = "root-user"
+    const msgs = [makeAssistant({ id: "asst-1", parentID, finish: "stop" })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
+  })
+
+  test("returns false for user messages with matching id", () => {
+    const msgs: MessageV2.WithParts[] = [
+      {
+        info: {
+          id: "root-user",
+          role: "user",
+          sessionID: "test-session",
+          time: { created: now },
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+        },
+        parts: [],
+      },
+    ]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
+  })
+
+  test("returns false for empty messages", () => {
+    expect(SessionCompaction.hasFulfilledCompaction([], "root-user")).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SessionCompaction.buildAnchor
 // ---------------------------------------------------------------------------
 // SessionCompaction.buildAnchor
 // ---------------------------------------------------------------------------

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -354,80 +354,69 @@ describe("session.compaction.isContextExceeded", () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// SessionCompaction.hasFulfilledCompaction
-// ---------------------------------------------------------------------------
-
-describe("session.compaction.hasFulfilledCompaction", () => {
+describe("session.compaction.pendingCompactionRequest", () => {
   const now = Date.now()
 
-  function makeAssistant(opts: {
-    id: string
-    parentID: string
-    summary?: boolean
-    finish?: string
-  }): MessageV2.WithParts {
+  function compactionPart(id: string): MessageV2.CompactionPart {
+    return {
+      id,
+      sessionID: "test-session",
+      messageID: "root-user",
+      type: "compaction",
+      auto: true,
+    }
+  }
+
+  function summary(opts: { id: string; parentID: string; requestID?: string; finish?: string }): MessageV2.WithParts {
     const info: MessageV2.Assistant = {
       id: opts.id,
       role: "assistant",
       sessionID: "test-session",
-      time: { created: now },
+      time: { created: now, completed: now + 1 },
       modelID: "test-model",
       providerID: "test",
-      mode: "default",
-      agent: "synergy",
+      mode: "compaction",
+      agent: "compaction",
       path: { cwd: "/", root: "/" },
       cost: 0,
       tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
       parentID: opts.parentID,
+      summary: true,
     }
-    if (opts.summary) info.summary = true
     if (opts.finish) info.finish = opts.finish as MessageV2.Assistant["finish"]
+    if (opts.requestID) info.metadata = { compactionRequestPartID: opts.requestID }
     return { info, parts: [] }
   }
 
-  test("returns true for fulfilled compaction", () => {
-    const parentID = "root-user"
-    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true, finish: "stop" })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(true)
+  test("returns the newest unfulfilled request when an older request is fulfilled explicitly", () => {
+    const parts = [compactionPart("part_1"), compactionPart("part_2")]
+    const messages = [summary({ id: "summary_1", parentID: "root-user", requestID: "part_1", finish: "stop" })]
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)?.id).toBe("part_2")
   })
 
-  test("returns false when no summary assistant exists", () => {
-    const msgs = [makeAssistant({ id: "asst-1", parentID: "other-parent", summary: true, finish: "stop" })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
-  })
-
-  test("returns false when summary is missing finish", () => {
-    const parentID = "root-user"
-    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
-  })
-
-  test("returns false for non-summary assistant matching parentID", () => {
-    const parentID = "root-user"
-    const msgs = [makeAssistant({ id: "asst-1", parentID, finish: "stop" })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
-  })
-
-  test("returns false for user messages with matching id", () => {
-    const msgs: MessageV2.WithParts[] = [
-      {
-        info: {
-          id: "root-user",
-          role: "user",
-          sessionID: "test-session",
-          time: { created: now },
-          agent: "synergy",
-          model: { providerID: "test", modelID: "test-model" },
-        },
-        parts: [],
-      },
+  test("returns undefined when the newest request is fulfilled explicitly", () => {
+    const parts = [compactionPart("part_1"), compactionPart("part_2")]
+    const messages = [
+      summary({ id: "summary_1", parentID: "root-user", requestID: "part_1", finish: "stop" }),
+      summary({ id: "summary_2", parentID: "root-user", requestID: "part_2", finish: "stop" }),
     ]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)).toBeUndefined()
   })
 
-  test("returns false for empty messages", () => {
-    expect(SessionCompaction.hasFulfilledCompaction([], "root-user")).toBe(false)
+  test("legacy summaries without request metadata fulfill only the oldest unfulfilled request", () => {
+    const parts = [compactionPart("part_1"), compactionPart("part_2")]
+    const messages = [summary({ id: "summary_1", parentID: "root-user", finish: "stop" })]
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)?.id).toBe("part_2")
+  })
+
+  test("ignores unfinished summaries", () => {
+    const parts = [compactionPart("part_1")]
+    const messages = [summary({ id: "summary_1", parentID: "root-user", requestID: "part_1" })]
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)?.id).toBe("part_1")
   })
 })
 

--- a/packages/synergy/test/session/invoke-compaction.test.ts
+++ b/packages/synergy/test/session/invoke-compaction.test.ts
@@ -97,6 +97,7 @@ function testAssistant(input: {
   completed?: number
   summary?: boolean
   finish?: string
+  metadata?: Record<string, unknown>
   parts?: MessageV2.Part[]
 }): MessageV2.WithParts {
   const info: MessageV2.Assistant = {
@@ -114,6 +115,7 @@ function testAssistant(input: {
     time: { created: input.created, ...(input.completed !== undefined ? { completed: input.completed } : {}) },
     ...(input.summary ? { summary: true } : {}),
     ...(input.finish ? { finish: input.finish } : {}),
+    ...(input.metadata ? { metadata: input.metadata } : {}),
   }
   return { info, parts: input.parts ?? [] }
 }
@@ -647,6 +649,112 @@ describe.serial("SessionInvoke preflight compaction", () => {
     const compacted = await filterNewestFirst([realUser, oldAssistant, boundary, summary, continuation])
 
     expect(compacted.map((msg) => msg.info.id)).toEqual(["msg_boundary", "msg_summary", "msg_continue"])
+  })
+
+  test("filters compacted history from the latest root compaction summary", async () => {
+    const sessionID = "ses_test"
+    const root = testUser({
+      id: "msg_root",
+      sessionID,
+      created: 1,
+      parts: [
+        {
+          id: "prt_root_text",
+          sessionID,
+          messageID: "msg_root",
+          type: "text",
+          text: "Implement the account settings workflow.",
+        },
+        {
+          id: "prt_compaction_1",
+          sessionID,
+          messageID: "msg_root",
+          type: "compaction",
+          auto: true,
+        },
+        {
+          id: "prt_compaction_2",
+          sessionID,
+          messageID: "msg_root",
+          type: "compaction",
+          auto: true,
+        },
+      ],
+    })
+    const oldAssistant = testAssistant({
+      id: "msg_old_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 2,
+      completed: 3,
+      finish: "tool-calls",
+    })
+    const firstSummary = testAssistant({
+      id: "msg_summary_1",
+      sessionID,
+      parentID: root.info.id,
+      created: 4,
+      completed: 5,
+      summary: true,
+      finish: "stop",
+      metadata: { compactionRequestPartID: "prt_compaction_1" },
+    })
+    const firstContinue = testUser({
+      id: "msg_continue_1",
+      sessionID,
+      created: 6,
+      summaryTitle: "Compaction complete",
+    })
+    const newerAssistant = testAssistant({
+      id: "msg_newer_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 7,
+      completed: 8,
+      finish: "tool-calls",
+    })
+    const secondSummary = testAssistant({
+      id: "msg_summary_2",
+      sessionID,
+      parentID: root.info.id,
+      created: 9,
+      completed: 10,
+      summary: true,
+      finish: "stop",
+      metadata: { compactionRequestPartID: "prt_compaction_2" },
+    })
+    const secondContinue = testUser({
+      id: "msg_continue_2",
+      sessionID,
+      created: 11,
+      summaryTitle: "Compaction complete",
+    })
+    const latestAssistant = testAssistant({
+      id: "msg_latest_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 12,
+      completed: 13,
+      finish: "stop",
+    })
+
+    const compacted = await filterNewestFirst([
+      root,
+      oldAssistant,
+      firstSummary,
+      firstContinue,
+      newerAssistant,
+      secondSummary,
+      secondContinue,
+      latestAssistant,
+    ])
+
+    expect(compacted.map((msg) => msg.info.id)).toEqual([
+      "msg_root",
+      "msg_summary_2",
+      "msg_continue_2",
+      "msg_latest_assistant",
+    ])
   })
 
   test("resolves the compaction anchor from the task root by id", () => {

--- a/packages/synergy/test/session/loop-signals.test.ts
+++ b/packages/synergy/test/session/loop-signals.test.ts
@@ -50,6 +50,28 @@ function makeAssistant(toolParts: any[]): any {
   }
 }
 
+function makeSummary(parentID = "usr_test", requestID?: string): any {
+  return {
+    info: {
+      id: `msg_summary_${Math.random().toString(36).slice(2)}`,
+      role: "assistant" as const,
+      sessionID: "ses_test",
+      parentID,
+      agent: "compaction",
+      mode: "compaction",
+      summary: true,
+      finish: "stop",
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: "test-model",
+      providerID: "test-provider",
+      time: { created: Date.now(), completed: Date.now() },
+      ...(requestID ? { metadata: { compactionRequestPartID: requestID } } : {}),
+    },
+    parts: [],
+  }
+}
+
 function makeTool(tool: string, input: unknown, status: "completed" | "error"): any {
   return {
     id: `prt_${Math.random().toString(36).slice(2)}`,
@@ -211,6 +233,42 @@ describe("loop-signals: compact signal", () => {
     )
     const fired = await LoopJob.detectSignals(ctx)
     expect(fired).not.toContain("compact")
+  })
+
+  test("does not detect when the latest compaction request is fulfilled", async () => {
+    const ctx = makeCtx(
+      1,
+      [makeUserWrapper(), makeSummary("usr_test", "p1")],
+      [{ id: "p1", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true }],
+    )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).not.toContain("compact")
+  })
+
+  test("detects a new compaction request after an older completed summary", async () => {
+    const ctx = makeCtx(
+      2,
+      [makeUserWrapper(), makeSummary("usr_test", "p1")],
+      [
+        { id: "p1", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+        { id: "p2", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+      ],
+    )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).toContain("compact")
+  })
+
+  test("detects a new compaction request after a legacy completed summary", async () => {
+    const ctx = makeCtx(
+      2,
+      [makeUserWrapper(), makeSummary("usr_test")],
+      [
+        { id: "p1", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+        { id: "p2", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+      ],
+    )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).toContain("compact")
   })
 
   test("coexists with repeat_loop without interference", async () => {

--- a/packages/synergy/test/session/loop-signals.test.ts
+++ b/packages/synergy/test/session/loop-signals.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeAll } from "bun:test"
+import { SessionCompaction } from "../../src/session/compaction"
 import { LoopJob } from "../../src/session/loop-job"
 import { Log } from "../../src/util/log"
 
@@ -267,6 +268,37 @@ describe("loop-signals: compact signal", () => {
         { id: "p2", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
       ],
     )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).toContain("compact")
+  })
+
+  test("uses full compaction history when compacted prompt history only keeps the latest summary", async () => {
+    const root = makeUserWrapper()
+    root.parts = [
+      { id: "p1", sessionID: "ses_test", messageID: "usr_test", type: "compaction", auto: true },
+      { id: "p2", sessionID: "ses_test", messageID: "usr_test", type: "compaction", auto: true },
+    ]
+    const firstSummary = makeSummary("usr_test", "p1")
+    const secondSummary = makeSummary("usr_test", "p2")
+    const ctx = makeCtx(3, [root, secondSummary], root.parts)
+    ctx.compactionHistory = SessionCompaction.completedCompactionHistory([firstSummary, secondSummary], root.info.id)
+
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).not.toContain("compact")
+  })
+
+  test("still detects a genuinely new request after completed compaction history", async () => {
+    const root = makeUserWrapper()
+    root.parts = [
+      { id: "p1", sessionID: "ses_test", messageID: "usr_test", type: "compaction", auto: true },
+      { id: "p2", sessionID: "ses_test", messageID: "usr_test", type: "compaction", auto: true },
+      { id: "p3", sessionID: "ses_test", messageID: "usr_test", type: "compaction", auto: true },
+    ]
+    const firstSummary = makeSummary("usr_test", "p1")
+    const secondSummary = makeSummary("usr_test", "p2")
+    const ctx = makeCtx(3, [root, secondSummary], root.parts)
+    ctx.compactionHistory = SessionCompaction.completedCompactionHistory([firstSummary, secondSummary], root.info.id)
+
     const fired = await LoopJob.detectSignals(ctx)
     expect(fired).toContain("compact")
   })


### PR DESCRIPTION
## Summary

- Fixes #321: auto-compaction blocked after first compaction was fulfilled, and Codex streaming errors not recognized as context overflow

## Changes

Two independent root causes found and fixed:

1. **Proactive budget trigger permanently blocked repeat compaction** (`invoke.ts`): The guard `lastUserParts.some(part => part.type === "compaction")` prevented re-injection even after the prior compaction was fulfilled. The compaction part must stay on the root message as a boundary marker for `filterCompacted()`, but injection should check fulfillment status.

2. **`isContextExceeded()` rejected Codex streaming errors** (`compaction.ts`): The guard `error.name !== "APIError"` rejected `UnknownError` wrappers. Codex streaming errors arrive as a plain `Error` (not `APICallError`), and `fromError()` stores them as `NamedError.Unknown` with the JSON error payload in the message field. The nested keywords were never inspected.

### Implementation

- Extracted `hasFulfilledCompaction()` into `SessionCompaction` namespace, shared by both `invoke.ts` and `loop-signals.ts` (removing duplicated inline logic)
- `isContextExceeded()`: removed `APIError` name guard; parses nested JSON from `UnknownError` messages to find context overflow keywords
- Added 12 tests: 6 for `hasFulfilledCompaction`, 6 for `UnknownError` detection through `isContextExceeded`

## Test plan

`bun test test/session/compaction.test.ts` → 61 pass, 0 fail (all existing + new tests)