### PR TITLE
Fix manual compact event sync

### DIFF
--- a/packages/synergy/src/server/session.ts
+++ b/packages/synergy/src/server/session.ts
@@ -745,8 +745,9 @@ export const SessionRoute = new Hono()
           break
         }
       }
+      const messageID = Identifier.ascending("message")
       const msg = await Session.updateMessage({
-        id: Identifier.ascending("message"),
+        id: messageID,
         role: "user",
         model: {
           providerID: body.providerID,
@@ -754,6 +755,9 @@ export const SessionRoute = new Hono()
         },
         sessionID,
         agent: currentAgent,
+        isRoot: true,
+        rootID: messageID,
+        visible: true,
         // Mark this as a compaction boundary so the frontend suppresses the
         // user chrome (the "What did we do so far?" prompt is internal) and
         // renders only the compaction card for the turn (issue #326).

--- a/packages/synergy/test/server/session-summarize.test.ts
+++ b/packages/synergy/test/server/session-summarize.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const { GlobalBus } = await import("../../src/bus/global")
+const { Scope } = await import("../../src/scope")
+const { ScopeContext } = await import("../../src/scope/context")
+const { Server } = await import("../../src/server/server")
+const { Session } = await import("../../src/session")
+const { Log } = await import("../../src/util/log")
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session summarize route", () => {
+  test("publishes a canonical compaction boundary root for event-driven sync", async () => {
+    const scope = (await Scope.fromDirectory(projectRoot)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const session = await Session.create({ title: "Compaction event test" })
+        const messages: any[] = []
+        const handler = (event: { directory?: string; payload: any }) => {
+          if (event.directory !== scope.directory) return
+          if (event.payload?.type !== "message.updated") return
+          messages.push(event.payload.properties.info)
+        }
+
+        GlobalBus.on("event", handler)
+        try {
+          const app = Server.App()
+          const response = await app.request(`/session/${session.id}/summarize`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-synergy-directory": scope.directory,
+            },
+            body: JSON.stringify({
+              providerID: "test-provider",
+              modelID: "test-model",
+            }),
+          })
+
+          // The test intentionally uses a fake provider/model. The loop may
+          // fail after the boundary is written, but event-driven sync relies
+          // on the boundary's earlier message.updated payload.
+          expect([200, 400, 500]).toContain(response.status)
+
+          const boundary = messages.find(
+            (message) =>
+              message.sessionID === session.id &&
+              message.role === "user" &&
+              message.metadata?.compactionBoundary === true,
+          )
+
+          expect(boundary).toBeDefined()
+          expect(boundary).toMatchObject({
+            isRoot: true,
+            rootID: boundary.id,
+            visible: true,
+          })
+        } finally {
+          GlobalBus.off("event", handler)
+          await Session.remove(session.id)
+        }
+      },
+    })
+  })
+})

--- a/packages/ui/src/components/session-turn-timeline.test.ts
+++ b/packages/ui/src/components/session-turn-timeline.test.ts
@@ -123,6 +123,16 @@ function compactionRecoveryPart(id: string, messageID: string): PartType {
   } as PartType
 }
 
+function compactionPart(id: string, messageID: string): PartType {
+  return {
+    id,
+    sessionID: "session",
+    messageID,
+    type: "compaction",
+    auto: false,
+  } as PartType
+}
+
 function textPart(id: string, messageID: string, text = "Hello"): PartType {
   return {
     id,
@@ -339,10 +349,18 @@ describe("session turn assistant collection", () => {
     // chrome, and the compaction card must appear even before the recovery part
     // exists (the "Compressing context..." state).
     const root = user("msg_manual_compact", { isRoot: true, metadata: { compactionBoundary: true } })
-    const parts = [textPart("prompt", root.id, "What did we do so far?")] as PartType[]
+    const parts = [
+      compactionPart("compaction-request", root.id),
+      textPart("prompt", root.id, "What did we do so far?"),
+    ] as PartType[]
     const compaction = compactionAssistant("msg_compaction_assistant", root.id)
 
-    // No compaction_recovery yet (LLM still running), part is undefined.
+    const rootItems = collectUserCompactionTimelineItems(root, parts)
+    expect(rootItems).toHaveLength(1)
+    expect(rootItems[0]).toMatchObject({ kind: "compaction", message: root, part: parts[0] })
+
+    // No compaction_recovery yet (LLM still running), part is undefined on the
+    // assistant card until the structured recovery part is written.
     const items = collectSessionTurnTimelineItems([compaction], {}, true)
     expect(items).toHaveLength(1)
     expect(items[0]).toMatchObject({ kind: "compaction", message: compaction })

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -127,8 +127,14 @@ export function collectUserCompactionTimelineItems(
   parts: readonly PartType[],
 ): SessionTurnTimelineItem[] {
   const compactionRecovery = parts.find((part) => part.type === "compaction_recovery")
-  if (!compactionRecovery) return []
-  return [{ kind: "compaction", message, part: compactionRecovery }]
+  if (compactionRecovery) return [{ kind: "compaction", message, part: compactionRecovery }]
+
+  if (!isCompactionBoundaryUser(message)) return []
+
+  const compactionRequest = parts.find((part) => part.type === "compaction")
+  if (!compactionRequest) return []
+
+  return [{ kind: "compaction", message, part: compactionRequest }]
 }
 
 export function shouldShowTurnDiffs(
@@ -623,8 +629,12 @@ export function SessionTurn(
     () => {
       const result: SessionTurnDisplayItem[] = []
       const msg = message()
-      if (msg) result.push(...collectUserCompactionTimelineItems(msg, parts()))
-      for (const item of displayMessages()) {
+      const display = displayMessages()
+      const hasCompactionAssistant = display.some(
+        (item) => item.role === "assistant" && isCompactionAssistant(item as AssistantMessage),
+      )
+      if (msg && !hasCompactionAssistant) result.push(...collectUserCompactionTimelineItems(msg, parts()))
+      for (const item of display) {
         if (item.role === "user") {
           const userMsg = item as UserMessage
           if (userMsg.isRoot === false) {
@@ -698,12 +708,14 @@ export function SessionTurn(
     providerPreludeElapsedLabel(providerPreludeStarted(), providerPreludeNow()),
   )
   const showProviderPrelude = createMemo(() =>
-    shouldShowProviderPrelude({
-      working: working(),
-      hasError: !!error(),
-      latestAssistant: lastAssistantMessage(),
-      latestAssistantTimelineItems: latestAssistantTimelineItems(),
-    }),
+    hasCompactionEvent()
+      ? false
+      : shouldShowProviderPrelude({
+          working: working(),
+          hasError: !!error(),
+          latestAssistant: lastAssistantMessage(),
+          latestAssistantTimelineItems: latestAssistantTimelineItems(),
+        }),
   )
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- Ensure the manual compaction boundary message emitted by `/session/:id/summarize` includes canonical root-message semantics in the `message.updated` event payload.
- Render the running compact card from the root compaction part while the recovery/result message has not arrived yet.
- Add regression coverage for event-driven sync and compact timeline rendering.

## Test Plan
- `cd packages/synergy && bun test test/server/session-summarize.test.ts test/session/compaction.test.ts test/session/invoke-compaction.test.ts`
- `cd packages/ui && bun test src/components/session-turn-timeline.test.ts`
- `cd packages/app && bun run typecheck`
- `cd packages/ui && bun run typecheck`
- `git diff --check`
- pre-push hook `bun turbo typecheck` passed during push

Related: #329, #326