### PR TITLE
fix: new project sorted to bottom of sidebar after add (#352)

### DIFF
--- a/packages/synergy/src/session/nav.ts
+++ b/packages/synergy/src/session/nav.ts
@@ -306,14 +306,17 @@ export namespace SessionNav {
             icon?: { url?: string; color?: string }
             directory?: string
             worktree?: string
-            time?: { archived?: number }
+            time?: { created?: number; archived?: number }
           }
         | undefined
       if (sid !== "home") {
         scopeInfo = await Storage.read<any>(StoragePath.scope(Identifier.asScopeID(sid))).catch(() => undefined)
       }
       if (scopeInfo?.time?.archived) continue
-      const latestActivityAt = activeEntries.length > 0 ? Math.max(...activeEntries.map((e) => e.lastActivityAt)) : 0
+      const latestActivityAt =
+        activeEntries.length > 0
+          ? Math.max(...activeEntries.map((e) => e.lastActivityAt))
+          : (scopeInfo?.time?.created ?? 0)
       results.push({
         scopeID: sid,
         scopeType: sid === "home" ? "home" : "project",


### PR DESCRIPTION
## Summary

- Fixes #352: when a newly added project has no sessions, `latestActivityAt` defaults to 0, sorting it to the bottom of the sidebar
- Uses the scope's `time.created` timestamp (project add time) as fallback so new projects appear near the top

## What changed

`packages/synergy/src/session/nav.ts` — `buildScopeIndex()`:
- Widen `scopeInfo` type annotation to include `time.created`
- Use `scopeInfo.time.created` as fallback when a project has no active sessions (`latestActivityAt = 0`)

## Verification

- No API contract changes — `ScopeNavEntry` unchanged
- No frontend changes needed — existing sort logic continues to work
- Formatter check passed