### PR TITLE
Harden session workspace execution context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,15 @@ Provider auth paths are distinct. The built-in `openai-codex` provider uses Chat
 
 `autonomous` is the unattended profile: it must never ask the user. Operations that cannot be automatically allowed must be automatically denied with a clear policy diagnostic. SmartAllow may auto-allow eligible false positives at high confidence, but failed SmartAllow checks deny instead of prompting.
 
+`guarded` is the interactive profile: it is the only standard profile that can ask the user for permission. Do not add ask flows to `autonomous`; if an unattended operation exceeds its policy, deny it.
+
 `smartAllow` reduces noise and false positives. In `guarded`, it can auto-allow safe asks before prompting. In `autonomous`, it can auto-allow eligible soft denies at a stricter threshold. It must use metadata or redacted evidence for secret-like files and must never send raw secret values to a model.
+
+External reads are allowed by default, including ordinary reads from a worktree session's original checkout. Do not treat non-sensitive `file_external_read` as a protected operation merely because it is outside the active workspace. Sensitive regions remain protected: credentials, secrets, private auth stores, and other explicit sensitive-path matches must still be denied or gated according to the active profile.
+
+Worktree isolation blocks writes, modifications, and execution outside the active worktree unless the active profile explicitly allows them. In particular, a worktree session may read ordinary files in the original checkout, but must not write to, modify, or run commands from the original checkout under `autonomous`.
+
+Skill roots are trusted runtime areas. Reading, writing, and running inside configured skill/plugin skill roots is allowed by the permission model; do not reclassify those paths as ordinary external writes or external execution unless they escape the trusted root.
 
 ### Config-aware work
 

--- a/bun.lock
+++ b/bun.lock
@@ -343,7 +343,6 @@
         "virtua": "catalog:",
       },
       "devDependencies": {
-        "@happy-dom/global-registrator": "20.0.11",
         "@tailwindcss/vite": "catalog:",
         "@tsconfig/node22": "catalog:",
         "@types/bun": "catalog:",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -144,13 +144,5 @@
       "entry": ["src/**/*.ts"],
       "project": ["src/**/*.ts"],
     },
-    "packages/meta-protocol": {
-      "entry": ["test/**/*.ts"],
-      "project": ["src/**/*.ts", "test/**/*.ts"],
-    },
-    "packages/meta-synergy": {
-      "entry": ["src/**/*.ts", "script/**/*.ts", "test/**/*.ts"],
-      "project": ["src/**/*.ts", "script/**/*.ts", "test/**/*.ts"],
-    },
   },
 }

--- a/packages/synergy/AGENTS.md
+++ b/packages/synergy/AGENTS.md
@@ -40,7 +40,9 @@ Do not bypass pre-push hooks. If a hook check fails, fix the root cause rather t
 
 ## Architecture
 
-- **Control profiles**: `src/control-profile/` owns user-facing access profile semantics; `src/enforcement/` owns capability classification and gate decisions; `src/permission/smart-allow.ts` owns high-confidence false-positive adjudication without raw secret disclosure; `src/sandbox/` owns OS enforcement only. Keep these layers separate and avoid reintroducing tool-local boundary checks. `full_access` must remain silent allow-all inside the permission system, while `autonomous` must never ask and must auto-deny anything it cannot safely allow.
+- **Control profiles**: `src/control-profile/` owns user-facing access profile semantics; `src/enforcement/` owns capability classification and gate decisions; `src/permission/smart-allow.ts` owns high-confidence false-positive adjudication without raw secret disclosure; `src/sandbox/` owns OS enforcement only. Keep these layers separate and avoid reintroducing tool-local boundary checks. `full_access` must remain silent allow-all inside the permission system. `guarded` is the interactive profile and may ask. `autonomous` must never ask; anything outside its policy is denied with a clear diagnostic.
+
+- **Permission first principles**: ordinary external reads are allowed, including non-sensitive reads from a worktree session's original checkout. Sensitive paths such as credentials, secrets, auth stores, and explicit secret candidates remain protected. Worktree isolation blocks writes, modifications, and execution outside the active worktree unless the active profile explicitly allows them; under `autonomous`, a worktree session may read ordinary original-checkout files but must not write to, modify, or run commands from the original checkout. Configured skill/plugin skill roots are trusted runtime areas: read, write, and execution inside those roots are allowed, and only escapes from those roots should be treated as ordinary external access.
 
 - **Tools**: Implement `Tool.Info` interface with `execute()` method
 - **Context**: Pass `sessionID` in tool context, use `App.provide()` for DI

