### PR TITLE
Fix note edit stale anchor recovery

### DIFF
--- a/packages/synergy/src/tool/note-edit.ts
+++ b/packages/synergy/src/tool/note-edit.ts
@@ -40,14 +40,14 @@ const deleteBlockOp = z.object({
 const setAttrsOp = z.object({
   action: z.literal("setAttrs"),
   blockId: z.string(),
-  expectedHash: z.string(),
+  expectedHash: z.string().optional(),
   attrs: z.record(z.string(), z.any()),
 })
 
 const replaceTextOp = z.object({
   action: z.literal("replaceText"),
   blockId: z.string(),
-  expectedHash: z.string(),
+  expectedHash: z.string().optional(),
   find: z.string().optional(),
   range: z.object({ from: z.number().int().min(0), to: z.number().int().min(0) }).optional(),
   replacement: z.string(),
@@ -88,6 +88,13 @@ const parameters = z.object({
   id: z.string().describe("The note ID to edit."),
   baseVersion: z.number().int().min(1).describe("Note version returned by note_read(format:'blocks'|'json')."),
   baseDocHash: z.string().optional().describe("DocHash returned by note_read. If provided, mismatches fail safely."),
+  freshen: z
+    .enum(["safe", "never"])
+    .optional()
+    .default("safe")
+    .describe(
+      "How to handle stale anchors. 'safe' re-reads and replays low-risk operations; 'never' preserves strict version/hash guards.",
+    ),
   dryRun: z.boolean().default(false).describe("Preview the edit without writing the note."),
   ops: z.array(operation).min(1).describe("Ordered list of anchored note edit operations."),
 })
@@ -130,6 +137,16 @@ type SemanticSeed = {
 }
 
 type ApplyResult = { doc: NoteDocument.Node; touched: string[]; semanticSeed: SemanticSeed }
+
+class ApplyOperationError extends Error {
+  constructor(
+    message: string,
+    readonly opIndex: number,
+    readonly action: Operation["action"] | undefined,
+  ) {
+    super(message)
+  }
+}
 
 const BLOCK_PREVIEW_LIMIT = 800
 const CONTEXT_RADIUS = 120
@@ -483,6 +500,84 @@ function applyOperation(doc: NoteDocument.Node, op: Operation): ApplyResult {
   }
 }
 
+function canFreshenOperation(op: Operation) {
+  switch (op.action) {
+    case "insertBefore":
+    case "insertAfter":
+    case "setAttrs":
+      return true
+    case "replaceText":
+      return op.find !== undefined && op.range === undefined
+    case "updateTableCell":
+      return op.cellId !== undefined
+    case "replaceBlock":
+    case "deleteBlock":
+    case "replaceRange":
+      return false
+  }
+}
+
+function assertCanFreshen(ops: Operation[]) {
+  const unsafe = ops.find((op) => !canFreshenOperation(op))
+  if (unsafe) {
+    throw new Error(`${unsafe.action} cannot be safely replayed after stale note anchors; re-read the note and retry.`)
+  }
+}
+
+function freshenedOperation(op: Operation): Operation {
+  switch (op.action) {
+    case "setAttrs":
+      return { ...op, expectedHash: undefined }
+    case "replaceText":
+      return { ...op, expectedHash: undefined }
+    case "updateTableCell":
+      return { ...op, expectedHash: undefined }
+    default:
+      return op
+  }
+}
+
+function applyOperations(input: { doc: NoteDocument.Node; ops: Operation[] }) {
+  let nextDoc = input.doc
+  const touched = new Set<string>()
+  const operationResults: OperationSemanticResult[] = []
+
+  for (const [opIndex, op] of input.ops.entries()) {
+    const stepBeforeDoc = nextDoc
+    const stepBeforeBlocks = NoteDocument.listBlocks(stepBeforeDoc)
+    let result: ApplyResult
+    try {
+      result = applyOperation(stepBeforeDoc, op)
+    } catch (error) {
+      throw new ApplyOperationError(error instanceof Error ? error.message : String(error), opIndex, op.action)
+    }
+    nextDoc = result.doc
+    const stepAfterBlocks = NoteDocument.listBlocks(nextDoc)
+    operationResults.push(
+      buildOperationResult({
+        opIndex,
+        action: op.action,
+        beforeDoc: stepBeforeDoc,
+        afterDoc: nextDoc,
+        beforeBlocks: stepBeforeBlocks,
+        afterBlocks: stepAfterBlocks,
+        seed: result.semanticSeed,
+      }),
+    )
+    for (const id of result.touched) touched.add(id)
+  }
+
+  const validation = NoteDocument.validate(nextDoc)
+  if (!validation.ok) {
+    throw new ApplyOperationError(
+      validation.errors.join("; "),
+      operationResults.length,
+      input.ops[operationResults.length]?.action,
+    )
+  }
+  return { nextDoc: validation.doc, touched, operationResults }
+}
+
 function changedBlocks(before: NoteDocument.Node, after: NoteDocument.Node, touched: Set<string>) {
   const beforeHashes = new Map(NoteDocument.listBlocks(before).map((block) => [block.id, block.hash]))
   return NoteDocument.listBlocks(after).filter(
@@ -673,73 +768,67 @@ export const NoteEditTool = Tool.define("note_edit", {
     const beforeDoc = NoteDocument.normalize(existing.content)
     const beforeHash = NoteDocument.hash(beforeDoc)
 
-    if (existing.version !== params.baseVersion) {
-      return errorResult({
-        id: params.id,
-        code: "VERSION_MISMATCH",
-        message: `note version changed since note_read. Expected ${params.baseVersion}, current ${existing.version}.`,
-        note: existing,
-      })
-    }
+    let activeOps = params.ops
+    let freshened = false
 
-    if (params.baseDocHash && params.baseDocHash !== beforeHash) {
-      return errorResult({
-        id: params.id,
-        code: "DOC_HASH_MISMATCH",
-        message: `note docHash changed since note_read. Expected ${params.baseDocHash}, current ${beforeHash}.`,
-        note: existing,
-      })
-    }
-
-    let nextDoc = beforeDoc
-    const touched = new Set<string>()
-    const operationResults: OperationSemanticResult[] = []
-
-    try {
-      for (const [opIndex, op] of params.ops.entries()) {
-        const stepBeforeDoc = nextDoc
-        const stepBeforeBlocks = NoteDocument.listBlocks(stepBeforeDoc)
-        const result = applyOperation(stepBeforeDoc, op)
-        nextDoc = result.doc
-        const stepAfterBlocks = NoteDocument.listBlocks(nextDoc)
-        operationResults.push(
-          buildOperationResult({
-            opIndex,
-            action: op.action,
-            beforeDoc: stepBeforeDoc,
-            afterDoc: nextDoc,
-            beforeBlocks: stepBeforeBlocks,
-            afterBlocks: stepAfterBlocks,
-            seed: result.semanticSeed,
-          }),
-        )
-        for (const id of result.touched) touched.add(id)
+    if (existing.version !== params.baseVersion || (params.baseDocHash && params.baseDocHash !== beforeHash)) {
+      const code = existing.version !== params.baseVersion ? "VERSION_MISMATCH" : "DOC_HASH_MISMATCH"
+      const message =
+        code === "VERSION_MISMATCH"
+          ? `note version changed since note_read. Expected ${params.baseVersion}, current ${existing.version}.`
+          : `note docHash changed since note_read. Expected ${params.baseDocHash}, current ${beforeHash}.`
+      if (params.freshen === "never") {
+        return errorResult({ id: params.id, code, message, note: existing })
       }
-
-      const validation = NoteDocument.validate(nextDoc)
-      if (!validation.ok) {
+      try {
+        assertCanFreshen(params.ops)
+      } catch (error) {
         return errorResult({
           id: params.id,
-          code: "INVALID_DOCUMENT",
-          message: validation.errors.join("; "),
+          code,
+          message: error instanceof Error ? error.message : String(error),
           note: existing,
-          blockIds: [...touched],
+          blockIds: [...new Set(params.ops.flatMap(targetIds))],
         })
       }
-      nextDoc = validation.doc
-    } catch (error) {
-      const failedOpIndex = operationResults.length
-      const failedAction = params.ops[failedOpIndex]?.action
-      return errorResult({
-        id: params.id,
-        code: "EDIT_PRECONDITION_FAILED",
-        message: error instanceof Error ? error.message : String(error),
-        note: existing,
-        blockIds: [...new Set(params.ops.flatMap(targetIds))],
-        failedOpIndex,
-        failedAction,
-      })
+      activeOps = params.ops.map(freshenedOperation)
+      freshened = true
     }
+
+    let applied: ReturnType<typeof applyOperations>
+    try {
+      applied = applyOperations({ doc: beforeDoc, ops: activeOps })
+    } catch (error) {
+      if (params.freshen !== "safe" || freshened) {
+        return errorResult({
+          id: params.id,
+          code: "EDIT_PRECONDITION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          note: existing,
+          blockIds: [...new Set(params.ops.flatMap(targetIds))],
+          failedOpIndex: error instanceof ApplyOperationError ? error.opIndex : 0,
+          failedAction: error instanceof ApplyOperationError ? error.action : params.ops[0]?.action,
+        })
+      }
+      try {
+        assertCanFreshen(params.ops)
+        activeOps = params.ops.map(freshenedOperation)
+        applied = applyOperations({ doc: beforeDoc, ops: activeOps })
+        freshened = true
+      } catch (freshenError) {
+        return errorResult({
+          id: params.id,
+          code: "EDIT_PRECONDITION_FAILED",
+          message: freshenError instanceof Error ? freshenError.message : String(freshenError),
+          note: existing,
+          blockIds: [...new Set(params.ops.flatMap(targetIds))],
+          failedOpIndex: freshenError instanceof ApplyOperationError ? freshenError.opIndex : 0,
+          failedAction: freshenError instanceof ApplyOperationError ? freshenError.action : params.ops[0]?.action,
+        })
+      }
+    }
+
+    const { nextDoc, touched, operationResults } = applied
 
     const changed = changedBlocks(beforeDoc, nextDoc, touched)
     const nextHash = NoteDocument.hash(nextDoc)
@@ -771,22 +860,45 @@ export const NoteEditTool = Tool.define("note_edit", {
           expectedVersion: existing.version,
         })
       } catch (error) {
-        if (error instanceof NoteError.Conflict) {
-          return errorResult({
-            id: params.id,
-            code: "WRITE_CONFLICT",
-            message: `note changed while applying edit. Expected ${params.baseVersion}, current ${error.data.note.version}.`,
-            note: error.data.note,
-          })
-        }
-        if (error instanceof Storage.NotFoundError) {
+        if (NoteError.Conflict.isInstance(error)) {
+          const conflict = error
+          if (params.freshen === "safe") {
+            try {
+              assertCanFreshen(params.ops)
+              existing = conflict.data.note
+              const latestDoc = NoteDocument.normalize(existing.content)
+              const retryOps = params.ops.map(freshenedOperation)
+              const retry = applyOperations({ doc: latestDoc, ops: retryOps })
+              existing = await NoteStore.updateAny(ScopeContext.current.scope.id, params.id, {
+                content: retry.nextDoc,
+                expectedVersion: existing.version,
+              })
+              freshened = true
+            } catch (retryError) {
+              return errorResult({
+                id: params.id,
+                code: "WRITE_CONFLICT",
+                message: retryError instanceof Error ? retryError.message : String(retryError),
+                note: conflict.data.note,
+              })
+            }
+          } else {
+            return errorResult({
+              id: params.id,
+              code: "WRITE_CONFLICT",
+              message: `note changed while applying edit. Expected ${params.baseVersion}, current ${conflict.data.note.version}.`,
+              note: conflict.data.note,
+            })
+          }
+        } else if (error instanceof Storage.NotFoundError) {
           return errorResult({
             id: params.id,
             code: "NOTE_DELETED",
             message: `note "${params.id}" was deleted while the edit was in progress.`,
           })
+        } else {
+          throw error
         }
-        throw error
       }
     }
 
@@ -800,6 +912,7 @@ export const NoteEditTool = Tool.define("note_edit", {
         `Version: ${finalVersion}`,
         `DocHash: ${nextHash}`,
         `Operations applied: ${params.ops.length}`,
+        freshened ? "Freshened stale anchors: yes" : undefined,
         `Changed blocks: ${changed.length}`,
         `Warnings: ${warnings.length ? warnings.join("; ") : "none"}`,
         "",
@@ -818,6 +931,7 @@ export const NoteEditTool = Tool.define("note_edit", {
         dryRun: params.dryRun,
         version: finalVersion,
         docHash: nextHash,
+        freshened,
         opCount: params.ops.length,
         changedBlockIds: changed.map((block) => block.id),
         changedBlocks: changed,

--- a/packages/synergy/src/tool/note-edit.txt
+++ b/packages/synergy/src/tool/note-edit.txt
@@ -1,10 +1,16 @@
 Performs precise anchored edits to note content. Blueprint notes are editable only in Plan Mode. Outside Plan Mode, Blueprint notes are read-only; use `note_read`, `note_search`, or `note_list` to inspect them, and use ordinary notes for deliverables.
 
 Always read first:
-- Call note_read({ ids:[...], format:"blocks" }) immediately before editing.
+- Call note_read({ ids:[...], format:"blocks" }) before editing.
 - Pass baseVersion from Version.
 - Pass baseDocHash from DocHash when available.
-- Pass blockId and expectedHash from the target block line.
+- Pass blockId and expectedHash from the target block line when available.
+
+Default stale-anchor recovery:
+- `freshen:"safe"` is the default. If the note version, docHash, or a low-risk block hash is stale, note_edit re-reads the latest note and replays safe operations against the latest stable block IDs.
+- Safe replay is limited to insertBefore, insertAfter, setAttrs, replaceText with a `find` string, and updateTableCell by `cellId`.
+- Unsafe operations such as replaceBlock, deleteBlock, replaceRange, and range-based replaceText still fail on stale anchors; re-read and retry deliberately.
+- Use `freshen:"never"` when you need strict old behavior: any version, docHash, or expectedHash mismatch fails without writing.
 
 Preferred operations:
 - replaceBlock: Replace one block by stable blockId. The old block is removed.
@@ -21,7 +27,7 @@ Content inputs:
 - { format:"json", json:{...} } inserts exact ProseMirror/Tiptap JSON. Use this for rich structures.
 
 Safety behavior:
-- Version mismatch, docHash mismatch, missing targets, hash mismatch, invalid JSON content, ambiguous text replacements, and replaceText ranges that include non-editable rendered content fail without writing.
+- Strict failures, unsafe stale operations, missing targets, invalid JSON content, ambiguous text replacements, and replaceText ranges that include non-editable rendered content fail without writing.
 - On failure, the tool returns current version, current docHash, failed operation index/action when applicable, and current block summaries so you can re-read/retry deliberately. A failed operation means no write occurred.
 - dryRun:true validates and returns the same semantic operation preview without writing.
 
@@ -29,3 +35,5 @@ Result interpretation:
 - Success output includes one section per operation. Inspect matched text, before/after context, checks, warnings, and changed-block classification before assuming the edit is correct.
 - `directChangedBlocks` are the operation's target, inserted, or deleted blocks; `ancestorChangedBlocks` are parent list/table/blockquote/container hashes changed by descendants; `unexpectedChangedBlocks` are changes outside that direct/ancestor set.
 - Warnings are not fatal, but they indicate a possible no-op, unexpected extra change, or semantic mismatch and should usually be followed by re-reading or correcting the note.
+
+Use note_write with mode:"replace" instead when rewriting most or all of a note/Blueprint and you have complete desired markdown content.

--- a/packages/synergy/src/tool/note-write.ts
+++ b/packages/synergy/src/tool/note-write.ts
@@ -58,6 +58,7 @@ async function updateExisting(input: {
   auditAgent?: string
   content(existing: Awaited<ReturnType<typeof NoteStore.getAny>>): unknown
   ctx: Tool.Context
+  optimistic?: boolean
 }) {
   const existing = await NoteStore.getAny(ScopeContext.current.scope.id, input.id)
   const nextTitle = input.title ?? existing.title
@@ -84,7 +85,7 @@ async function updateExisting(input: {
     title: input.title ?? undefined,
     content: input.content(existing),
     tags: input.tags ?? undefined,
-    expectedVersion: existing.version,
+    ...(input.optimistic === false ? {} : { expectedVersion: existing.version }),
   }
 
   if (nextKind === "note") {
@@ -235,6 +236,7 @@ export const NoteWriteTool = Tool.define("note_write", {
         auditAgent: params.auditAgent,
         content: () => tiptapContent,
         ctx,
+        optimistic: false,
       })
     }
 

--- a/packages/synergy/src/tool/note-write.txt
+++ b/packages/synergy/src/tool/note-write.txt
@@ -1,9 +1,11 @@
-Create a new note or update an existing one. A Blueprint is not a separate document type; it is a note with kind:"blueprint". Content should be provided in markdown format — it will be converted to the internal ProseMirror JSON format for storage.
+Create a new note or overwrite an existing note with complete markdown content. A Blueprint is not a separate document type; it is a note with kind:"blueprint". Content is converted to the internal ProseMirror JSON format for storage.
 
-Three modes are available:
+Modes are retained for compatibility:
 - "create" (default): Creates a new note. Requires `title` and `content`.
-- "append": Adds content to the end of an existing note. Requires `id` and `content`. The new content is appended as additional blocks after the existing document's blocks.
-- "replace": Overwrites the content of an existing note. Requires `id` and `content`.
+- "append": Adds content to the end of an existing note. Requires `id` and `content`. This is an optimistic update and may report a conflict if the note changes while appending.
+- "replace": Overwrites the entire existing note content. Requires `id` and `content`. This is the reliable full-document write path, analogous to file write; use it when you have generated the complete desired note from the latest content or when rewriting most of a Blueprint.
+
+Prefer `note_edit` for targeted changes to a few blocks. Prefer `note_write` with `mode:"replace"` for broad rewrites, large Blueprint reshaping, or recovery after local edit structure is no longer useful. Do not use append/replace as a blind fallback after a failed edit unless the replacement content is intentionally complete.
 
 The `scope` parameter controls where new notes are created:
 - "current" (default): Creates in the current project scope
@@ -16,5 +18,3 @@ Use `kind:"blueprint"` in Plan Mode when the note should become executable throu
 In Plan Mode, use `kind:"note"` to convert a Blueprint note back to a plain note. Blueprint notes may include `description`, `defaultAgent`, and `auditAgent` metadata; Blueprint run state lives on BlueprintLoop, not on the note itself.
 
 When updating (append/replace), the note is found automatically regardless of scope. The `tags` parameter can be provided to set or update tags on any mode.
-
-Note: For surgical edits to specific parts of a note without rewriting the whole document, use `note_edit` instead.

--- a/packages/synergy/test/tool/note-blueprint-policy.test.ts
+++ b/packages/synergy/test/tool/note-blueprint-policy.test.ts
@@ -37,6 +37,7 @@ function anchoredReplace(
     id: note.id,
     baseVersion: note.version,
     baseDocHash: NoteDocument.hash(note.content),
+    freshen: "safe" as const,
     dryRun: false,
     ops: [
       {

--- a/packages/synergy/test/tool/note-edit.test.ts
+++ b/packages/synergy/test/tool/note-edit.test.ts
@@ -53,6 +53,7 @@ describe("note_edit anchored operations", () => {
         const result = await execute({
           id: note.id,
           baseVersion: note.version,
+          freshen: "never",
           ops: [
             {
               action: "replaceBlock",
@@ -908,6 +909,80 @@ describe("note_edit anchored operations", () => {
         expect(result.metadata.operationResults[0].semantic.replacementText).toBe("new")
         expect(result.metadata.operationResults[0].checks.noop).toBe(false)
         expect(result.output).toContain("Operation 1 replaceBlock: applied")
+        expect(noteText(current.content)).toContain("old")
+      },
+    })
+  })
+
+  test("safe freshen replays unique replaceText after stale version", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Freshen replaceText",
+          content: { type: "doc", content: [paragraph("first target"), paragraph("tail")] },
+        })
+        const block = NoteDocument.listBlocks(note.content).find((item) => item.text.trim() === "first target")!
+        await NoteStore.update(scope.id, note.id, {
+          expectedVersion: note.version,
+          content: { type: "doc", content: [paragraph("intro"), ...(note.content.content ?? [])] },
+        })
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          baseDocHash: NoteDocument.hash(note.content),
+          ops: [
+            {
+              action: "replaceText",
+              blockId: block.id,
+              expectedHash: block.hash,
+              find: "target",
+              replacement: "updated",
+            },
+          ],
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(result.metadata.freshened).toBe(true)
+        expect(noteText(current.content)).toContain("first updated")
+        expect(noteText(current.content)).toContain("intro")
+      },
+    })
+  })
+
+  test("safe freshen refuses unsafe stale replaceBlock without writing", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Unsafe freshen",
+          content: { type: "doc", content: [paragraph("old")] },
+        })
+        const block = NoteDocument.listBlocks(note.content)[0]
+        await NoteStore.update(scope.id, note.id, { expectedVersion: note.version })
+
+        const result = await execute({
+          id: note.id,
+          baseVersion: note.version,
+          ops: [
+            {
+              action: "replaceBlock",
+              blockId: block.id,
+              expectedHash: block.hash,
+              content: { format: "text", text: "new" },
+            },
+          ],
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(result.metadata.errorCode).toBe("VERSION_MISMATCH")
         expect(noteText(current.content)).toContain("old")
       },
     })

--- a/packages/synergy/test/tool/note-write.test.ts
+++ b/packages/synergy/test/tool/note-write.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import { NoteMarkdown, NoteStore } from "../../src/note"
+import { Scope } from "../../src/scope"
+import { ScopeContext } from "../../src/scope/context"
+import { Session } from "../../src/session"
+import { NoteWriteTool } from "../../src/tool/note-write"
+import type { Tool } from "../../src/tool/tool"
+import { tmpdir } from "../fixture/fixture"
+
+function ctx(sessionID: string): Tool.Context {
+  return {
+    sessionID,
+    messageID: "",
+    callID: "",
+    agent: "test-strategist",
+    abort: AbortSignal.any([]),
+    metadata: () => {},
+    ask: async () => {},
+  }
+}
+
+async function execute(input: any) {
+  const session = await Session.create({})
+  const tool = await NoteWriteTool.init()
+  return tool.execute(input, ctx(session.id))
+}
+
+function markdownText(content: unknown) {
+  return NoteMarkdown.toMarkdown(content).trim()
+}
+
+describe("note_write", () => {
+  test("replace overwrites the latest note content as a stable full-document write", async () => {
+    await using tmp = await tmpdir()
+    const scope = (await Scope.fromDirectory(tmp.path)).scope
+
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const note = await NoteStore.create({
+          title: "Replace target",
+          content: NoteMarkdown.fromMarkdown("old"),
+        })
+        await NoteStore.update(scope.id, note.id, {
+          expectedVersion: note.version,
+          content: NoteMarkdown.fromMarkdown("concurrent update"),
+        })
+
+        const result = await execute({
+          id: note.id,
+          mode: "replace",
+          content: "final content",
+        })
+
+        const current = await NoteStore.get(scope.id, note.id)
+        expect(result.metadata.conflict).toBeUndefined()
+        expect(result.metadata.action).toBe("replace")
+        expect(markdownText(current.content)).toBe("final content")
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `note_edit` safe stale-anchor recovery for low-risk operations while keeping strict `freshen: \"never\"` behavior available.
- Make `note_write mode:\"replace\"` a reliable full-document overwrite path for broad note/Blueprint rewrites.
- Update tool guidance and add focused tests for safe freshen, unsafe stale edits, Blueprint policy typing, and stable replace overwrites.

## Verification
- `bun test test/tool/note-edit.test.ts test/tool/note-write.test.ts test/tool/note-blueprint-policy.test.ts` (from `packages/synergy`)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`

Closes #401