### PR TITLE
docs(tool): clarify file search behavior

### DIFF
--- a/packages/synergy/src/tool/file-search.ts
+++ b/packages/synergy/src/tool/file-search.ts
@@ -11,11 +11,23 @@ export const FileSearchTool = Tool.define("file_search", {
     query: z
       .string()
       .describe(
-        "Fuzzy filename, directory name, module name, path fragment, code symbol, or literal content snippet to search for",
+        "Fuzzy filename, directory name, module name, path fragment, code symbol, or exact literal content snippet to search for",
       ),
-    limit: z.coerce.number().int().min(1).max(100).optional().describe("Maximum total results across all search modes"),
-    include: z.string().optional().describe("Optional comma-separated glob patterns to include"),
-    exclude: z.string().optional().describe("Optional comma-separated glob patterns to exclude"),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe("Maximum total merged results across path, content, and symbol matches; defaults to 50"),
+    include: z
+      .string()
+      .optional()
+      .describe("Optional comma-separated glob patterns to include for path and content search"),
+    exclude: z
+      .string()
+      .optional()
+      .describe("Optional comma-separated glob patterns to exclude from path and content search"),
   }),
   async execute(params, ctx) {
     await ctx.ask({

--- a/packages/synergy/src/tool/file-search.txt
+++ b/packages/synergy/src/tool/file-search.txt
@@ -1,5 +1,19 @@
 Hybrid workspace search that combines fuzzy file path matching, literal file-content search, and LSP workspace symbol lookup.
 
-Run all three modes concurrently and merge results with path matches first, then content hits, then symbols. Use this when you roughly know a filename, directory name, module name, path fragment, code symbol, or a literal text snippet in file contents. Empty queries fall back to path-only listing. The content search is literal (not regex), and symbol search requires an active language server.
+Use this when you roughly know a filename, directory name, module name, path fragment, code symbol, or an exact literal snippet in file contents.
 
-For regex content search with anchored editable results, use scan_files. For syntax-aware queries, use parse_code. For file reading, use view_file.
+Parameters:
+- query: Search text. Empty or whitespace-only queries list files and directories only.
+- limit: Maximum total merged results returned across path, content, and symbol matches. Defaults to 50; allowed range is 1-100.
+- include: Optional comma-separated glob patterns to include. Applies to path and content search.
+- exclude: Optional comma-separated glob patterns to exclude. Applies to path and content search.
+
+Search behavior:
+- Path search uses fuzzy matching over workspace file and directory paths.
+- Content search uses fixed-string literal matching, not regex. A query with spaces searches for that exact text including spaces; it is not multi-keyword AND.
+- Symbol search uses workspace symbols from an active language server. Results depend on LSP availability and may ignore include/exclude filters.
+- Non-empty searches return merged results in priority order: path matches first, then content hits, then symbols.
+- If path search finds no matches, the file index may be refreshed and path search retried before content and symbol results are merged.
+- Empty or whitespace-only queries do not search content or symbols.
+
+For multi-keyword AND logic, use multiple targeted calls or scan_files with an appropriate regex. For regex content search with anchored editable results, use scan_files. For syntax-aware queries, use parse_code. For file reading, use view_file.


### PR DESCRIPTION
## Summary
- Expands the agent-facing `file_search` description with parameter semantics, merge order, and search-mode behavior.
- Clarifies literal fixed-string content matching, space-containing queries, include/exclude glob scope, and LSP-dependent symbol results.
- Tightens parameter schema descriptions to match the documented behavior.

Fixes #404

## Test
- `cd packages/synergy && bun test test/tool/file-search.test.ts`