### PR TITLE
fix: reduce runtime memory retention (fixes #241)

### DIFF
--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -28,7 +28,8 @@ export namespace Cortex {
   const taskRuns: Map<string, Promise<void>> = new Map()
   const acquiredTasks = new Set<string>()
 
-  const CLEANUP_DELAY_MS = 20 * 60 * 1000
+  const PROMPT_COMPACT_DELAY_MS = 30 * 1000
+  const TASK_CLEANUP_DELAY_MS = 5 * 60 * 1000
   const EXTERNAL_TASK_RESULT_CHAR_LIMIT = 120_000
   const EXTERNAL_TASK_RESULT_HEAD_CHARS = 20_000
   const DEFAULT_SUBAGENT_BLOCKED_TOOLS = [
@@ -193,6 +194,7 @@ export namespace Cortex {
     }
 
     tasks.set(taskID, task)
+    SessionManager.registerChildRuntime(session.id)
 
     if (task.visibility !== "hidden") {
       Bus.publish(Event.TaskCreated, { task })
@@ -481,22 +483,20 @@ export namespace Cortex {
     setTimeout(() => {
       const task = tasks.get(taskID)
       if (task) {
-        task.prompt = ""
-        log.info("task prompt evicted", { taskID })
+        task.prompt = truncate(task.prompt, 4096)
+        task.progress = undefined
+        log.info("task compacted", { taskID })
       }
-    }, CLEANUP_DELAY_MS)
+    }, PROMPT_COMPACT_DELAY_MS)
 
-    setTimeout(
-      () => {
-        void (async () => {
-          tasks.delete(taskID)
-          acquiredTasks.delete(taskID)
-          SessionManager.unregisterRuntime(task.sessionID)
-          log.info("task cleaned up", { taskID })
-        })()
-      },
-      CLEANUP_DELAY_MS + 5 * 60 * 1000,
-    )
+    setTimeout(() => {
+      void (async () => {
+        tasks.delete(taskID)
+        acquiredTasks.delete(taskID)
+        SessionManager.unregisterRuntime(task.sessionID)
+        log.info("task cleaned up", { taskID })
+      })()
+    }, TASK_CLEANUP_DELAY_MS)
   }
 
   async function updateDagNode(task: CortexTypes.Task): Promise<void> {

--- a/packages/synergy/src/external-agent/processor.ts
+++ b/packages/synergy/src/external-agent/processor.ts
@@ -11,6 +11,7 @@ import { SessionToolInput } from "@/session/tool-input"
 
 export namespace ExternalAgentProcessor {
   const log = Log.create({ service: "external-agent.processor" })
+  const TOOL_OUTPUT_CHAR_LIMIT = 64_000
 
   function formatAgentLabel(agent: string) {
     return agent
@@ -139,7 +140,11 @@ export namespace ExternalAgentProcessor {
 
           case "tool_output": {
             const existing = toolOutputs.get(event.id) ?? ""
-            toolOutputs.set(event.id, existing + event.output)
+            const combined = existing + event.output
+            toolOutputs.set(
+              event.id,
+              combined.length > TOOL_OUTPUT_CHAR_LIMIT ? combined.slice(-TOOL_OUTPUT_CHAR_LIMIT) : combined,
+            )
             break
           }
 

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -57,6 +57,7 @@ export namespace SessionManager {
       onCancel(): void
     }[]
     lastActiveAt: number
+    isChild: boolean
   }
 
   const runtimes = new Map<string, SessionRuntime>()
@@ -100,7 +101,8 @@ export namespace SessionManager {
   }
 
   const IDLE_SWEEP_INTERVAL_MS = 5 * 60 * 1000
-  const IDLE_TTL_MS = 30 * 60 * 1000
+  const USER_IDLE_TTL_MS = 30 * 60 * 1000
+  const CHILD_SESSION_IDLE_TTL_MS = 5 * 60 * 1000
 
   const sweepTimer = setInterval(() => {
     const now = Date.now()
@@ -112,9 +114,10 @@ export namespace SessionManager {
           continue
         }
       }
-      if (now - runtime.lastActiveAt < IDLE_TTL_MS) continue
+      const ttl = runtime.isChild ? CHILD_SESSION_IDLE_TTL_MS : USER_IDLE_TTL_MS
+      if (now - runtime.lastActiveAt < ttl) continue
       runtimes.delete(sessionID)
-      log.info("swept idle runtime", { sessionID })
+      log.info("swept idle runtime", { sessionID, isChild: runtime.isChild })
     }
   }, IDLE_SWEEP_INTERVAL_MS)
   sweepTimer.unref()
@@ -198,9 +201,30 @@ export namespace SessionManager {
       status: { type: "idle" },
       waiters: [],
       lastActiveAt: Date.now(),
+      isChild: false,
     }
     runtimes.set(sessionID, runtime)
     log.info("registered runtime", { sessionID })
+    return runtime
+  }
+
+  export function registerChildRuntime(sessionID: string): SessionRuntime {
+    const existing = runtimes.get(sessionID)
+    if (existing) {
+      existing.isChild = true
+      existing.lastActiveAt = Date.now()
+      return existing
+    }
+
+    const runtime: SessionRuntime = {
+      sessionID,
+      status: { type: "idle" },
+      waiters: [],
+      lastActiveAt: Date.now(),
+      isChild: true,
+    }
+    runtimes.set(sessionID, runtime)
+    log.info("registered child runtime", { sessionID })
     return runtime
   }
 

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -477,6 +477,12 @@ export const LocalBashBackend = {
       aborted = true
       cleanupAllTimers()
       void kill()
+      setTimeout(() => {
+        if (!exited && regProc) {
+          regProc.exited = true
+          ProcessRegistry.markExited(regProc, -1, "SIGKILL")
+        }
+      }, 30_000)
     }
 
     ctx.abort.addEventListener("abort", abortHandler, { once: true })


### PR DESCRIPTION
## Summary
#241 identified Cortex task lifecycle, session runtime TTL, external-agent tool output, and orphaned bash process as the real memory retention sources beyond #150's snapshot/history fixes. This PR addresses the root causes.

## What changed
1. **Compact Cortex task state on terminal status** (`cortex/manager.ts`): truncate prompt to 4K and release progress immediately (30s delay) instead of 20 minutes. Reduce total task cleanup delay from 25 min → 5 min.
2. **Differentiate child session runtime TTL** (`session/manager.ts`): add `isChild` flag to `SessionRuntime`, `registerChildRuntime()`, and sweep child runtimes at 5 min instead of 30 min.
3. **Truncate external-agent tool output** (`external-agent/processor.ts`): cap buffered tool output at 64K chars, same limit used by native process registry.
4. **Bash abort watchdog** (`tool/bash/local.ts`): force-mark orphaned processes as exited after 30s grace period in `abortHandler()` when the child process exit event never arrives.

## Verification
- Lint: 0 warnings, 0 errors
- Format: passes prettier check
- All changes are focused lifecycle improvements with no public API surface changes