### PR TITLE
fix(sandbox): export Landlock path rule constant

### DIFF
--- a/packages/synergy/src/sandbox/helper-linux/src/landlock.rs
+++ b/packages/synergy/src/sandbox/helper-linux/src/landlock.rs
@@ -113,7 +113,7 @@ fn push_rule_once(rules: &mut Vec<LandlockRule>, rule: LandlockRule) {
 
 #[cfg(target_os = "linux")]
 mod sys {
-    use libc::{c_int, c_long, c_uint, c_void, size_t};
+    use libc::{c_int, c_long, c_uint, size_t};
     use std::ffi::CString;
     use std::io;
     use std::os::unix::ffi::OsStrExt;
@@ -125,7 +125,7 @@ mod sys {
     const SYS_LANDLOCK_RESTRICT_SELF: c_long = 446;
 
     // Rule type: path-beneath is the only type in the current kernel.
-    const LANDLOCK_RULE_PATH_BENEATH: c_uint = 1;
+    pub const LANDLOCK_RULE_PATH_BENEATH: c_uint = 1;
 
     // Filesystem access flags (from linux/landlock.h).
     const LANDLOCK_ACCESS_FS_EXECUTE: u64 = 1 << 0;


### PR DESCRIPTION
## Summary
- Export the Landlock path rule constant from the Linux sandbox helper so downstream helper code can use the shared rule definition.

## Changes
| File | Change |
|------|--------|
| packages/synergy/src/sandbox/helper-linux/src/landlock.rs | Export the path rule constant instead of keeping it private. |

## Verification
- prettier hook passed
- oxlint hook passed
- pre-push full turbo typecheck currently fails in unrelated packages/ui missing dependency/type declarations: dompurify, streaming-markdown, jsdom
