### PR TITLE
Fix session attachment memory usage

### DIFF
--- a/packages/synergy/src/attachment/index.ts
+++ b/packages/synergy/src/attachment/index.ts
@@ -6,6 +6,7 @@ import { Identifier } from "@/id/id"
 import { Global } from "@/global"
 import type { MessageV2 } from "@/session/message-v2"
 import { Document } from "@/util/document"
+import { Asset } from "@/asset/asset"
 
 const LOCAL_MEDIA_MIME_PREFIXES = ["image/", "audio/", "video/"]
 
@@ -171,19 +172,37 @@ export namespace Attachment {
   export async function toPart(input: PartInput): Promise<MessageV2.AttachmentPart> {
     const file = Bun.file(input.filepath)
     const fallbackPolicy = policy({ filepath: input.filepath, filename: input.filename, mime: input.mime })
+    const bytes = await file.bytes()
+    const model = input.model ?? fallbackPolicy.model
+    const attachmentMetadata =
+      input.metadata?.attachment &&
+      typeof input.metadata.attachment === "object" &&
+      !Array.isArray(input.metadata.attachment)
+        ? input.metadata.attachment
+        : {}
+    const url =
+      model.mode === "provider-file"
+        ? dataUrl(input.mime, bytes)
+        : `asset://${await Asset.write(Buffer.from(bytes), input.mime, input.filename)}`
     return {
       id: input.id ?? Identifier.ascending("part"),
       sessionID: input.sessionID,
       messageID: input.messageID,
       type: "attachment",
-      url: dataUrl(input.mime, await file.bytes()),
+      url,
       mime: input.mime,
       filename: input.filename,
       localPath: input.localPath,
       source: input.source,
       presentation: input.presentation ?? fallbackPolicy.presentation,
-      model: input.model ?? fallbackPolicy.model,
-      metadata: input.metadata,
+      model,
+      metadata: {
+        ...input.metadata,
+        attachment: {
+          ...attachmentMetadata,
+          size: bytes.byteLength,
+        },
+      },
     }
   }
 

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -15,6 +15,7 @@ import { iife } from "@/util/iife"
 import { type SystemError } from "bun"
 import type { Scope } from "@/scope"
 import { Attachment } from "@/attachment"
+import { Asset } from "@/asset/asset"
 import { Log } from "@/util/log"
 import { SessionBounds } from "./bounds"
 
@@ -832,6 +833,64 @@ export namespace MessageV2 {
     return part.mime !== "application/x-directory"
   }
 
+  function shouldExternalizeAttachment(part: AttachmentPart): boolean {
+    if (!part.url.startsWith("data:")) return false
+    if (attachmentModelMode(part) === "provider-file") return false
+    return true
+  }
+
+  async function externalizeAttachment(part: AttachmentPart): Promise<AttachmentPart> {
+    if (!shouldExternalizeAttachment(part)) return part
+    const decoded = Attachment.decodeDataUrl(part.url)
+    const assetID = await Asset.write(decoded.buffer, part.mime, part.filename)
+    const attachmentMetadata =
+      part.metadata?.attachment &&
+      typeof part.metadata.attachment === "object" &&
+      !Array.isArray(part.metadata.attachment)
+        ? part.metadata.attachment
+        : {}
+    return {
+      ...part,
+      url: `asset://${assetID}`,
+      metadata: {
+        ...part.metadata,
+        attachment: {
+          ...attachmentMetadata,
+          size: decoded.buffer.length,
+        },
+      },
+    }
+  }
+
+  async function externalizePart(part: Part): Promise<{ part: Part; changed: boolean }> {
+    if (part.type === "attachment") {
+      const next = await externalizeAttachment(part)
+      return { part: next, changed: next !== part }
+    }
+    if (part.type !== "tool" || part.state.status !== "completed" || !part.state.attachments?.length) {
+      return { part, changed: false }
+    }
+    let changed = false
+    const attachments = await Promise.all(
+      part.state.attachments.map(async (attachment) => {
+        const next = await externalizeAttachment(attachment)
+        if (next !== attachment) changed = true
+        return next
+      }),
+    )
+    if (!changed) return { part, changed: false }
+    return {
+      part: {
+        ...part,
+        state: {
+          ...part.state,
+          attachments,
+        },
+      },
+      changed: true,
+    }
+  }
+
   function attachmentHash(part: AttachmentPart): string {
     return new Bun.CryptoHasher("sha256").update(part.url).digest("hex").slice(0, 16)
   }
@@ -1065,14 +1124,33 @@ export namespace MessageV2 {
       const partIDs = await Storage.scan(StoragePath.messageParts(scopeID, sessionID, messageID))
       const keys = partIDs.map((id) => StoragePath.messagePart(scopeID, sessionID, messageID, id as Identifier.PartID))
       const results = await Storage.readMany<MessageV2.Part>(keys)
-      const parts = results.filter((p): p is MessageV2.Part => p !== undefined)
+      const parts = await Promise.all(
+        results
+          .filter((p): p is MessageV2.Part => p !== undefined)
+          .map(async (part) => {
+            const externalized = await externalizePart(part)
+            if (externalized.changed) {
+              await Storage.write(
+                StoragePath.messagePart(scopeID, sessionID, messageID, externalized.part.id as Identifier.PartID),
+                externalized.part,
+              )
+            }
+            return externalized.part
+          }),
+      )
       parts.sort((a, b) => (a.id > b.id ? 1 : -1))
-      for (const part of parts) {
+      return parts.map((part) => {
         if (part.type === "tool" && part.state.status === "completed" && part.state.time.compacted) {
-          part.state.output = ""
+          return {
+            ...part,
+            state: {
+              ...part.state,
+              output: "",
+            },
+          }
         }
-      }
-      return parts
+        return part
+      })
     },
   )
 

