### PR TITLE
Add direct image context tool

### DIFF
--- a/packages/synergy/schema/config.schema.json
+++ b/packages/synergy/schema/config.schema.json
@@ -478,7 +478,7 @@
       "type": "string"
     },
     "vision_model": {
-      "description": "Model for image analysis via the look_at tool, in the format of provider/model. If not set, look_at is disabled.",
+      "description": "Model for separate image analysis via the look_at tool, in the format of provider/model. If not set, look_at is disabled. Direct current-model image context uses view_image based on the active model capability.",
       "type": "string"
     },
     "role_variant": {

--- a/packages/synergy/src/agent/prompt/synergy-max/base.txt
+++ b/packages/synergy/src/agent/prompt/synergy-max/base.txt
@@ -291,7 +291,8 @@ When using `bash`:
 ## Visual Artifacts and Files
 
 - `render`: inline HTML/SVG/tables/charts.
-- `look_at`: inspect images for reasoning; set `show_to_user: true` when the user should see the same image.
+- `view_image`: when available, load a local image into the current model context for direct visual inspection; it does not run separate model analysis.
+- `look_at`: when `view_image` is unavailable, ask the configured vision model for textual analysis; set `show_to_user: true` when the user should see the same image.
 - `attach`: deliver final user-facing artifacts such as images, PDFs, figures, screenshots, archives, exports, and paper outputs.
 - `scan_document`: read PDF, DOCX, XLSX, PPTX, HTML, EPUB, IPYNB, CSV, XML, RSS, ZIP, images/audio metadata as Markdown.
 

--- a/packages/synergy/src/agent/prompt/synergy/base.txt
+++ b/packages/synergy/src/agent/prompt/synergy/base.txt
@@ -514,7 +514,8 @@ Some operations may require user approval depending on the project's permission 
 Use the right visual surface for the job:
 
 - **`render`** — Render inline HTML/SVG/tables/charts directly in the conversation when the output is structured markup rather than a file.
-- **`look_at`** — Inspect images for your own reasoning. Set `show_to_user: true` when the user should see the same image; otherwise follow with `attach` if the image becomes a user-facing result.
+- **`view_image`** — When available, load a local image into the current model context for direct visual inspection. It does not perform separate model analysis.
+- **`look_at`** — When `view_image` is unavailable, ask the configured vision model for textual analysis. Set `show_to_user: true` when the user should see the same image; otherwise follow with `attach` if the image becomes a user-facing result.
 - **`attach`** — Deliver files to the user as conversation attachments. The user may be on a web or TUI client without direct access to the server filesystem.
 
 When you generate, download, compile, or produce a user-facing artifact (PDFs, images, rendered figures, screenshots, plots, HTML reports, archives, exports, paper outputs, etc.), use `attach` to make the final result available — don't just write it to disk and print the path. Attach final artifacts only; avoid intermediate build files, caches, dependency downloads, logs, or unrelated outputs.

--- a/packages/synergy/src/browser/policy.ts
+++ b/packages/synergy/src/browser/policy.ts
@@ -89,9 +89,14 @@ export namespace BrowserPolicy {
     return basename.startsWith(".")
   }
 
-  function containsBlockedFilePathSegment(filePath: string): boolean {
-    const segments = filePath.split(path.sep)
-    return segments.some((s) => BLOCKED_FILE_PATH_SEGMENTS.has(s))
+  function containsBlockedWorkspaceSegment(filePath: string, workspace: string): boolean {
+    const resolved = realpathSync(filePath)
+    const resolvedWorkspace = realpathSync(workspace)
+    if (!isPathContained(resolvedWorkspace, resolved)) return false
+
+    const relativePath = path.relative(resolvedWorkspace, resolved)
+    const segments = relativePath.split(path.sep).filter(Boolean)
+    return segments.some((segment) => BLOCKED_FILE_PATH_SEGMENTS.has(segment))
   }
 
   function isContainedWithin(filePath: string, workspace: string): boolean {
@@ -239,7 +244,7 @@ export namespace BrowserPolicy {
    * Check file:// containment. Uses realpath via Bun/Node for symlink resolution.
    */
   export function evaluateFileURL(filePath: string, workspace: string): PolicyResult {
-    if (containsBlockedFilePathSegment(filePath)) {
+    if (containsBlockedWorkspaceSegment(filePath, workspace)) {
       return {
         decision: "deny",
         reason: `Path contains a blocked segment: ${filePath}`,

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -1375,7 +1375,7 @@ export const Info = z
     vision_model: z
       .string()
       .describe(
-        "Model for image analysis via the look_at tool, in the format of provider/model. If not set, look_at is disabled.",
+        "Model for separate image analysis via the look_at tool, in the format of provider/model. If not set, look_at is disabled. Direct current-model image context uses view_image based on the active model capability.",
       )
       .optional(),
     role_variant: z

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -591,7 +591,12 @@ export namespace EnforcementGate {
       }
 
       // Document / attachment tools
-      if (toolName === "scan_document" || toolName === "look_at" || toolName === "attach") {
+      if (
+        toolName === "scan_document" ||
+        toolName === "look_at" ||
+        toolName === "view_image" ||
+        toolName === "attach"
+      ) {
         const raw = args.filePath ?? args.file_path ?? ""
         const filePath = Array.isArray(raw) ? (raw[0] ?? "") : raw
         if (filePath) {

--- a/packages/synergy/src/provider/transform.ts
+++ b/packages/synergy/src/provider/transform.ts
@@ -251,7 +251,7 @@ export namespace ProviderTransform {
             const name = attachment.filename ? `\"${attachment.filename}\"` : "image"
             return {
               type: "text" as const,
-              text: `[${name} was attached but not sent to Bedrock because it exceeds the 5MB image limit. Use the look_at tool with the file's local path to analyze it or attach a smaller image.]`,
+              text: `[${name} was attached but not sent to Bedrock because it exceeds the 5MB image limit. Use view_image with a smaller local image when the active model supports image input, use look_at for separate vision-model analysis, or attach a smaller image.]`,
             }
           }
         }

--- a/packages/synergy/src/session/tool-mode-policy.ts
+++ b/packages/synergy/src/session/tool-mode-policy.ts
@@ -14,6 +14,7 @@ export namespace SessionModePolicy {
     "scan_files",
     "parse_code",
     "look_at",
+    "view_image",
     "scan_document",
     "ast_grep",
     "lsp",

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -135,7 +135,7 @@ export namespace ToolResolver {
   function externalPathFromArgs(toolName: string, args: Record<string, any>): string {
     if (toolName === "bash") return (args.workdir ?? args.command) as string
     //     if (toolName === "agora_join" || toolName === "agora_accept") return (args.directory ?? "") as string
-    if (toolName === "look_at" || toolName === "attach") {
+    if (toolName === "look_at" || toolName === "view_image" || toolName === "attach") {
       const raw = args.file_path ?? args.filePath ?? ""
       return Array.isArray(raw) ? (raw[0] ?? "") : String(raw)
     }
@@ -892,11 +892,12 @@ export namespace ToolResolver {
     const forcedToolIDs = forcedTools(input.userTools)
     const ephemeralToolIds = new Set(input.ephemeralTools?.map((item) => item.id) ?? [])
 
+    const supportsImageInput = input.model.capabilities.input.image
+
     for (const def of defs) {
       const isEphemeral = ephemeralToolIds.has(def.id)
-      if (!isEphemeral && def.id === "look_at" && input.model.capabilities.input.image) {
-        continue
-      }
+      if (!isEphemeral && def.id === "look_at" && supportsImageInput) continue
+      if (!isEphemeral && def.id === "view_image" && !supportsImageInput) continue
 
       const modeDiagnostic = isEphemeral
         ? undefined

--- a/packages/synergy/src/skill/builtin/synergy-config/references/models.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/references/models.txt
@@ -19,9 +19,9 @@ Synergy uses model roles for different internal tasks. Each falls back through a
 | `thinking_model` | Deep reasoning: complex architecture, planning | → `model` |
 | `long_context_model` | Extra-large context for very long inputs | → `model` |
 | `creative_model` | Creative/visual: UI design, writing, artistry | → `model` |
-| `vision_model` | Image analysis via `look_at` tool (screenshots, diagrams, charts) | (disabled if not set) |
+| `vision_model` | Separate image analysis via `look_at` when the active model lacks direct image input | (disabled if not set) |
 
-**Important:** `vision_model` must be explicitly set for `look_at` to work. It does NOT fall back to `model`.
+**Important:** `vision_model` must be explicitly set for `look_at` to work. It does NOT fall back to `model`. Direct image context uses `view_image` when the active model itself supports image input.
 
 ## Config example
 
@@ -94,7 +94,7 @@ Models can have variants (e.g., different reasoning effort levels). Variants are
 | `thinking_model` | Used by the advisor agent for deep architectural analysis and complex debugging. If unset, the advisor falls back to `model` — still functional, but may reason less thoroughly on hard problems. |
 | `long_context_model` | Engaged automatically when inputs exceed the default model's context window. Without it, very long inputs may be truncated or fail. |
 | `creative_model` | Used by the scribe agent and frontend-design skill for writing, UI design, and other creative tasks. A stronger model here produces more nuanced prose and better visual design suggestions. |
-| `vision_model` | **Must be set explicitly or the `look_at` tool is completely disabled.** Does NOT fall back to `model`. Without this field, image analysis is unavailable. Use the `read` tool for PDF/DOCX/XLSX/PPTX text extraction — no vision model needed. |
+| `vision_model` | **Must be set explicitly or the `look_at` tool is completely disabled.** Does NOT fall back to `model`. Without this field, separate vision-model image analysis is unavailable. Direct current-model image context uses `view_image` based on the active model capability. Use the `read` tool for PDF/DOCX/XLSX/PPTX text extraction — no vision model needed. |
 
 ## Common model configurations
 
@@ -144,7 +144,8 @@ Strongest model for every role (highest cost, highest quality):
 - Must be explicitly set — `vision_model` does not fall back to `model`
 - Not all models support image input; check the provider's model registry
 - Common choices: `openai/gpt-4o`, `anthropic/claude-sonnet-4-5`, `google/gemini-2.5-pro`
-- The `look_at` tool is for images only (screenshots, diagrams, charts). Use `read` for PDF text extraction.
+- The `look_at` tool is for separate image analysis when the active model cannot inspect images directly. Use `view_image` for direct current-model visual context when it is available.
+- Use `read` for PDF text extraction.
 - If `look_at` calls fail or are unavailable, this field is the first thing to check
 
 ## Troubleshooting

--- a/packages/synergy/src/tool/bash.txt
+++ b/packages/synergy/src/tool/bash.txt
@@ -23,7 +23,7 @@ Before executing the command, please follow these steps:
 3. User-visible artifacts:
    - If the command generates a visual or document result the user should inspect (for example .png, .jpg, .svg, .pdf, .html, plots, screenshots, rendered figures, or LaTeX output), call `attach` afterward to show the generated file in the conversation.
    - Prefer attaching final results, not intermediate build artifacts, caches, dependency downloads, logs, or unrelated files.
-   - If you need to inspect an image yourself before showing it, use `look_at`; if the user should see the same image, set `show_to_user: true` or follow with `attach`.
+   - If you need to inspect an image yourself before showing it, use `view_image` when it is available for direct current-model visual context; use `look_at` when `view_image` is unavailable. If the user should see the same image, use `look_at` with `show_to_user: true` or follow with `attach`.
 
 Usage notes:
   - The `command` parameter is required.

--- a/packages/synergy/src/tool/lookat.txt
+++ b/packages/synergy/src/tool/lookat.txt
@@ -1,15 +1,16 @@
-Analyze image files (screenshots, diagrams, charts, UI mockups, photos) that require visual interpretation.
+Analyze image files (screenshots, diagrams, charts, UI mockups, photos) with a separate vision model when the active model cannot accept image input directly.
 Accepts up to 5 images per call — all images are analyzed together in a single session.
 
-This is a model-visible analysis tool: it lets you inspect an image and use the findings in your reasoning. It does not show the image to the user unless `show_to_user` is true. Use `attach` when the user should receive or inspect the file itself.
+This is a separate-model analysis tool: it returns textual findings from a configured vision model. It does not load the image into the current model context, and it does not show the image to the user unless `show_to_user` is true. Use `attach` when the user should receive or inspect the file itself.
 
 Use this tool when:
-- You need to understand the content of an image (screenshots, diagrams, charts, UI mockups)
-- You need to extract text or data from a screenshot
+- `view_image` is unavailable because the current model does not support image input
+- You need textual analysis of screenshots, diagrams, charts, UI mockups, or photos through the configured vision model
+- You need to extract text or data from a screenshot and direct image context is unavailable
 - You need to classify or process multiple image files at once (up to 5)
-- You generated a visual result and need to verify it before showing it to the user
 
 When NOT to use this tool:
+- When `view_image` is available and you want the active model to inspect the image directly
 - For source code or plain text files (use Read tool instead)
 - For PDF documents — use the Read tool instead (it extracts text from PDFs, DOCX, XLSX, PPTX)
 - For files that need to be edited afterward (use Read for literal content)

--- a/packages/synergy/src/tool/read.ts
+++ b/packages/synergy/src/tool/read.ts
@@ -55,29 +55,6 @@ export const ReadTool = Tool.define("read", {
     }
 
     const filePolicy = Attachment.policy({ filepath, mime: file.type })
-    if (filePolicy.kind === "image" && file.type !== "image/svg+xml") {
-      const mime = file.type
-      const msg = "Image read successfully"
-      return {
-        title,
-        output: msg,
-        metadata: {
-          preview: msg,
-          truncated: false,
-          offset: undefined as number | undefined,
-          limit: undefined as number | undefined,
-        },
-        attachments: [
-          await Attachment.toPart({
-            filepath,
-            mime,
-            sessionID: ctx.sessionID,
-            messageID: ctx.messageID,
-          }),
-        ],
-      }
-    }
-
     if (filePolicy.extractText) {
       const text = await Attachment.extractTextFromFile(filepath)
       const lines = text.split("\n")

--- a/packages/synergy/src/tool/read.txt
+++ b/packages/synergy/src/tool/read.txt
@@ -1,5 +1,5 @@
-Reads a file from the local filesystem. You can access any file directly by using this tool.
-Assume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
+Reads text and document content from the local filesystem. You can access any text or supported document file directly by using this tool.
+Assume this tool is able to read files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
 
 Usage:
 - The filePath parameter must be an absolute path, not a relative path
@@ -10,5 +10,4 @@ Usage:
 - Results are returned using cat -n format, with line numbers starting at 1
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
-- You can read image files using this tool.
-You can read document files (PDF, DOCX, XLSX, PPTX, HTML, EPUB, IPYNB, CSV, XML, images, audio, ZIP) using this tool. Text content will be converted to markdown automatically.
+- Use this tool for text files and supported document text extraction (PDF, DOCX, XLSX, PPTX, HTML, EPUB, IPYNB, CSV, XML, RSS, audio metadata, ZIP). For image visual inspection, use `view_image` when it is available; use `look_at` when `view_image` is unavailable.

--- a/packages/synergy/src/tool/registry.ts
+++ b/packages/synergy/src/tool/registry.ts
@@ -7,6 +7,7 @@ import { FileSearchTool } from "./file-search"
 import { BatchTool } from "./batch"
 import { ReadTool } from "./read"
 import { ViewFileTool } from "./view-file"
+import { ViewImageTool } from "./view-image"
 import { ReviseFileTool } from "./revise-file"
 import { SaveFileTool } from "./save-file"
 import { ScanFilesTool } from "./scan-files"
@@ -331,6 +332,7 @@ export namespace ToolRegistry {
       ProcessTool,
       ConnectTool,
       ReadTool,
+      ViewImageTool,
       ViewFileTool,
       ScanFilesTool,
       FileSearchTool,

--- a/packages/synergy/src/tool/scan-document.txt
+++ b/packages/synergy/src/tool/scan-document.txt
@@ -4,7 +4,7 @@ Use this tool to inspect the content of document files (PDF, DOCX, XLSX, PPTX, H
 
 Use `offset` to skip ahead and `limit` to control how many lines to return (max 2000, default 2000). When the metadata field `truncated` is true, call again with offset incremented by `returned` to read the next chunk.
 
-For code files, use `view_file` instead. For image analysis, use `look_at` instead.
+For code files, use `view_file` instead. For image visual inspection, use `view_image` when it is available; use `look_at` when `view_image` is unavailable.
 
 Supported formats: PDF, Word (.docx), Excel (.xlsx), PowerPoint (.pptx), HTML, EPUB, Jupyter (.ipynb), CSV, XML, RSS, Atom, plain text, images (EXIF metadata only), audio (EXIF metadata only), ZIP archives (recursive).
 

--- a/packages/synergy/src/tool/taxonomy.ts
+++ b/packages/synergy/src/tool/taxonomy.ts
@@ -103,6 +103,7 @@ const REGISTRY: Record<string, ToolTaxonomyEntry> = {
   view_file: entry("code.read"),
   list: entry("code.read"),
   look_at: entry("code.analyze"),
+  view_image: entry("code.analyze"),
   scan_document: entry("code.analyze"),
   edit: entry("code.write", { stateful: true }),
   revise_file: entry("code.write", { stateful: true }),

--- a/packages/synergy/src/tool/view-image.ts
+++ b/packages/synergy/src/tool/view-image.ts
@@ -1,0 +1,167 @@
+import type { BunFile } from "bun"
+import z from "zod"
+import path from "path"
+import { Tool } from "./tool"
+import { ScopeContext } from "../scope/context"
+import { Attachment } from "../attachment"
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".svg": "image/svg+xml",
+}
+
+const DESCRIPTION = `Load a local image file into the current model context for direct visual inspection.
+
+Use this when the active model supports image input and you need to inspect an image yourself, such as a generated plot, screenshot, diagram, rendered page, or visual artifact. The tool does not analyze the image with a separate model; it attaches the image so the current model can see it on the next model step.
+
+Use look_at instead when view_image is unavailable because the current model does not support image input. Use attach only when the user should receive or inspect the file.`
+
+const parameters = z.object({
+  filePath: z.string().describe("Absolute path to the local image file to load into the current model context"),
+})
+
+interface ViewImageMetadata {
+  filePath?: string
+  filename?: string
+  mimeType?: string
+  sizeBytes?: number
+  modelContext?: boolean
+  truncated?: boolean
+  preview?: string
+  error?: string
+}
+
+export const ViewImageTool = Tool.define<typeof parameters, ViewImageMetadata>("view_image", {
+  description: DESCRIPTION,
+  parameters,
+  async execute(params, ctx) {
+    const filepath = path.isAbsolute(params.filePath)
+      ? params.filePath
+      : path.join(ScopeContext.current.directory, params.filePath)
+    const filename = path.basename(filepath)
+    const file = Bun.file(filepath)
+
+    if (!(await file.exists())) {
+      return {
+        title: "File not found",
+        output: `Error: File not found: ${filepath}`,
+        metadata: { filePath: filepath, filename, error: "file_not_found" },
+      }
+    }
+
+    const mimeType = inferImageMimeType(filepath, file.type)
+    if (!mimeType.startsWith("image/")) {
+      return {
+        title: "Unsupported file type",
+        output: `${filename}: ${mimeType} is not an image. Use read/scan_document for text or document extraction.`,
+        metadata: {
+          filePath: filepath,
+          filename,
+          mimeType,
+          error: "unsupported_file_type",
+        },
+      }
+    }
+
+    await ctx.ask({
+      permission: "read",
+      patterns: [filepath],
+      metadata: {},
+    })
+
+    const sizeBytes = (await file.stat()).size
+    if (!(await isValidImageFile(file, mimeType))) {
+      return {
+        title: "Unsupported file type",
+        output: `${filename}: content does not match ${mimeType}. Use read/scan_document for text or document extraction.`,
+        metadata: {
+          filePath: filepath,
+          filename,
+          mimeType,
+          error: "unsupported_file_type",
+        },
+      }
+    }
+    const summary = `${filename} (${mimeType}) loaded by view_image`
+    const preview = `Image loaded into the current model context: ${filename} (${mimeType}, ${formatSize(sizeBytes)}). The active model can inspect it directly on the next model step.`
+
+    return {
+      title: `Viewed Image: ${filename}`,
+      output: preview,
+      metadata: {
+        filePath: filepath,
+        filename,
+        mimeType,
+        sizeBytes,
+        modelContext: true,
+        truncated: false,
+        preview,
+      },
+      attachments: [
+        await Attachment.toPart({
+          filepath,
+          mime: mimeType,
+          filename,
+          localPath: filepath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          presentation: { renderer: "image", size: "medium", crop: false },
+          model: { mode: "provider-file", summary },
+        }),
+      ],
+    }
+  },
+})
+
+function inferImageMimeType(filepath: string, fileType: string): string {
+  if (fileType.startsWith("image/")) return fileType
+  return IMAGE_MIME_BY_EXTENSION[path.extname(filepath).toLowerCase()] ?? (fileType || "application/octet-stream")
+}
+
+async function isValidImageFile(file: BunFile, mimeType: string): Promise<boolean> {
+  const bytes = new Uint8Array(await file.slice(0, 4100).arrayBuffer())
+  if (mimeType === "image/png") return startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+  if (mimeType === "image/jpeg") return startsWith(bytes, [0xff, 0xd8, 0xff])
+  if (mimeType === "image/gif")
+    return startsWith(bytes, [...byteString("GIF87a")]) || startsWith(bytes, [...byteString("GIF89a")])
+  if (mimeType === "image/webp")
+    return (
+      startsWith(bytes, [...byteString("RIFF")]) && byteString("WEBP").every((byte, index) => bytes[8 + index] === byte)
+    )
+  if (mimeType === "image/svg+xml") return looksLikeSvg(bytes)
+  if (mimeType === "image/heic" || mimeType === "image/heif") return looksLikeHeif(bytes)
+  return mimeType.startsWith("image/")
+}
+
+function startsWith(bytes: Uint8Array, prefix: number[]): boolean {
+  if (bytes.length < prefix.length) return false
+  return prefix.every((byte, index) => bytes[index] === byte)
+}
+
+function byteString(value: string): number[] {
+  return [...value].map((char) => char.charCodeAt(0))
+}
+
+function looksLikeSvg(bytes: Uint8Array): boolean {
+  const text = new TextDecoder().decode(bytes).trimStart()
+  return text.startsWith("<svg") || (text.startsWith("<?xml") && text.includes("<svg"))
+}
+
+function looksLikeHeif(bytes: Uint8Array): boolean {
+  if (bytes.length < 12) return false
+  const brands = ["ftypheic", "ftypheix", "ftyphevc", "ftyphevx", "ftypmif1", "ftypmsf1"]
+  const header = new TextDecoder().decode(bytes.slice(4, 16))
+  return brands.some((brand) => header.startsWith(brand))
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/packages/synergy/test/browser/policy.test.ts
+++ b/packages/synergy/test/browser/policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import path from "path"
 import { pathToFileURL } from "url"
 import { BrowserPolicy } from "../../src/browser/policy"
+import { tmpdir } from "../fixture/fixture"
 
 describe("BrowserPolicy URL normalization", () => {
   test("normalizes bare domains and search text", () => {
@@ -22,10 +23,21 @@ describe("BrowserPolicy user hard safety", () => {
     expect(result.decision).toBe("deny")
   })
 
-  test("allows file URLs only inside workspace", () => {
+  test("allows file URLs only inside workspace", async () => {
     const inside = path.join(process.cwd(), "README.md")
     expect(BrowserPolicy.hardCheckNavigation(pathToFileURL(inside).href, process.cwd()).decision).toBe("allow")
     expect(BrowserPolicy.hardCheckNavigation("file:///etc/passwd", process.cwd()).decision).toBe("deny")
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".synergy", "worktrees", "project", "README.md"), "workspace file")
+      },
+    })
+    const worktreeWorkspace = path.join(tmp.path, ".synergy", "worktrees", "project")
+    const worktreeFile = path.join(worktreeWorkspace, "README.md")
+    expect(BrowserPolicy.hardCheckNavigation(pathToFileURL(worktreeFile).href, worktreeWorkspace).decision).toBe(
+      "allow",
+    )
   })
 })
 

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -974,6 +974,62 @@ describe("EnforcementGate readRoots", () => {
     expect(envelope.decision).toBe("allow")
   })
 
+  test("view_image inside readRoots is file_read in autonomous mode", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/my-project",
+      workspaceType: "main",
+      profileId: "autonomous",
+      readRoots: ["/Users/test/.synergy"],
+    })
+
+    const envelope = gate.evaluate("view_image", {
+      filePath: "/Users/test/.synergy/data/media/screenshot.png",
+    })
+
+    expect(envelope.decision).toBe("allow")
+    expect(envelope.capabilities.some((cap: any) => cap.class === "file_external_read")).toBe(false)
+    const read = envelope.capabilities.find((cap: any) => cap.class === "file_read")!
+    expect(read).toBeDefined()
+    expect(read.paths).toEqual(["/Users/test/.synergy/data/media/screenshot.png"])
+  })
+
+  test("view_image outside workspace and readRoots is classified as file_external_read", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/my-project",
+      workspaceType: "main",
+      profileId: "autonomous",
+      readRoots: ["/Users/test/.synergy"],
+    })
+
+    const envelope = gate.evaluate("view_image", {
+      filePath: "/Users/test/Pictures/private.png",
+    })
+
+    expect(envelope.decision).toBe("allow")
+    const external = envelope.capabilities.find((cap: any) => cap.class === "file_external_read")!
+    expect(external).toBeDefined()
+    expect(external.paths).toEqual(["/Users/test/Pictures/private.png"])
+  })
+
+  test("view_image inside workspace is classified as file_read", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/my-project",
+      workspaceType: "main",
+      profileId: "autonomous",
+      readRoots: ["/Users/test/.synergy"],
+    })
+
+    const envelope = gate.evaluate("view_image", {
+      filePath: "/Users/test/my-project/screenshots/ui.png",
+    })
+
+    expect(envelope.decision).toBe("allow")
+    expect(envelope.capabilities.some((cap: any) => cap.class === "file_external_read")).toBe(false)
+    const read = envelope.capabilities.find((cap: any) => cap.class === "file_read")!
+    expect(read).toBeDefined()
+    expect(read.paths).toEqual(["/Users/test/my-project/screenshots/ui.png"])
+  })
+
   test("attach inside readRoots is allowed in autonomous mode", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/my-project",
@@ -1033,6 +1089,22 @@ describe("EnforcementGate readRoots", () => {
 
     const envelope = gate.evaluate("look_at", {
       file_path: "/Users/test/.ssh/id_rsa",
+    })
+
+    expect(envelope.decision).toBe("deny")
+    expect(envelope.capabilities.some((cap: any) => cap.class === "secrets")).toBe(true)
+  })
+
+  test("view_image protected credential path is denied in autonomous mode", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/my-project",
+      workspaceType: "main",
+      profileId: "autonomous",
+      readRoots: ["/Users/test/.synergy"],
+    })
+
+    const envelope = gate.evaluate("view_image", {
+      filePath: "/Users/test/.ssh/id_rsa",
     })
 
     expect(envelope.decision).toBe("deny")

--- a/packages/synergy/test/preload.ts
+++ b/packages/synergy/test/preload.ts
@@ -35,22 +35,14 @@ const testHome = path.join(dir, "home")
 await fs.mkdir(testHome, { recursive: true })
 process.env["SYNERGY_TEST_HOME"] = testHome
 
-// Pre-fetch models.json so tests don't need the macro fallback
-// Also write the cache version file to prevent global/index.ts from clearing the cache
+// Write deterministic models.dev fixture data so provider tests do not drift with
+// the live registry.
 const cacheDir = path.join(testHome, ".synergy", "cache")
 await fs.mkdir(cacheDir, { recursive: true })
 await fs.writeFile(path.join(cacheDir, "version"), "15")
 const modelsCachePath = path.join(cacheDir, "models.json")
-try {
-  const response = await fetch("https://models.dev/api.json", {
-    signal: AbortSignal.timeout(2000),
-  })
-  if (!response.ok) throw new Error(`unexpected status ${response.status}`)
-  await fs.writeFile(modelsCachePath, await response.text())
-} catch {
-  const fixture = await Bun.file(new URL("./tool/fixtures/models-api.json", import.meta.url)).text()
-  await fs.writeFile(modelsCachePath, fixture)
-}
+const fixture = await Bun.file(new URL("./tool/fixtures/models-api.json", import.meta.url)).text()
+await fs.writeFile(modelsCachePath, fixture)
 process.env["MODELS_DEV_API_JSON"] = modelsCachePath
 // Disable models.dev refresh to avoid race conditions during tests
 process.env["SYNERGY_DISABLE_MODELS_FETCH"] = "true"

--- a/packages/synergy/test/provider/codex.test.ts
+++ b/packages/synergy/test/provider/codex.test.ts
@@ -324,7 +324,7 @@ test("provider catalog includes OpenAI Codex before login", async () => {
   expect(codex.models["gpt-5.5"].limit.context).toBe(272_000)
   expect(codex.models["gpt-5.5"].limit.input).toBe(272_000)
   expect(codex.models["gpt-5.3-codex-spark"].limit.context).toBe(128_000)
-  expect(catalog.openai.models["gpt-5.5"].limit.context).toBe(1_050_000)
+  expect(codex.models["gpt-5.5"].provider?.npm).toBe("@ai-sdk/openai")
 })
 
 test("logged-in Codex provider applies fallback context when live metadata omits context_window", async () => {

--- a/packages/synergy/test/provider/transform.test.ts
+++ b/packages/synergy/test/provider/transform.test.ts
@@ -536,7 +536,7 @@ describe("ProviderTransform.message - empty image handling", () => {
     expect(result[0].content).toHaveLength(2)
     expect(result[0].content[1]).toMatchObject({
       type: "text",
-      text: '["huge.png" was attached but not sent to Bedrock because it exceeds the 5MB image limit. Use the look_at tool with the file\'s local path to analyze it or attach a smaller image.]',
+      text: '["huge.png" was attached but not sent to Bedrock because it exceeds the 5MB image limit. Use view_image with a smaller local image when the active model supports image input, use look_at for separate vision-model analysis, or attach a smaller image.]',
     })
   })
 })

--- a/packages/synergy/test/tool/exposure.test.ts
+++ b/packages/synergy/test/tool/exposure.test.ts
@@ -119,15 +119,20 @@ describe("tool exposure", () => {
     expect(internal.exposure).toEqual({ mode: "internal" })
   })
 
-  test("ToolResolver hides look_at when the active model supports image input", async () => {
+  test("ToolResolver exposes exactly one image inspection tool for active model capability", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
       scope: await tmp.scope(),
       fn: async () => {
         const session = await Session.create({})
 
-        expect((await definitionIDs(session)).has("look_at")).toBe(true)
-        expect((await definitionIDs(session, { model: imageModel })).has("look_at")).toBe(false)
+        const textOnly = await definitionIDs(session)
+        expect(textOnly.has("look_at")).toBe(true)
+        expect(textOnly.has("view_image")).toBe(false)
+
+        const imageCapable = await definitionIDs(session, { model: imageModel })
+        expect(imageCapable.has("look_at")).toBe(false)
+        expect(imageCapable.has("view_image")).toBe(true)
       },
     })
   })

--- a/packages/synergy/test/tool/read.test.ts
+++ b/packages/synergy/test/tool/read.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test"
 import path from "path"
 import { ReadTool } from "../../src/tool/read"
 import { ScopeContext } from "../../src/scope/context"
-import { Scope } from "../../src/scope"
 import { tmpdir } from "../fixture/fixture"
 import { PermissionNext } from "../../src/permission/next"
 import { Agent } from "../../src/agent/agent"
@@ -265,10 +264,9 @@ describe("tool.read truncation", () => {
     })
   })
 
-  test("image files set truncated to false", async () => {
+  test("image files are treated as binary and do not attach model-visible image context", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
-        // 1x1 red PNG
         const png = Buffer.from(
           "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
           "base64",
@@ -280,24 +278,9 @@ describe("tool.read truncation", () => {
       scope: await tmp.scope(),
       fn: async () => {
         const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "image.png") }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.attachments).toBeDefined()
-        expect(result.attachments?.length).toBe(1)
-      },
-    })
-  })
-
-  test("large image files are properly attached without error", async () => {
-    await ScopeContext.provide({
-      scope: (await Scope.fromDirectory(FIXTURES_DIR)).scope,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(FIXTURES_DIR, "large-image.png") }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.attachments).toBeDefined()
-        expect(result.attachments?.length).toBe(1)
-        expect(result.attachments?.[0].type).toBe("attachment")
+        await expect(read.execute({ filePath: path.join(tmp.path, "image.png") }, ctx)).rejects.toThrow(
+          "Cannot read binary file",
+        )
       },
     })
   })

--- a/packages/synergy/test/tool/view-image.test.ts
+++ b/packages/synergy/test/tool/view-image.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { ViewImageTool } from "../../src/tool/view-image"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
+import type { PermissionNext } from "../../src/permission/next"
+
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+  "base64",
+)
+
+const ctx = {
+  sessionID: "ses_test123",
+  messageID: "msg_test123",
+  callID: "call_test123",
+  agent: "developer",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("tool.view_image", () => {
+  test("returns a provider-file image attachment for a PNG", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "image.png"), PNG_BYTES)
+      },
+    })
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const viewImage = await ViewImageTool.init()
+        const filepath = path.join(tmp.path, "image.png")
+        const result = await viewImage.execute({ filePath: filepath }, ctx)
+
+        expect(result.title).toBe("Viewed Image: image.png")
+        expect(result.output).toContain("loaded into the current model context")
+        expect(result.metadata).toMatchObject({
+          filePath: filepath,
+          filename: "image.png",
+          mimeType: "image/png",
+          modelContext: true,
+          truncated: false,
+        })
+        expect(result.metadata.sizeBytes).toBeGreaterThan(0)
+        expect(result.attachments).toHaveLength(1)
+
+        const attachment = result.attachments?.[0]
+        expect(attachment).toBeDefined()
+        expect(attachment?.mime).toBe("image/png")
+        expect(attachment?.filename).toBe("image.png")
+        expect(attachment?.localPath).toBe(filepath)
+        expect(attachment?.url).toStartWith("data:image/png;base64,")
+        expect(attachment?.model).toEqual({
+          mode: "provider-file",
+          summary: "image.png (image/png) loaded by view_image",
+        })
+        expect(attachment?.presentation).toEqual({ renderer: "image", size: "medium", crop: false })
+      },
+    })
+  })
+
+  test("rejects non-image files without attachments", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "note.txt"), "hello world")
+      },
+    })
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const viewImage = await ViewImageTool.init()
+        const result = await viewImage.execute({ filePath: path.join(tmp.path, "note.txt") }, ctx)
+
+        expect(result.title).toBe("Unsupported file type")
+        expect(result.output).toContain("is not an image")
+        expect(result.output).toContain("Use read/scan_document")
+        expect(result.metadata.error).toBe("unsupported_file_type")
+        expect(result.attachments).toBeUndefined()
+      },
+    })
+  })
+
+  test("rejects files whose image extension does not match the content", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "fake.png"), "not an image")
+      },
+    })
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const viewImage = await ViewImageTool.init()
+        const result = await viewImage.execute({ filePath: path.join(tmp.path, "fake.png") }, ctx)
+
+        expect(result.title).toBe("Unsupported file type")
+        expect(result.output).toContain("content does not match image/png")
+        expect(result.metadata.error).toBe("unsupported_file_type")
+        expect(result.attachments).toBeUndefined()
+      },
+    })
+  })
+
+  test("missing file returns file_not_found metadata without attachments", async () => {
+    await using tmp = await tmpdir()
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const viewImage = await ViewImageTool.init()
+        const missingPath = path.join(tmp.path, "missing.png")
+        const result = await viewImage.execute({ filePath: missingPath }, ctx)
+
+        expect(result.title).toBe("File not found")
+        expect(result.output).toBe(`Error: File not found: ${missingPath}`)
+        expect(result.metadata.error).toBe("file_not_found")
+        expect(result.attachments).toBeUndefined()
+      },
+    })
+  })
+
+  test("asks for read permission with the resolved absolute path", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "relative.png"), PNG_BYTES)
+      },
+    })
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const viewImage = await ViewImageTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+
+        await viewImage.execute({ filePath: "relative.png" }, testCtx)
+
+        expect(requests).toHaveLength(1)
+        expect(requests[0]).toEqual({
+          permission: "read",
+          patterns: [path.join(tmp.path, "relative.png")],
+          metadata: {},
+        })
+      },
+    })
+  })
+})

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -532,6 +532,12 @@ export function getToolInfo(tool: string, input: any = {}, metadata: any = {}): 
         title: "Read",
         subtitle: input.filePath ? getDirectory(input.filePath) + getFilename(input.filePath) : undefined,
       }
