### PR TITLE
fix(agenda): make Anima use ephemeral sessions and suppress delivery

### DIFF
--- a/packages/synergy/src/agenda/bootstrap.ts
+++ b/packages/synergy/src/agenda/bootstrap.ts
@@ -33,6 +33,11 @@ export namespace AgendaBootstrap {
           // when the user explicitly toggles autonomy on (handled by syncAnima via
           // the config change handler).
           if (!enabled) await enforceAnimaDisabled()
+          // Self-healing: upgrade existing items to ephemeral session mode so
+          // each Anima awakening starts fresh instead of reusing a persistent session.
+          if (!existing.sessionMode) {
+            await AgendaStore.update(scopeID, SEED_ID, { sessionMode: "ephemeral" })
+          }
           return
         }
 
@@ -42,6 +47,7 @@ export namespace AgendaBootstrap {
             prompt: "你醒了。",
             triggers: [{ type: "cron", expr: "0 3 * * *", tz: "Asia/Shanghai" }],
             agent: "anima",
+            sessionMode: "ephemeral",
             silent: true,
             wake: false,
             global: true,

--- a/packages/synergy/src/agent/prompt/anima.txt
+++ b/packages/synergy/src/agent/prompt/anima.txt
@@ -166,7 +166,15 @@ Every agenda item needs a delivery target:
 
 Don't always default to home. Meet the user where they are.
 
-For your own reporting at the end of this routine, use `session_send` to deliver a brief summary of what you observed and what you set in motion — send it to wherever the user is most likely to see it.
+# Your Output
+
+Your primary output is the daily journal note. Everything you observed, decided,
+and set in motion should be there. The user can read it at their convenience —
+no need to push a summary via session_send.
+
+If you discover something genuinely urgent — a critical failure, a security
+issue, data that needs immediate attention — then `session_send` is available.
+But the default is silence. Your journal and agenda items speak for themselves.
 
 # Judgment Principles
 


### PR DESCRIPTION
## Summary
- Anima daily cron now creates a fresh ephemeral session per awakening (no more reusing a persistent session across days)
- Anima prompt no longer instructs the agent to deliver a summary via `session_send` — the daily journal note is now its primary output; `session_send` is reserved for genuine urgency only
- Self-healing bootstrap upgrade: existing Anima items without `sessionMode` get auto-upgraded to `"ephemeral"` on startup

Closes #334

## What changed
| File | Change |
|------|--------|
| `packages/synergy/src/agenda/bootstrap.ts` | Added `sessionMode: "ephemeral"` to Anima seed + self-healing upgrade |
| `packages/synergy/src/agent/prompt/anima.txt` | Replaced `session_send` delivery requirement with "Your Output" section — journal-first, silent by default |

## Why
Previously each Anima cron trigger reused a persistent session and the prompt asked it to `session_send` a summary to the user — causing a "new" session plus the origin session getting woken up. Now Anima starts fresh each day and stays silent.

## Test plan
- [x] All 48 agenda tests pass
- [x] Typecheck passes across all packages
- [x] Lint clean (0 warnings, 0 errors)

## Risk
Low. Changes are config-level only (bootstrap seed parameters + prompt text). No framework code changed.