### PR TITLE
feat(session): add iterative clarification workflow to plan mode prompts

### DIFF
--- a/packages/synergy/src/session/prompt/plan-mode-synergy-max.txt
+++ b/packages/synergy/src/session/prompt/plan-mode-synergy-max.txt
@@ -1,7 +1,7 @@
 <plan-mode-synergy-max>
 In coding Plan Mode, produce a Blueprint that is strong enough for autonomous implementation.
 
-Before writing the Blueprint, check whether implementation could start immediately without asking product, architecture, API, migration, compatibility, or UX questions. If not, ask the user first.
+Before writing the Blueprint, investigate the codebase and gather context to understand the landscape. Identify decisions the user must own — product direction, architecture tradeoffs, API design, migration strategy, compatibility choices, UX behavior, or acceptance criteria. Ask the user about unresolved decisions before finalizing the Blueprint; you do not need to ask everything upfront. It is natural to investigate, discover a fuzzy point, ask, get an answer, continue, and ask again.
 
 It should cover:
 - Current codebase evidence and file-level entry points

--- a/packages/synergy/src/session/prompt/plan-mode-synergy.txt
+++ b/packages/synergy/src/session/prompt/plan-mode-synergy.txt
@@ -5,7 +5,7 @@ As synergy in Plan Mode, focus on:
 - Producing a Blueprint that a downstream agent can follow autonomously
 - The Blueprint should explain what to do, why, what to avoid, and what "done" looks like
 - Finalizing only decision-complete Blueprints; do not leave choices for the downstream agent
-- Asking the user instead of adding Open Decisions, Open Questions, TBDs, or unresolved alternatives
+- Asking the user instead of adding Open Decisions, Open Questions, TBDs, or unresolved alternatives; investigate first, then ask, and iterate as new questions surface
 - Use whatever structure fits the domain: narrative prose, bullet points, tables, sections
 - Use the user's domain as the frame. A writing Blueprint should read like an editorial brief, a research Blueprint like an evidence plan, an analysis Blueprint like a reasoning plan, a design Blueprint like a product/design brief, and a coding Blueprint like an engineering plan.
 - Do not import another domain's specialized checklist unless the user's task actually belongs to that domain.

--- a/packages/synergy/src/session/prompt/plan-mode.txt
+++ b/packages/synergy/src/session/prompt/plan-mode.txt
@@ -5,7 +5,12 @@ Your job is to create or refine a high-quality Blueprint: a human-readable desig
 
 A Blueprint is an executable delivery contract. It must be decision-complete: a later execution session should not need to choose the intended outcome, domain strategy, artifact shape, user-facing behavior, quality bar, acceptance criteria, or other user-owned decisions.
 
-Do not create or update a Blueprint while blocking ambiguity remains. If the document would contain Open Decisions, Open Questions, TBDs, unresolved alternatives, or instructions for the execution session to ask the user later, ask the user first and wait for the answer.
+A Blueprint often starts with ambiguity: the user's request may be high-level, and critical design tradeoffs only surface after investigation. Your clarification workflow is:
+
+1. Gather context first — inspect code, docs, sessions, memory, and external sources to understand the landscape.
+2. Identify decisions the user must own — product direction, architecture tradeoffs, API design, migration strategy, UX behavior, acceptance criteria, or scope boundaries.
+3. Ask blocking questions at the right time. You do not need to ask everything upfront; it is natural to investigate, discover a fuzzy point, ask, get an answer, continue, and ask again. Multiple rounds of clarification are expected for complex Blueprints.
+4. Do not create or update a Blueprint while blocking ambiguity remains. If the document would contain Open Decisions, Open Questions, TBDs, unresolved alternatives, or instructions for the execution session to ask the user later, ask the user and wait.
 
 You may include Assumptions only when they are locked execution defaults chosen from evidence, project conventions, or explicit user direction. Do not use Assumptions to hide unresolved decisions.
 


### PR DESCRIPTION
## Summary

Plan mode prompts previously had "ask the user" semantics but lacked a structured clarification workflow. The guidance was a one-shot check before writing — it didn't teach the model to **investigate first and iterate through clarification rounds**.

## What changed

Three prompt files updated:

### `plan-mode.txt` (generic, applies to all agents)
Replaced the single "Do not create or update a Blueprint while blocking ambiguity remains" line with a 4-step workflow:
1. Gather context first
2. Identify decisions the user must own
3. Ask blocking questions at the right time (not necessarily upfront; multiple rounds OK)
4. Finalize only when zero ambiguity remains

### `plan-mode-synergy-max.txt` (coding)
Expanded the one-shot "check whether implementation could start immediately...if not, ask" into an iterative investigate-then-ask loop:
- Investigate the codebase first
- Identify user-owned decisions (product, architecture, API, migration, compatibility, UX)
- Ask as fuzzy points surface; iterate naturally

### `plan-mode-synergy.txt` (general synergy)
Added "investigate first, then ask, and iterate as new questions surface" to the existing bullet.

## Principle

The model should not feel forced to guess all questions upfront. It should gather context, discover fuzzy points naturally, ask blocking questions (possibly multiple rounds), and only produce a Blueprint when all user-owned decisions are resolved.