### PR TITLE
ci: increase test job timeout from 5 to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary

The Test CI job has been hitting the 5-minute timeout on recent runs. The job runs `bun turbo test` (4 packages, 459 test files total) followed by `bun test --coverage` for Synergy package (347 test files), which easily exceeds 5 minutes.

15 minutes gives enough headroom while still preventing runaway jobs.

## Change

- `.github/workflows/ci.yml`: `timeout-minutes: 5` → `timeout-minutes: 15`