### PR TITLE
fix(permission): align SmartAllow with gate boundaries

### DIFF
--- a/packages/synergy/src/agent/builtin-internal.ts
+++ b/packages/synergy/src/agent/builtin-internal.ts
@@ -142,7 +142,7 @@ export function createBuiltinInternalAgents(ctx: BuiltinAgentContext): Record<st
       temperature: 0,
       permission: PermissionNext.fromConfig({ "*": "deny" }),
       prompt: PROMPT_SMART_ALLOW,
-      ...resolveAgentModelRole(ctx, "mini"),
+      ...resolveAgentModelRole(ctx, "mid"),
     },
     "agent-generator": {
       name: "agent-generator",

--- a/packages/synergy/src/agent/prompt/smart-allow.txt
+++ b/packages/synergy/src/agent/prompt/smart-allow.txt
@@ -1,13 +1,31 @@
-You are Synergy's Smart allow classifier. Your job is to decide whether one pending agent tool operation is safe enough to allow automatically.
+You are Synergy's SmartAllow classifier. Your job is to reduce permission noise by deciding whether one pending tool operation is truly dangerous or can be automatically allowed.
 
-You are only called after Synergy's deterministic permission gate has already filtered out hard safety boundaries. Never assume you can override protected paths, external writes, credential or identity boundaries, destructive shell operations, hardline commands, platform control, or plugin secret access.
+SmartAllow is not a general safety policy. The permission system owns hard safety boundaries through capability metadata such as non-bypassable operations, opaque operations, and exact secret roots. Classify only the concrete operation shown to you.
 
-Classify the operation from the raw facts only:
+Decision principle:
+- Classify as "safe" when the operation is routine development work and you do not see a concrete danger signal.
+- Classify as "risky" when there is a specific ambiguity that could change the safety outcome.
+- Classify as "dangerous" only when the operation clearly attempts harmful, irreversible, secret-exposing, identity-affecting, or system-level behavior.
 
-- "safe": routine local development, read-only inspection, reversible workspace-local edits, standard build/test commands, or ordinary browsing/searching.
-- "risky": cross-boundary ambiguity, unusual network or shell behavior, unclear target ownership, or operations whose safety depends on missing context.
-- "dangerous": likely data loss, credential exposure, irreversible publication/deployment, privilege escalation, destructive shell behavior, force pushes, mass deletion, or anything that should require a human or remain blocked.
+Common "safe" operations include normal build, test, lint, typecheck, format, package install, local file edits in the workspace, local file organization, code search, git status/diff/log/add/commit/branch/checkout, and documentation or web lookup.
 
-Respond with JSON only:
+Concrete danger signals include exposing API keys or credentials, sending messages or email as the user, modifying permissions or prompts, writing outside the workspace, system configuration changes, broad recursive deletion, hard reset, force push, and executing untrusted downloaded code.
 
-{"risk":"safe|risky|dangerous","reason":"brief reason","confidence":0.0}
+Output contract:
+- Return exactly one JSON object.
+- Do not use markdown fences.
+- Do not add explanatory text outside JSON.
+- Use exactly these keys: "risk", "reason", "confidence".
+- "risk" must be one of "safe", "risky", or "dangerous".
+- "reason" must be a short plain string.
+- "confidence" must be a number from 0 to 1.
+
+Examples:
+Input: Tool: bash; Command: bun test packages/synergy/test/permission/smart-allow.test.ts
+Output: {"risk":"safe","reason":"focused test command in workspace","confidence":0.93}
+
+Input: Tool: revise_file; Path: packages/synergy/src/permission/smart-allow.ts
+Output: {"risk":"safe","reason":"workspace-local source edit","confidence":0.9}
+
+Input: Tool: bash; Command: printenv OPENAI_API_KEY
+Output: {"risk":"dangerous","reason":"attempts to expose an API key","confidence":0.98}

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -391,7 +391,7 @@ function classifyProtectedPathCapability(
     protectedMatch.category === "secrets" || protectedMatch.exactSecretRoot ? "secrets" : "protected_op"
   uniqueCapability(caps, {
     class: capabilityClass,
-    nonBypassable: protectedMatch.exactSecretRoot === true,
+    nonBypassable: protectedMatch.smartAllowEligible !== true,
     opaque: protectedMatch.exactSecretRoot === true,
     reason: protectedMatch.reason,
     metadata: {

--- a/packages/synergy/src/permission/smart-allow.ts
+++ b/packages/synergy/src/permission/smart-allow.ts
@@ -5,7 +5,6 @@ import { LLM } from "@/session/llm"
 import type { MessageV2 } from "@/session/message-v2"
 import type { Capability } from "@/enforcement/gate"
 import { Log } from "@/util/log"
-import { capabilityNonBypassable } from "@ericsanchezok/synergy-util/capability"
 
 export namespace SmartAllow {
   const log = Log.create({ service: "permission.smart-allow" })
@@ -40,18 +39,6 @@ export namespace SmartAllow {
     disabled: boolean
   }
 
-  const HARD_CAPABILITIES = new Set([
-    "shell_destructive",
-    "secrets",
-    "shell_hardline",
-    "identity_act",
-    "communication_email",
-    "channel_outbound",
-    "permission_hook",
-    "prompt_transform",
-    "compaction_transform",
-    "browser_eval_trusted",
-  ])
   const SECRET_VALUE_PATTERN = /(api[_-]?key|token|secret|password|credential|cookie)/i
   const PLACEHOLDER_VALUE_PATTERN =
     /^(|example|placeholder|changeme|change_me|your[_-]?(key|token|secret|password)?[_-]?here|xxx+|todo)$/i
@@ -79,8 +66,8 @@ export namespace SmartAllow {
 
   export function hasHardBoundary(capabilities: Capability[]): boolean {
     return capabilities.some((cap) => {
-      if (cap.metadata?.smartAllowEligible === true && cap.metadata?.exactSecretRoot !== true) return false
-      return cap.nonBypassable || cap.opaque || capabilityNonBypassable(cap.class) || HARD_CAPABILITIES.has(cap.class)
+      if (cap.metadata?.smartAllowEligible === true) return false
+      return cap.nonBypassable || cap.opaque
     })
   }
 
@@ -221,7 +208,6 @@ export namespace SmartAllow {
       user,
       tools: {},
       model,
-      small: true,
       messages: [{ role: "user", content: buildPrompt(input) }],
       abort: AbortSignal.timeout(10_000),
       sessionID,
@@ -264,7 +250,7 @@ export namespace SmartAllow {
           .join("\n")}`
       : ""
 
-    return `Assess whether this eligible ${input.policyAction} should be auto-allowed.
+    return `Evaluate whether this tool operation should skip the normal permission prompt.
 
 Tool: ${input.tool}
 Workspace: ${input.workspace}
@@ -273,9 +259,7 @@ ${path ? `Path: ${path}` : ""}
 ${url ? `URL: ${url}` : ""}
 ${query ? `Query: ${query}` : ""}${evidence}
 
-Remember: this classifier only receives bypassable metadata and redacted evidence. If context is missing, classify as risky.
-
-Respond JSON only: {"risk":"safe|risky|dangerous","reason":"brief","confidence":0.0-1.0}`
+Return one JSON object only, with no markdown or extra text: {"risk":"safe|risky|dangerous","reason":"brief","confidence":0.0-1.0}`
   }
 
   export function shouldAutoAllow(

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -2481,4 +2481,35 @@ describe("security invariants: nonBypassable permission boundaries", () => {
     expect(secrets).toBeDefined()
     expect(secrets!.metadata?.protectedCategory).toBe("secrets")
   })
+
+  test("real secret candidates are explicit nonBypassable boundaries", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "full_access",
+    })
+
+    const result = gate.classify("revise_file", {
+      input: "[.env#abcd]\nSWAP 1..1:\n+SECRET=x\n",
+    })
+    const secrets = result.capabilities.find((c: any) => c.class === "secrets")
+    expect(secrets).toBeDefined()
+    expect(secrets!.nonBypassable).toBe(true)
+  })
+
+  test("dotenv examples stay SmartAllow-eligible", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "full_access",
+    })
+
+    const result = gate.classify("revise_file", {
+      input: "[.env.example#abcd]\nSWAP 1..1:\n+OPENAI_API_KEY=your_key_here\n",
+    })
+    const secrets = result.capabilities.find((c: any) => c.class === "secrets")
+    expect(secrets).toBeDefined()
+    expect(secrets!.nonBypassable).toBe(false)
+    expect(secrets!.metadata?.smartAllowEligible).toBe(true)
+  })
 })

--- a/packages/synergy/test/permission/smart-allow.test.ts
+++ b/packages/synergy/test/permission/smart-allow.test.ts
@@ -48,12 +48,12 @@ describe("SmartAllow eligibility", () => {
     expect(SmartAllow.isEligible("deny", caps)).toBe(true)
   })
 
-  test("rejects non-bypassable, opaque, and hard capabilities", () => {
+  test("rejects non-bypassable and opaque capabilities", () => {
     expect(SmartAllow.isEligible("ask", [{ class: "file_write", nonBypassable: true }])).toBe(false)
     expect(SmartAllow.isEligible("ask", [{ class: "file_write", nonBypassable: false, opaque: true }])).toBe(false)
-    expect(SmartAllow.isEligible("deny", [{ class: "shell_destructive", nonBypassable: false }])).toBe(false)
-    expect(SmartAllow.isEligible("deny", [{ class: "identity_act", nonBypassable: false }])).toBe(false)
-    expect(SmartAllow.isEligible("deny", [{ class: "secrets", nonBypassable: false }])).toBe(false)
+    expect(SmartAllow.isEligible("deny", [{ class: "shell_destructive", nonBypassable: false }])).toBe(true)
+    expect(SmartAllow.isEligible("deny", [{ class: "identity_act", nonBypassable: false }])).toBe(true)
+    expect(SmartAllow.isEligible("deny", [{ class: "secrets", nonBypassable: false }])).toBe(true)
   })
 
   test("allows explicitly marked secret-candidate false positives", () => {


### PR DESCRIPTION
## Summary
- Remove SmartAllow's private hard-capability list so eligibility relies on actual capability metadata (`nonBypassable`, `opaque`, `exactSecretRoot`) instead of a second truth source.
- Move protected-path SmartAllow eligibility into the enforcement gate capability output, keeping real secret candidates non-bypassable while allowing dotenv examples through SmartAllow.
- Retune SmartAllow for permission-noise reduction: use the `mid` model role, remove `small: true`, and rewrite the classifier prompt with strict JSON output rules and examples.

## Why
SmartAllow exists to reduce noisy guarded-mode asks and autonomous false-positive denies. The previous prompt biased the classifier toward `risky` whenever context was sparse, and the private hard-capability list duplicated the permission gate's boundary semantics.

## Verification
- `bun test test/permission/smart-allow.test.ts` from `packages/synergy`
- `bun test test/enforcement/gate.test.ts` from `packages/synergy`
- `bun test test/enforcement/protected-paths.test.ts` from `packages/synergy`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run monorepo:check`
- `bun run package:check`

## Notes
`bun install` was run in the isolated worktree to restore workspace dependencies before local test execution.