### PR TITLE
Fix Lattice toolbar badge

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -492,6 +492,26 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     })
   }
 
+  const cancelLattice = async () => {
+    if (!params.id) {
+      setPendingLattice(null)
+      return
+    }
+
+    try {
+      await sdk.client.lattice.session.mode({
+        id: params.id,
+        latticeModeInput: { enabled: false },
+      })
+    } catch (err) {
+      showToast({
+        type: "error",
+        title: "Failed to cancel Lattice",
+        description: err instanceof Error ? err.message : "Request failed",
+      })
+    }
+  }
+
   const openLatticeDialog = (event?: Event) => {
     if (blueprintModeLocked()) {
       event?.preventDefault()
@@ -1445,6 +1465,26 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         </span>
                       </span>
                       <span class="prompt-input-compact-label text-12-medium leading-none">Plan</span>
+                    </button>
+                  </Tooltip>
+                </Show>
+                <Show when={latticeActive()}>
+                  <Tooltip placement="top" value="Cancel Lattice">
+                    <button
+                      type="button"
+                      aria-label="Cancel Lattice"
+                      class="prompt-input-toolbar-button prompt-input-compact-control group flex items-center gap-1.5 text-text-weak hover:text-text-base"
+                      onClick={() => void cancelLattice()}
+                    >
+                      <span class="relative flex size-4 shrink-0 items-center justify-center">
+                        <span class="absolute inset-0 flex items-center justify-center opacity-100 transition-opacity group-hover:opacity-0">
+                          <Icon name={getSemanticIcon("prompt.lattice")} size="small" class="text-icon-weak" />
+                        </span>
+                        <span class="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100">
+                          <Icon name={getSemanticIcon("action.close")} size="small" class="text-icon-base" />
+                        </span>
+                      </span>
+                      <span class="prompt-input-compact-label text-12-medium leading-none">Lattice</span>
                     </button>
                   </Tooltip>
                 </Show>

--- a/packages/ui/src/components/semantic-icon.tsx
+++ b/packages/ui/src/components/semantic-icon.tsx
@@ -123,7 +123,7 @@ export const SemanticIconToken = {
   // Prompt composer and command entry
   "prompt.attach": "paperclip",
   "prompt.plan": "list-checks",
-  "prompt.lattice": "route",
+  "prompt.lattice": "orbit",
   "prompt.shell": "file-terminal",
   "prompt.signal": "signal",
   "prompt.submit": "corner-down-left",

--- a/packages/ui/src/components/semantic-icon.tsx
+++ b/packages/ui/src/components/semantic-icon.tsx
@@ -123,6 +123,7 @@ export const SemanticIconToken = {
   // Prompt composer and command entry
   "prompt.attach": "paperclip",
   "prompt.plan": "list-checks",
+  "prompt.lattice": "route",
   "prompt.shell": "file-terminal",
   "prompt.signal": "signal",
   "prompt.submit": "corner-down-left",


### PR DESCRIPTION
## Summary
- Add a dedicated semantic icon token for Lattice prompt state.
- Show a persistent compact Lattice badge in the prompt toolbar when Lattice is active or armed.
- Let the badge cancel active/armed Lattice mode directly, matching the Plan Mode compact affordance.

## Verification
- bun run format:check
- bun run lint
- bun run typecheck *(blocked: local environment is missing `tsgo`)*

Closes #403