--- a/packages/synergy/src/agenda/delivery.ts
+++ b/packages/synergy/src/agenda/delivery.ts
@@ -1,4 +1,5 @@
-import { SessionInbox } from "../session/inbox"
+import { Identifier } from "../id/id"
+import { SessionManager } from "../session/manager"
 import { Log } from "../util/log"
 import { AgendaTypes } from "./types"
 
@@ -24,7 +25,6 @@ export namespace AgendaDelivery {
     }
 
     try {
-      const { SessionManager } = await import("../session/manager")
       const session = await SessionManager.getSession(target)
       if (!session) {
         log.warn("delivery target session not found", {
@@ -34,14 +34,20 @@ export namespace AgendaDelivery {
         return
       }
 
-      await SessionInbox.deliver({
-        sessionID: session.id,
-        mode: "task",
-        message: {
-          role: "user",
-          visible: true,
-          parts: [{ type: "text", text }],
-          origin: { type: "agenda", sessionID: input.sessionID },
+      await SessionManager.deliver({
+        target: session.id,
+        mail: {
+          type: "user",
+          metadata: { source: "agenda", sourceSessionID: input.sessionID },
+          parts: [
+            {
+              id: Identifier.ascending("part"),
+              sessionID: session.id,
+              messageID: Identifier.ascending("message"),
+              type: "text",
+              text,
+            },
+          ],
         },
       })
     } catch (err) {

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -9,7 +9,6 @@ import { Log } from "../util/log"
 import { Session } from "../session"
 import { SessionInvoke, resolveInputParts } from "../session/invoke"
 import { SessionManager } from "../session/manager"
-import { SessionInbox } from "../session/inbox"
 import { Agent } from "../agent/agent"
 import { MessageV2 } from "../session/message-v2"
 import { CortexTypes } from "./types"
@@ -533,14 +532,20 @@ export namespace Cortex {
       .filter(Boolean)
       .join("\n")
 
-    void SessionInbox.deliver({
-      sessionID: task.parentSessionID,
-      mode: "steer",
-      message: {
-        role: "user",
-        visible: true,
-        parts: [{ type: "text", text: notification }],
-        origin: { type: "cortex", sessionID: task.sessionID },
+    void SessionManager.deliver({
+      target: task.parentSessionID,
+      mail: {
+        type: "user",
+        metadata: { source: "cortex", sourceSessionID: task.sessionID },
+        parts: [
+          {
+            id: Identifier.ascending("part"),
+            sessionID: task.parentSessionID,
+            messageID: Identifier.ascending("message"),
+            type: "text",
+            text: notification,
+          },
+        ],
       },
     }).catch((error) => {
       log.error("failed to notify parent session", { taskID: task.id, parentSessionID: task.parentSessionID, error })

--- a/packages/synergy/src/session/continuation-kernel.ts
+++ b/packages/synergy/src/session/continuation-kernel.ts
@@ -7,6 +7,9 @@ import { SessionManager } from "./manager"
 import { MessageV2 } from "./message-v2"
 import { SessionProgress } from "./progress"
 import type { Info as SessionInfo } from "./types"
+import { BlueprintContinuationPolicy } from "./blueprint-continuation"
+import { LightLoopContinuationPolicy } from "./light-loop-continuation"
+import { LatticeContinuationPolicy } from "../lattice/policy"
 
 /**
  * Session Continuation Kernel.
@@ -145,15 +148,8 @@ export namespace ContinuationKernel {
   function registerBuiltins(): void {
     if (builtinsRegistered) return
     builtinsRegistered = true
-    // Static requires avoid a top-level import cycle (policies import the
-    // kernel for its types). Registration happens once, lazily.
-    const { BlueprintContinuationPolicy } =
-      require("./blueprint-continuation") as typeof import("./blueprint-continuation")
     register(BlueprintContinuationPolicy)
-    const { LightLoopContinuationPolicy } =
-      require("./light-loop-continuation") as typeof import("./light-loop-continuation")
     register(LightLoopContinuationPolicy)
-    const { LatticeContinuationPolicy } = require("../lattice/policy") as typeof import("../lattice/policy")
     register(LatticeContinuationPolicy)
   }
 

--- a/packages/synergy/src/session/inbox.ts
+++ b/packages/synergy/src/session/inbox.ts
@@ -346,19 +346,6 @@ export namespace SessionInbox {
     return !!(await latestRootID(sessionID))
   }
 
-  async function wakeIfRunnable(item: StoredItem): Promise<void> {
-    const { SessionManager } = await import("./manager")
-    if (SessionManager.isRunning(item.sessionID)) return
-    if (!(await hasRunnableItem(item.sessionID))) return
-
-    log.info("waking idle session for inbox item", { sessionID: item.sessionID, itemID: item.id, mode: item.mode })
-    void import("./invoke")
-      .then(({ SessionInvoke }) => SessionInvoke.loop(item.sessionID))
-      .catch((error) => {
-        log.error("async inbox wake failed", { sessionID: item.sessionID, itemID: item.id, error })
-      })
-  }
-
   export async function list(sessionID: string): Promise<Item[]> {
     return (await listStored(sessionID)).map(publicItem)
   }
@@ -420,7 +407,6 @@ export namespace SessionInbox {
     }
 
     await writeItem(item)
-    await wakeIfRunnable(item)
     return { itemID, messageID }
   })
 

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -131,7 +131,7 @@ export namespace SessionInvoke {
       }
 
       try {
-        return await loop(input.sessionID)
+        return await loopBody(input.sessionID)
       } catch (error) {
         await writeErrorAssistantIfMissing(input.sessionID, message.info as MessageV2.User, error).catch((err) => {
           log.error("failed to persist invocation error", { sessionID: input.sessionID, error: err })
@@ -184,6 +184,10 @@ export namespace SessionInvoke {
   }
 
   export const loop = fn(Identifier.schema("session"), async (sessionID) => {
+    return SessionManager.run(sessionID, () => loopBody(sessionID))
+  })
+
+  async function loopBody(sessionID: string): Promise<MessageV2.WithParts> {
     ContinuationKernel.init()
     LatticeBridge.init()
     SessionManager.registerRuntime(sessionID)
@@ -212,6 +216,7 @@ export namespace SessionInvoke {
     let step = 0
     let emergencyCompactionTriggered = false
     let session = await Session.get(sessionID)
+    SessionManager.assertExecutionContext(session, "session loop")
     let scopeID = (session.scope as Scope).id
 
     outer: while (true) {
@@ -220,6 +225,7 @@ export namespace SessionInvoke {
         log.info("loop", { step, sessionID })
         if (abort.aborted) break
         session = await Session.get(sessionID)
+        SessionManager.assertExecutionContext(session, "session loop refresh")
         scopeID = (session.scope as Scope).id
         let msgs = await effectiveCompactedMessages(sessionID)
 
@@ -964,7 +970,7 @@ Do not stop early, do not pretend the task is complete, and do not hide missing 
       q.onComplete(resultMessage)
     }
     return resultMessage
-  })
+  }
 
   export function selectResultMessage(messages: MessageV2.WithParts[]): MessageV2.WithParts | undefined {
     let lastReplyRequiredUser: MessageV2.User | undefined

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -9,6 +9,7 @@ import type { MessageV2 } from "./message-v2"
 import { BusyError } from "./error"
 import { SessionEvent } from "./event"
 import type { Scope } from "@/scope"
+import { ScopeContext } from "@/scope/context"
 import { Info, type StatusInfo } from "./types"
 import { SessionEndpoint } from "./endpoint"
 import { SessionInbox } from "./inbox"
@@ -230,6 +231,7 @@ export namespace SessionManager {
         workspace,
         ensure: scope.type === "project",
         fn: async () => {
+          assertExecutionContext(session, "session manager run")
           const workspace = (session as Info).workspace
           if (workspace?.type !== "git_worktree") return fn()
           const { Worktree } = await import("../project/worktree")
@@ -247,6 +249,30 @@ export namespace SessionManager {
         unregisterRuntime(session.id)
       }
     }
+  }
+
+  export function assertExecutionContext(session: Info, phase: string): void {
+    const expected = session.workspace
+    if (!expected || expected.type !== "git_worktree") return
+
+    const actualWorkspace = ScopeContext.tryWorkspace()
+    if (actualWorkspace?.path === expected.path) return
+
+    const actualPath = actualWorkspace?.path ?? ScopeContext.tryScope()?.directory
+    log.error("session execution workspace mismatch", {
+      sessionID: session.id,
+      phase,
+      expected: expected.path,
+      actual: actualPath,
+      actualType: actualWorkspace?.type ?? "scope",
+    })
+    throw new Error(
+      [
+        `Session ${session.id} is bound to worktree ${expected.path},`,
+        `but ${phase} is running in ${actualPath ?? "no workspace context"}.`,
+        "Refusing to continue outside the session workspace.",
+      ].join(" "),
+    )
   }
 
   export function acquire(sessionID: string): AbortSignal | undefined {
@@ -299,9 +325,23 @@ export namespace SessionManager {
     })
 
     if (await SessionInbox.hasRunnableItem(sessionID)) {
-      const { SessionInvoke } = await import("./invoke")
-      await SessionInvoke.loop(sessionID)
+      scheduleWake(sessionID, "release")
     }
+  }
+
+  export async function wake(sessionID: string): Promise<void> {
+    if (isRunning(sessionID)) return
+    if (!(await SessionInbox.hasRunnableItem(sessionID))) return
+    const { SessionInvoke } = await import("./invoke")
+    await SessionInvoke.loop(sessionID)
+  }
+
+  export function scheduleWake(sessionID: string, reason: string): void {
+    setTimeout(() => {
+      void wake(sessionID).catch((error) => {
+        log.error("async session wake failed", { sessionID, reason, error })
+      })
+    }, 0)
   }
 
   export function setStatus(sessionID: string, status: StatusInfo): void {
@@ -400,21 +440,15 @@ export namespace SessionManager {
       return
     }
 
-    const process = async () => {
-      const { SessionInvoke } = await import("./invoke")
-      await SessionInvoke.loop(session.id)
-    }
-
     if (input.waitForProcessing === false) {
       log.info("mail queued (session idle), processing asynchronously", { sessionID: session.id })
-      void process().catch((error) => {
-        log.error("async inbox processing failed", { sessionID: session.id, error })
-      })
+      releaseIfIdle()
+      scheduleWake(session.id, "deliver")
       return
     }
 
     log.info("mail queued (session idle), processing", { sessionID: session.id })
-    await process()
+    await wake(session.id)
   }
 
   // --- Pending Reply ---
@@ -441,42 +475,44 @@ export namespace SessionManager {
 
   function emitStatus(runtime: SessionRuntime, status: StatusInfo): void {
     const payload = { sessionID: runtime.sessionID, status }
-    try {
-      Bus.publish(SessionEvent.Status, payload)
-      if (status.type === "idle") {
-        Bus.publish(SessionEvent.Idle, { sessionID: runtime.sessionID })
+    publishStatus(runtime.sessionID, SessionEvent.Status.type, payload, () => Bus.publish(SessionEvent.Status, payload))
+    if (status.type === "idle") {
+      const idlePayload = { sessionID: runtime.sessionID }
+      publishStatus(runtime.sessionID, SessionEvent.Idle.type, idlePayload, () =>
+        Bus.publish(SessionEvent.Idle, idlePayload),
+      )
+    }
+  }
+
+  function publishStatus(
+    sessionID: string,
+    type: string,
+    properties: Record<string, unknown>,
+    publish: () => Promise<void>,
+  ): void {
+    void publish().catch((e) => {
+      if (!(e instanceof Context.NotFound)) {
+        log.error("failed to publish session status event", { sessionID, type, error: e })
+        return
       }
-    } catch (e) {
-      if (!(e instanceof Context.NotFound)) throw e
-      void requireSession(runtime.sessionID)
+      void requireSession(sessionID)
         .then((session) => {
           const scope = session.scope as Scope
           GlobalBus.emit("event", {
             directory: scope.directory,
             payload: {
-              type: "session.status",
-              properties: payload,
+              type,
+              properties,
             },
           })
-          if (status.type === "idle") {
-            GlobalBus.emit("event", {
-              directory: scope.directory,
-              payload: {
-                type: "session.idle",
-                properties: { sessionID: runtime.sessionID },
-              },
-            })
-          }
         })
         .catch((err) => {
-          // Session was cleaned up before the async fallback ran — idle event dropped.
-          if (status.type === "idle") {
-            log.warn("emitStatus fallback: session already cleaned up, idle event dropped", {
-              sessionID: runtime.sessionID,
-              error: (err as Error)?.message ?? String(err),
-            })
-          }
+          log.warn("emitStatus fallback: session already cleaned up, event dropped", {
+            sessionID,
+            type,
+            error: (err as Error)?.message ?? String(err),
+          })
         })
-    }
+    })
   }
 }

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -21,6 +21,7 @@ import type { ToolDisplay } from "@ericsanchezok/synergy-plugin/tool"
 import { Log } from "@/util/log"
 import { TimeoutConfig } from "@/util/timeout-config"
 import { Session } from "."
+import { SessionManager } from "./manager"
 import type { Info } from "./types"
 import type { MessageV2 } from "./message-v2"
 import type { SessionProcessor } from "./processor"
@@ -1214,6 +1215,9 @@ export namespace ToolResolver {
 
               try {
                 toolTrace = await startToolTrace(runtimeInput, ctx, item.id, args as Record<string, unknown>)
+                if (runtimeInput.session) {
+                  SessionManager.assertExecutionContext(runtimeInput.session, `tool resolver:${item.id}`)
+                }
                 const workspace = ScopeContext.current.directory
                 const workspaceInfo = ScopeContext.current.workspace
                 const profileId = await Session.resolveEffectiveControlProfile({
@@ -1461,6 +1465,9 @@ export namespace ToolResolver {
 
                 try {
                   toolTrace = await startToolTrace(runtimeInput, ctx, key, args as Record<string, unknown>)
+                  if (runtimeInput.session) {
+                    SessionManager.assertExecutionContext(runtimeInput.session, `tool resolver:${key}`)
+                  }
                   const workspace = ScopeContext.current.directory
                   const workspaceInfo = ScopeContext.current.workspace
                   const profileId = await Session.resolveEffectiveControlProfile({

--- a/packages/synergy/src/tool/session-control.ts
+++ b/packages/synergy/src/tool/session-control.ts
@@ -9,8 +9,6 @@ import { Identifier } from "../id/id"
 import { Agent } from "../agent/agent"
 import { MessageV2 } from "../session/message-v2"
 import { SessionInteraction } from "../session/interaction"
-import { ScopeContext } from "../scope/context"
-import { Scope } from "../scope"
 import DESCRIPTION from "./session-control.txt"
 
 const Action = z.enum(["status", "compact", "abort", "question_reply", "question_reject", "permission_reply"])
@@ -55,15 +53,14 @@ export const SessionControlTool = Tool.define("session_control", {
       return handleStatus(sessionID)
     }
 
-    const withScope = <T>(fn: () => Promise<T>) =>
-      ScopeContext.provide({ scope: session.scope as Scope, workspace: session.workspace, fn })
+    const inSession = <T>(fn: () => Promise<T>) => SessionManager.run(sessionID, fn)
 
     switch (params.action) {
       case "compact": {
-        return withScope(() => handleCompact(sessionID))
+        return inSession(() => handleCompact(sessionID))
       }
       case "abort": {
-        return withScope(() => handleAbort(sessionID))
+        return inSession(() => handleAbort(sessionID))
       }
       case "question_reply": {
         if (!params.requestID) {
@@ -72,13 +69,13 @@ export const SessionControlTool = Tool.define("session_control", {
         if (!params.answers) {
           throw new Error("answers is required for question_reply")
         }
-        return withScope(() => handleQuestionReply(params.requestID!, params.answers!))
+        return inSession(() => handleQuestionReply(params.requestID!, params.answers!))
       }
       case "question_reject": {
         if (!params.requestID) {
           throw new Error("requestID is required for question_reject")
         }
-        return withScope(() => handleQuestionReject(params.requestID!))
+        return inSession(() => handleQuestionReject(params.requestID!))
       }
       case "permission_reply": {
         if (!params.requestID) {
@@ -87,7 +84,7 @@ export const SessionControlTool = Tool.define("session_control", {
         if (!params.reply) {
           throw new Error("reply is required for permission_reply")
         }
-        return withScope(() => handlePermissionReply(params.requestID!, params.reply!, params.message))
+        return inSession(() => handlePermissionReply(params.requestID!, params.reply!, params.message))
       }
     }
   },
@@ -199,7 +196,7 @@ async function handleCompact(sessionID: string) {
     text: "What did we do so far?",
   })
 
-  SessionInvoke.loop(sessionID).catch(() => {})
+  SessionManager.scheduleWake(sessionID, "session_control.compact")
 
   return {
     title: `Compacted ${sessionID}`,

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -32,21 +32,37 @@ describe("EnforcementGate path classification", () => {
     expect(primary.nonBypassable).toBe(false)
   })
 
-  test("read of original checkout in worktree is classified as bypassable file_external_read", async () => {
+  test("read of original checkout in worktree stays a bypassable external read", async () => {
     const gate = await EnforcementGate.create({
-      activeWorkspace: "/Users/test/synergy-control-profile",
+      activeWorkspace: "/Users/test/synergy/.synergy/worktrees/feature-x",
       workspaceType: "worktree",
+      originalCheckout: "/Users/test/synergy",
     })
 
-    // The original checkout is a sibling directory, not inside the
-    // active worktree workspace.
     const result = gate.classify("read", {
-      filePath: "/Users/test/synergy/src/index.ts",
+      filePath: "/Users/test/synergy/packages/synergy/src/index.ts",
     })
 
     const external = result.capabilities.find((c: any) => c.class === "file_external_read")!
     expect(external).toBeDefined()
     expect(external.nonBypassable).toBe(false)
+    expect(result.capabilities.some((c: any) => c.class === "protected_op")).toBe(false)
+  })
+
+  test("autonomous allows non-sensitive reads from the original checkout for worktree sessions", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy/.synergy/worktrees/feature-x",
+      workspaceType: "worktree",
+      originalCheckout: "/Users/test/synergy",
+      profileId: "autonomous",
+    })
+
+    const envelope = gate.evaluate("read", {
+      filePath: "/Users/test/synergy/packages/synergy/src/index.ts",
+    })
+
+    expect(envelope.decision).toBe("allow")
+    expect(envelope.capabilities.some((c: any) => c.class === "protected_op")).toBe(false)
   })
 
   test("protected home credential read carries secrets capability separately from file_external_read", async () => {
@@ -94,6 +110,25 @@ describe("EnforcementGate path classification", () => {
     })
 
     const external = result.capabilities.find((c: any) => c.class === "file_external_write")!
+    expect(external).toBeDefined()
+    expect(external.nonBypassable).toBe(true)
+  })
+
+  test("autonomous denies save_file writes into the original checkout for worktree sessions", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy/.synergy/worktrees/feature-x",
+      workspaceType: "worktree",
+      originalCheckout: "/Users/test/synergy",
+      profileId: "autonomous",
+    })
+
+    const envelope = gate.evaluate("save_file", {
+      filePath: "/Users/test/synergy/packages/ui/src/main.tsx",
+    })
+
+    expect(envelope.decision).toBe("deny")
+    expect(envelope.refusal?.matchedPermission).toBe("file_external_write")
+    const external = envelope.capabilities.find((c: any) => c.class === "file_external_write")!
     expect(external).toBeDefined()
     expect(external.nonBypassable).toBe(true)
   })

--- a/packages/synergy/test/session/inbox.test.ts
+++ b/packages/synergy/test/session/inbox.test.ts
@@ -6,6 +6,7 @@ import { Session } from "../../src/session"
 import { SessionInbox } from "../../src/session/inbox"
 import { SessionManager } from "../../src/session/manager"
 import { SessionInvoke } from "../../src/session/invoke"
+import { AgendaDelivery } from "../../src/agenda/delivery"
 import { tmpdir } from "../fixture/fixture"
 
 Log.init({ print: false })
@@ -264,6 +265,48 @@ describe("SessionInbox", () => {
           expect(finished).toBe(true)
         } finally {
           release.resolve()
+          ;(SessionInvoke.loop as any) = originalLoop
+          SessionManager.unregisterRuntime(session.id)
+        }
+      },
+    })
+  })
+
+  test("agenda delivery wakes through session manager and preserves agenda origin", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        const session = await Session.create({})
+        const originalLoop = SessionInvoke.loop
+        let loopSessionID: string | undefined
+        ;(SessionInvoke.loop as any) = mock(async (sessionID: string) => {
+          loopSessionID = sessionID
+        })
+
+        try {
+          await AgendaDelivery.deliver({
+            sessionID: "ses_agenda_run",
+            lastMessage: "agenda completed",
+            item: {
+              id: "ag_test",
+              status: "done",
+              title: "Daily check",
+              origin: { scope, sessionID: session.id },
+              triggers: [],
+              prompt: "check status",
+              silent: false,
+            } as any,
+          })
+
+          const items = await SessionInbox.list(session.id)
+          expect(loopSessionID).toBe(session.id)
+          expect(items).toHaveLength(1)
+          expect(items[0].mode).toBe("task")
+          expect(items[0].source.type).toBe("agenda")
+          expect(items[0].message?.origin).toEqual({ type: "agenda", sessionID: "ses_agenda_run" })
+        } finally {
           ;(SessionInvoke.loop as any) = originalLoop
           SessionManager.unregisterRuntime(session.id)
         }

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -18,6 +18,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { Identifier } from "../../src/id/id"
 import { Cortex } from "../../src/cortex/manager"
 import { Embedding } from "../../src/vector/embedding"
+import { Worktree } from "../../src/project/worktree"
 
 const sessionID = "ses_test"
 
@@ -191,6 +192,228 @@ async function createSessionWithUser(options?: { silent?: boolean }) {
   })
   return { session, user }
 }
+
+function withTimeout<T>(promise: Promise<T>, label: string, ms = 2_000): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    }),
+  ])
+}
+
+async function createWorktreeSessionWithUser(name: string) {
+  const session = await Session.create({})
+  const worktree = await Worktree.create({
+    sessionID: session.id,
+    name,
+    baseRef: "current",
+    bind: true,
+  })
+  const user = await Session.updateMessage({
+    id: Identifier.ascending("message"),
+    role: "user",
+    sessionID: session.id,
+    agent: "synergy",
+    model: { providerID: "test-provider", modelID: "test-model" },
+    time: { created: Date.now() },
+  })
+  await Session.updatePart({
+    id: Identifier.ascending("part"),
+    messageID: user.id,
+    sessionID: session.id,
+    type: "text",
+    text: "Run in the active worktree",
+  })
+  return { session, worktree, user }
+}
+
+async function removeWorktreeSession(sessionID: string, worktreeID: string | undefined) {
+  if (worktreeID) {
+    await Worktree.remove({ sessionID, target: worktreeID, force: true }).catch(() => undefined)
+  }
+  await Session.remove(sessionID).catch(() => undefined)
+}
+
+describe("SessionInvoke workspace execution context", () => {
+  test("direct loop restores the persisted worktree workspace without ambient scope", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+    let sessionID = ""
+    let worktreeID: string | undefined
+    let worktreePath = ""
+    let assistantPath: MessageV2.Assistant["path"] | undefined
+    let systemPrompt = ""
+    const restore = installBasicLoopMocks({
+      onProcess: async (input, assistant) => {
+        assistantPath = assistant.path
+        systemPrompt = input.system.join("\n")
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope,
+        fn: async () => {
+          const created = await createWorktreeSessionWithUser("loop-context")
+          sessionID = created.session.id
+          worktreeID = created.worktree.id
+          worktreePath = created.worktree.path
+        },
+      })
+
+      await SessionInvoke.loop.force(sessionID)
+
+      expect(assistantPath).toEqual({ cwd: worktreePath, root: worktreePath })
+      expect(systemPrompt).toContain(`Working directory: ${worktreePath}`)
+      expect(systemPrompt).toContain(`Workspace path: ${worktreePath}`)
+      expect(systemPrompt).toContain(`Original checkout: ${tmp.path}`)
+    } finally {
+      restore()
+      SessionManager.unregisterRuntime(sessionID)
+      if (sessionID) {
+        await ScopeContext.provide({
+          scope,
+          fn: () => removeWorktreeSession(sessionID, worktreeID),
+        })
+      }
+    }
+  })
+
+  test("asynchronous delivery wakes an idle worktree session inside the worktree", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+    let sessionID = ""
+    let worktreeID: string | undefined
+    let worktreePath = ""
+    let assistantPath: MessageV2.Assistant["path"] | undefined
+    const processed = Promise.withResolvers<void>()
+    const restore = installBasicLoopMocks({
+      onProcess: async (_input, assistant) => {
+        assistantPath = assistant.path
+        processed.resolve()
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope,
+        fn: async () => {
+          const session = await Session.create({})
+          const worktree = await Worktree.create({
+            sessionID: session.id,
+            name: "delivery-context",
+            baseRef: "current",
+            bind: true,
+          })
+          sessionID = session.id
+          worktreeID = worktree.id
+          worktreePath = worktree.path
+        },
+      })
+
+      await SessionManager.deliver({
+        target: sessionID,
+        waitForProcessing: false,
+        mail: {
+          type: "user",
+          agent: "synergy",
+          model: { providerID: "test-provider", modelID: "test-model" },
+          metadata: { source: "blueprint" },
+          parts: [
+            {
+              id: Identifier.ascending("part"),
+              sessionID,
+              messageID: Identifier.ascending("message"),
+              type: "text",
+              text: "Continue from Blueprint",
+            },
+          ],
+        },
+      })
+
+      await withTimeout(processed.promise, "worktree delivery wake")
+
+      expect(assistantPath).toEqual({ cwd: worktreePath, root: worktreePath })
+    } finally {
+      restore()
+      SessionManager.unregisterRuntime(sessionID)
+      if (sessionID) {
+        await ScopeContext.provide({
+          scope,
+          fn: () => removeWorktreeSession(sessionID, worktreeID),
+        })
+      }
+    }
+  })
+
+  test("release-scheduled wake re-enters the worktree workspace", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const scope = await tmp.scope()
+    let sessionID = ""
+    let worktreeID: string | undefined
+    let worktreePath = ""
+    let assistantPath: MessageV2.Assistant["path"] | undefined
+    const processed = Promise.withResolvers<void>()
+    const restore = installBasicLoopMocks({
+      onProcess: async (_input, assistant) => {
+        assistantPath = assistant.path
+        processed.resolve()
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope,
+        fn: async () => {
+          const session = await Session.create({})
+          const worktree = await Worktree.create({
+            sessionID: session.id,
+            name: "release-context",
+            baseRef: "current",
+            bind: true,
+          })
+          sessionID = session.id
+          worktreeID = worktree.id
+          worktreePath = worktree.path
+          await SessionInbox.enqueueMail({
+            sessionID,
+            mail: {
+              type: "user",
+              agent: "synergy",
+              model: { providerID: "test-provider", modelID: "test-model" },
+              parts: [
+                {
+                  id: Identifier.ascending("part"),
+                  sessionID,
+                  messageID: Identifier.ascending("message"),
+                  type: "text",
+                  text: "Queued at release",
+                },
+              ],
+            },
+          })
+        },
+      })
+
+      SessionManager.registerRuntime(sessionID)
+      SessionManager.acquire(sessionID)
+      await SessionManager.release(sessionID)
+      await withTimeout(processed.promise, "release wake")
+
+      expect(assistantPath).toEqual({ cwd: worktreePath, root: worktreePath })
+    } finally {
+      restore()
+      SessionManager.unregisterRuntime(sessionID)
+      if (sessionID) {
+        await ScopeContext.provide({
+          scope,
+          fn: () => removeWorktreeSession(sessionID, worktreeID),
+        })
+      }
+    }
+  })
+})
 
 describe("SessionInvoke.selectResultMessage", () => {
   test("selects the last assistant for the latest reply-required user turn", () => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,6 @@
     "generate:tailwind": "bun run script/tailwind.ts"
   },
   "devDependencies": {
-    "@happy-dom/global-registrator": "20.0.11",
     "@tailwindcss/vite": "catalog:",
     "@tsconfig/node22": "catalog:",
     "@types/bun": "catalog:",


### PR DESCRIPTION
## Summary
- Route public session loop/wake paths through `SessionManager.run()` so persisted worktree sessions always execute inside their bound workspace.
- Move idle wake ownership out of `SessionInbox` and into `SessionManager`, including deliver/release/session_control/automatic continuation paths.
- Fail closed when a worktree session is about to run or resolve tools outside its persisted workspace.
- Preserve the permission first principle that ordinary external reads, including original-checkout reads, are allowed while writes/modifications/execution remain gated.
- Document the control-profile and skill-root permission first principles in `AGENTS.md`.

## Verification
- `cd packages/synergy && bun test test/session/workspace.test.ts test/session/inbox.test.ts test/session/invoke.test.ts test/tool/workspace-boundary.test.ts test/tool/bash.test.ts test/enforcement/gate.test.ts test/session/continuation-kernel.test.ts test/session/blueprint-continuation.test.ts test/session/light-loop-continuation.test.ts test/lattice/policy.test.ts`
- `cd packages/synergy && bun test test/enforcement/gate.test.ts test/tool/workspace-boundary.test.ts test/tool/bash.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run deadcode`
- `bun run quality:quick`

Refs #454