### PR TITLE
[codex] fix repeated auto compaction boundary

### DIFF
--- a/docs/architecture/session-message-core.md
+++ b/docs/architecture/session-message-core.md
@@ -182,7 +182,8 @@ steer 唤醒的 loop 与普通 loop 完全同构：R 不变，模型看到新注
 - **anchor 解析**：`resolveAnchor(R) = R 的 parts 中 origin=="user" 的 text`，找不到文本（纯附件/agenda 触发的任务）时退到 `R.summary.title`。删除三级 fallback、删除 `isAnchorEligibleUser` 启发式、删除 `compactionAnchor` metadata 接力。因为 R 是持久化消息，跨多次 compaction 依然可以按 `rootID` 直接读到——**不依赖它还在上下文窗口里**。
 - **auto-continue**："Continue if you have next steps" + anchor 文本作为一条 `steer` 注入（`rootID = R.id`，`origin: {type:"compaction"}`，`visible: false`）。它不再成为新 parent，turn 不再断裂，`Turn.resolveRealUser` 这类回溯补丁可删。
 - **emergency compaction**（`invoke.ts:892-911`）：同样从"创建新 user message 当新 parent"改为注入 steer + compaction part。
-- `filterCompacted`、prune、mechanical fallback、`compaction_recovery` part 全部机制不变。
+- **有效视图裁剪**：`filterCompacted` 以最新完成的 compaction summary assistant 作为截断点；保留任务 root R、已完成的 compaction summaries（较旧 summary 标记 `includeInContext:false` 仅供调度计数）、以及最新 summary 之后的新消息。这样 root 继续承担任务归属，summary 承担上下文压缩边界。
+- prune、mechanical fallback、`compaction_recovery` part 全部机制不变。
 
 ---
 

--- a/docs/architecture/session-message-core/01-message-assembly.md
+++ b/docs/architecture/session-message-core/01-message-assembly.md
@@ -43,13 +43,13 @@ Session.messages({sessionID})
   = rawMessages（按 id 升序全量读取）
     → applyEvents（history.ts:259，过滤 activeRollbacks 的 droppedMessageIDs 集合）
 → filterCompacted（message-v2.ts:945，从新到旧回溯，
