### PR TITLE
feat(session): add iterative clarification workflow to plan mode prompts

### DIFF
--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -36,15 +36,46 @@ export namespace SessionCompaction {
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 
+  /**
+   * Check whether a compaction request for the given parent user message has
+   * already been fulfilled — i.e., there exists a completed summary assistant
+   * message targeting that parent. Used by both the proactive budget trigger
+   * and the compact signal to distinguish "compaction already pending" from
+   * "compaction already completed and should not block another."
+   */
+  export function hasFulfilledCompaction(messages: MessageV2.WithParts[], parentID: string): boolean {
+    return messages.some((m) => {
+      if (m.info.role !== "assistant") return false
+      const a = m.info as MessageV2.Assistant
+      return a.summary === true && !!a.finish && a.parentID === parentID
+    })
+  }
+
   /** Detect whether a processor error was caused by exceeding the model's context window. */
   export function isContextExceeded(error: unknown): boolean {
     if (!error || typeof error !== "object") return false
     const obj = error as { name?: string; data?: { message?: string; statusCode?: number; responseBody?: string } }
-    if (obj.name !== "APIError") return false
-    // Check the primary error message and the raw response body, since
-    // ProviderTransform.error() may rewrite the message and drop keywords.
-    const texts = [obj.data?.message ?? "", obj.data?.responseBody ?? ""].map((s) => s.toLowerCase())
-    return texts.some(
+
+    const texts: string[] = [obj.data?.message ?? "", obj.data?.responseBody ?? ""]
+
+    // Provider streaming errors (e.g. SSE error events from OpenAI Codex) may
+    // arrive as a plain Error instead of APICallError, and fromError() stores
+    // them as NamedError.Unknown with the JSON-stringified error payload in
+    // the message field. Try to extract nested keywords so emergency compaction
+    // can still recognize them.
+    if (typeof obj.data?.message === "string") {
+      try {
+        const nested = JSON.parse(obj.data.message)
+        for (const key of ["code", "type", "message"]) {
+          if (typeof nested?.error?.[key] === "string") texts.push(nested.error[key])
+        }
+        if (typeof nested?.error === "string") texts.push(nested.error)
+      } catch {}
+    }
+
+    const lower = texts.filter(Boolean).map((s) => s.toLowerCase())
+    if (lower.length === 0) return false
+    return lower.some(
       (msg) =>
         msg.includes("context_length_exceeded") ||
         msg.includes("context length") ||

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -36,19 +36,42 @@ export namespace SessionCompaction {
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 
-  /**
-   * Check whether a compaction request for the given parent user message has
-   * already been fulfilled — i.e., there exists a completed summary assistant
-   * message targeting that parent. Used by both the proactive budget trigger
-   * and the compact signal to distinguish "compaction already pending" from
-   * "compaction already completed and should not block another."
-   */
-  export function hasFulfilledCompaction(messages: MessageV2.WithParts[], parentID: string): boolean {
-    return messages.some((m) => {
-      if (m.info.role !== "assistant") return false
-      const a = m.info as MessageV2.Assistant
-      return a.summary === true && !!a.finish && a.parentID === parentID
-    })
+  function completedSummaries(messages: MessageV2.WithParts[], parentID: string): MessageV2.Assistant[] {
+    return messages
+      .map((m) => m.info)
+      .filter(
+        (info): info is MessageV2.Assistant =>
+          info.role === "assistant" && info.summary === true && !!info.finish && info.parentID === parentID,
+      )
+  }
+
+  function summaryRequestID(summary: MessageV2.Assistant): string | undefined {
+    const value = summary.metadata?.compactionRequestPartID
+    return typeof value === "string" ? value : undefined
+  }
+
+  export function pendingCompactionRequest(
+    messages: MessageV2.WithParts[],
+    parentID: string,
+    parts: MessageV2.Part[],
+  ): MessageV2.CompactionPart | undefined {
+    const requests = parts.filter((part): part is MessageV2.CompactionPart => part.type === "compaction")
+    if (requests.length === 0) return undefined
+
+    const requestIDs = new Set(requests.map((part) => part.id))
+    const fulfilled = new Set<string>()
+    for (const summary of completedSummaries(messages, parentID)) {
+      const requestID = summaryRequestID(summary)
+      if (requestID) {
+        if (requestIDs.has(requestID)) fulfilled.add(requestID)
+        continue
+      }
+
+      const legacyRequest = requests.find((part) => !fulfilled.has(part.id))
+      if (legacyRequest) fulfilled.add(legacyRequest.id)
+    }
+
+    return requests.findLast((part) => !fulfilled.has(part.id))
   }
 
   /** Detect whether a processor error was caused by exceeding the model's context window. */
@@ -355,6 +378,7 @@ export namespace SessionCompaction {
 
   export async function process(input: {
     parentID: string
+    requestPartID: string
     messages: MessageV2.WithParts[]
     sessionID: string
     abort: AbortSignal
@@ -396,6 +420,9 @@ export namespace SessionCompaction {
       providerID: model.providerID,
       time: {
         created: Date.now(),
+      },
+      metadata: {
+        compactionRequestPartID: input.requestPartID,
       },
     })) as MessageV2.Assistant
     const processor = SessionProcessor.create({
@@ -549,10 +576,12 @@ export namespace SessionCompaction {
       return []
     },
     async execute(ctx) {
-      const part = ctx.lastUserParts.find((p): p is MessageV2.CompactionPart => p.type === "compaction")!
+      const part = pendingCompactionRequest(ctx.messages, ctx.lastUser.id, ctx.lastUserParts)
+      if (!part) return "pass"
       const result = await process({
         messages: ctx.messages,
         parentID: ctx.lastUser.id,
+        requestPartID: part.id,
         abort: ctx.abort,
         sessionID: ctx.sessionID,
         auto: part.auto,

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -895,19 +895,8 @@ export namespace SessionInvoke {
     }
   }
 
-  /**
-   * Returns true when a compaction part is present on the root user message BUT
-   * the compaction has already been fulfilled (completed summary exists). When
-   * fulfilled, the part acts as a boundary marker for filterCompacted() but
-   * should NOT block future proactive compaction requests.
-   *
-   * False means either no compaction part is present, or the part is still
-   * pending (unfulfilled) — in both cases the proactive trigger can proceed.
-   */
   function compactionPending(jobCtx: LoopJob.Context): boolean {
-    const hasCompactionPart = jobCtx.lastUserParts.some((part) => part.type === "compaction")
-    if (!hasCompactionPart) return false
-    return !SessionCompaction.hasFulfilledCompaction(jobCtx.messages, jobCtx.lastUser.id)
+    return !!SessionCompaction.pendingCompactionRequest(jobCtx.messages, jobCtx.lastUser.id, jobCtx.lastUserParts)
   }
 
   // --- Helpers ---

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -659,11 +659,7 @@ export namespace SessionInvoke {
         })
         promptDecideTimer.stop()
 
-        if (
-          !jobCtx.compactionAutoDisabled &&
-          !jobCtx.lastUserParts.some((part) => part.type === "compaction") &&
-          promptDecision.shouldCompact
-        ) {
+        if (!jobCtx.compactionAutoDisabled && !compactionPending(jobCtx) && promptDecision.shouldCompact) {
           log.info("prompt budget exceeded, injecting compaction", {
             sessionID,
             total: promptDecision.measure.total,
@@ -897,6 +893,21 @@ export namespace SessionInvoke {
       const msg = messages[index]
       if (msg.info.role === "assistant") return msg
     }
+  }
+
+  /**
+   * Returns true when a compaction part is present on the root user message BUT
+   * the compaction has already been fulfilled (completed summary exists). When
+   * fulfilled, the part acts as a boundary marker for filterCompacted() but
+   * should NOT block future proactive compaction requests.
+   *
+   * False means either no compaction part is present, or the part is still
+   * pending (unfulfilled) — in both cases the proactive trigger can proceed.
+   */
+  function compactionPending(jobCtx: LoopJob.Context): boolean {
+    const hasCompactionPart = jobCtx.lastUserParts.some((part) => part.type === "compaction")
+    if (!hasCompactionPart) return false
+    return !SessionCompaction.hasFulfilledCompaction(jobCtx.messages, jobCtx.lastUser.id)
   }
 
   // --- Helpers ---

--- a/packages/synergy/src/session/loop-signals.ts
+++ b/packages/synergy/src/session/loop-signals.ts
@@ -3,6 +3,7 @@ import { LoopJob } from "./loop-job"
 import { Session } from "."
 import { Identifier } from "../id/id"
 import { MessageV2 } from "./message-v2"
+import { SessionCompaction } from "./compaction"
 import { Log } from "@/util/log"
 import { ScopeContext } from "../scope/context"
 const log = Log.create({ service: "session.loop-signals" })
@@ -29,12 +30,7 @@ LoopJob.defineSignal({
     // in the window after compaction runs. Fire only while the request is still
     // pending — i.e. no completed compaction summary for R exists yet — otherwise
     // the loop would re-compact endlessly instead of resuming the task.
-    const fulfilled = ctx.messages.some((m) => {
-      if (m.info.role !== "assistant") return false
-      const a = m.info as MessageV2.Assistant
-      return a.summary === true && !!a.finish && a.parentID === ctx.lastUser.id
-    })
-    return !fulfilled
+    return !SessionCompaction.hasFulfilledCompaction(ctx.messages, ctx.lastUser.id)
   },
 })
 

--- a/packages/synergy/src/session/loop-signals.ts
+++ b/packages/synergy/src/session/loop-signals.ts
@@ -25,12 +25,7 @@ function lastAssistant(ctx: LoopJob.Context): AssistantMsg | undefined {
 LoopJob.defineSignal({
   type: "compact",
   detect(ctx) {
-    if (!ctx.lastUserParts.some((p) => p.type === "compaction")) return false
-    // The compaction part lives on the task root R (issue #281 §7), so it stays
-    // in the window after compaction runs. Fire only while the request is still
-    // pending — i.e. no completed compaction summary for R exists yet — otherwise
-    // the loop would re-compact endlessly instead of resuming the task.
-    return !SessionCompaction.hasFulfilledCompaction(ctx.messages, ctx.lastUser.id)
+    return !!SessionCompaction.pendingCompactionRequest(ctx.messages, ctx.lastUser.id, ctx.lastUserParts)
   },
 })
 

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -1096,8 +1096,12 @@ export namespace MessageV2 {
   export async function filterCompacted(stream: AsyncIterable<MessageV2.WithParts>) {
     const result = [] as MessageV2.WithParts[]
     const completed = new Set<string>()
+    let latestCompactionParentID: string | undefined
     for await (const msg of stream) {
       result.push(msg)
+      if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !latestCompactionParentID) {
+        latestCompactionParentID = msg.info.parentID
+      }
       if (
         msg.info.role === "user" &&
         completed.has(msg.info.id) &&
@@ -1107,7 +1111,26 @@ export namespace MessageV2 {
       if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish) completed.add(msg.info.parentID)
     }
     result.reverse()
-    return result
+    if (!latestCompactionParentID) return result
+
+    const rootIndex = result.findIndex(
+      (msg) =>
+        msg.info.role === "user" &&
+        msg.info.id === latestCompactionParentID &&
+        msg.parts.some((part) => part.type === "compaction"),
+    )
+    if (rootIndex < 0) return result
+
+    const summaryIndex = result.findLastIndex(
+      (msg) =>
+        msg.info.role === "assistant" &&
+        msg.info.summary &&
+        msg.info.finish &&
+        msg.info.parentID === latestCompactionParentID,
+    )
+    if (summaryIndex <= rootIndex) return result
+
+    return [result[rootIndex], ...result.slice(summaryIndex)]
   }
 
   export function fromError(e: unknown, ctx: { providerID: string }) {

--- a/packages/synergy/src/session/prompt/plan-mode-synergy-max.txt
+++ b/packages/synergy/src/session/prompt/plan-mode-synergy-max.txt
@@ -1,7 +1,7 @@
 <plan-mode-synergy-max>
 In coding Plan Mode, produce a Blueprint that is strong enough for autonomous implementation.
 
-Before writing the Blueprint, check whether implementation could start immediately without asking product, architecture, API, migration, compatibility, or UX questions. If not, ask the user first.
+Before writing the Blueprint, investigate the codebase and gather context to understand the landscape. Identify decisions the user must own — product direction, architecture tradeoffs, API design, migration strategy, compatibility choices, UX behavior, or acceptance criteria. Ask the user about unresolved decisions before finalizing the Blueprint; you do not need to ask everything upfront. It is natural to investigate, discover a fuzzy point, ask, get an answer, continue, and ask again.
 
 It should cover:
 - Current codebase evidence and file-level entry points

--- a/packages/synergy/src/session/prompt/plan-mode-synergy.txt
+++ b/packages/synergy/src/session/prompt/plan-mode-synergy.txt
@@ -5,7 +5,7 @@ As synergy in Plan Mode, focus on:
 - Producing a Blueprint that a downstream agent can follow autonomously
 - The Blueprint should explain what to do, why, what to avoid, and what "done" looks like
 - Finalizing only decision-complete Blueprints; do not leave choices for the downstream agent
-- Asking the user instead of adding Open Decisions, Open Questions, TBDs, or unresolved alternatives
+- Asking the user instead of adding Open Decisions, Open Questions, TBDs, or unresolved alternatives; investigate first, then ask, and iterate as new questions surface
 - Use whatever structure fits the domain: narrative prose, bullet points, tables, sections
 - Use the user's domain as the frame. A writing Blueprint should read like an editorial brief, a research Blueprint like an evidence plan, an analysis Blueprint like a reasoning plan, a design Blueprint like a product/design brief, and a coding Blueprint like an engineering plan.
 - Do not import another domain's specialized checklist unless the user's task actually belongs to that domain.

--- a/packages/synergy/src/session/prompt/plan-mode.txt
+++ b/packages/synergy/src/session/prompt/plan-mode.txt
@@ -5,7 +5,12 @@ Your job is to create or refine a high-quality Blueprint: a human-readable desig
 
 A Blueprint is an executable delivery contract. It must be decision-complete: a later execution session should not need to choose the intended outcome, domain strategy, artifact shape, user-facing behavior, quality bar, acceptance criteria, or other user-owned decisions.
 
-Do not create or update a Blueprint while blocking ambiguity remains. If the document would contain Open Decisions, Open Questions, TBDs, unresolved alternatives, or instructions for the execution session to ask the user later, ask the user first and wait for the answer.
+A Blueprint often starts with ambiguity: the user's request may be high-level, and critical design tradeoffs only surface after investigation. Your clarification workflow is:
+
+1. Gather context first — inspect code, docs, sessions, memory, and external sources to understand the landscape.
+2. Identify decisions the user must own — product direction, architecture tradeoffs, API design, migration strategy, UX behavior, acceptance criteria, or scope boundaries.
+3. Ask blocking questions at the right time. You do not need to ask everything upfront; it is natural to investigate, discover a fuzzy point, ask, get an answer, continue, and ask again. Multiple rounds of clarification are expected for complex Blueprints.
+4. Do not create or update a Blueprint while blocking ambiguity remains. If the document would contain Open Decisions, Open Questions, TBDs, unresolved alternatives, or instructions for the execution session to ask the user later, ask the user and wait.
 
 You may include Assumptions only when they are locked execution defaults chosen from evidence, project conventions, or explicit user direction. Do not use Assumptions to hide unresolved decisions.
 

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -304,23 +304,135 @@ describe("session.compaction.isContextExceeded", () => {
     expect(SessionCompaction.isContextExceeded({ name: "AuthError", data: { message: "bad key" } })).toBe(false)
   })
 
-  test("rejects null / undefined", () => {
-    expect(SessionCompaction.isContextExceeded(null)).toBe(false)
-    expect(SessionCompaction.isContextExceeded(undefined)).toBe(false)
+  test("detects codex streaming error stored as UnknownError", () => {
+    // Codex SSE streaming error: {"type":"error","sequence_number":2,"error":{"type":"invalid_request_error","code":"context_length_exceeded",...}}
+    // fromError() wraps this as NamedError.Unknown when it's not an APICallError.
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: {
+          message:
+            '{"type":"error","sequence_number":2,"error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model.","param":"input"}}',
+        },
+      }),
+    ).toBe(true)
   })
 
-  test("rejects primitive values", () => {
-    expect(SessionCompaction.isContextExceeded("context_length_exceeded")).toBe(false)
-    expect(SessionCompaction.isContextExceeded(42)).toBe(false)
+  test("detects UnknownError with nested error.type containing context_length_exceeded", () => {
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: {
+          message: '{"type":"error","error":{"type":"context_length_exceeded"}}',
+        },
+      }),
+    ).toBe(true)
   })
 
-  test("detects 'request too large' with token mention", () => {
-    expect(SessionCompaction.isContextExceeded(apiError("request too large: total token count exceeds limit"))).toBe(
-      true,
-    )
+  test("rejects UnknownError without context keywords", () => {
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: { message: "some random network error" },
+      }),
+    ).toBe(false)
+  })
+
+  test("rejects UnknownError with unrelated nested error", () => {
+    expect(
+      SessionCompaction.isContextExceeded({
+        name: "UnknownError",
+        data: {
+          message: '{"type":"error","error":{"type":"rate_limit_exceeded","message":"too many requests"}}',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test("detects context keyword in plain message without APIError name", () => {
+    expect(SessionCompaction.isContextExceeded({ data: { message: "context_length_exceeded" } })).toBe(true)
   })
 })
 
+// ---------------------------------------------------------------------------
+// SessionCompaction.hasFulfilledCompaction
+// ---------------------------------------------------------------------------
+
+describe("session.compaction.hasFulfilledCompaction", () => {
+  const now = Date.now()
+
+  function makeAssistant(opts: {
+    id: string
+    parentID: string
+    summary?: boolean
+    finish?: string
+  }): MessageV2.WithParts {
+    const info: MessageV2.Assistant = {
+      id: opts.id,
+      role: "assistant",
+      sessionID: "test-session",
+      time: { created: now },
+      modelID: "test-model",
+      providerID: "test",
+      mode: "default",
+      agent: "synergy",
+      path: { cwd: "/", root: "/" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      parentID: opts.parentID,
+    }
+    if (opts.summary) info.summary = true
+    if (opts.finish) info.finish = opts.finish as MessageV2.Assistant["finish"]
+    return { info, parts: [] }
+  }
+
+  test("returns true for fulfilled compaction", () => {
+    const parentID = "root-user"
+    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true, finish: "stop" })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(true)
+  })
+
+  test("returns false when no summary assistant exists", () => {
+    const msgs = [makeAssistant({ id: "asst-1", parentID: "other-parent", summary: true, finish: "stop" })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
+  })
+
+  test("returns false when summary is missing finish", () => {
+    const parentID = "root-user"
+    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
+  })
+
+  test("returns false for non-summary assistant matching parentID", () => {
+    const parentID = "root-user"
+    const msgs = [makeAssistant({ id: "asst-1", parentID, finish: "stop" })]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
+  })
+
+  test("returns false for user messages with matching id", () => {
+    const msgs: MessageV2.WithParts[] = [
+      {
+        info: {
+          id: "root-user",
+          role: "user",
+          sessionID: "test-session",
+          time: { created: now },
+          agent: "synergy",
+          model: { providerID: "test", modelID: "test-model" },
+        },
+        parts: [],
+      },
+    ]
+    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
+  })
+
+  test("returns false for empty messages", () => {
+    expect(SessionCompaction.hasFulfilledCompaction([], "root-user")).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SessionCompaction.buildAnchor
 // ---------------------------------------------------------------------------
 // SessionCompaction.buildAnchor
 // ---------------------------------------------------------------------------

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -354,80 +354,69 @@ describe("session.compaction.isContextExceeded", () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// SessionCompaction.hasFulfilledCompaction
-// ---------------------------------------------------------------------------
-
-describe("session.compaction.hasFulfilledCompaction", () => {
+describe("session.compaction.pendingCompactionRequest", () => {
   const now = Date.now()
 
-  function makeAssistant(opts: {
-    id: string
-    parentID: string
-    summary?: boolean
-    finish?: string
-  }): MessageV2.WithParts {
+  function compactionPart(id: string): MessageV2.CompactionPart {
+    return {
+      id,
+      sessionID: "test-session",
+      messageID: "root-user",
+      type: "compaction",
+      auto: true,
+    }
+  }
+
+  function summary(opts: { id: string; parentID: string; requestID?: string; finish?: string }): MessageV2.WithParts {
     const info: MessageV2.Assistant = {
       id: opts.id,
       role: "assistant",
       sessionID: "test-session",
-      time: { created: now },
+      time: { created: now, completed: now + 1 },
       modelID: "test-model",
       providerID: "test",
-      mode: "default",
-      agent: "synergy",
+      mode: "compaction",
+      agent: "compaction",
       path: { cwd: "/", root: "/" },
       cost: 0,
       tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
       parentID: opts.parentID,
+      summary: true,
     }
-    if (opts.summary) info.summary = true
     if (opts.finish) info.finish = opts.finish as MessageV2.Assistant["finish"]
+    if (opts.requestID) info.metadata = { compactionRequestPartID: opts.requestID }
     return { info, parts: [] }
   }
 
-  test("returns true for fulfilled compaction", () => {
-    const parentID = "root-user"
-    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true, finish: "stop" })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(true)
+  test("returns the newest unfulfilled request when an older request is fulfilled explicitly", () => {
+    const parts = [compactionPart("part_1"), compactionPart("part_2")]
+    const messages = [summary({ id: "summary_1", parentID: "root-user", requestID: "part_1", finish: "stop" })]
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)?.id).toBe("part_2")
   })
 
-  test("returns false when no summary assistant exists", () => {
-    const msgs = [makeAssistant({ id: "asst-1", parentID: "other-parent", summary: true, finish: "stop" })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
-  })
-
-  test("returns false when summary is missing finish", () => {
-    const parentID = "root-user"
-    const msgs = [makeAssistant({ id: "asst-1", parentID, summary: true })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
-  })
-
-  test("returns false for non-summary assistant matching parentID", () => {
-    const parentID = "root-user"
-    const msgs = [makeAssistant({ id: "asst-1", parentID, finish: "stop" })]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, parentID)).toBe(false)
-  })
-
-  test("returns false for user messages with matching id", () => {
-    const msgs: MessageV2.WithParts[] = [
-      {
-        info: {
-          id: "root-user",
-          role: "user",
-          sessionID: "test-session",
-          time: { created: now },
-          agent: "synergy",
-          model: { providerID: "test", modelID: "test-model" },
-        },
-        parts: [],
-      },
+  test("returns undefined when the newest request is fulfilled explicitly", () => {
+    const parts = [compactionPart("part_1"), compactionPart("part_2")]
+    const messages = [
+      summary({ id: "summary_1", parentID: "root-user", requestID: "part_1", finish: "stop" }),
+      summary({ id: "summary_2", parentID: "root-user", requestID: "part_2", finish: "stop" }),
     ]
-    expect(SessionCompaction.hasFulfilledCompaction(msgs, "root-user")).toBe(false)
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)).toBeUndefined()
   })
 
-  test("returns false for empty messages", () => {
-    expect(SessionCompaction.hasFulfilledCompaction([], "root-user")).toBe(false)
+  test("legacy summaries without request metadata fulfill only the oldest unfulfilled request", () => {
+    const parts = [compactionPart("part_1"), compactionPart("part_2")]
+    const messages = [summary({ id: "summary_1", parentID: "root-user", finish: "stop" })]
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)?.id).toBe("part_2")
+  })
+
+  test("ignores unfinished summaries", () => {
+    const parts = [compactionPart("part_1")]
+    const messages = [summary({ id: "summary_1", parentID: "root-user", requestID: "part_1" })]
+
+    expect(SessionCompaction.pendingCompactionRequest(messages, "root-user", parts)?.id).toBe("part_1")
   })
 })
 

--- a/packages/synergy/test/session/invoke-compaction.test.ts
+++ b/packages/synergy/test/session/invoke-compaction.test.ts
@@ -97,6 +97,7 @@ function testAssistant(input: {
   completed?: number
   summary?: boolean
   finish?: string
+  metadata?: Record<string, unknown>
   parts?: MessageV2.Part[]
 }): MessageV2.WithParts {
   const info: MessageV2.Assistant = {
@@ -114,6 +115,7 @@ function testAssistant(input: {
     time: { created: input.created, ...(input.completed !== undefined ? { completed: input.completed } : {}) },
     ...(input.summary ? { summary: true } : {}),
     ...(input.finish ? { finish: input.finish } : {}),
+    ...(input.metadata ? { metadata: input.metadata } : {}),
   }
   return { info, parts: input.parts ?? [] }
 }
@@ -647,6 +649,112 @@ describe.serial("SessionInvoke preflight compaction", () => {
     const compacted = await filterNewestFirst([realUser, oldAssistant, boundary, summary, continuation])
 
     expect(compacted.map((msg) => msg.info.id)).toEqual(["msg_boundary", "msg_summary", "msg_continue"])
+  })
+
+  test("filters compacted history from the latest root compaction summary", async () => {
+    const sessionID = "ses_test"
+    const root = testUser({
+      id: "msg_root",
+      sessionID,
+      created: 1,
+      parts: [
+        {
+          id: "prt_root_text",
+          sessionID,
+          messageID: "msg_root",
+          type: "text",
+          text: "Implement the account settings workflow.",
+        },
+        {
+          id: "prt_compaction_1",
+          sessionID,
+          messageID: "msg_root",
+          type: "compaction",
+          auto: true,
+        },
+        {
+          id: "prt_compaction_2",
+          sessionID,
+          messageID: "msg_root",
+          type: "compaction",
+          auto: true,
+        },
+      ],
+    })
+    const oldAssistant = testAssistant({
+      id: "msg_old_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 2,
+      completed: 3,
+      finish: "tool-calls",
+    })
+    const firstSummary = testAssistant({
+      id: "msg_summary_1",
+      sessionID,
+      parentID: root.info.id,
+      created: 4,
+      completed: 5,
+      summary: true,
+      finish: "stop",
+      metadata: { compactionRequestPartID: "prt_compaction_1" },
+    })
+    const firstContinue = testUser({
+      id: "msg_continue_1",
+      sessionID,
+      created: 6,
+      summaryTitle: "Compaction complete",
+    })
+    const newerAssistant = testAssistant({
+      id: "msg_newer_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 7,
+      completed: 8,
+      finish: "tool-calls",
+    })
+    const secondSummary = testAssistant({
+      id: "msg_summary_2",
+      sessionID,
+      parentID: root.info.id,
+      created: 9,
+      completed: 10,
+      summary: true,
+      finish: "stop",
+      metadata: { compactionRequestPartID: "prt_compaction_2" },
+    })
+    const secondContinue = testUser({
+      id: "msg_continue_2",
+      sessionID,
+      created: 11,
+      summaryTitle: "Compaction complete",
+    })
+    const latestAssistant = testAssistant({
+      id: "msg_latest_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 12,
+      completed: 13,
+      finish: "stop",
+    })
+
+    const compacted = await filterNewestFirst([
+      root,
+      oldAssistant,
+      firstSummary,
+      firstContinue,
+      newerAssistant,
+      secondSummary,
+      secondContinue,
+      latestAssistant,
+    ])
+
+    expect(compacted.map((msg) => msg.info.id)).toEqual([
+      "msg_root",
+      "msg_summary_2",
+      "msg_continue_2",
+      "msg_latest_assistant",
+    ])
   })
 
   test("resolves the compaction anchor from the task root by id", () => {

--- a/packages/synergy/test/session/loop-signals.test.ts
+++ b/packages/synergy/test/session/loop-signals.test.ts
@@ -50,6 +50,28 @@ function makeAssistant(toolParts: any[]): any {
   }
 }
 
+function makeSummary(parentID = "usr_test", requestID?: string): any {
+  return {
+    info: {
+      id: `msg_summary_${Math.random().toString(36).slice(2)}`,
+      role: "assistant" as const,
+      sessionID: "ses_test",
+      parentID,
+      agent: "compaction",
+      mode: "compaction",
+      summary: true,
+      finish: "stop",
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: "test-model",
+      providerID: "test-provider",
+      time: { created: Date.now(), completed: Date.now() },
+      ...(requestID ? { metadata: { compactionRequestPartID: requestID } } : {}),
+    },
+    parts: [],
+  }
+}
+
 function makeTool(tool: string, input: unknown, status: "completed" | "error"): any {
   return {
     id: `prt_${Math.random().toString(36).slice(2)}`,
@@ -211,6 +233,42 @@ describe("loop-signals: compact signal", () => {
     )
     const fired = await LoopJob.detectSignals(ctx)
     expect(fired).not.toContain("compact")
+  })
+
+  test("does not detect when the latest compaction request is fulfilled", async () => {
+    const ctx = makeCtx(
+      1,
+      [makeUserWrapper(), makeSummary("usr_test", "p1")],
+      [{ id: "p1", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true }],
+    )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).not.toContain("compact")
+  })
+
+  test("detects a new compaction request after an older completed summary", async () => {
+    const ctx = makeCtx(
+      2,
+      [makeUserWrapper(), makeSummary("usr_test", "p1")],
+      [
+        { id: "p1", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+        { id: "p2", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+      ],
+    )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).toContain("compact")
+  })
+
+  test("detects a new compaction request after a legacy completed summary", async () => {
+    const ctx = makeCtx(
+      2,
+      [makeUserWrapper(), makeSummary("usr_test")],
+      [
+        { id: "p1", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+        { id: "p2", sessionID: "ses_test", messageID: "m1", type: "compaction", auto: true },
+      ],
+    )
+    const fired = await LoopJob.detectSignals(ctx)
+    expect(fired).toContain("compact")
   })
 
   test("coexists with repeat_loop without interference", async () => {


### PR DESCRIPTION
## Summary

Plan mode prompts previously had "ask the user" semantics but lacked a structured clarification workflow. The guidance was a one-shot check before writing — it didn't teach the model to **investigate first and iterate through clarification rounds**.

## What changed

Three prompt files updated:

### `plan-mode.txt` (generic, applies to all agents)
Replaced the single "Do not create or update a Blueprint while blocking ambiguity remains" line with a 4-step workflow:
1. Gather context first
2. Identify decisions the user must own
3. Ask blocking questions at the right time (not necessarily upfront; multiple rounds OK)
4. Finalize only when zero ambiguity remains

### `plan-mode-synergy-max.txt` (coding)
Expanded the one-shot "check whether implementation could start immediately...if not, ask" into an iterative investigate-then-ask loop:
- Investigate the codebase first
- Identify user-owned decisions (product, architecture, API, migration, compatibility, UX)
- Ask as fuzzy points surface; iterate naturally

### `plan-mode-synergy.txt` (general synergy)
Added "investigate first, then ask, and iterate as new questions surface" to the existing bullet.

## Principle

The model should not feel forced to guess all questions upfront. It should gather context, discover fuzzy points naturally, ask blocking questions (possibly multiple rounds), and only produce a Blueprint when all user-owned decisions are resolved.