### PR TITLE
fix(session): add missing origin: "system" in catch-all file attachment path

### DIFF
--- a/packages/synergy/src/session/input.ts
+++ b/packages/synergy/src/session/input.ts
@@ -576,6 +576,7 @@ export async function createUserMessage(input: InvokeInput, rootIDOverride?: str
                 messageID: info.id,
                 sessionID: input.sessionID,
                 type: "text",
+                origin: "system" as const,
                 text: `Called the Read tool with the following input: {\"filePath\":\"${filepath}\"}`,
               },
               await Attachment.toPart({


### PR DESCRIPTION
## Summary

Fix regression from `9f49e614` that caused image uploads to sometimes swallow the user's prompt text.

## Root cause

`9f49e614` migrated 14 system-injected text part injection points from `synthetic: true` to `origin: "system"`, but missed the catch-all path at `input.ts:574-580`. Without `origin`, the post-processing loop (line 626-629) incorrectly marks the injected `"Called the Read tool…"` part as `origin: "user"`, making it indistinguishable from the user's real text.

Since `visibleUserMessageText()` uses `.find()` to pick the first non-system text part, the displayed text depends on ULID serialization order — sometimes correct, sometimes the tool description.

## Fix

Add `origin: "system" as const` to the catch-all text part, matching the other 14 injection points in the same file.

## Before/After

- **Before**: When user uploads an image with text "分析这张图", the frontend randomly shows either "分析这张图" or `Called the Read tool with the following input: {"filePath":"..."}`
- **After**: The "Called the Read tool…" part is always properly classified as system-injected and filtered out by `visibleUserMessageText()`

Fixes #354

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>