### PR TITLE
fix session nav activity bounce

### DIFF
--- a/packages/app/src/context/layout-nav.test.ts
+++ b/packages/app/src/context/layout-nav.test.ts
@@ -85,6 +85,24 @@ describe("navUpdateFromSession", () => {
     })
   })
 
+  test("uses the authoritative nav entry activity when provided", () => {
+    const u = navUpdateFromSession(
+      {
+        id: "s1",
+        title: "Running update",
+        time: { updated: 9999 },
+      },
+      entry({ id: "s1", lastActivityAt: 1234 }),
+    )
+
+    expect(u.lastActivityAt).toBe(1234)
+    expect(u.title).toBe("Running update")
+  })
+
+  test("falls back to time.updated for new session events without navEntry", () => {
+    expect(navUpdateFromSession({ id: "new", time: { updated: 9999 } }).lastActivityAt).toBe(9999)
+  })
+
   test("marks archived when time.archived is set", () => {
     expect(navUpdateFromSession({ id: "s1", time: { archived: 999 } }).archived).toBe(true)
   })
@@ -109,8 +127,27 @@ describe("applySessionToNavList", () => {
     expect(updated.title).toBe("new")
     expect(updated.pinned).toBe(7)
     expect(updated.lastActivityAt).toBe(99)
-    // updating lastActivityAt in place is enough — orderNavEntries reorders at read
     expect(orderNavEntries(r.list.items).map((e) => e.id)).toEqual(["a", "b"])
+  })
+
+  test("keeps running session order when authoritative nav activity is stable", () => {
+    const l = list([
+      entry({ id: "running", title: "old", lastActivityAt: 1 }),
+      entry({ id: "other", lastActivityAt: 5 }),
+    ])
+    const r = applySessionToNavList(
+      l,
+      navUpdateFromSession(
+        { id: "running", title: "still running", time: { updated: 99 } },
+        entry({ id: "running", lastActivityAt: 1 }),
+      ),
+    )
+
+    expect(r.applied).toBe(true)
+    const updated = r.list.items.find((e) => e.id === "running")!
+    expect(updated.title).toBe("still running")
+    expect(updated.lastActivityAt).toBe(1)
+    expect(orderNavEntries(r.list.items).map((e) => e.id)).toEqual(["other", "running"])
   })
 
   test("removes an archived entry and decrements total", () => {

--- a/packages/app/src/context/layout-nav.ts
+++ b/packages/app/src/context/layout-nav.ts
@@ -18,19 +18,22 @@ export type NavSessionUpdate = {
   completionNoticeUnread?: boolean
 }
 
-export function navUpdateFromSession(info: {
-  id: string
-  title?: string
-  pinned?: number
-  parentID?: string
-  time?: { updated?: number; archived?: number }
-  completionNotice?: { unread?: boolean }
-}): NavSessionUpdate {
+export function navUpdateFromSession(
+  info: {
+    id: string
+    title?: string
+    pinned?: number
+    parentID?: string
+    time?: { updated?: number; archived?: number }
+    completionNotice?: { unread?: boolean }
+  },
+  navEntry?: Pick<NavEntry, "lastActivityAt">,
+): NavSessionUpdate {
   return {
     id: info.id,
     title: info.title,
     pinned: info.pinned,
-    lastActivityAt: info.time?.updated,
+    lastActivityAt: navEntry?.lastActivityAt ?? info.time?.updated,
     archived: !!info.time?.archived,
     parentID: info.parentID,
     completionNoticeUnread: info.completionNotice?.unread,

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -508,8 +508,15 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     onMount(() => {
       const unsub = globalSdk.event.listen((e) => {
         if ((e.details as { type?: string })?.type !== "session.updated") return
-        const info = (e.details as { properties?: { info?: { scope?: { id?: string; directory?: string } } } })
-          ?.properties?.info
+        const properties = (
+          e.details as {
+            properties?: {
+              info?: { scope?: { id?: string; directory?: string } }
+              navEntry?: NavEntry
+            }
+          }
+        )?.properties
+        const info = properties?.info
         const scope = info?.scope
         if (!scope) return
 
@@ -517,7 +524,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         // this session immediately (title/pin/activity/archive), so the sidebar
         // doesn't lag the debounced refetch. The refetch below still runs as the
         // authority for ordering, new entries, and project aggregates.
-        const navUpdate = navUpdateFromSession(info as Parameters<typeof navUpdateFromSession>[0])
+        const navUpdate = navUpdateFromSession(info as Parameters<typeof navUpdateFromSession>[0], properties?.navEntry)
         {
           const recentResult = applySessionToNavList(recentEntries, navUpdate)
           if (recentResult.applied) setRecentEntries(recentResult.list)

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -5911,6 +5911,7 @@ export type EventSessionUpdated = {
   type: "session.updated"
   properties: {
     info: Session
+    navEntry?: SessionNavEntry
   }
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -32791,6 +32791,9 @@
             "properties": {
               "info": {
                 "$ref": "#/components/schemas/Session"
+              },
+              "navEntry": {
+                "$ref": "#/components/schemas/SessionNavEntry"
               }
             },
             "required": ["info"]

--- a/packages/synergy/src/session/event.ts
+++ b/packages/synergy/src/session/event.ts
@@ -2,12 +2,14 @@ import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
 import { SnapshotSchema } from "@/session/snapshot-schema"
 import { Info, StatusInfo } from "./types"
+import { SessionNavEntry } from "./nav"
 
 export const SessionEvent = {
   Updated: BusEvent.define(
     "session.updated",
     z.object({
       info: Info,
+      navEntry: SessionNavEntry.optional(),
     }),
   ),
   Deleted: BusEvent.define(

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -286,7 +286,7 @@ export namespace Session {
   const lastPublish = new Map<string, { key: string; at: number }>()
   const PUBLISH_DEDUP_THROTTLE_MS = 1000
 
-  async function publishInfo(event: typeof SessionEvent.Updated, session: Info) {
+  async function publishInfo(event: typeof SessionEvent.Updated, session: Info, navEntry?: SessionNavEntry) {
     const info = await withRuntimeInfo(session)
     const key = publishCompareKey(info)
     const now = Date.now()
@@ -304,7 +304,7 @@ export namespace Session {
     }
     if (info.time.archived) lastPublish.delete(session.id)
     else lastPublish.set(session.id, { key, at: now })
-    Bus.publish(event, { info })
+    Bus.publish(event, { info, navEntry })
   }
 
   export async function create(input?: {
@@ -385,7 +385,7 @@ export namespace Session {
     await writeEndpointIndex(result)
     await upsertPageIndexEntry(scope.id, toPageIndexEntry(result))
     if (result.parentID) await upsertChildIndexEntry(scope.id, result.parentID, toChildIndexEntry(result))
-    await SessionNav.upsertNavEntry(toNavEntry(result))
+    const navEntry = await SessionNav.upsertNavEntry(toNavEntry(result))
 
     if (result.agenda) {
       await Storage.write(StoragePath.agendaSession(result.agenda.itemID, result.id), {
@@ -397,7 +397,7 @@ export namespace Session {
     SessionManager.registerRuntime(result.id)
     Scope.touch(scope.id)
 
-    await publishInfo(SessionEvent.Updated, result)
+    await publishInfo(SessionEvent.Updated, result, navEntry)
     return withRuntimeInfo(result)
   }
 
@@ -591,8 +591,8 @@ export namespace Session {
       draft.completionNotice.unread = false
     })
 
-    await SessionNav.upsertNavEntry(toNavEntry(result))
-    await publishInfo(SessionEvent.Updated, result)
+    const navEntry = await SessionNav.upsertNavEntry(toNavEntry(result))
+    await publishInfo(SessionEvent.Updated, result, navEntry)
     return withRuntimeInfo(result)
   }
 
@@ -617,7 +617,7 @@ export namespace Session {
     if (result.parentID) {
       await upsertChildIndexEntry(scope.id, result.parentID, toChildIndexEntry(result))
     }
-    await SessionNav.upsertNavEntry(toNavEntry(result), {
+    const navEntry = await SessionNav.upsertNavEntry(toNavEntry(result), {
       preserveActivityAt: before.pendingReply === true && result.pendingReply === true,
     })
 
@@ -636,7 +636,7 @@ export namespace Session {
         log.warn("failed to detach worktree during session archive", { sessionID: result.id, error })
       })
     }
-    await publishInfo(SessionEvent.Updated, result)
+    await publishInfo(SessionEvent.Updated, result, navEntry)
     return withRuntimeInfo(result)
   }
 

--- a/packages/synergy/src/session/nav.ts
+++ b/packages/synergy/src/session/nav.ts
@@ -334,7 +334,7 @@ export namespace SessionNav {
   export async function upsertNavEntry(
     entry: SessionNavEntry,
     options?: { preserveActivityAt?: boolean },
-  ): Promise<void> {
+  ): Promise<SessionNavEntry> {
     const index = await readNavIndex(entry.scopeID)
     const existing = index.entries.findIndex((e) => e.id === entry.id)
     const nextEntry =
@@ -351,6 +351,7 @@ export namespace SessionNav {
     else index.entries.splice(insertAt, 0, nextEntry)
     index.updatedAt = Date.now()
     await Storage.write(StoragePath.sessionNavIndex(Identifier.asScopeID(nextEntry.scopeID)), index)
+    return nextEntry
   }
 
   export async function removeNavEntry(scopeID: string, sessionID: string): Promise<void> {

--- a/packages/synergy/test/session/nav-event.test.ts
+++ b/packages/synergy/test/session/nav-event.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { Bus } from "../../src/bus"
+import { ScopeContext } from "../../src/scope/context"
+import { Session } from "../../src/session"
+import { SessionEvent } from "../../src/session/event"
+
+describe("session.updated nav entry payload", () => {
+  test("publishes the authoritative nav entry when a session is created", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const resolved = Promise.withResolvers<{
+          info: Session.Info
+          navEntry?: { id: string; lastActivityAt: number }
+        }>()
+        const unsub = Bus.subscribe(SessionEvent.Updated, (event) => {
+          resolved.resolve(
+            event.properties as { info: Session.Info; navEntry?: { id: string; lastActivityAt: number } },
+          )
+        })
+
+        const session = await Session.create({ title: "New project session" })
+        const received = await resolved.promise
+        unsub()
+
+        expect(received.info.id).toBe(session.id)
+        expect(received.navEntry?.id).toBe(session.id)
+        expect(received.navEntry?.lastActivityAt).toBe(session.time.updated)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("publishes stable authoritative nav activity during a running session update", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({ title: "Running" })
+        const started = await Session.update(session.id, (draft) => {
+          draft.pendingReply = true
+          draft.title = "Running started"
+        })
+
+        const resolved = Promise.withResolvers<{
+          info: Session.Info
+          navEntry?: { id: string; lastActivityAt: number }
+        }>()
+        const unsub = Bus.subscribe(SessionEvent.Updated, (event) => {
+          if (event.properties.info.id === session.id) {
+            resolved.resolve(
+              event.properties as { info: Session.Info; navEntry?: { id: string; lastActivityAt: number } },
+            )
+          }
+        })
+
+        const updated = await Session.update(session.id, (draft) => {
+          draft.title = "Running still"
+        })
+        const received = await resolved.promise
+        unsub()
+
+        expect(updated.time.updated).toBeGreaterThan(started.time.updated)
+        expect(received.info.title).toBe("Running still")
+        expect(received.navEntry?.id).toBe(session.id)
+        expect(received.navEntry?.lastActivityAt).toBe(started.time.updated)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Publish the authoritative `SessionNavEntry` with `session.updated` events so the frontend uses the same sidebar sort key as the server.
- Preserve new-session/new-project activity ordering by falling back to `time.updated` when no nav entry is present.
- Add regression coverage for stable running-session nav ordering and the event payload contract.

## Tests
- `./script/generate.ts`
- `bun test src/context/layout-nav.test.ts` (from `packages/app`)
- `bun test test/session/nav-event.test.ts test/session/nav-index.test.ts` (from `packages/synergy`)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- pre-push hook: format, lint, typecheck, sherif

Fixes #367.