### PR TITLE
fix(frontend): preserve note scroll on metadata updates

### DIFF
--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -32,6 +32,7 @@ import {
   isActiveBlueprintLoopStatus,
   type BlueprintRunMode,
 } from "@/components/note/blueprint-run-session"
+import { getNoteSnapshotDelta } from "@/components/note/note-snapshot"
 import "./note-panel.css"
 
 type LoopStatus = BlueprintLoopInfo["status"]
@@ -1470,22 +1471,23 @@ function NoteEditor(props: { id: string; directory: string; onBack: () => void; 
   }
 
   function applySnapshot(snapshot: NoteInfo) {
+    const delta = getNoteSnapshotDelta(baseNote(), snapshot)
     const ed = editor()
     setBaseNote(snapshot)
-    setTitle(snapshot.title)
-    setTags(snapshot.tags ?? [])
+    if (delta.titleChanged) setTitle(snapshot.title)
+    if (delta.tagsChanged) setTags(snapshot.tags ?? [])
     setConflict(null)
     setDirty(false)
-    if (ed && !ed.isDestroyed) {
-      const { from } = ed.state.selection
-      ed.commands.setContent(snapshot.content as any, { emitUpdate: false })
-      const docSize = ed.state.doc.content.size
-      if (from > 0 && from < docSize) {
-        try {
-          ed.commands.setTextSelection(from)
-        } catch {
-          /* position may be invalid */
-        }
+    if (!delta.contentChanged || !ed || ed.isDestroyed) return
+
+    const { from } = ed.state.selection
+    ed.commands.setContent(snapshot.content as any, { emitUpdate: false })
+    const docSize = ed.state.doc.content.size
+    if (from > 0 && from < docSize) {
+      try {
+        ed.commands.setTextSelection(from)
+      } catch {
+        /* position may be invalid */
       }
     }
   }

--- a/packages/app/src/components/note/document-editor-core.tsx
+++ b/packages/app/src/components/note/document-editor-core.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, onCleanup, Show } from "solid-js"
+import { createSignal, onCleanup, onMount, Show } from "solid-js"
 import { Editor } from "@tiptap/core"
 import StarterKit from "@tiptap/starter-kit"
 import Placeholder from "@tiptap/extension-placeholder"
@@ -489,7 +489,7 @@ export function DocumentEditorCore(props: DocumentEditorCoreProps) {
   let bubbleRef!: HTMLDivElement
   const [editorInstance, setEditorInstance] = createSignal<Editor>()
 
-  createEffect(() => {
+  onMount(() => {
     const instance = new Editor({
       element: editorRef,
       extensions: createDocumentEditorExtensions({

--- a/packages/app/src/components/note/note-snapshot.test.ts
+++ b/packages/app/src/components/note/note-snapshot.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { getNoteSnapshotDelta } from "./note-snapshot"
+
+const content = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Keep my scroll position" }],
+    },
+  ],
+}
+
+describe("getNoteSnapshotDelta", () => {
+  test("treats metadata-only note updates as stable editor content", () => {
+    expect(
+      getNoteSnapshotDelta(
+        {
+          title: "Blueprint",
+          tags: ["draft"],
+          content,
+        },
+        {
+          title: "Blueprint",
+          tags: ["draft"],
+          content: structuredClone(content),
+        },
+      ),
+    ).toEqual({
+      contentChanged: false,
+      tagsChanged: false,
+      titleChanged: false,
+    })
+  })
+
+  test("detects title and tag changes without forcing an editor content reset", () => {
+    expect(
+      getNoteSnapshotDelta(
+        {
+          title: "Blueprint",
+          tags: ["draft"],
+          content,
+        },
+        {
+          title: "Renamed Blueprint",
+          tags: ["draft", "active"],
+          content,
+        },
+      ),
+    ).toEqual({
+      contentChanged: false,
+      tagsChanged: true,
+      titleChanged: true,
+    })
+  })
+
+  test("detects remote document content changes", () => {
+    expect(
+      getNoteSnapshotDelta(
+        {
+          title: "Blueprint",
+          tags: [],
+          content,
+        },
+        {
+          title: "Blueprint",
+          tags: [],
+          content: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Remote edit" }],
+              },
+            ],
+          },
+        },
+      ).contentChanged,
+    ).toBe(true)
+  })
+})

--- a/packages/app/src/components/note/note-snapshot.ts
+++ b/packages/app/src/components/note/note-snapshot.ts
@@ -1,0 +1,29 @@
+import type { NoteInfo } from "@ericsanchezok/synergy-sdk/client"
+import { isDeepEqual } from "remeda"
+
+type NoteSnapshotComparable = Pick<NoteInfo, "content" | "tags" | "title">
+
+export type NoteSnapshotDelta = {
+  contentChanged: boolean
+  tagsChanged: boolean
+  titleChanged: boolean
+}
+
+export function getNoteSnapshotDelta(
+  current: NoteSnapshotComparable | null | undefined,
+  snapshot: NoteSnapshotComparable,
+): NoteSnapshotDelta {
+  if (!current) {
+    return {
+      contentChanged: true,
+      tagsChanged: true,
+      titleChanged: true,
+    }
+  }
+
+  return {
+    contentChanged: !isDeepEqual(current.content, snapshot.content),
+    tagsChanged: !isDeepEqual(current.tags ?? [], snapshot.tags ?? []),
+    titleChanged: current.title !== snapshot.title,
+  }
+}


### PR DESCRIPTION
## What this PR for?
Fixes #442.

Metadata-only `note.updated` events from BlueprintLoop status changes, pin/global updates, or other note metadata writes could refresh the note resource and force the open Tiptap editor to reset its document content. That rebuilt the editor DOM and sent the reader back to the top of the note.

## Summary
- Add a note snapshot delta helper so metadata-only refreshes update note state without calling `setContent()`.
- Keep `DocumentEditorCore` editor construction mount-only, matching its initial-content contract.
- Cover metadata-only, title/tag-only, and real content-change cases with focused tests.

## Test
- [x] `bun test src/components/note/note-snapshot.test.ts src/components/note/blueprint-run-session.test.ts` from `packages/app`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run --cwd packages/app build`
- [x] `bun run quality:quick`

## Before/After
**Before:** metadata-only note refreshes could rebuild the editor and jump the note viewport to the top.
**After:** metadata refreshes update note metadata without resetting editor content or remounting the Tiptap editor.