-   遇到"带 compaction part 且已有完成 summary assistant 的 user 消息"即截断）
+   以最新完成的 compaction summary assistant 作为截断点，回溯保留对应 boundary user）
 ```
 
 要点：
 
 - 回退是**软删除**：消息不动，事件（`RollbackEvent.droppedMessageIDs`）在读路径过滤。
-- compaction 截断后，摘要 assistant（`summary: true`）留在窗口内，代替被截断的历史。
+- compaction 截断后，任务 root 和摘要 assistant（`summary: true`）留在窗口内，代替被截断的历史；重复 auto-compaction 时，较旧 summary 保留为 `includeInContext:false` 以供 pending-compaction 计数，不重复进入模型上下文。
 - 被 prune 的 tool part 在 `MessageV2.parts`（message-v2.ts:919）读取时把 `output` 置空（`state.time.compacted` 存在时）。
 
 ### 1.2 新设计
@@ -59,7 +59,7 @@ Session.messages({sessionID})
 1. **回退过滤改为前缀切割**：`RollbackEvent` 通用形式记 `cutMessageID`，`applyEvents` 的谓词从"id ∈ droppedMessageIDs 集合"变为"存在 active 事件使 `msg.id >= cutMessageID`"。`/undo` 的 root 步长与消息级 rewind 共用同一事件与过滤。
 2. **rootID 组的原子性由切点选择保证**：cut 点只能落在消息边界上；按 root 边界切时整组消失，按消息级 rewind 切时留下"root 存在、无终止回复"的半任务——这是合法状态（`needsModelCall` 为真但不自启）。
 
-`filterCompacted` 不变。
+`filterCompacted` 保持为 L2 确定性投影；它不改变落盘消息，只在有效视图中表达最新 compaction 边界。
 
 ---
 

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -1174,19 +1174,44 @@ export namespace MessageV2 {
 
   export async function filterCompacted(stream: AsyncIterable<MessageV2.WithParts>) {
     const result = [] as MessageV2.WithParts[]
-    const completed = new Set<string>()
+    const skipped = [] as MessageV2.WithParts[]
+    let boundaryUserID: string | undefined
+    let foundBoundary = false
     for await (const msg of stream) {
-      result.push(msg)
+      if (!boundaryUserID) {
+        result.push(msg)
+        if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish) boundaryUserID = msg.info.parentID
+        continue
+      }
+
       if (
-        msg.info.role === "user" &&
-        completed.has(msg.info.id) &&
-        msg.parts.some((part) => part.type === "compaction")
+        msg.info.role !== "user" ||
+        msg.info.id !== boundaryUserID ||
+        !msg.parts.some((part) => part.type === "compaction")
+      ) {
+        skipped.push(msg)
+        continue
+      }
+
+      const boundaryID = boundaryUserID
+      result.push(
+        ...skipped
+          .filter((item) => isFulfilledCompactionSummary(item, boundaryID))
+          .map((item) => ({ ...item, info: { ...item.info, includeInContext: false } })),
       )
-        break
-      if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish) completed.add(msg.info.parentID)
+      result.push(msg)
+      foundBoundary = true
+      break
     }
+    if (boundaryUserID && !foundBoundary) result.push(...skipped)
     result.reverse()
     return result
+  }
+
+  function isFulfilledCompactionSummary(msg: MessageV2.WithParts, parentID: string): boolean {
+    if (msg.info.role !== "assistant") return false
+    const assistant = msg.info as MessageV2.Assistant
+    return assistant.parentID === parentID && assistant.summary === true && !!assistant.finish
   }
 
   export function fromError(e: unknown, ctx: { providerID: string }) {

--- a/packages/synergy/test/session/invoke-compaction.test.ts
+++ b/packages/synergy/test/session/invoke-compaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock } from "bun:test"
+import { afterAll, beforeAll, describe, expect, test, mock } from "bun:test"
 import { Session } from "../../src/session"
 import { SessionInvoke } from "../../src/session/invoke"
 import { SessionProcessor } from "../../src/session/processor"
@@ -15,13 +15,35 @@ import { Log } from "../../src/util/log"
 import { Config } from "../../src/config/config"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionCompaction } from "../../src/session/compaction"
+import { Embedding } from "../../src/vector/embedding"
 
 Log.init({ print: false })
+
+const originalEmbeddingGenerate = Embedding.generate
+
+beforeAll(() => {
+  ;(Embedding.generate as any) = mock(async (input: Parameters<typeof Embedding.generate>[0]) => ({
+    id: input.id,
+    vector: [],
+    model: "test-embedding",
+  }))
+})
+
+afterAll(() => {
+  ;(Embedding.generate as any) = originalEmbeddingGenerate
+})
 
 class CompactionIntercept extends Error {
   constructor() {
     super("compaction part injected")
   }
+}
+
+function isCompactionIntercept(error: unknown): boolean {
+  if (error instanceof CompactionIntercept) return true
+  if (!error || typeof error !== "object") return false
+  const nested = error as { error?: unknown; suppressed?: unknown }
+  return nested.error instanceof CompactionIntercept || nested.suppressed instanceof CompactionIntercept
 }
 
 function testModel() {
@@ -52,6 +74,26 @@ function primaryAgent() {
     options: {},
   }
 }
+
+async function fastLoopTestConfig(originalConfigCurrent: typeof Config.current) {
+  const config = await originalConfigCurrent()
+  return {
+    ...config,
+    library: {
+      ...config.library,
+      memory: {
+        ...config.library?.memory,
+        enabled: false,
+      },
+      experience: {
+        ...config.library?.experience,
+        retrieve: false,
+      },
+    },
+    compaction: { auto: true, maxHistoryImages: 8 },
+  }
+}
+
 function testUser(input: {
   id: string
   sessionID: string
@@ -148,10 +190,7 @@ describe.serial("SessionInvoke preflight compaction", () => {
     try {
       ;(Provider.getModel as any) = mock(async () => testModel())
       ;(Agent.get as any) = mock(async () => primaryAgent())
-      ;(Config.current as any) = mock(async () => ({
-        ...(await originalConfigCurrent()),
-        compaction: { auto: true, maxHistoryImages: 8 },
-      }))
+      ;(Config.current as any) = mock(async () => fastLoopTestConfig(originalConfigCurrent))
       ;(ToolResolver.definitions as any) = mock(async () => [])
       ;(ToolResolver.resolveWithAvailability as any) = mock(async () => ({ tools: {}, activeToolIDs: [] }))
       ;(PromptBudgeter.buildPlan as any) = mock(async () => ({
@@ -213,8 +252,14 @@ describe.serial("SessionInvoke preflight compaction", () => {
             text: "Please continue with next steps.",
           })
 
-          await expect(SessionInvoke.loop.force(sessionID)).rejects.toBeInstanceOf(CompactionIntercept)
+          let intercepted: unknown
+          try {
+            await SessionInvoke.loop.force(sessionID)
+          } catch (error) {
+            intercepted = error
+          }
 
+          expect(isCompactionIntercept(intercepted)).toBe(true)
           expect(interceptedCompactionParts).toHaveLength(1)
           const [compactionPart] = interceptedCompactionParts
           expect(compactionPart.sessionID).toBe(sessionID)
@@ -266,10 +311,7 @@ describe.serial("SessionInvoke preflight compaction", () => {
     try {
       ;(Provider.getModel as any) = mock(async () => testModel())
       ;(Agent.get as any) = mock(async () => primaryAgent())
-      ;(Config.current as any) = mock(async () => ({
-        ...(await originalConfigCurrent()),
-        compaction: { auto: true, maxHistoryImages: 8 },
-      }))
+      ;(Config.current as any) = mock(async () => fastLoopTestConfig(originalConfigCurrent))
       ;(ToolResolver.definitions as any) = mock(async (input: Parameters<typeof ToolResolver.definitions>[0]) => {
         definitionToolStates.push(input.session?.toolState)
         return []
@@ -377,10 +419,7 @@ describe.serial("SessionInvoke preflight compaction", () => {
     try {
       ;(Provider.getModel as any) = mock(async () => testModel())
       ;(Agent.get as any) = mock(async () => primaryAgent())
-      ;(Config.current as any) = mock(async () => ({
-        ...(await originalConfigCurrent()),
-        compaction: { auto: true, maxHistoryImages: 8 },
-      }))
+      ;(Config.current as any) = mock(async () => fastLoopTestConfig(originalConfigCurrent))
       ;(ToolResolver.definitions as any) = mock(async () => [])
       ;(ToolResolver.resolveWithAvailability as any) = mock(async () => ({ tools: {}, activeToolIDs: [] }))
       ;(PromptBudgeter.buildPlan as any) = mock(async () => ({
@@ -647,6 +686,142 @@ describe.serial("SessionInvoke preflight compaction", () => {
     const compacted = await filterNewestFirst([realUser, oldAssistant, boundary, summary, continuation])
 
     expect(compacted.map((msg) => msg.info.id)).toEqual(["msg_boundary", "msg_summary", "msg_continue"])
+  })
+
+  test("filters repeated root-anchored auto-compactions to the latest summary", async () => {
+    const sessionID = "ses_test"
+    const root = testUser({
+      id: "msg_root",
+      sessionID,
+      created: 1,
+      parts: [
+        {
+          id: "prt_root_text",
+          sessionID,
+          messageID: "msg_root",
+          type: "text",
+          text: "Implement the compact boundary fix.",
+        },
+        {
+          id: "prt_compact_1",
+          sessionID,
+          messageID: "msg_root",
+          type: "compaction",
+          auto: true,
+        },
+        {
+          id: "prt_compact_2",
+          sessionID,
+          messageID: "msg_root",
+          type: "compaction",
+          auto: true,
+        },
+      ],
+    })
+    const oldAssistant = testAssistant({
+      id: "msg_old_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 2,
+      completed: 3,
+      finish: "tool-calls",
+      parts: [
+        {
+          id: "prt_old_text",
+          sessionID,
+          messageID: "msg_old_assistant",
+          type: "text",
+          text: "Large pre-compaction trajectory.",
+        },
+      ],
+    })
+    const summary1 = testAssistant({
+      id: "msg_summary_1",
+      sessionID,
+      parentID: root.info.id,
+      created: 4,
+      completed: 5,
+      summary: true,
+      finish: "stop",
+    })
+    const continue1 = testUser({
+      id: "msg_continue_1",
+      sessionID,
+      created: 6,
+      summaryTitle: "Compaction complete",
+      parts: [
+        {
+          id: "prt_continue_1",
+          sessionID,
+          messageID: "msg_continue_1",
+          type: "text",
+          synthetic: true,
+          text: "Continue if you have next steps",
+        },
+      ],
+    })
+    const middleAssistant = testAssistant({
+      id: "msg_middle_assistant",
+      sessionID,
+      parentID: root.info.id,
+      created: 7,
+      completed: 8,
+      finish: "tool-calls",
+      parts: [
+        {
+          id: "prt_middle_text",
+          sessionID,
+          messageID: "msg_middle_assistant",
+          type: "text",
+          text: "Large trajectory after the first compaction.",
+        },
+      ],
+    })
+    const summary2 = testAssistant({
+      id: "msg_summary_2",
+      sessionID,
+      parentID: root.info.id,
+      created: 9,
+      completed: 10,
+      summary: true,
+      finish: "stop",
+    })
+    const continue2 = testUser({
+      id: "msg_continue_2",
+      sessionID,
+      created: 11,
+      summaryTitle: "Compaction complete",
+      parts: [
+        {
+          id: "prt_continue_2",
+          sessionID,
+          messageID: "msg_continue_2",
+          type: "text",
+          synthetic: true,
+          text: "Continue if you have next steps",
+        },
+      ],
+    })
+
+    const compacted = await filterNewestFirst([
+      root,
+      oldAssistant,
+      summary1,
+      continue1,
+      middleAssistant,
+      summary2,
+      continue2,
+    ])
+
+    expect(compacted.map((msg) => msg.info.id)).toEqual([
+      "msg_root",
+      "msg_summary_1",
+      "msg_summary_2",
+      "msg_continue_2",
+    ])
+    expect(compacted.find((msg) => msg.info.id === "msg_summary_1")?.info.includeInContext).toBe(false)
+    expect(compacted.find((msg) => msg.info.id === "msg_summary_2")?.info.includeInContext).toBeUndefined()
+    expect(SessionCompaction.hasPendingCompaction(root.parts, compacted, root.info.id)).toBe(false)
   })
 
   test("resolves the compaction anchor from the task root by id", () => {


### PR DESCRIPTION
## What changed

- Changed `MessageV2.filterCompacted` to treat the latest completed compaction summary as the effective context cut point.
- Preserved the task root and completed compaction summaries for scheduling/counting, while marking older summaries `includeInContext:false` so they do not re-enter the model prompt.
- Added a regression test for repeated root-anchored auto-compactions and stabilized the related invoke compaction tests by mocking embedding recall.
- Updated session-message-core architecture docs to reflect the current compaction effective-view behavior.

## Why

Automatic compaction stores compaction request parts on the task root. The old filter stopped at that root, so after the first successful compaction the effective prompt could still include the large pre-compaction trajectory. Subsequent budget checks could immediately inject another compaction, creating a repeated compaction loop.

## Validation

- `bun test test/session/invoke-compaction.test.ts`
- `bun test test/session/compaction.test.ts test/session/message-v2.test.ts test/session/prompt-budgeter.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run monorepo:check`
- `bun run package:check`
- Push pre-hook also ran format, lint, typecheck, and monorepo checks.
