### PR TITLE
fix(desktop): prevent orphan processes on Ctrl+C, surface server log on startup failure

### DIFF
--- a/packages/desktop/src/server-manager.ts
+++ b/packages/desktop/src/server-manager.ts
@@ -147,9 +147,12 @@ export class DesktopServerManager {
       return this.url
     } catch (error) {
       this.state = "failed"
-      this.lastError = error instanceof Error ? error.message : String(error)
+      const message = error instanceof Error ? error.message : String(error)
+      const logTail = await readLogTail(this.logFile)
+      const detail = logTail ? `${message}\n\nServer log tail:\n${logTail}` : message
+      this.lastError = detail
       await this.stop()
-      throw error
+      throw new Error(detail, { cause: error instanceof Error ? error : undefined })
     }
   }
 
@@ -222,4 +225,21 @@ function sourceSynergyRoot(): string | null {
     path.resolve(dirname, "../../../packages/synergy"),
   ]
   return candidates.find((candidate) => fs.existsSync(path.join(candidate, "src/index.ts"))) ?? null
+}
+
+async function readLogTail(logFile: string | null): Promise<string | null> {
+  if (!logFile) return null
+  try {
+    const stat = await fsp.stat(logFile)
+    if (stat.size === 0) return "(empty)"
+    const fd = await fsp.open(logFile, "r")
+    const maxBytes = 8192
+    const start = Math.max(0, stat.size - maxBytes)
+    const buf = Buffer.alloc(maxBytes)
+    const { bytesRead } = await fd.read(buf, 0, maxBytes, start)
+    await fd.close()
+    return buf.subarray(0, bytesRead).toString("utf-8")
+  } catch {
+    return null
+  }
 }

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -537,17 +537,29 @@ async function runSerial(processes: DevProcessSpec[]): Promise<number> {
 async function runParallel(plan: DevPlan): Promise<number> {
   await assertPreflight(plan)
   const children: ReturnType<typeof spawnDevProcess>[] = []
-  const cleanup = () => {
+  let exiting = false
+  const cleanup = async () => {
     for (const child of children) {
       if (child.exitCode === null) child.kill()
     }
+    // Wait for children to exit gracefully (max 3s), then force-kill stragglers.
+    const settle = Promise.allSettled(children.map((c) => c.exited))
+    const timeout = new Promise<void>((r) => setTimeout(r, 3000))
+    await Promise.race([settle, timeout])
+    for (const child of children) {
+      if (child.exitCode === null) child.kill("SIGKILL")
+    }
   }
-  process.once("SIGINT", () => {
-    cleanup()
+  process.once("SIGINT", async () => {
+    if (exiting) return
+    exiting = true
+    await cleanup()
     process.exit(130)
   })
-  process.once("SIGTERM", () => {
-    cleanup()
+  process.once("SIGTERM", async () => {
+    if (exiting) return
+    exiting = true
+    await cleanup()
     process.exit(143)
   })
   try {

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -571,10 +571,10 @@ async function runParallel(plan: DevPlan): Promise<number> {
     if (plan.openUrl) openExternal(plan.openUrl)
     if (children.length === 0) return 0
     const firstExit = await Promise.race(children.map((child) => child.exited))
-    cleanup()
+    await cleanup()
     return firstExit
   } catch (error) {
-    cleanup()
+    await cleanup()
     throw error
   }
 }


### PR DESCRIPTION
## Summary

- **Script dev.ts**: Fix the SIGINT/SIGTERM cleanup path to await child processes with a 3s grace period and SIGKILL fallback, preventing orphan Bun.spawn children (server + Vite app) from leaking on macOS
- **Desktop server-manager.ts**: Append the last 8 KB of the server log to error messages on startup failure, so users see *why* the server exited instead of just "fetch failed"

## Root cause

`bun dev web` / `bun dev desktop` ran `process.exit()` immediately after `child.kill()` inside the SIGINT handler. On macOS, the server child process often survived as an orphan, holding the runtime lock file and the default port (4096). Next Desktop launch then hit `ServerProcessLock.AlreadyRunningError` and displayed a blank error page.

## Changes

| File | Change |
|---|---|
| `script/dev.ts:537-564` | `cleanup()` is now async — awaits `c.exited` with 3s timeout, then `SIGKILL`; duplicate-signal guard via `exiting` flag |
| `packages/desktop/src/server-manager.ts:148-156` | Catch block reads last 8 KB of `server.log` and wraps in a new Error with the log tail |
| `packages/desktop/src/server-manager.ts:230-245` | New `readLogTail()` helper |

## Verification

- `oxlint` passes with 0 errors on both files

Closes #459