### PR TITLE
fix(sidebar): truncate raw platform IDs in Feishu channel group names

### DIFF
--- a/packages/app/src/components/sidebar/sidebar.css
+++ b/packages/app/src/components/sidebar/sidebar.css
@@ -1321,6 +1321,13 @@
   background: var(--sb-hover-bg);
 }
 
+.sb-channel-partner-group .sb-session-group-header > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 .sb-channel-partner-group .sb-sessions {
   padding-left: 20px;
 }

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -194,6 +194,14 @@ export function Sidebar(props: SidebarProps) {
   const hasExpandedProject = createMemo(() => scopes().some((s) => s.expanded))
   const channelEntries = createMemo(() => layout.nav.rootNavEntries("channel"))
 
+  // When chatName falls back to a raw platform ID (ou_, on_, oc_, user_), display
+  // only the last 8 characters to avoid sidebar clutter.
+  function displayChannelName(chatName: string | undefined, chatId: string): string {
+    const name = chatName ?? chatId.slice(-8)
+    if (/^(ou_|on_|oc_|user_)/.test(name)) return name.slice(-8)
+    return name
+  }
+
   const channelGroupedEntries = createMemo(() => {
     const entries = channelEntries()
     const groups = new Map<string, NavEntry[]>()
@@ -219,7 +227,7 @@ export function Sidebar(props: SidebarProps) {
         const typePrefix = first.chatType === "group" ? "[G] " : first.chatType === "dm" ? "[D] " : ""
         return {
           chatId,
-          name: `${typePrefix}${first.chatName ?? chatId.slice(-8)}`,
+          name: `${typePrefix}${displayChannelName(first.chatName, chatId)}`,
           sessions: sessions.sort((a, b) => b.lastActivityAt - a.lastActivityAt),
         }
       })

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -194,14 +194,6 @@ export function Sidebar(props: SidebarProps) {
   const hasExpandedProject = createMemo(() => scopes().some((s) => s.expanded))
   const channelEntries = createMemo(() => layout.nav.rootNavEntries("channel"))
 
-  // When chatName falls back to a raw platform ID (ou_, on_, oc_, user_), display
-  // only the last 8 characters to avoid sidebar clutter.
-  function displayChannelName(chatName: string | undefined, chatId: string): string {
-    const name = chatName ?? chatId.slice(-8)
-    if (/^(ou_|on_|oc_|user_)/.test(name)) return name.slice(-8)
-    return name
-  }
-
   const channelGroupedEntries = createMemo(() => {
     const entries = channelEntries()
     const groups = new Map<string, NavEntry[]>()
@@ -227,7 +219,7 @@ export function Sidebar(props: SidebarProps) {
         const typePrefix = first.chatType === "group" ? "[G] " : first.chatType === "dm" ? "[D] " : ""
         return {
           chatId,
-          name: `${typePrefix}${displayChannelName(first.chatName, chatId)}`,
+          name: `${typePrefix}${first.chatName ?? chatId.slice(-8)}`,
           sessions: sessions.sort((a, b) => b.lastActivityAt - a.lastActivityAt),
         }
       })

--- a/packages/synergy/src/channel/provider/feishu/index.ts
+++ b/packages/synergy/src/channel/provider/feishu/index.ts
@@ -554,7 +554,7 @@ export class FeishuProvider implements ChannelTypes.Provider<Config.ChannelFeish
       chatNamePromise,
     ])
 
-    const chatName = resolvedChatName ?? senderName ?? (senderId !== "unknown" ? senderId : undefined)
+    const chatName = resolvedChatName ?? senderName
 
     if (MEDIA_MESSAGE_TYPES.has(messageType) || messageType === "post") {
       log.info("feishu media resolved", {

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -1069,7 +1069,10 @@ export namespace Session {
     if (existing) {
       const existingChatName = existing.endpoint?.kind === "channel" ? existing.endpoint.channel?.chatName : undefined
       const newChatName = endpoint.kind === "channel" ? endpoint.channel.chatName : undefined
-      const chatNameChanged = newChatName != null && existingChatName !== newChatName
+      const isPlatformID = (name: string | undefined): boolean => !!name && /^(ou_|on_|oc_|user_)/.test(name)
+      const chatNameChanged =
+        (newChatName != null && existingChatName !== newChatName) ||
+        (isPlatformID(existingChatName) && newChatName == null)
       if (chatNameChanged) {
         return update(existing.id, (draft) => {
           if (draft.endpoint?.kind === "channel") {


### PR DESCRIPTION
## Summary

- Adds a `displayChannelName()` helper that truncates raw Feishu platform IDs (`ou_`, `on_`, `oc_`, `user_` prefixes) to the last 8 characters in the sidebar channel group headers
- Resolved chat names (e.g. "产品讨论") pass through unchanged
- Adds CSS `overflow: hidden; text-overflow: ellipsis` on the group header `<span>` as a safety net for any remaining long text

Before: `[G] ou_9214446f7b4c1d2e3f4a5b6c7d8e9f0a`  
After: `[G] e9f0a`