### PR TITLE
fix(codex): gate external agent on native auth

### DIFF
--- a/packages/synergy/src/agent/agent.ts
+++ b/packages/synergy/src/agent/agent.ts
@@ -22,6 +22,7 @@ import { ExternalAgent } from "@/external-agent/bridge"
 import { ExternalAgentDiscovery } from "@/external-agent/discovery"
 import { Plugin } from "../plugin"
 import { MODEL_ROLE_IDS, ModelRole, type ModelRole as ModelRoleType } from "../provider/model-role"
+import { CodexProvider } from "@/provider/codex"
 
 export namespace Agent {
   const log = Log.create({ service: "agent" })
@@ -346,7 +347,7 @@ export namespace Agent {
     } catch (e) {
       log.warn("failed to import external agent adapters", { error: String(e) })
     }
-    const discovered = await ExternalAgentDiscovery.discover()
+    const discovered = await ExternalAgentDiscovery.discover(externalConfig)
     log.info("external agent discovery results", {
       discovered: [...discovered.keys()],
     })
@@ -360,6 +361,13 @@ export namespace Agent {
         log.info("external agent auto_discover disabled", { name })
         continue
       }
+      if (name === "codex") {
+        const access = await CodexProvider.resolveToken({ allowMissing: true }).catch(() => undefined)
+        if (!access) {
+          log.info("codex external agent skipped until openai-codex provider is authenticated")
+          continue
+        }
+      }
       const { disabled: _, path, model, auto_discover: __, ...adapterConfig } = overrides ?? {}
       const externalField = {
         adapter: info.adapter,
@@ -367,6 +375,7 @@ export namespace Agent {
         version: info.version,
         config: {
           ...(model ? { model } : {}),
+          ...(name === "codex" ? { nativeAuth: true } : {}),
           ...adapterConfig,
         },
       }

--- a/packages/synergy/src/external-agent/adapter/codex.ts
+++ b/packages/synergy/src/external-agent/adapter/codex.ts
@@ -95,8 +95,8 @@ class CodexAdapter implements ExternalAgent.Adapter {
   private stderrBuffer = ""
   private gotStdoutEvents = false
 
-  async discover(): Promise<{ available: boolean; path?: string; version?: string }> {
-    const binPath = Bun.which("codex")
+  async discover(config?: Record<string, unknown>): Promise<{ available: boolean; path?: string; version?: string }> {
+    const binPath = resolveCodexCommandPath(config)
     if (!binPath) return { available: false }
 
     try {
@@ -135,6 +135,9 @@ class CodexAdapter implements ExternalAgent.Adapter {
     // are forwarded to avoid leaking the Synergy process environment to Codex.
     const configEnv = (this.adapterConfig.env as Record<string, string> | undefined) ?? {}
     const currentEnv = buildCodexProcessEnv(process.env, this.env, configEnv)
+    if (this.adapterConfig.nativeAuth === true) {
+      delete currentEnv.SYNERGY_CODEX_API_KEY
+    }
     const prompt = composeTurnInput(context)
 
     const command = this.commandPath()
@@ -223,7 +226,8 @@ class CodexAdapter implements ExternalAgent.Adapter {
 
     const baseURL = this.adapterConfig.baseURL as string | undefined
     const providerID = this.adapterConfig.providerID as string | undefined
-    if (baseURL) {
+    const nativeAuth = this.adapterConfig.nativeAuth === true
+    if (!nativeAuth && baseURL) {
       const alias = providerID ?? "synergy"
       args.push("-c", `model_provider="${alias}"`)
       args.push("-c", `model_providers.${alias}.name="${alias}"`)
@@ -257,9 +261,7 @@ class CodexAdapter implements ExternalAgent.Adapter {
   }
 
   private commandPath(): string {
-    const configured = this.adapterConfig.path
-    if (typeof configured === "string" && configured.trim()) return configured
-    return "codex"
+    return resolveCodexCommandPath(this.adapterConfig) ?? "codex"
   }
 
   private readStdout(proc: import("bun").Subprocess<"pipe", "pipe", "pipe">): void {
@@ -472,3 +474,9 @@ function extractItemText(item: Record<string, unknown>): string {
 }
 
 ExternalAgent.register("codex", () => new CodexAdapter())
+
+export function resolveCodexCommandPath(config?: Record<string, unknown>): string | undefined {
+  const configured = config?.path
+  if (typeof configured === "string" && configured.trim()) return configured
+  return Bun.which("codex") ?? undefined
+}

--- a/packages/synergy/src/external-agent/bridge.ts
+++ b/packages/synergy/src/external-agent/bridge.ts
@@ -100,7 +100,7 @@ export namespace ExternalAgent {
     readonly capabilities: Capabilities
 
     /** Check whether the external binary is available on this machine. */
-    discover(): Promise<{ available: boolean; path?: string; version?: string }>
+    discover(config?: Record<string, unknown>): Promise<{ available: boolean; path?: string; version?: string }>
 
     /** Spawn or connect to the external agent process. */
     start(opts: StartOptions): Promise<void>

--- a/packages/synergy/src/external-agent/discovery.ts
+++ b/packages/synergy/src/external-agent/discovery.ts
@@ -4,7 +4,9 @@ import { ExternalAgent } from "./bridge"
 export namespace ExternalAgentDiscovery {
   const log = Log.create({ service: "external-agent.discovery" })
 
-  export async function discover(): Promise<Map<string, ExternalAgent.Info>> {
+  export async function discover(
+    config?: Record<string, Record<string, unknown> | undefined>,
+  ): Promise<Map<string, ExternalAgent.Info>> {
     const results = new Map<string, ExternalAgent.Info>()
     const names = ExternalAgent.listAdapters()
 
@@ -12,7 +14,7 @@ export namespace ExternalAgentDiscovery {
       names.map(async (name) => {
         const adapter = ExternalAgent.getAdapter(name)
         if (!adapter) return { name, available: false }
-        const result = await adapter.discover()
+        const result = await adapter.discover(config?.[name])
         return { name, ...result }
       }),
     )
@@ -38,7 +40,10 @@ export namespace ExternalAgentDiscovery {
     return results
   }
 
-  export async function discoverOne(name: string): Promise<ExternalAgent.Info | undefined> {
+  export async function discoverOne(
+    name: string,
+    config?: Record<string, unknown>,
+  ): Promise<ExternalAgent.Info | undefined> {
     const adapter = ExternalAgent.getAdapter(name)
     if (!adapter) {
       log.warn("adapter not registered", { adapter: name })
@@ -46,7 +51,7 @@ export namespace ExternalAgentDiscovery {
     }
 
     try {
-      const result = await adapter.discover()
+      const result = await adapter.discover(config)
       if (!result.available) {
         log.debug("adapter not available", { adapter: name })
         return undefined

--- a/packages/synergy/src/external-agent/processor.ts
+++ b/packages/synergy/src/external-agent/processor.ts
@@ -280,7 +280,7 @@ export namespace ExternalAgentProcessor {
     )
 
     const parts = await MessageV2.parts({ sessionID, messageID: assistantMessage.id })
-    return { info: { ...assistantMessage, visible: true }, parts }
+    return { info: assistantMessage, parts }
   }
 
   async function finalizeTextPart(part: MessageV2.TextPart | undefined) {

--- a/packages/synergy/src/external-agent/processor.ts
+++ b/packages/synergy/src/external-agent/processor.ts
@@ -39,6 +39,7 @@ export namespace ExternalAgentProcessor {
       role: "assistant",
       sessionID,
       parentID,
+      visible: true,
       agent,
       mode: agent,
       path: {
@@ -279,7 +280,7 @@ export namespace ExternalAgentProcessor {
     )
 
     const parts = await MessageV2.parts({ sessionID, messageID: assistantMessage.id })
-    return { info: assistantMessage, parts }
+    return { info: { ...assistantMessage, visible: true }, parts }
   }
 
   async function finalizeTextPart(part: MessageV2.TextPart | undefined) {

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -1366,9 +1366,9 @@ export namespace SessionInvoke {
   function applyModelOverride(config: Record<string, unknown>, adapterName: string, override: ExternalModelInfo): void {
     switch (adapterName) {
       case "codex":
-        config.model = override.model
-        if (override.providerID) config.providerID = override.providerID
-        if (override.baseURL) config.baseURL = override.baseURL
+        // Codex external agent uses the native Codex/ChatGPT authentication path.
+        // It should only be exposed after the openai-codex provider is authenticated,
+        // and must not receive OpenAI-compatible baseURL/API-key overrides.
         break
       case "claude-code":
         config.model = override.model

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -361,7 +361,8 @@ export namespace SessionInvoke {
           }
 
           const runConfig = applyExternalPermissionMode({ ...agent.external.config }, adapter.name, profileId)
-          const override = await resolveExternalModelOverride(R.model, adapter.name)
+          const codexNativeAuth = adapter.name === "codex" && runConfig.nativeAuth === true
+          const override = codexNativeAuth ? undefined : await resolveExternalModelOverride(R.model, adapter.name)
           if (override && adapter.capabilities.modelSwitch) {
             applyModelOverride(runConfig, adapter.name, override)
           }

--- a/packages/synergy/test/external-agent/bridge.test.ts
+++ b/packages/synergy/test/external-agent/bridge.test.ts
@@ -9,7 +9,9 @@ class TestAdapter implements ExternalAgent.Adapter {
     interrupt: false,
   }
 
-  async discover() {
+  // Accept config in discover signature per updated Adapter interface, but
+  // ignore it — adapters that don't consume config are still valid.
+  async discover(_config?: Record<string, unknown>) {
     return { available: true }
   }
 
@@ -47,4 +49,80 @@ test("getAdapter without sessionID preserves default singleton behavior", () => 
 
   expect(first).toBeDefined()
   expect(first).toBe(second)
+})
+
+test("discover forwards per-adapter config from discovery helper", async () => {
+  let receivedConfig: Record<string, unknown> | undefined
+  class DiscoverAdapter implements ExternalAgent.Adapter {
+    readonly name = "test-discover"
+    readonly started = false
+    readonly capabilities: ExternalAgent.Capabilities = {
+      modelSwitch: false,
+      interrupt: false,
+    }
+
+    async discover(config?: Record<string, unknown>) {
+      receivedConfig = config
+      return { available: true, path: "/usr/bin/test" }
+    }
+
+    async start() {}
+    async *turn(): AsyncGenerator<ExternalAgent.BridgeEvent> {
+      yield { type: "turn_complete" }
+    }
+    async interrupt() {}
+    async shutdown() {}
+  }
+
+  const name = `test-discover-${Date.now()}`
+  ExternalAgent.register(name, () => new DiscoverAdapter())
+
+  const cfg = {
+    [name]: { path: "/custom/path", model: "gpt-5.5", nativeAuth: true },
+  }
+  const { ExternalAgentDiscovery } = await import("../../src/external-agent/discovery")
+  const results = await ExternalAgentDiscovery.discover(cfg)
+
+  expect(receivedConfig).toEqual({ path: "/custom/path", model: "gpt-5.5", nativeAuth: true })
+  expect(results.has(name)).toBe(true)
+  expect(results.get(name)?.path).toBe("/usr/bin/test")
+})
+
+test("adapter that does not consume config still satisfies discovery contract", async () => {
+  let callCount = 0
+  class NoConfigAdapter implements ExternalAgent.Adapter {
+    readonly name = "test-no-config"
+    readonly started = false
+    readonly capabilities: ExternalAgent.Capabilities = {
+      modelSwitch: false,
+      interrupt: false,
+    }
+
+    // discover() ignores the config parameter — this mirrors the behavior of
+    // claude-code / openclaw adapters that use Bun.which() without a config path.
+    async discover(_?: Record<string, unknown>) {
+      callCount++
+      return { available: true, path: Bun.which("node") ?? undefined, version: "1.0" }
+    }
+
+    async start() {}
+    async *turn(): AsyncGenerator<ExternalAgent.BridgeEvent> {
+      yield { type: "turn_complete" }
+    }
+    async interrupt() {}
+    async shutdown() {}
+  }
+
+  const name = `test-no-config-${Date.now()}`
+  ExternalAgent.register(name, () => new NoConfigAdapter())
+
+  const { ExternalAgentDiscovery } = await import("../../src/external-agent/discovery")
+  const results = await ExternalAgentDiscovery.discover({ [name]: undefined })
+
+  // The adapter received the call and did not crash, even though its discover
+  // signature accepts config but ignores it. This is the contract guarantee for
+  // claude-code and openclaw adapters that have not yet adopted config-driven
+  // discovery.
+  expect(callCount).toBe(1)
+  expect(results.has(name)).toBe(true)
 })

--- a/packages/synergy/test/external-agent/codex.test.ts
+++ b/packages/synergy/test/external-agent/codex.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, test } from "bun:test"
-import { buildCodexProcessEnv, normalizeCodexSandbox } from "../../src/external-agent/adapter/codex"
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  buildCodexProcessEnv,
+  normalizeCodexSandbox,
+  resolveCodexCommandPath,
+} from "../../src/external-agent/adapter/codex"
 import { ExternalAgent } from "../../src/external-agent/bridge"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const cleanupDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
 
 describe("Codex external adapter environment", () => {
   test("builds an allowlisted process env and preserves explicit Codex API key", () => {
@@ -68,6 +81,42 @@ describe("Codex external adapter sandbox normalization", () => {
 })
 
 describe("Codex external adapter CLI args", () => {
+  test("uses configured path for discovery and version checks", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "synergy-codex-test-"))
+    cleanupDirs.push(dir)
+    const binary = path.join(dir, "codex-wrapper")
+    await Bun.write(binary, "#!/bin/sh\necho codex-test 1.2.3\n")
+    await Bun.spawn(["chmod", "+x", binary]).exited
+
+    const adapter = ExternalAgent.getAdapter("codex", `codex-test-${Date.now()}-discover`) as any
+    const info = await adapter.discover({ path: binary })
+
+    expect(resolveCodexCommandPath({ path: binary })).toBe(binary)
+    expect(info.available).toBe(true)
+    expect(info.path).toBe(binary)
+    expect(info.version).toBe("codex-test 1.2.3")
+  })
+
+  test("native auth ignores baseURL provider config and injected API key", async () => {
+    const adapter = ExternalAgent.getAdapter("codex", `codex-test-${Date.now()}-native-auth`) as any
+    await adapter.start({
+      cwd: "/tmp/synergy-test",
+      env: { SYNERGY_CODEX_API_KEY: "should-not-be-used" },
+      config: {
+        nativeAuth: true,
+        model: "gpt-5.5",
+        providerID: "openai-codex",
+        baseURL: "https://chatgpt.com/backend-api/codex",
+      },
+    })
+
+    const args = adapter.buildArgs({ sessionID: "ses_test", prompt: "hello" }) as string[]
+    expect(args).toContain("--model")
+    expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.5")
+    expect(args.join(" ")).not.toContain("model_provider")
+    expect(args.join(" ")).not.toContain("SYNERGY_CODEX_API_KEY")
+  })
+
   test("does not let sandbox config bypass controlProfile", async () => {
     const adapter = ExternalAgent.getAdapter("codex", `codex-test-${Date.now()}-sandbox`) as any
     await adapter.start({

--- a/packages/synergy/test/external-agent/codex.test.ts
+++ b/packages/synergy/test/external-agent/codex.test.ts
@@ -115,6 +115,15 @@ describe("Codex external adapter CLI args", () => {
     expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.5")
     expect(args.join(" ")).not.toContain("model_provider")
     expect(args.join(" ")).not.toContain("SYNERGY_CODEX_API_KEY")
+
+    // Simulate the turn() env construction + nativeAuth deletion pattern:
+    // buildCodexProcessEnv copies injected SYNERGY_CODEX_API_KEY in,
+    // then nativeAuth deletes it before passing to the child process.
+    const configEnv = (adapter.adapterConfig?.env as Record<string, string> | undefined) ?? {}
+    const env = buildCodexProcessEnv(process.env, adapter.env ?? {}, configEnv)
+    expect(env.SYNERGY_CODEX_API_KEY).toBe("should-not-be-used")
+    delete env.SYNERGY_CODEX_API_KEY
+    expect(env.SYNERGY_CODEX_API_KEY).toBeUndefined()
   })
 
   test("does not let sandbox config bypass controlProfile", async () => {

--- a/packages/synergy/test/external-agent/processor.test.ts
+++ b/packages/synergy/test/external-agent/processor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { ExternalAgentProcessor } from "../../src/external-agent/processor"
+import type { ExternalAgent } from "../../src/external-agent/bridge"
+import { Identifier } from "../../src/id/id"
+import { ScopeContext } from "../../src/scope/context"
+import { Session } from "../../src/session"
+import { tmpdir } from "../fixture/fixture"
+
+describe("ExternalAgentProcessor", () => {
+  test("writes external assistant results as visible messages", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({ scope: await tmp.scope() })
+        const parent = await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          sessionID: session.id,
+          role: "user",
+          visible: true,
+          isRoot: true,
+          rootID: Identifier.ascending("message"),
+          agent: "codex",
+          model: { providerID: "openai-codex", modelID: "gpt-5.5" },
+          time: { created: Date.now() },
+        })
+        const adapter: ExternalAgent.Adapter = {
+          name: "codex",
+          started: true,
+          capabilities: { modelSwitch: true, interrupt: true },
+          async discover() {
+            return { available: true }
+          },
+          async start() {},
+          async *turn() {
+            yield { type: "text_delta", text: "Codex finished successfully." }
+            yield { type: "turn_complete" }
+          },
+          async interrupt() {},
+          async shutdown() {},
+        }
+
+        const result = await ExternalAgentProcessor.process({
+          sessionID: session.id,
+          agent: "codex",
+          adapter,
+          parentID: parent.id,
+          model: { providerID: "openai-codex", modelID: "gpt-5.5" },
+          context: { sessionID: session.id, prompt: "test" },
+          approvalDelegate: async () => false,
+          abort: new AbortController().signal,
+        })
+
+        expect(result.info.visible).toBe(true)
+        expect(result.parts.some((part) => part.type === "text" && part.text.includes("Codex finished"))).toBe(true)
+
+        const messages = await Session.messages({ sessionID: session.id })
+        const assistant = messages.find((message) => message.info.id === result.info.id)?.info
+        expect(assistant?.visible).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Gate the Codex external agent on authenticated openai-codex provider access.
- Use the configured Codex path consistently for discovery/version checks and runtime execution.
- Mark external-agent assistant messages visible so Codex sub-sessions show returned results.

## Changes
| File | Change |
|------|--------|
| packages/synergy/src/agent/agent.ts | Only expose Codex external agent after openai-codex auth is available. |
| packages/synergy/src/external-agent/adapter/codex.ts | Keep native auth isolated from OpenAI-compatible override env/baseURL handling. |
| packages/synergy/src/external-agent/discovery.ts | Pass configured external-agent config into discovery. |
| packages/synergy/src/session/invoke.ts | Avoid model/baseURL override for native-auth Codex external agent. |
| packages/synergy/src/external-agent/processor.ts | Persist external-agent assistant messages as visible. |
| packages/synergy/test/external-agent/*.test.ts | Cover configured Codex discovery path/native auth and visible external-agent result messages. |

## Verification
- bun test test/external-agent/processor.test.ts test/external-agent/codex.test.ts
- bun run --cwd packages/synergy typecheck
- prettier hook passed
- oxlint hook passed
- pre-push full turbo typecheck currently fails in unrelated packages/ui missing dependency/type declarations: dompurify, streaming-markdown, jsdom
