### PR TITLE
Fix quick switcher model row toggles

### DIFF
--- a/packages/app/src/components/model-manager.tsx
+++ b/packages/app/src/components/model-manager.tsx
@@ -288,6 +288,7 @@ export const ConnectedModelManager: Component<{
   const local = optionalLocal()
   const standalone = local ? undefined : createStandaloneModelPreferences(models, providers.default)
   const modelState = () => local?.model ?? standalone
+  const selectable = () => props.selectable !== false
   const currentModel = () => (props.selectable === false ? undefined : modelState()?.current())
   const selectModel = (model: ModelKey) => {
     if (local) {
@@ -305,27 +306,32 @@ export const ConnectedModelManager: Component<{
       key={(x) => `${x.provider.id}:${x.id}`}
       items={models}
       current={currentModel()}
+      interactive={selectable()}
       filterKeys={["provider.name", "name", "id"]}
       groupBy={(x) => x.provider.name}
       sortGroupsBy={sortModelGroups(globalSync.data.provider.profiles)}
-      onSelect={(x) => {
-        if (!x) return
-        if (props.selectable === false) return
-        selectModel({ modelID: x.id, providerID: x.provider.id })
-        props.onSelect?.()
-      }}
+      onSelect={
+        selectable()
+          ? (x) => {
+              if (!x) return
+              selectModel({ modelID: x.id, providerID: x.provider.id })
+              props.onSelect?.()
+            }
+          : undefined
+      }
     >
       {(model) => (
         <div class="model-manager-row w-full min-w-0 flex items-center justify-between gap-x-3">
           <ModelManagerRow model={model} />
           <div class="model-manager-actions flex items-center gap-x-3 shrink-0" onClick={(e) => e.stopPropagation()}>
-            <span class="model-manager-quick-label text-12-regular text-text-weak">Quick</span>
             <Switch
               checked={modelState()?.inQuickSwitcher({ modelID: model.id, providerID: model.provider.id }) ?? false}
               onChange={(checked) => {
                 modelState()?.setQuickSwitcher({ modelID: model.id, providerID: model.provider.id }, checked)
               }}
-            />
+            >
+              <span class="model-manager-quick-label text-12-regular text-text-weak">Quick</span>
+            </Switch>
           </div>
         </div>
       )}

--- a/packages/app/src/components/settings/panels/ModelsPanel.test.ts
+++ b/packages/app/src/components/settings/panels/ModelsPanel.test.ts
@@ -34,4 +34,11 @@ describe("Models panel UI contract", () => {
     expect(modelManager).toContain("setQuickSwitcher")
     expect(modelManager).toContain('Persist.global("model"')
   })
+
+  test("quick-switcher management rows are static rows with labeled switches", () => {
+    expect(modelsPanel).toContain("selectable={false}")
+    expect(modelManager).toContain("interactive={selectable()}")
+    expect(modelManager).toContain(": undefined")
+    expect(modelManager).toContain('<span class="model-manager-quick-label')
+  })
 })

--- a/packages/app/src/components/settings/settings-panel.css
+++ b/packages/app/src/components/settings/settings-panel.css
@@ -1097,6 +1097,12 @@
   justify-content: flex-end;
 }
 
+.settings-connected-model-list .model-manager-actions [data-component="switch"] {
+  min-height: 28px;
+  gap: 10px;
+  cursor: pointer;
+}
+
 /* ===== Library settings ===== */
 
 .ds-content-inner:has(> .settings-library-shell) {

--- a/packages/ui/src/components/list.css
+++ b/packages/ui/src/components/list.css
@@ -232,6 +232,9 @@
           &:active {
             background: var(--workbench-selected-bg-hover, var(--surface-raised-base-active));
           }
+          &[data-interactive="false"]:active {
+            background: transparent;
+          }
           &:focus-visible {
             outline: none;
           }

--- a/packages/ui/src/components/list.test.ts
+++ b/packages/ui/src/components/list.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+
+const listSource = await Bun.file(new URL("./list.tsx", import.meta.url)).text()
+const listStyles = await Bun.file(new URL("./list.css", import.meta.url)).text()
+
+describe("List component contract", () => {
+  test("supports non-interactive rows without button semantics", () => {
+    expect(listSource).toContain("interactive?: boolean")
+    expect(listSource).toContain("const interactive = () => props.interactive ?? true")
+    expect(listSource).toContain('data-interactive="false"')
+    expect(listSource).toContain("<div")
+    expect(listSource).toContain('data-interactive="true"')
+    expect(listSource).toContain("<button")
+    expect(listStyles).toContain('&[data-interactive="false"]:active')
+    expect(listStyles).toContain("background: transparent")
+  })
+})

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -14,6 +14,7 @@ export interface ListProps<T> extends FilteredListProps<T> {
   class?: string
   children: (item: T) => JSX.Element
   emptyMessage?: string
+  interactive?: boolean
   onKeyEvent?: (event: KeyboardEvent, item: T | undefined) => void
   onMove?: (item: T | undefined) => void
   activeIcon?: IconName
@@ -36,6 +37,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
   const { filter, grouped, flat, active, setActive, onKeyDown, onInput } = useFilteredList<T>(props)
 
   const searchProps = () => (typeof props.search === "object" ? props.search : {})
+  const interactive = () => props.interactive ?? true
   let searchContainerRef: HTMLDivElement | undefined
 
   onMount(() => {
@@ -121,6 +123,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
     props.onKeyEvent?.(e, selected)
 
     if (e.key === "Enter") {
+      if (!interactive()) return
       e.preventDefault()
       if (selected) handleSelect(selected, index)
     } else {
@@ -157,6 +160,26 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
       <div data-slot="list-header" data-stuck={stuck()} ref={setHeader}>
         {props.category}
       </div>
+    )
+  }
+
+  function ListItemContent(row: { item: T }): JSX.Element {
+    return (
+      <>
+        {props.children(row.item)}
+        <Show when={interactive() && row.item === props.current}>
+          <span data-slot="list-item-selected-icon">
+            <Icon name="check" />
+          </span>
+        </Show>
+        <Show when={interactive() && props.activeIcon}>
+          {(icon) => (
+            <span data-slot="list-item-active-icon">
+              <Icon name={icon()} />
+            </span>
+          )}
+        </Show>
+      </>
     )
   }
 
@@ -206,35 +229,38 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
                 <div data-slot="list-items">
                   <For each={group.items}>
                     {(item, i) => (
-                      <button
-                        data-slot="list-item"
-                        data-key={props.key(item)}
-                        data-active={props.key(item) === active()}
-                        data-selected={item === props.current}
-                        onClick={() => handleSelect(item, i())}
-                        type="button"
-                        onMouseMove={() => {
-                          setStore("mouseActive", true)
-                          setActive(props.key(item))
-                        }}
-                        onMouseLeave={() => {
-                          setActive(null)
-                        }}
+                      <Show
+                        when={interactive()}
+                        fallback={
+                          <div
+                            data-slot="list-item"
+                            data-key={props.key(item)}
+                            data-active={false}
+                            data-interactive="false"
+                          >
+                            <ListItemContent item={item} />
+                          </div>
+                        }
                       >
-                        {props.children(item)}
-                        <Show when={item === props.current}>
-                          <span data-slot="list-item-selected-icon">
-                            <Icon name="check" />
-                          </span>
-                        </Show>
-                        <Show when={props.activeIcon}>
-                          {(icon) => (
-                            <span data-slot="list-item-active-icon">
-                              <Icon name={icon()} />
-                            </span>
-                          )}
-                        </Show>
-                      </button>
+                        <button
+                          data-slot="list-item"
+                          data-key={props.key(item)}
+                          data-active={props.key(item) === active()}
+                          data-selected={item === props.current}
+                          data-interactive="true"
+                          onClick={() => handleSelect(item, i())}
+                          type="button"
+                          onMouseMove={() => {
+                            setStore("mouseActive", true)
+                            setActive(props.key(item))
+                          }}
+                          onMouseLeave={() => {
+                            setActive(null)
+                          }}
+                        >
+                          <ListItemContent item={item} />
+                        </button>
+                      </Show>
                     )}
                   </For>
                 </div>


### PR DESCRIPTION
## Summary
- add a non-interactive List row mode so settings rows do not present fake selection affordances
- render quick-switch model rows as static rows while keeping the right-side Switch as the actual control
- label the Quick switch directly and remove non-interactive active feedback

## Tests
- bun test ./src/components/list.test.ts (packages/ui)
- bun test ./src/components/settings/panels/ModelsPanel.test.ts (packages/app)
- bun run typecheck
- pre-push: prettier --check, oxlint, typecheck, sherif