### PR TITLE
fix: reduce runtime output retention (fixes #241)

### DIFF
--- a/packages/synergy/src/process/registry.ts
+++ b/packages/synergy/src/process/registry.ts
@@ -7,8 +7,8 @@ import { PerformanceMetrics } from "@/performance/metrics"
 const log = Log.create({ service: "process.registry" })
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000 // 30 minutes
-const MAX_OUTPUT_CHARS = 200_000
-const TAIL_CHARS = 2000
+const MAX_OUTPUT_CHARS = 64_000
+const TAIL_CHARS = 8000
 
 export namespace ProcessRegistry {
   export type Status = "running" | "completed" | "failed" | "killed"


### PR DESCRIPTION
## Summary
Process output was retained up to 200K chars in the running registry and persisted for 30 minutes after completion. Reduced the per-process output cap to 64K chars and increased tail retention to 8K chars for better diagnostics while reducing memory pressure.

## What changed
- `process/registry.ts`: `MAX_OUTPUT_CHARS` from 200,000 → 64,000; `TAIL_CHARS` from 2,000 → 8,000

## Verification
- Text diff review confirms constants-only change

Fixes #241