### PR TITLE
fix quick switcher model persistence

### DIFF
--- a/packages/app/src/components/model-manager.tsx
+++ b/packages/app/src/components/model-manager.tsx
@@ -1,5 +1,4 @@
-import { createMemo, Show, type Accessor, type Component } from "solid-js"
-import { createStore } from "solid-js/store"
+import { createMemo, Show, type Component } from "solid-js"
 import { List } from "@ericsanchezok/synergy-ui/list"
 import { Switch } from "@ericsanchezok/synergy-ui/switch"
 import { Tag } from "@ericsanchezok/synergy-ui/tag"
@@ -7,7 +6,6 @@ import { compareProviderIDs, type ProviderRecommendationMap } from "@/components
 import { useGlobalSync } from "@/context/global-sync"
 import { useLocal, type LocalModel, type ModelKey } from "@/context/local"
 import { useProviders } from "@/hooks/use-providers"
-import { Persist, persisted } from "@/utils/persist"
 
 export function sortModelGroups(profiles: ProviderRecommendationMap) {
   return (a: { category: string; items: LocalModel[] }, b: { category: string; items: LocalModel[] }) => {
@@ -136,122 +134,39 @@ function newest(models: LocalModel[]) {
   return [...models].sort((a, b) => String(b.release_date ?? "").localeCompare(String(a.release_date ?? "")))[0]
 }
 
-function createStandaloneModelPreferences(models: Accessor<LocalModel[]>, defaults: Accessor<Record<string, string>>) {
-  function migrateModelStore(value: unknown) {
-    if (!value || typeof value !== "object") return value
+export type QuickSwitcherModelPreference = ModelKey & { state: "add" | "remove" }
 
-    const record = value as Record<string, unknown>
-    const recent = Array.isArray(record.recent) ? (record.recent as ModelKey[]) : []
-    const quickSwitcher = Array.isArray(record.quickSwitcher)
-      ? (record.quickSwitcher as (ModelKey & { state: "add" | "remove" })[])
-      : Array.isArray(record.user)
-        ? record.user.flatMap((item) => {
-            if (!item || typeof item !== "object") return []
-            const entry = item as Record<string, unknown>
-            if (typeof entry.providerID !== "string" || typeof entry.modelID !== "string") return []
-            const state = entry.visibility === "hide" ? "remove" : "add"
-            return [{ providerID: entry.providerID, modelID: entry.modelID, state: state as "add" | "remove" }]
-          })
-        : []
+function quickSwitcherPreferenceMap(preferences: QuickSwitcherModelPreference[]) {
+  const map = new Map<string, "add" | "remove">()
+  for (const item of preferences) {
+    map.set(modelKey(item), item.state)
+  }
+  return map
+}
 
-    return {
-      quickSwitcher,
-      recent,
-    }
+function nextQuickSwitcherPreferences(
+  preferences: QuickSwitcherModelPreference[],
+  recommended: Set<string>,
+  model: ModelKey,
+  included: boolean,
+): QuickSwitcherModelPreference[] {
+  const recommendedByDefault = recommended.has(modelKey(model))
+  const nextState: "add" | "remove" | undefined =
+    included === recommendedByDefault ? undefined : included ? "add" : "remove"
+  const index = preferences.findIndex((item) => item.providerID === model.providerID && item.modelID === model.modelID)
+
+  if (!nextState) {
+    if (index < 0) return preferences
+    return preferences.filter((_, itemIndex) => itemIndex !== index)
   }
 
-  const [store, setStore] = persisted(
-    {
-      ...Persist.global("model", ["model.v1"]),
-      migrate: migrateModelStore,
-    },
-    createStore<{
-      quickSwitcher: (ModelKey & { state: "add" | "remove" })[]
-      recent: ModelKey[]
-    }>({
-      quickSwitcher: [],
-      recent: [],
-    }),
-  )
-
-  const recommended = createMemo(() => {
-    const result: ModelKey[] = []
-    const push = (model: LocalModel | undefined) => {
-      if (!model) return
-      result.push({ providerID: model.provider.id, modelID: model.id })
-    }
-
-    const providerIDs = [...new Set(models().map((model) => model.provider.id))]
-    for (const providerID of providerIDs) {
-      const providerModels = models().filter((model) => model.provider.id === providerID)
-      if (providerModels.length === 0) continue
-
-      const defaultModelID = defaults()[providerID]
-      push(providerModels.find((model) => model.id === defaultModelID))
-      push(newest(providerModels.filter((model) => model.reasoning)))
-      push(newest(providerModels.filter((model) => (model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0)))
-      push(
-        newest(
-          providerModels.filter(
-            (model) =>
-              model.modalities?.input?.includes("image") ||
-              model.modalities?.input?.includes("pdf") ||
-              model.modalities?.input?.includes("video"),
-          ),
-        ),
-      )
-    }
-
-    return uniqueModelKeys(result)
-  })
-
-  const recommendedSet = createMemo(() => new Set(recommended().map(modelKey)))
-  const quickSwitcherPreferenceMap = createMemo(() => {
-    const map = new Map<string, "add" | "remove">()
-    for (const item of store.quickSwitcher) {
-      map.set(modelKey(item), item.state)
-    }
-    return map
-  })
-
-  function inQuickSwitcher(model: ModelKey) {
-    const key = modelKey(model)
-    const preference = quickSwitcherPreferenceMap().get(key)
-    if (preference === "remove") return false
-    if (preference === "add") return true
-    return recommendedSet().has(key)
+  if (index >= 0) {
+    const next = [...preferences]
+    next[index] = { ...preferences[index], state: nextState }
+    return next
   }
 
-  function setQuickSwitcher(model: ModelKey, included: boolean) {
-    const recommendedByDefault = recommendedSet().has(modelKey(model))
-    const nextState = included === recommendedByDefault ? undefined : included ? "add" : "remove"
-    const index = store.quickSwitcher.findIndex(
-      (item) => item.providerID === model.providerID && item.modelID === model.modelID,
-    )
-
-    if (!nextState) {
-      if (index >= 0) {
-        setStore("quickSwitcher", (items) => items.filter((_, itemIndex) => itemIndex !== index))
-      }
-      return
-    }
-
-    if (index >= 0) {
-      setStore("quickSwitcher", index, { ...store.quickSwitcher[index], state: nextState })
-      return
-    }
-
-    setStore("quickSwitcher", store.quickSwitcher.length, { ...model, state: nextState })
-  }
-
-  return {
-    current: () => undefined,
-    inQuickSwitcher,
-    setQuickSwitcher,
-    set(model: ModelKey | undefined) {
-      if (model) setQuickSwitcher(model, true)
-    },
-  }
+  return [...preferences, { ...model, state: nextState }]
 }
 
 export const ConnectedModelManager: Component<{
@@ -259,6 +174,8 @@ export const ConnectedModelManager: Component<{
   class?: string
   searchAutofocus?: boolean
   selectable?: boolean
+  quickSwitcher?: QuickSwitcherModelPreference[]
+  onQuickSwitcherChange?: (preferences: QuickSwitcherModelPreference[]) => void
   onSelect?: () => void
 }> = (props) => {
   const globalSync = useGlobalSync()
@@ -286,16 +203,59 @@ export const ConnectedModelManager: Component<{
   )
 
   const local = optionalLocal()
-  const standalone = local ? undefined : createStandaloneModelPreferences(models, providers.default)
-  const modelState = () => local?.model ?? standalone
   const selectable = () => props.selectable !== false
-  const currentModel = () => (props.selectable === false ? undefined : modelState()?.current())
-  const selectModel = (model: ModelKey) => {
-    if (local) {
-      local.model.set(model, { recent: true })
+  const currentModel = () => (props.selectable === false ? undefined : local?.model.current())
+  const recommended = createMemo(() => {
+    const result: ModelKey[] = []
+    const push = (model: LocalModel | undefined) => {
+      if (!model) return
+      result.push({ providerID: model.provider.id, modelID: model.id })
+    }
+
+    const providerIDs = [...new Set(models().map((model) => model.provider.id))]
+    for (const providerID of providerIDs) {
+      const providerModels = models().filter((model) => model.provider.id === providerID)
+      if (providerModels.length === 0) continue
+
+      const defaultModelID = providers.default()[providerID]
+      push(providerModels.find((model) => model.id === defaultModelID))
+      push(newest(providerModels.filter((model) => model.reasoning)))
+      push(newest(providerModels.filter((model) => (model.cost?.input ?? 0) === 0 && (model.cost?.output ?? 0) === 0)))
+      push(
+        newest(
+          providerModels.filter(
+            (model) =>
+              model.modalities?.input?.includes("image") ||
+              model.modalities?.input?.includes("pdf") ||
+              model.modalities?.input?.includes("video"),
+          ),
+        ),
+      )
+    }
+
+    return uniqueModelKeys(result)
+  })
+  const recommendedSet = createMemo(() => new Set(recommended().map(modelKey)))
+  const preferenceMap = createMemo(() =>
+    quickSwitcherPreferenceMap(props.quickSwitcher ?? local?.model.quickSwitcherPreferences() ?? []),
+  )
+  const inQuickSwitcher = (model: ModelKey) => {
+    const preference = preferenceMap().get(modelKey(model))
+    if (preference === "remove") return false
+    if (preference === "add") return true
+    return recommendedSet().has(modelKey(model))
+  }
+  const setQuickSwitcher = (model: ModelKey, included: boolean) => {
+    const current: QuickSwitcherModelPreference[] = props.quickSwitcher ?? local?.model.quickSwitcherPreferences() ?? []
+    const next = nextQuickSwitcherPreferences(current, recommendedSet(), model, included)
+    if (props.onQuickSwitcherChange) {
+      props.onQuickSwitcherChange(next)
       return
     }
-    standalone?.set(model)
+    return
+  }
+  const selectModel = (model: ModelKey) => {
+    local?.model.set(model, { recent: true })
   }
 
   return (
@@ -325,9 +285,9 @@ export const ConnectedModelManager: Component<{
           <ModelManagerRow model={model} />
           <div class="model-manager-actions flex items-center gap-x-3 shrink-0" onClick={(e) => e.stopPropagation()}>
             <Switch
-              checked={modelState()?.inQuickSwitcher({ modelID: model.id, providerID: model.provider.id }) ?? false}
+              checked={inQuickSwitcher({ modelID: model.id, providerID: model.provider.id })}
               onChange={(checked) => {
-                modelState()?.setQuickSwitcher({ modelID: model.id, providerID: model.provider.id }, checked)
+                setQuickSwitcher({ modelID: model.id, providerID: model.provider.id }, checked)
               }}
             >
               <span class="model-manager-quick-label text-12-regular text-text-weak">Quick</span>

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -147,6 +147,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
       thinking_model: cfg?.thinking_model ?? "",
       long_context_model: cfg?.long_context_model ?? "",
       creative_model: cfg?.creative_model ?? "",
+      quick_switcher: cfg?.quick_switcher?.models ?? [],
     }
   })
 
@@ -491,6 +492,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
             onVariantChange={(roleId, variant) =>
               setSettings("roleVariant", roleId, variant || (undefined as unknown as string))
             }
+            onQuickSwitcherChange={(preferences) => setSettings("models", "quick_switcher", preferences)}
             onConnectProvider={() => setActiveTab("providers")}
           />
         )

--- a/packages/app/src/components/settings/catalog.ts
+++ b/packages/app/src/components/settings/catalog.ts
@@ -334,6 +334,7 @@ export const FIELD_SAVE_STRATEGY: Record<string, SettingsFieldStrategy> = {
   long_context_model: "explicit",
   creative_model: "explicit",
   role_variant: "explicit",
+  quick_switcher: "background",
   enabled_providers: "background",
   disabled_providers: "background",
   embedding: "explicit",

--- a/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
@@ -29,6 +29,33 @@ describe("settings config patch", () => {
     })
   })
 
+  test("persists quick switcher model preferences through the models domain", () => {
+    const state = defaultSettingsState("enter")
+    state.models.quick_switcher = [{ providerID: "openai", modelID: "gpt-5.5", state: "add" }]
+
+    const patch = buildPatch({
+      cfg: {} as Config,
+      state,
+      originalMcps: {},
+    })
+
+    expect(patch.quick_switcher).toEqual({
+      models: [{ providerID: "openai", modelID: "gpt-5.5", state: "add" }],
+    })
+  })
+
+  test("clears quick switcher config when all preferences return to defaults", () => {
+    const state = defaultSettingsState("enter")
+
+    const patch = buildPatch({
+      cfg: { quick_switcher: { models: [{ providerID: "openai", modelID: "gpt-5.5", state: "remove" }] } } as Config,
+      state,
+      originalMcps: {},
+    })
+
+    expect(patch.quick_switcher).toEqual({ models: [] })
+  })
+
   test("provider idle timeout can be disabled with false", () => {
     const state = defaultSettingsState("enter")
     state.runtime.providerIdleTimeout = "false"

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -57,6 +57,13 @@ function buildModelPatch(cfg: Config, state: SettingsState, patch: Record<string
   if (JSON.stringify(cleanedVariant) !== JSON.stringify(origVariant ?? {})) {
     patch.role_variant = Object.keys(cleanedVariant).length ? cleanedVariant : undefined
   }
+
+  const cleanedQuickSwitcher = state.models.quick_switcher.filter(
+    (item) => item.providerID && item.modelID && (item.state === "add" || item.state === "remove"),
+  )
+  if (JSON.stringify(cleanedQuickSwitcher) !== JSON.stringify(cfg.quick_switcher?.models ?? [])) {
+    patch.quick_switcher = { models: cleanedQuickSwitcher }
+  }
 }
 
 function buildProviderPatch(cfg: Config, state: SettingsState, patch: Record<string, unknown>) {

--- a/packages/app/src/components/settings/hooks/useSettingsForm.test.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { readLegacyQuickSwitcherPreferences } from "./useSettingsForm"
+
+describe("settings form legacy quick switcher migration", () => {
+  test("reads current quick switcher preferences from the legacy localStorage key", () => {
+    const storage = storageWithModel({
+      quickSwitcher: [
+        { providerID: "openai", modelID: "gpt-5.5", state: "add" },
+        { providerID: "anthropic", modelID: "claude-sonnet", state: "remove" },
+        { providerID: "bad", modelID: "ignored", state: "invalid" },
+      ],
+    })
+
+    expect(readLegacyQuickSwitcherPreferences(storage)).toEqual([
+      { providerID: "openai", modelID: "gpt-5.5", state: "add" },
+      { providerID: "anthropic", modelID: "claude-sonnet", state: "remove" },
+    ])
+  })
+
+  test("converts older user visibility preferences", () => {
+    const storage = storageWithModel({
+      user: [
+        { providerID: "openai", modelID: "gpt-5.5", visibility: "show" },
+        { providerID: "anthropic", modelID: "claude-sonnet", visibility: "hide" },
+      ],
+    })
+
+    expect(readLegacyQuickSwitcherPreferences(storage)).toEqual([
+      { providerID: "openai", modelID: "gpt-5.5", state: "add" },
+      { providerID: "anthropic", modelID: "claude-sonnet", state: "remove" },
+    ])
+  })
+})
+
+function storageWithModel(value: unknown): Storage {
+  const entries = new Map<string, string>([["synergy.global.dat:model", JSON.stringify(value)]])
+  return {
+    get length() {
+      return entries.size
+    },
+    clear() {
+      entries.clear()
+    },
+    getItem(key: string) {
+      return entries.get(key) ?? null
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null
+    },
+    removeItem(key: string) {
+      entries.delete(key)
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, value)
+    },
+  }
+}

--- a/packages/app/src/components/settings/hooks/useSettingsForm.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.ts
@@ -1,7 +1,7 @@
 import type { Config } from "@ericsanchezok/synergy-sdk/client"
 import type { SetStoreFunction } from "solid-js/store"
 import type { SendShortcut } from "@/context/input"
-import type { SettingsState } from "../types"
+import type { QuickSwitcherPreference, SettingsState } from "../types"
 import {
   MODEL_DEFAULTS,
   TOAST_TYPES,
@@ -48,6 +48,7 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
     thinking_model: cfg.thinking_model ?? MODEL_DEFAULTS.thinking_model,
     long_context_model: cfg.long_context_model ?? MODEL_DEFAULTS.long_context_model,
     creative_model: cfg.creative_model ?? MODEL_DEFAULTS.creative_model,
+    quick_switcher: cfg.quick_switcher?.models ?? readLegacyQuickSwitcherPreferences(),
   })
   params.setSettings("roleVariant", cfg.role_variant ?? {})
 
@@ -177,6 +178,39 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
 
   params.setInitialized(true)
   return setName
+}
+
+export function readLegacyQuickSwitcherPreferences(storage: Storage = localStorage): QuickSwitcherPreference[] {
+  const raw = storage.getItem("synergy.global.dat:model")
+  if (!raw) return []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!parsed || typeof parsed !== "object") return []
+
+  const record = parsed as Record<string, unknown>
+  const preferences = Array.isArray(record.quickSwitcher)
+    ? (record.quickSwitcher as QuickSwitcherPreference[])
+    : Array.isArray(record.user)
+      ? record.user.flatMap((item) => {
+          if (!item || typeof item !== "object") return []
+          const entry = item as Record<string, unknown>
+          if (typeof entry.providerID !== "string" || typeof entry.modelID !== "string") return []
+          const state = entry.visibility === "hide" ? "remove" : "add"
+          return [{ providerID: entry.providerID, modelID: entry.modelID, state: state as "add" | "remove" }]
+        })
+      : []
+
+  return preferences.filter(
+    (item) =>
+      typeof item.providerID === "string" &&
+      typeof item.modelID === "string" &&
+      (item.state === "add" || item.state === "remove"),
+  )
 }
 
 function formatList(values: string[] | undefined): string {

--- a/packages/app/src/components/settings/hooks/useSettingsSave.test.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsSave.test.ts
@@ -5,7 +5,7 @@ import { MODEL_ROLES } from "../types"
 
 const domains: ConfigDomainSummary[] = [
   domain("general", ["snapshot", "theme", "username"]),
-  domain("models", ["model", "mini_model"]),
+  domain("models", ["model", "mini_model", "quick_switcher"]),
   domain("permissions", ["permission", "controlProfile", "sandbox", "smartAllow"]),
 ]
 
@@ -28,6 +28,12 @@ describe("settings save routing", () => {
 
   test("throws when a patch field has no save strategy", () => {
     expect(() => strategyForPatch({ unknownField: true })).toThrow("does not define a save strategy")
+  })
+
+  test("routes quick switcher patches through background save", () => {
+    const grouped = groupPatchByDomain({ quick_switcher: { models: [] } }, domains)
+    expect(grouped.get("models")).toEqual({ quick_switcher: { models: [] } })
+    expect(strategyForPatch({ quick_switcher: { models: [] } })).toEqual(["background"])
   })
 
   test("routes model role patches through explicit save", () => {

--- a/packages/app/src/components/settings/model-role-draft.test.ts
+++ b/packages/app/src/components/settings/model-role-draft.test.ts
@@ -125,6 +125,7 @@ function models(overrides: Partial<ModelsStore> = {}): ModelsStore {
     thinking_model: "",
     long_context_model: "",
     creative_model: "",
+    quick_switcher: [],
     ...overrides,
   }
 }

--- a/packages/app/src/components/settings/panels/ModelsPanel.test.ts
+++ b/packages/app/src/components/settings/panels/ModelsPanel.test.ts
@@ -32,7 +32,8 @@ describe("Models panel UI contract", () => {
     expect(modelsPanel).not.toContain("onManageModels")
     expect(modelsPanel).not.toContain(">Manage models<")
     expect(modelManager).toContain("setQuickSwitcher")
-    expect(modelManager).toContain('Persist.global("model"')
+    expect(modelManager).toContain("onQuickSwitcherChange")
+    expect(modelManager).not.toContain('Persist.global("model"')
   })
 
   test("quick-switcher management rows are static rows with labeled switches", () => {

--- a/packages/app/src/components/settings/panels/ModelsPanel.tsx
+++ b/packages/app/src/components/settings/panels/ModelsPanel.tsx
@@ -17,6 +17,7 @@ export function ModelsPanel(props: {
   popoverLayer?: HTMLElement
   onModelChange: (key: ModelKey, value: string) => void
   onVariantChange: (roleId: string, variant: string) => void
+  onQuickSwitcherChange: (preferences: ModelsStore["quick_switcher"]) => void
   onConnectProvider: () => void
 }) {
   const providerGroups = () => groupByProvider(props.providerModels())
@@ -105,7 +106,13 @@ export function ModelsPanel(props: {
         title="Quick switcher models"
         description="Pick the connected models that appear in model switchers and command shortcuts."
       >
-        <ConnectedModelManager class="settings-connected-model-list" searchAutofocus={false} selectable={false} />
+        <ConnectedModelManager
+          class="settings-connected-model-list"
+          searchAutofocus={false}
+          selectable={false}
+          quickSwitcher={props.models.quick_switcher}
+          onQuickSwitcherChange={props.onQuickSwitcherChange}
+        />
       </SettingsSection>
     </SettingsPage>
   )

--- a/packages/app/src/components/settings/types.ts
+++ b/packages/app/src/components/settings/types.ts
@@ -199,6 +199,12 @@ export type GeneralStore = {
   sendShortcut: SendShortcut
 }
 
+export type QuickSwitcherPreference = {
+  providerID: string
+  modelID: string
+  state: "add" | "remove"
+}
+
 export type ModelsStore = {
   model: string
   nano_model: string
@@ -208,6 +214,7 @@ export type ModelsStore = {
   thinking_model: string
   long_context_model: string
   creative_model: string
+  quick_switcher: QuickSwitcherPreference[]
 }
 
 export type PluginsStore = {
@@ -290,6 +297,7 @@ export function defaultSettingsState(sendShortcut: SendShortcut): SettingsState 
       thinking_model: MODEL_DEFAULTS.thinking_model,
       long_context_model: MODEL_DEFAULTS.long_context_model,
       creative_model: MODEL_DEFAULTS.creative_model,
+      quick_switcher: [],
     },
     providers: {
       enabledProviders: "",

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -300,9 +300,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       const recommendedSet = createMemo(() => new Set(recommended().map(keyOf)))
 
+      const quickSwitcherPreferences = createMemo(() => sync.data.config.quick_switcher?.models ?? [])
+
       const quickSwitcherPreferenceMap = createMemo(() => {
         const map = new Map<string, "add" | "remove">()
-        for (const item of store.quickSwitcher) {
+        for (const item of quickSwitcherPreferences()) {
           map.set(keyOf(item), item.state)
         }
         return map
@@ -373,28 +375,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         return recommendedSet().has(key)
       }
 
-      function updateQuickSwitcherPreference(model: ModelKey, included: boolean) {
-        const recommendedByDefault = recommendedSet().has(keyOf(model))
-        const nextState = included === recommendedByDefault ? undefined : included ? "add" : "remove"
-        const index = store.quickSwitcher.findIndex(
-          (item) => item.providerID === model.providerID && item.modelID === model.modelID,
-        )
-
-        if (!nextState) {
-          if (index >= 0) {
-            setStore("quickSwitcher", (items) => items.filter((_, itemIndex) => itemIndex !== index))
-          }
-          return
-        }
-
-        if (index >= 0) {
-          setStore("quickSwitcher", index, { ...store.quickSwitcher[index], state: nextState })
-          return
-        }
-
-        setStore("quickSwitcher", store.quickSwitcher.length, { ...model, state: nextState })
-      }
-
       const quickSwitcherOnly = createMemo(() =>
         all().filter((item) => inQuickSwitcher({ providerID: item.provider.id, modelID: item.id })),
       )
@@ -430,6 +410,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         recent,
         all,
         quickSwitcher,
+        quickSwitcherPreferences,
         cycle,
         set(model: ModelKey | undefined, options?: { recent?: boolean }) {
           batch(() => {
@@ -437,7 +418,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             // to fallbackModel() keeps a concrete value when the caller clears.
             const resolved = model ?? fallbackModel()
             if (resolved) setDraft("model", intentKey(), resolved)
-            if (model) updateQuickSwitcherPreference(model, true)
             if (options?.recent && model) {
               const uniq = uniqueBy([model, ...store.recent], (x) => x.providerID + x.modelID)
               if (uniq.length > 5) uniq.pop()
@@ -455,9 +435,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
         },
         inQuickSwitcher,
-        setQuickSwitcher(model: ModelKey, included: boolean) {
-          updateQuickSwitcherPreference(model, included)
-        },
         isRecommended(model: ModelKey) {
           return recommendedSet().has(keyOf(model))
         },

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1427,6 +1427,31 @@ export type ProviderCatalogConfig = {
   offlineCache?: boolean
 }
 
+export type QuickSwitcherModelConfig = {
+  /**
+   * Provider id for the quick switcher model preference
+   */
+  providerID: string
+  /**
+   * Model id for the quick switcher model preference
+   */
+  modelID: string
+  /**
+   * Whether to force-add or force-remove the model from the quick switcher
+   */
+  state: "add" | "remove"
+}
+
+/**
+ * Quick switcher model visibility preferences
+ */
+export type QuickSwitcherConfig = {
+  /**
+   * Per-model quick switcher visibility preferences
+   */
+  models?: Array<QuickSwitcherModelConfig>
+}
+
 export type ModelRole = "vision" | "nano" | "mini" | "mid" | "thinking" | "long" | "creative"
 
 export type PermissionActionConfig = "ask" | "allow" | "deny"
@@ -2586,6 +2611,7 @@ export type Config = {
   role_variant?: {
     [key: string]: string
   }
+  quick_switcher?: QuickSwitcherConfig
   /**
    * Default agent to use when none is specified. Must be a primary agent. Falls back to 'synergy' if not set or if the specified agent is invalid.
    */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -21260,6 +21260,40 @@
         },
         "additionalProperties": false
       },
+      "QuickSwitcherModelConfig": {
+        "type": "object",
+        "properties": {
+          "providerID": {
+            "description": "Provider id for the quick switcher model preference",
+            "type": "string"
+          },
+          "modelID": {
+            "description": "Model id for the quick switcher model preference",
+            "type": "string"
+          },
+          "state": {
+            "description": "Whether to force-add or force-remove the model from the quick switcher",
+            "type": "string",
+            "enum": ["add", "remove"]
+          }
+        },
+        "required": ["providerID", "modelID", "state"],
+        "additionalProperties": false
+      },
+      "QuickSwitcherConfig": {
+        "description": "Quick switcher model visibility preferences",
+        "type": "object",
+        "properties": {
+          "models": {
+            "description": "Per-model quick switcher visibility preferences",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickSwitcherModelConfig"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "ModelRole": {
         "type": "string",
         "enum": ["vision", "nano", "mini", "mid", "thinking", "long", "creative"]
@@ -23122,6 +23156,9 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "quick_switcher": {
+            "$ref": "#/components/schemas/QuickSwitcherConfig"
           },
           "default_agent": {
             "description": "Default agent to use when none is specified. Must be a primary agent. Falls back to 'synergy' if not set or if the specified agent is invalid.",

--- a/packages/synergy/src/config/domain.ts
+++ b/packages/synergy/src/config/domain.ts
@@ -61,6 +61,7 @@ export namespace ConfigDomain {
       "creative_model",
       "vision_model",
       "role_variant",
+      "quick_switcher",
     ]),
     def("providers", "20-providers.jsonc", "Providers", [
       "provider",

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -1247,6 +1247,24 @@ export const PluginMarketplace = z
 export type PluginMarketplace = z.infer<typeof PluginMarketplace>
 
 export const PLUGIN_MARKETPLACE_DEFAULTS = DEFAULT_PLUGIN_MARKETPLACE_CONFIG as Required<PluginMarketplace>
+const QuickSwitcherModel = z
+  .object({
+    providerID: z.string().describe("Provider id for the quick switcher model preference"),
+    modelID: z.string().describe("Model id for the quick switcher model preference"),
+    state: z.enum(["add", "remove"]).describe("Whether to force-add or force-remove the model from the quick switcher"),
+  })
+  .strict()
+  .meta({ ref: "QuickSwitcherModelConfig" })
+export type QuickSwitcherModel = z.infer<typeof QuickSwitcherModel>
+
+export const QuickSwitcher = z
+  .object({
+    models: z.array(QuickSwitcherModel).optional().describe("Per-model quick switcher visibility preferences"),
+  })
+  .strict()
+  .meta({ ref: "QuickSwitcherConfig" })
+export type QuickSwitcher = z.infer<typeof QuickSwitcher>
+
 export const Info = z
   .object({
     $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
@@ -1384,6 +1402,7 @@ export const Info = z
       .describe(
         "Default variant (e.g. low, medium, high, xhigh) applied per model role. Requires the resolved model to support the named variant.",
       ),
+    quick_switcher: QuickSwitcher.optional().describe("Quick switcher model visibility preferences"),
     default_agent: z
       .string()
       .optional()


### PR DESCRIPTION
## Summary
- Persist quick switcher model visibility preferences in the backend models config domain (`quick_switcher` in `10-models.jsonc`).
- Wire Settings to read/write quick switcher preferences through config patches and remove the duplicate localStorage-backed Settings store.
- Migrate legacy browser localStorage preferences when Settings initializes, including older `user` visibility entries.

## Notes
- Legacy quick switcher preferences are migrated client-side from `synergy.global.dat:model` because server config migrations cannot read browser localStorage.
- Users who never open Settings will continue to see backend/default quick switcher behavior until Settings initialization performs that migration.

Fixes #397

## Verification
- `bun test src/components/settings/hooks/useConfigPatch.test.ts src/components/settings/hooks/useSettingsSave.test.ts src/components/settings/hooks/useSettingsForm.test.ts src/components/settings/model-role-draft.test.ts src/components/settings/panels/ModelsPanel.test.ts` from `packages/app`
- `bun test test/config/domain.test.ts` from `packages/synergy`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`