### PR TITLE
feat(settings): add coauthor reminder toggle

### DIFF
--- a/packages/app/src/components/settings/catalog.test.ts
+++ b/packages/app/src/components/settings/catalog.test.ts
@@ -67,6 +67,7 @@ describe("settings catalog", () => {
   test("field save strategies are metadata-only and cover editable fields", () => {
     expect(FIELD_SAVE_STRATEGY.snapshot).toBe("auto")
     expect(FIELD_SAVE_STRATEGY.controlProfile).toBe("explicit")
+    expect(FIELD_SAVE_STRATEGY.experimental).toBe("background")
     expect(FIELD_SAVE_STRATEGY.email).toBe("explicit")
     for (const role of MODEL_ROLES) {
       expect(FIELD_SAVE_STRATEGY[role.key]).toBe("explicit")

--- a/packages/app/src/components/settings/catalog.ts
+++ b/packages/app/src/components/settings/catalog.ts
@@ -236,12 +236,12 @@ export const BUILTIN_SETTINGS_SECTIONS: SettingsCatalogSection[] = [
   ),
   section(
     "timeouts",
-    "Timeouts",
+    "Agents",
     "Runtime",
     30,
     "settings.timeouts",
-    "Agent, provider, and tool timeout controls.",
-    ["timeout", "provider", "tool", "coauthor", "commit", "git", "prompt"],
+    "Agent prompt behavior, provider timeouts, and tool timeout controls.",
+    ["agent", "timeout", "provider", "tool", "coauthor", "commit", "git", "prompt"],
     ["runtime"],
   ),
   section(
@@ -355,6 +355,7 @@ export const FIELD_SAVE_STRATEGY: Record<string, SettingsFieldStrategy> = {
   question: "background",
   compaction: "auto",
   timeout: "background",
+  experimental: "background",
   watcher: "background",
   formatter: "explicit",
   lsp: "explicit",

--- a/packages/app/src/components/settings/catalog.ts
+++ b/packages/app/src/components/settings/catalog.ts
@@ -241,7 +241,7 @@ export const BUILTIN_SETTINGS_SECTIONS: SettingsCatalogSection[] = [
     30,
     "settings.timeouts",
     "Agent, provider, and tool timeout controls.",
-    ["timeout", "provider", "tool"],
+    ["timeout", "provider", "tool", "coauthor", "commit", "git", "prompt"],
     ["runtime"],
   ),
   section(

--- a/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
@@ -45,4 +45,42 @@ describe("settings config patch", () => {
       tool: { default_sec: 7200 },
     })
   })
+
+  test("coauthor reminder defaults on without materializing experimental config", () => {
+    const state = defaultSettingsState("enter")
+
+    expect(
+      buildPatch({
+        cfg: {} as Config,
+        state,
+        originalMcps: {},
+      }).experimental,
+    ).toBeUndefined()
+  })
+
+  test("coauthor reminder can be disabled in experimental config", () => {
+    const state = defaultSettingsState("enter")
+    state.runtime.coauthorReminder = "false"
+
+    expect(
+      buildPatch({
+        cfg: {} as Config,
+        state,
+        originalMcps: {},
+      }).experimental,
+    ).toEqual({ coauthor_reminder: false })
+  })
+
+  test("coauthor reminder can be re-enabled from explicit false", () => {
+    const state = defaultSettingsState("enter")
+    state.runtime.coauthorReminder = "true"
+
+    expect(
+      buildPatch({
+        cfg: { experimental: { coauthor_reminder: false } } as Config,
+        state,
+        originalMcps: {},
+      }).experimental,
+    ).toEqual({ coauthor_reminder: true })
+  })
 })

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -176,6 +176,12 @@ function buildRuntimePatch(cfg: Config, state: SettingsState, patch: Record<stri
   const timeout = buildTimeoutPatch(cfg, runtime)
   if (timeout.changed) patch.timeout = timeout.value
 
+  const coauthorReminder = runtime.coauthorReminder === "true"
+  const currentCoauthorReminder = cfg.experimental?.coauthor_reminder !== false
+  if (coauthorReminder !== currentCoauthorReminder) {
+    patch.experimental = { ...(cfg.experimental ?? {}), coauthor_reminder: coauthorReminder }
+  }
+
   const watcherIgnore = parseList(runtime.watcherIgnore)
   if (JSON.stringify(watcherIgnore) !== JSON.stringify(cfg.watcher?.ignore ?? [])) {
     patch.watcher = watcherIgnore.length ? { ...(cfg.watcher ?? {}), ignore: watcherIgnore } : undefined

--- a/packages/app/src/components/settings/hooks/useSettingsForm.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.ts
@@ -125,6 +125,7 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
     toolOverrides: formatRecord(cfg.timeout?.tool?.overrides),
     watcherIgnore: formatList(cfg.watcher?.ignore),
     logLevel: cfg.logLevel ?? UI_DEFAULTS.logLevel,
+    coauthorReminder: cfg.experimental?.coauthor_reminder !== false ? "true" : "false",
   })
 
   params.setSettings("email", {

--- a/packages/app/src/components/settings/panels/RuntimePanels.tsx
+++ b/packages/app/src/components/settings/panels/RuntimePanels.tsx
@@ -108,7 +108,7 @@ export function TimeoutsPanel(props: {
   onRuntimeChange: (key: keyof RuntimeStore, value: string) => void
 }) {
   return (
-    <SettingsPage title="Timeouts" description="Agent, provider, and tool timeout controls.">
+    <SettingsPage title="Agents" description="Agent prompt behavior, provider timeouts, and tool timeout controls.">
       <SettingsSection title="Agent">
         <SettingRow
           title="Co-author Reminder"

--- a/packages/app/src/components/settings/panels/RuntimePanels.tsx
+++ b/packages/app/src/components/settings/panels/RuntimePanels.tsx
@@ -111,6 +111,16 @@ export function TimeoutsPanel(props: {
     <SettingsPage title="Timeouts" description="Agent, provider, and tool timeout controls.">
       <SettingsSection title="Agent">
         <SettingRow
+          title="Co-author Reminder"
+          description="Remind agents to include the Synergy co-author footer when creating git commits."
+          trailing={
+            <Switch
+              checked={props.runtime.coauthorReminder !== "false"}
+              onChange={(value) => props.onRuntimeChange("coauthorReminder", value ? "true" : "false")}
+            />
+          }
+        />
+        <SettingRow
           title="Invoke Timeout"
           description="Milliseconds before a task invoke call times out."
           trailing={

--- a/packages/app/src/components/settings/types.ts
+++ b/packages/app/src/components/settings/types.ts
@@ -59,6 +59,7 @@ export const UI_DEFAULTS = {
   toolOverrides: "" as string,
   watcherIgnore: "" as string,
   logLevel: "" as string,
+  coauthorReminder: "true" as string,
 } as const
 
 /** Resolve Config.permission (object or string) into a simple UI string. */
@@ -255,6 +256,7 @@ export type RuntimeStore = {
   toolOverrides: string
   watcherIgnore: string
   logLevel: string
+  coauthorReminder: string
 }
 
 export type SettingsState = {
@@ -331,6 +333,7 @@ export function defaultSettingsState(sendShortcut: SendShortcut): SettingsState 
       toolOverrides: UI_DEFAULTS.toolOverrides,
       watcherIgnore: UI_DEFAULTS.watcherIgnore,
       logLevel: UI_DEFAULTS.logLevel,
+      coauthorReminder: UI_DEFAULTS.coauthorReminder,
     },
     email: {
       enabled: true,

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2734,6 +2734,10 @@ export type Config = {
      */
     batch_tool?: boolean
     /**
+     * Include the git commit Co-authored-by footer reminder in agent prompts
+     */
+    coauthor_reminder?: boolean
+    /**
      * Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)
      */
     openTelemetry?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -23454,6 +23454,10 @@
                 "description": "Enable the batch tool",
                 "type": "boolean"
               },
+              "coauthor_reminder": {
+                "description": "Include the git commit Co-authored-by footer reminder in agent prompts",
+                "type": "boolean"
+              },
               "openTelemetry": {
                 "description": "Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)",
                 "type": "boolean"

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -1562,6 +1562,10 @@ export const Info = z
     experimental: z
       .object({
         batch_tool: z.boolean().optional().describe("Enable the batch tool"),
+        coauthor_reminder: z
+          .boolean()
+          .optional()
+          .describe("Include the git commit Co-authored-by footer reminder in agent prompts"),
         openTelemetry: z
           .boolean()
           .optional()

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -652,8 +652,10 @@ export namespace SessionInvoke {
         const gitHealthBlock = GitHealth.injectCached(ScopeContext.current.directory)
         if (gitHealthBlock) systemParts.push(gitHealthBlock)
 
-        // Layer 4.55: Always-on — git commit coauthor footer reminder
-        systemParts.push(`<coauthor-reminder>\n${COAUTHOR_REMINDER.trim()}\n</coauthor-reminder>`)
+        // Layer 4.55: Configurable — git commit coauthor footer reminder
+        if ((await Config.current()).experimental?.coauthor_reminder !== false) {
+          systemParts.push(`<coauthor-reminder>\n${COAUTHOR_REMINDER.trim()}\n</coauthor-reminder>`)
+        }
 
         // Layer 5: Dynamic — upcoming agenda wake-ups (always at the end)
         if (agendaReminder) systemParts.push(agendaReminder)

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -73,6 +73,7 @@ function assistantMessage(id: string, parentID: string, text: string): MessageV2
 function installBasicLoopMocks(options?: {
   onBuildPlan?: (input: any) => void
   onProcess?: (input: any, assistant: MessageV2.Assistant, callIndex: number) => Promise<void> | void
+  config?: Record<string, unknown>
 }) {
   const originalGetModel = Provider.getModel
   const originalGetAgent = Agent.get
@@ -115,6 +116,7 @@ function installBasicLoopMocks(options?: {
     ...(await originalConfigCurrent()),
     compaction: { auto: true, maxHistoryImages: 8 },
     library: { memory: { enabled: false }, experience: { retrieve: false } },
+    ...options?.config,
   }))
   ;(ToolResolver.definitions as any) = mock(async () => [])
   ;(ToolResolver.resolveWithAvailability as any) = mock(async () => ({ tools: {}, activeToolIDs: [] }))
@@ -660,6 +662,67 @@ describe("SessionInvoke inbox boundaries", () => {
           expect(guided!.info.isRoot).toBe(false)
           expect(guided!.info.rootID).toBe(user.id)
           expect(guided!.info.origin?.type).toBe("user")
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+})
+
+describe("SessionInvoke coauthor reminder prompt", () => {
+  test("includes the coauthor reminder by default", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    let systemPrompt = ""
+    const restore = installBasicLoopMocks({
+      onProcess: async (input) => {
+        systemPrompt = input.system.join("\n")
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect(systemPrompt).toContain("<coauthor-reminder>")
+          expect(systemPrompt).toContain("Co-authored-by: synergy-agent")
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
+  test("omits the coauthor reminder when explicitly disabled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    let systemPrompt = ""
+    const restore = installBasicLoopMocks({
+      config: { experimental: { coauthor_reminder: false } },
+      onProcess: async (input) => {
+        systemPrompt = input.system.join("\n")
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect(systemPrompt).not.toContain("<coauthor-reminder>")
+          expect(systemPrompt).not.toContain("Co-authored-by: synergy-agent")
         },
       })
     } finally {


### PR DESCRIPTION
## Summary
- Add `experimental.coauthor_reminder` as a default-on config gate for the git co-author prompt injection.
- Expose a Settings toggle under Runtime > Timeouts > Agent to disable or re-enable the reminder.
- Regenerate SDK/OpenAPI config types and add focused backend/frontend coverage.

## Tests
- `./script/generate.ts`
- `cd packages/synergy && bun test test/session/invoke.test.ts`
- `cd packages/app && bun test src/components/settings/hooks/useConfigPatch.test.ts`
- `cd packages/app && bun run typecheck`
- `cd packages/synergy && bun run typecheck`
- `git diff --check`
- `bun run lint`

Closes #394