### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,3 +726,15 @@ bun run desktop:pack                           # validate local desktop packagin
 Regenerate the SDK after modifying server routes or route schemas.
 
 ## Documentation Rules
+
+---
+
+## Star History
+
+<a href="https://star-history.com/#SII-Holos/synergy&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SII-Holos/synergy&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SII-Holos/synergy&type=Date&theme=light" />
+    <img alt="Star History Chart for SII-Holos/synergy" src="https://api.star-history.com/svg?repos=SII-Holos/synergy&type=Date" />
+  </picture>
+</a>


### PR DESCRIPTION
## Summary

- Adds a **Star History** section at the end of `README.md` with an auto-dark/light theme embed for `SII-Holos/synergy`
- Uses the GitHub-recommended `<picture>` element pattern from star-history.com
- The chart is linked to star-history.com for interactive exploration

## Test

- Verified the markdown renders correctly
- Only `README.md` changed — the commit is clean (1 file, +12 lines)