### PR TITLE
feat(ui): show completed turn stats

### DIFF
--- a/packages/ui/src/components/session-turn-timeline.test.ts
+++ b/packages/ui/src/components/session-turn-timeline.test.ts
@@ -9,6 +9,43 @@ import type {
 
 const Empty = () => null
 
+mock.module("@ericsanchezok/synergy-util/binary", () => ({
+  Binary: {
+    search: <T>(items: T[], value: string, getValue: (item: T) => string) => {
+      const index = items.findIndex((item) => getValue(item) === value)
+      return index >= 0 ? { found: true, index } : { found: false, index: -1 }
+    },
+  },
+}))
+mock.module("@ericsanchezok/synergy-util/model-limit", () => ({
+  ModelLimit: {
+    actualInput: (tokens: { input: number; cache: { read: number; write: number } }) =>
+      tokens.input + tokens.cache.read + tokens.cache.write,
+  },
+}))
+mock.module("@ericsanchezok/synergy-util/path", () => ({
+  getDirectory: (path: string) => path.slice(0, path.lastIndexOf("/")),
+  getFilename: (path: string) => path.slice(path.lastIndexOf("/") + 1),
+}))
+mock.module("solid-js", () => ({
+  createEffect: () => {},
+  createMemo: (fn: () => unknown) => fn,
+  createSignal: (initial: unknown) => {
+    let value = initial
+    return [() => value, (next: unknown) => (value = typeof next === "function" ? next(value) : next)]
+  },
+  ErrorBoundary: Empty,
+  For: Empty,
+  Match: Empty,
+  on: (_source: unknown, fn: unknown) => fn,
+  onCleanup: () => {},
+  Show: Empty,
+  Switch: Empty,
+}))
+mock.module("solid-js/store", () => ({
+  createStore: (initial: unknown) => [initial, () => {}],
+}))
+mock.module("solid-js/web", () => ({ Dynamic: Empty }))
 mock.module("../context", () => ({ useData: () => ({ store: {}, serverUrl: "" }) }))
 mock.module("../context/diff", () => ({ useDiffComponent: () => Empty }))
 mock.module("../hooks", () => ({
@@ -26,6 +63,16 @@ mock.module("./accordion", () => {
 })
 mock.module("./attachment-card", () => ({ AttachmentGallery: Empty }))
 mock.module("./button", () => ({ Button: Empty }))
+mock.module("./clipboard", () => ({
+  createCopyController: () => ({
+    copied: () => false,
+    copy: () => {},
+    disabled: () => false,
+    icon: () => "copy",
+    state: () => "idle",
+    tooltip: () => "Copy Markdown",
+  }),
+}))
 mock.module("./diff-changes", () => ({ DiffChanges: Empty }))
 mock.module("./compaction-card", () => ({ CompactionCard: Empty }))
 mock.module("./error-card", () => ({ ErrorCard: Empty }))
@@ -35,6 +82,7 @@ mock.module("./media-generation-card", () => ({ MediaGenerationCard: Empty }))
 mock.module("./message-part", () => ({ Message: Empty, Part: Empty }))
 mock.module("./session-turn.css", () => ({}))
 mock.module("./sticky-accordion-header", () => ({ StickyAccordionHeader: Empty }))
+mock.module("./special-user-message", () => ({ getSpecialUserMessageRenderer: () => undefined }))
 mock.module("./tool-renders", () => ({}))
 mock.module("./typewriter", () => ({ Typewriter: Empty }))
 
@@ -47,9 +95,12 @@ const {
   isGuidedContextUserMessage,
   shouldShowTurnDiffs,
   shouldShowTurnUserChrome,
+  formatTurnCost,
+  formatTurnTokenCount,
   providerPreludeElapsedLabel,
   providerPreludeText,
   shouldShowProviderPrelude,
+  turnCompletionStats,
   timelineItemStableKey,
   timelineVisualKind,
 } = await import("./session-turn")
@@ -485,6 +536,89 @@ describe("session turn timeline", () => {
     expect(providerPreludeElapsedLabel(1_000, 61_000)).toBe("01:00")
     expect(providerPreludeElapsedLabel(1_000, 3_601_000)).toBe("1:00:00")
     expect(providerPreludeElapsedLabel(undefined, 1_000)).toBeUndefined()
+  })
+
+  test("formats completed turn token and cost labels compactly", () => {
+    expect(formatTurnTokenCount(999)).toBe("999")
+    expect(formatTurnTokenCount(12_345)).toBe("12.3k")
+    expect(formatTurnTokenCount(1_250_000)).toBe("1.3M")
+    expect(formatTurnCost(0)).toBeUndefined()
+    expect(formatTurnCost(0.0042)).toBe("$0.0042")
+    expect(formatTurnCost(0.04)).toBe("$0.04")
+  })
+
+  test("builds completed turn stats from assistant timing, tokens, reasoning, and cost", () => {
+    const message = {
+      ...completedAssistant("assistant-stats"),
+      time: { created: 1_000, completed: 62_000 },
+      tokens: {
+        input: 12_345,
+        output: 678,
+        reasoning: 42,
+        cache: { read: 100, write: 0 },
+      },
+      cost: 0.0042,
+    } as AssistantMessage
+
+    expect(turnCompletionStats([message])).toEqual({
+      duration: "01:01",
+      segments: ["12.4k input", "678 output", "42 reasoning", "$0.0042"],
+    })
+  })
+
+  test("builds completed turn stats for textless or zero-cost turns", () => {
+    const message = {
+      ...completedAssistant("assistant-stats"),
+      time: { created: 1_000, completed: 3_601_000 },
+      tokens: {
+        input: 0,
+        output: 2048,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      cost: 0,
+    } as AssistantMessage
+
+    expect(turnCompletionStats([message])).toEqual({
+      duration: "1:00:00",
+      segments: ["2,048 output"],
+    })
+  })
+
+  test("aggregates completed turn stats across all assistant messages in the turn", () => {
+    const first = {
+      ...completedAssistant("assistant-first"),
+      time: { created: 1_000, completed: 10_000 },
+      tokens: {
+        input: 1_000,
+        output: 200,
+        reasoning: 20,
+        cache: { read: 100, write: 50 },
+      },
+      cost: 0.01,
+    } as AssistantMessage
+    const second = {
+      ...completedAssistant("assistant-second"),
+      time: { created: 20_000, completed: 62_000 },
+      tokens: {
+        input: 2_000,
+        output: 300,
+        reasoning: 30,
+        cache: { read: 0, write: 0 },
+      },
+      cost: 0.02,
+    } as AssistantMessage
+
+    expect(turnCompletionStats([first, second])).toEqual({
+      duration: "01:01",
+      segments: ["3,150 input", "500 output", "50 reasoning", "$0.03"],
+    })
+  })
+
+  test("does not build completed turn stats before all assistant messages complete", () => {
+    expect(turnCompletionStats([])).toBeUndefined()
+    expect(turnCompletionStats([assistant("assistant-running")])).toBeUndefined()
+    expect(turnCompletionStats([completedAssistant("assistant-done"), assistant("assistant-running")])).toBeUndefined()
   })
 
   test("keeps reasoning before a running media placeholder and later text", () => {

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -221,6 +221,7 @@
   [data-component="provider-prelude"] {
     display: flex;
     align-items: baseline;
+    flex-wrap: wrap;
     min-height: 22px;
     font-size: var(--font-size-small);
     font-weight: var(--font-weight-regular);
@@ -239,12 +240,17 @@
     background: var(--border-base);
   }
 
+  [data-component="provider-prelude"][data-variant="completed"]::before {
+    background: var(--text-subtle);
+  }
+
   [data-slot="provider-prelude-separator"] {
     margin-inline: 6px;
     color: var(--text-subtle);
   }
 
-  [data-slot="provider-prelude-time"] {
+  [data-slot="provider-prelude-time"],
+  [data-slot="provider-prelude-stat"] {
     color: var(--text-subtle);
     font-size: var(--font-size-x-small);
     font-variant-numeric: tabular-nums;

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@ericsanchezok/synergy-sdk/client"
 import { useData } from "../context"
 import { getDirectory, getFilename } from "@ericsanchezok/synergy-util/path"
+import { ModelLimit } from "@ericsanchezok/synergy-util/model-limit"
 
 import { Binary } from "@ericsanchezok/synergy-util/binary"
 import { createEffect, createMemo, createSignal, For, Match, on, onCleanup, ParentProps, Show, Switch } from "solid-js"
@@ -85,6 +86,10 @@ export type SessionTurnTimelineVisualKind =
   | "compaction"
 
 const DEFAULT_PROVIDER_PRELUDE_TEXT = "Awaiting response…"
+export type TurnCompletionStats = {
+  duration: string
+  segments: string[]
+}
 
 export function providerPreludeElapsedLabel(started: number | undefined, now: number): string | undefined {
   if (started == null) return undefined
@@ -99,6 +104,62 @@ export function providerPreludeElapsedLabel(started: number | undefined, now: nu
 
   if (hours > 0) return `${hours}:${mm}:${ss}`
   return `${mm}:${ss}`
+}
+
+export function formatTurnTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${Number((value / 1_000_000).toFixed(1))}M`
+  if (value >= 10_000) return `${Number((value / 1_000).toFixed(1))}k`
+  return value.toLocaleString()
+}
+
+export function formatTurnCost(value: number): string | undefined {
+  if (value <= 0) return undefined
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value)
+}
+
+export function turnCompletionStats(messages: readonly AssistantMessage[]): TurnCompletionStats | undefined {
+  const completed = messages.filter((message) => message.time.completed != null)
+  if (completed.length === 0 || completed.length !== messages.length) return undefined
+
+  const firstStarted = completed.reduce<number | undefined>((earliest, message) => {
+    if (message.time.created == null) return earliest
+    if (earliest == null || message.time.created < earliest) return message.time.created
+    return earliest
+  }, undefined)
+  const lastCompleted = completed.reduce<number | undefined>((latest, message) => {
+    if (message.time.completed == null) return latest
+    if (latest == null || message.time.completed > latest) return message.time.completed
+    return latest
+  }, undefined)
+  const duration = lastCompleted == null ? undefined : providerPreludeElapsedLabel(firstStarted, lastCompleted)
+  if (!duration) return undefined
+
+  const totals = completed.reduce(
+    (sum, message) => {
+      const tokens = message.tokens
+      if (tokens) {
+        sum.input += ModelLimit.actualInput(tokens)
+        sum.output += tokens.output
+        sum.reasoning += tokens.reasoning
+      }
+      sum.cost += message.cost ?? 0
+      return sum
+    },
+    { input: 0, output: 0, reasoning: 0, cost: 0 },
+  )
+
+  const segments: string[] = []
+  if (totals.input > 0) segments.push(`${formatTurnTokenCount(totals.input)} input`)
+  if (totals.output > 0) segments.push(`${formatTurnTokenCount(totals.output)} output`)
+  if (totals.reasoning > 0) segments.push(`${formatTurnTokenCount(totals.reasoning)} reasoning`)
+  const cost = formatTurnCost(totals.cost)
+  if (cost) segments.push(cost)
+
+  return { duration, segments }
 }
 
 function visibleAttachmentParts(files: AttachmentPart[] | undefined): AttachmentPart[] {
@@ -456,9 +517,20 @@ function TimelineDisplay(props: {
   return <TimelineItemDisplay item={props.item} serverUrl={props.serverUrl} />
 }
 
-function ProviderPrelude(props: { text: string; elapsed?: string }) {
+function ProviderPrelude(props: {
+  text: string
+  elapsed?: string
+  segments?: readonly string[]
+  variant?: "running" | "completed"
+}) {
   return (
-    <div data-component="provider-prelude" role="status" aria-live="polite" aria-label={props.text}>
+    <div
+      data-component="provider-prelude"
+      data-variant={props.variant ?? "running"}
+      role="status"
+      aria-live="polite"
+      aria-label={props.text}
+    >
       <span data-slot="provider-prelude-text">{props.text}</span>
       <Show when={props.elapsed}>
         {(elapsed) => (
@@ -472,6 +544,16 @@ function ProviderPrelude(props: { text: string; elapsed?: string }) {
           </>
         )}
       </Show>
+      <For each={props.segments ?? []}>
+        {(segment) => (
+          <>
+            <span data-slot="provider-prelude-separator" aria-hidden="true">
+              ·
+            </span>
+            <span data-slot="provider-prelude-stat">{segment}</span>
+          </>
+        )}
+      </For>
     </div>
   )
 }
@@ -749,6 +831,10 @@ export function SessionTurn(
           latestAssistantTimelineItems: latestAssistantTimelineItems(),
         }),
   )
+  const completedTurnStats = createMemo(() => {
+    if (working() || hasCompactionEvent() || error()) return undefined
+    return turnCompletionStats(assistantMessages())
+  })
 
   createEffect(() => {
     if (!showProviderPrelude()) {
@@ -846,7 +932,14 @@ export function SessionTurn(
                         </Show>
                       </div>
                     </Show>
-                    <Show when={hasTimelineItems() || showProviderPrelude() || (!working() && hasDiffs())}>
+                    <Show
+                      when={
+                        hasTimelineItems() ||
+                        showProviderPrelude() ||
+                        completedTurnStats() ||
+                        (!working() && hasDiffs())
+                      }
+                    >
                       <div data-slot="session-turn-timeline">
                         <For each={timelineItemKeys()}>
                           {(key, index) => {
@@ -891,6 +984,18 @@ export function SessionTurn(
                               elapsed={providerPreludeElapsed()}
                             />
                           </div>
+                        </Show>
+                        <Show when={completedTurnStats()}>
+                          {(stats) => (
+                            <div data-slot="session-turn-timeline-item" data-kind="provider-prelude">
+                              <ProviderPrelude
+                                text="Completed"
+                                elapsed={stats().duration}
+                                segments={stats().segments}
+                                variant="completed"
+                              />
+                            </div>
+                          )}
                         </Show>
                         <Show when={!working() && hasDiffs()}>
                           <Accordion


### PR DESCRIPTION
## Summary
- Keep the provider prelude visible after a session turn completes with elapsed duration, token usage, reasoning tokens, and cost.
- Aggregate completed turn stats across all assistant messages in the turn.
- Cover formatting, textless/zero-cost turns, multi-assistant aggregation, and incomplete-turn suppression in session-turn tests.

## Verification
- bun test src/components/session-turn-timeline.test.ts (from packages/ui)
- bunx prettier --check src/components/session-turn.tsx src/components/session-turn.css src/components/session-turn-timeline.test.ts (from packages/ui)
- bun run lint

## Notes
- packages/ui typecheck could not run in this environment because the script depends on `tsgo`, which is not installed here.

Closes #386