### PR TITLE
fix(codex): gate external agent on native auth

### DIFF
--- a/packages/synergy/src/agent/agent.ts
+++ b/packages/synergy/src/agent/agent.ts
@@ -22,6 +22,7 @@ import { ExternalAgent } from "@/external-agent/bridge"
 import { ExternalAgentDiscovery } from "@/external-agent/discovery"
 import { Plugin } from "../plugin"
 import { MODEL_ROLE_IDS } from "../provider/model-role"
+import { CodexProvider } from "@/provider/codex"
 
 export namespace Agent {
   const log = Log.create({ service: "agent" })
@@ -343,7 +344,7 @@ export namespace Agent {
     } catch (e) {
       log.warn("failed to import external agent adapters", { error: String(e) })
     }
-    const discovered = await ExternalAgentDiscovery.discover()
+    const discovered = await ExternalAgentDiscovery.discover(externalConfig)
     log.info("external agent discovery results", {
       discovered: [...discovered.keys()],
     })
@@ -357,6 +358,13 @@ export namespace Agent {
         log.info("external agent auto_discover disabled", { name })
         continue
       }
+      if (name === "codex") {
+        const access = await CodexProvider.resolveToken({ allowMissing: true }).catch(() => undefined)
+        if (!access) {
+          log.info("codex external agent skipped until openai-codex provider is authenticated")
+          continue
+        }
+      }
       const { disabled: _, path, model, auto_discover: __, ...adapterConfig } = overrides ?? {}
       const externalField = {
         adapter: info.adapter,
@@ -364,6 +372,7 @@ export namespace Agent {
         version: info.version,
         config: {
           ...(model ? { model } : {}),
+          ...(name === "codex" ? { nativeAuth: true } : {}),
           ...adapterConfig,
         },
       }

--- a/packages/synergy/src/external-agent/adapter/codex.ts
+++ b/packages/synergy/src/external-agent/adapter/codex.ts
@@ -95,8 +95,8 @@ class CodexAdapter implements ExternalAgent.Adapter {
   private stderrBuffer = ""
   private gotStdoutEvents = false
 
-  async discover(): Promise<{ available: boolean; path?: string; version?: string }> {
-    const binPath = Bun.which("codex")
+  async discover(config?: Record<string, unknown>): Promise<{ available: boolean; path?: string; version?: string }> {
+    const binPath = resolveCodexCommandPath(config)
     if (!binPath) return { available: false }
 
     try {
@@ -135,6 +135,9 @@ class CodexAdapter implements ExternalAgent.Adapter {
     // are forwarded to avoid leaking the Synergy process environment to Codex.
     const configEnv = (this.adapterConfig.env as Record<string, string> | undefined) ?? {}
     const currentEnv = buildCodexProcessEnv(process.env, this.env, configEnv)
+    if (this.adapterConfig.nativeAuth === true) {
+      delete currentEnv.SYNERGY_CODEX_API_KEY
+    }
     const prompt = composeTurnInput(context)
 
     const command = this.commandPath()
@@ -223,7 +226,8 @@ class CodexAdapter implements ExternalAgent.Adapter {
 
     const baseURL = this.adapterConfig.baseURL as string | undefined
     const providerID = this.adapterConfig.providerID as string | undefined
-    if (baseURL) {
+    const nativeAuth = this.adapterConfig.nativeAuth === true
+    if (!nativeAuth && baseURL) {
       const alias = providerID ?? "synergy"
       args.push("-c", `model_provider="${alias}"`)
       args.push("-c", `model_providers.${alias}.name="${alias}"`)
@@ -257,9 +261,7 @@ class CodexAdapter implements ExternalAgent.Adapter {
   }
 
   private commandPath(): string {
-    const configured = this.adapterConfig.path
-    if (typeof configured === "string" && configured.trim()) return configured
-    return "codex"
+    return resolveCodexCommandPath(this.adapterConfig) ?? "codex"
   }
 
   private readStdout(proc: import("bun").Subprocess<"pipe", "pipe", "pipe">): void {
@@ -472,3 +474,9 @@ function extractItemText(item: Record<string, unknown>): string {
 }
 
 ExternalAgent.register("codex", () => new CodexAdapter())
+
+export function resolveCodexCommandPath(config?: Record<string, unknown>): string | undefined {
+  const configured = config?.path
+  if (typeof configured === "string" && configured.trim()) return configured
+  return Bun.which("codex") ?? undefined
+}

--- a/packages/synergy/src/external-agent/bridge.ts
+++ b/packages/synergy/src/external-agent/bridge.ts
@@ -100,7 +100,7 @@ export namespace ExternalAgent {
     readonly capabilities: Capabilities
 
     /** Check whether the external binary is available on this machine. */
-    discover(): Promise<{ available: boolean; path?: string; version?: string }>
+    discover(config?: Record<string, unknown>): Promise<{ available: boolean; path?: string; version?: string }>
 
     /** Spawn or connect to the external agent process. */
     start(opts: StartOptions): Promise<void>

--- a/packages/synergy/src/external-agent/discovery.ts
+++ b/packages/synergy/src/external-agent/discovery.ts
@@ -4,7 +4,9 @@ import { ExternalAgent } from "./bridge"
 export namespace ExternalAgentDiscovery {
   const log = Log.create({ service: "external-agent.discovery" })
 
-  export async function discover(): Promise<Map<string, ExternalAgent.Info>> {
+  export async function discover(
+    config?: Record<string, Record<string, unknown> | undefined>,
+  ): Promise<Map<string, ExternalAgent.Info>> {
     const results = new Map<string, ExternalAgent.Info>()
     const names = ExternalAgent.listAdapters()
 
@@ -12,7 +14,7 @@ export namespace ExternalAgentDiscovery {
       names.map(async (name) => {
         const adapter = ExternalAgent.getAdapter(name)
         if (!adapter) return { name, available: false }
-        const result = await adapter.discover()
+        const result = await adapter.discover(config?.[name])
         return { name, ...result }
       }),
     )
@@ -38,7 +40,10 @@ export namespace ExternalAgentDiscovery {
     return results
   }
 
-  export async function discoverOne(name: string): Promise<ExternalAgent.Info | undefined> {
+  export async function discoverOne(
+    name: string,
+    config?: Record<string, unknown>,
+  ): Promise<ExternalAgent.Info | undefined> {
     const adapter = ExternalAgent.getAdapter(name)
     if (!adapter) {
       log.warn("adapter not registered", { adapter: name })
@@ -46,7 +51,7 @@ export namespace ExternalAgentDiscovery {
     }
 
     try {
-      const result = await adapter.discover()
+      const result = await adapter.discover(config)
       if (!result.available) {
         log.debug("adapter not available", { adapter: name })
         return undefined

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -1263,9 +1263,9 @@ export namespace SessionInvoke {
   function applyModelOverride(config: Record<string, unknown>, adapterName: string, override: ExternalModelInfo): void {
     switch (adapterName) {
       case "codex":
-        config.model = override.model
-        if (override.providerID) config.providerID = override.providerID
-        if (override.baseURL) config.baseURL = override.baseURL
+        // Codex external agent uses the native Codex/ChatGPT authentication path.
+        // It should only be exposed after the openai-codex provider is authenticated,
+        // and must not receive OpenAI-compatible baseURL/API-key overrides.
         break
       case "claude-code":
         config.model = override.model

--- a/packages/synergy/test/external-agent/codex.test.ts
+++ b/packages/synergy/test/external-agent/codex.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, test } from "bun:test"
-import { buildCodexProcessEnv, normalizeCodexSandbox } from "../../src/external-agent/adapter/codex"
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  buildCodexProcessEnv,
+  normalizeCodexSandbox,
+  resolveCodexCommandPath,
+} from "../../src/external-agent/adapter/codex"
 import { ExternalAgent } from "../../src/external-agent/bridge"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const cleanupDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
 
 describe("Codex external adapter environment", () => {
   test("builds an allowlisted process env and preserves explicit Codex API key", () => {
@@ -68,6 +81,42 @@ describe("Codex external adapter sandbox normalization", () => {
 })
 
 describe("Codex external adapter CLI args", () => {
+  test("uses configured path for discovery and version checks", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "synergy-codex-test-"))
+    cleanupDirs.push(dir)
+    const binary = path.join(dir, "codex-wrapper")
+    await Bun.write(binary, "#!/bin/sh\necho codex-test 1.2.3\n")
+    await Bun.spawn(["chmod", "+x", binary]).exited
+
+    const adapter = ExternalAgent.getAdapter("codex", `codex-test-${Date.now()}-discover`) as any
+    const info = await adapter.discover({ path: binary })
+
+    expect(resolveCodexCommandPath({ path: binary })).toBe(binary)
+    expect(info.available).toBe(true)
+    expect(info.path).toBe(binary)
+    expect(info.version).toBe("codex-test 1.2.3")
+  })
+
+  test("native auth ignores baseURL provider config and injected API key", async () => {
+    const adapter = ExternalAgent.getAdapter("codex", `codex-test-${Date.now()}-native-auth`) as any
+    await adapter.start({
+      cwd: "/tmp/synergy-test",
+      env: { SYNERGY_CODEX_API_KEY: "should-not-be-used" },
+      config: {
+        nativeAuth: true,
+        model: "gpt-5.5",
+        providerID: "openai-codex",
+        baseURL: "https://chatgpt.com/backend-api/codex",
+      },
+    })
+
+    const args = adapter.buildArgs({ sessionID: "ses_test", prompt: "hello" }) as string[]
+    expect(args).toContain("--model")
+    expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.5")
+    expect(args.join(" ")).not.toContain("model_provider")
+    expect(args.join(" ")).not.toContain("SYNERGY_CODEX_API_KEY")
+  })
+
   test("does not let sandbox config bypass controlProfile", async () => {
     const adapter = ExternalAgent.getAdapter("codex", `codex-test-${Date.now()}-sandbox`) as any
     await adapter.start({


### PR DESCRIPTION
## Summary
- Expose the Codex external agent only when the `openai-codex` provider has usable OAuth credentials.
- Pass external-agent config into discovery so configured Codex wrapper paths are used for discovery and version checks.
- Keep Codex external-agent runtime on native auth by ignoring OpenAI-compatible `baseURL`/API-key overrides when `nativeAuth` is enabled.

## Changes
| File | Change |
|------|--------|
| `packages/synergy/src/agent/agent.ts` | Gates Codex external agent registration on `openai-codex` auth and sets `nativeAuth: true`. |
| `packages/synergy/src/external-agent/discovery.ts` | Allows discovery to receive adapter config. |
| `packages/synergy/src/external-agent/bridge.ts` | Extends adapter discovery contract with optional config. |
| `packages/synergy/src/external-agent/adapter/codex.ts` | Uses configured path for discovery/runtime and suppresses provider/API-key override args under native auth. |
| `packages/synergy/src/session/invoke.ts` | Stops applying OpenAI-compatible model overrides to Codex external agent. |
| `packages/synergy/test/external-agent/codex.test.ts` | Adds focused coverage for configured path discovery and native auth CLI args. |

## Verification
- `bun run prettier --write ...` on changed files passed.
- `git diff --check` passed.
- `bun test test/external-agent/codex.test.ts test/session/invoke-external.test.ts` had all 10 test assertions pass; command exited non-zero only because package coverage config reports broad coverage for loaded modules.
- `bun run typecheck` could not be completed in the isolated `/tmp` worktree because dependency/generated package resolution was inconsistent with `origin/main` (`tsgo` / `@tsconfig/node22` and plugin manifest generated type drift). No typecheck errors were reported in the changed Codex files before the run stopped on unrelated packages.