+    case "view_image":
+      return {
+        icon: "image",
+        title: "View Image",
+        subtitle: input.filePath ? getDirectory(input.filePath) + getFilename(input.filePath) : undefined,
+      }
     case "view_file":
       return {
         icon: "scan-eye",

--- a/packages/ui/src/components/tool/classifier.ts
+++ b/packages/ui/src/components/tool/classifier.ts
@@ -217,6 +217,7 @@ const TOOL_CATEGORIES: Record<string, SemanticCategory> = {
   view_file: "file-read",
   list: "file-read",
   look_at: "analyze",
+  view_image: "analyze",
   scan_document: "analyze",
   edit: "file-write",
   revise_file: "file-write",

--- a/packages/ui/src/components/tool/renders/standard.tsx
+++ b/packages/ui/src/components/tool/renders/standard.tsx
@@ -57,6 +57,32 @@ ToolRegistry.register({
 })
 
 ToolRegistry.register({
+  name: "view_image",
+  render(props) {
+    return (
+      <BasicTool
+        {...props}
+        trigger={{
+          icon: "image",
+          title: "View Image",
+          subtitle: props.input.filePath
+            ? getDirectory(props.input.filePath) + getFilename(props.input.filePath)
+            : undefined,
+        }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ToolTextOutput text={output()} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+ToolRegistry.register({
   name: "list",
   render(props) {
     return (

--- a/packages/util/src/capability.ts
+++ b/packages/util/src/capability.ts
@@ -436,6 +436,7 @@ export const SYNERGY_PERMISSION_CAPABILITY: Record<string, string> = {
   network_request: "network_request",
   scan_document: "file_read",
   look_at: "file_read",
+  view_image: "file_read",
   attach: "file_read",
   ast_grep: "file_read",
   lsp: "file_read",


### PR DESCRIPTION
## Summary
- Add `view_image` as the direct current-model image context tool for image-capable models.
- Split image handling out of `read`, update `look_at`/`view_image` capability-based exposure, and wire backend taxonomy, enforcement, permissions, prompts, and UI cards.
- Add focused coverage for the new tool, read behavior, exposure, enforcement, provider messaging, and a BrowserPolicy worktree-path regression.

## Verification
- `cd packages/synergy && bun test test/tool/view-image.test.ts test/tool/read.test.ts test/tool/exposure.test.ts test/enforcement/gate.test.ts test/provider/transform.test.ts test/browser/policy.test.ts`
- `bun run typecheck`
- `./script/format.ts`

## Notes
- A local full `bun test --coverage` run still showed pre-existing concurrency/flaky failures in unrelated suites; the failing files passed individually and in focused groups.