--- a/packages/synergy/test/session/attachment-transport.test.ts
+++ b/packages/synergy/test/session/attachment-transport.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Attachment } from "../../src/attachment"
+import { Asset } from "../../src/asset/asset"
+import { Identifier } from "../../src/id/id"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Session } from "../../src/session"
+import { ScopeContext } from "../../src/scope/context"
+import { Storage } from "../../src/storage/storage"
+import { StoragePath } from "../../src/storage/path"
+
+describe("session attachment transport", () => {
+  test("stores summary attachments as asset references instead of data URLs", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const session = await Session.create({})
+        try {
+          const filepath = path.join(tmp.path, "doc.pdf")
+          await Bun.write(filepath, "fake pdf bytes")
+
+          const part = await Attachment.toPart({
+            filepath,
+            mime: "application/pdf",
+            filename: "doc.pdf",
+            sessionID: session.id,
+            messageID: Identifier.ascending("message"),
+          })
+
+          expect(part.url.startsWith("asset://")).toBe(true)
+          expect(part.url.startsWith("data:")).toBe(false)
+
+          const asset = await Asset.read(part.url.slice("asset://".length))
+          expect(await asset?.text()).toBe("fake pdf bytes")
+        } finally {
+          await Session.remove(session.id)
+        }
+      },
+    })
+  })
+
+  test("externalizes legacy non-provider-file data URL attachments when reading parts", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const session = await Session.create({})
+        try {
+          const user = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            sessionID: session.id,
+            role: "user",
+            agent: "test",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+          })
+          const assistant = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            sessionID: session.id,
+            role: "assistant",
+            parentID: user.id,
+            time: { created: Date.now(), completed: Date.now() },
+            modelID: "test-model",
+            providerID: "test-provider",
+            path: { cwd: tmp.path, root: tmp.path },
+            mode: "test",
+            agent: "test",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            finish: "stop",
+          })
+          const legacyBytes = Buffer.from("legacy pdf bytes")
+          const partID = Identifier.ascending("part")
+          await Session.updatePart({
+            id: partID,
+            sessionID: session.id,
+            messageID: assistant.id,
+            type: "tool",
+            callID: "call_legacy",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: {},
+              output: "read",
+              outputBytes: 4,
+              title: "read",
+              metadata: {},
+              time: { start: Date.now(), end: Date.now() },
+              attachments: [
+                {
+                  id: Identifier.ascending("part"),
+                  sessionID: session.id,
+                  messageID: assistant.id,
+                  type: "attachment",
+                  mime: "application/pdf",
+                  filename: "legacy.pdf",
+                  url: `data:application/pdf;base64,${legacyBytes.toString("base64")}`,
+                  model: { mode: "summary", summary: "legacy.pdf (application/pdf)" },
+                },
+              ],
+            },
+          })
+
+          const parts = await MessageV2.parts({ sessionID: session.id, messageID: assistant.id })
+          const tool = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+          const attachment = tool?.state.status === "completed" ? tool.state.attachments?.[0] : undefined
+
+          expect(attachment?.url.startsWith("asset://")).toBe(true)
+          expect(attachment?.url.startsWith("data:")).toBe(false)
+          expect((attachment?.metadata?.attachment as { size?: number } | undefined)?.size).toBe(legacyBytes.length)
+
+          const persisted = await Storage.read<MessageV2.ToolPart>(
+            StoragePath.messagePart(
+              Identifier.asScopeID(scope.id),
+              Identifier.asSessionID(session.id),
+              Identifier.asMessageID(assistant.id),
+              partID,
+            ),
+          )
+          const persistedAttachment =
+            persisted.state.status === "completed" ? persisted.state.attachments?.[0] : undefined
+          expect(persistedAttachment?.url).toBe(attachment?.url)
+          expect(await (await Asset.read(attachment!.url.slice("asset://".length)))?.text()).toBe("legacy pdf bytes")
+        } finally {
+          await Session.remove(session.id)
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Store non-provider-file session attachments as `asset://` references instead of inline `data:` URLs.
- Lazily externalize legacy non-provider-file `data:` attachments when reading message parts, then write the lightweight asset reference back to storage.
- Preserve provider-file data URLs so image/file model input behavior is not changed.

## Profiling Notes
- Local session forensics found large persisted message parts caused by inline PDF/base64 attachments.
- Some single attachment parts were tens of MB, and one sampled session accumulated more than 1GB of attachment JSON payloads.
- This reduces the payload pulled into frontend sync/message buckets when opening or prefetching multiple sessions.

## Test Plan
- `cd packages/synergy && bun test test/session/attachment-transport.test.ts test/tool/read.test.ts test/session/message-v2.test.ts`
- `cd packages/synergy && bun run typecheck`
- `git diff --check`
- pre-push hook: `bun turbo typecheck` and formatting check passed