### PR TITLE
Restart-safe session state recovery

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+1580842cd4b7af1decf47ffc6af2375010f76a80:packages/synergy/test/observability/redaction.test.ts:curl-auth-header:36
+1580842cd4b7af1decf47ffc6af2375010f76a80:packages/synergy/test/observability/diagnostics.test.ts:curl-auth-header:83

--- a/docs/open-source-quality.md
+++ b/docs/open-source-quality.md
@@ -101,12 +101,12 @@ bun run package:check
 
 ## Workflow Validation
 
-The `workflow:check` script downloads actionlint and runs it against all workflow files in `.github/workflows/`, then runs zizmor for GitHub Actions security analysis.
+The `workflow:check` script uses an installed `actionlint` binary when available, otherwise downloads the pinned actionlint release, then runs zizmor for GitHub Actions security analysis.
 
 Run locally:
 
 ```bash
-bun run workflow:check      # requires network access
+bun run workflow:check      # install actionlint locally to avoid the actionlint download fallback
 ```
 
 ## Secret Scanning

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -1433,7 +1433,7 @@ function NoteEditor(props: {
   const directory = () => props.directory
 
   const [note, { refetch }] = createResource(
-    () => ({ id: props.id, dir: directory() }),
+    () => ({ id: props.id, dir: directory(), reconnect: globalSync.reconnectVersion() }),
     async ({ id, dir }) => {
       if (!dir) return null
       const result = await sdk.client.note.get({ id, directory: dir })

--- a/packages/synergy/src/blueprint/loop-store.ts
+++ b/packages/synergy/src/blueprint/loop-store.ts
@@ -25,7 +25,7 @@ function isValidTransition(from: LoopStatus, to: LoopStatus): boolean {
   return TRANSITIONS[from]?.includes(to) ?? false
 }
 
-function isActiveLoopStatus(status: LoopStatus) {
+export function isActiveLoopStatus(status: LoopStatus) {
   return status === "armed" || status === "running" || status === "waiting" || status === "auditing"
 }
 

--- a/packages/synergy/src/blueprint/service.ts
+++ b/packages/synergy/src/blueprint/service.ts
@@ -188,12 +188,11 @@ If the task is blocked beyond recovery, call blueprint_loop_finish({ loopID: "${
   export async function start(scopeID: string, loopID: string, userPrompt?: string): Promise<Info> {
     const normalized = normalizeStartUserPrompt(userPrompt)
     const before = await BlueprintLoopStore.get(scopeID, loopID)
-    await SessionWorkflowService.prepareBlueprintLoopBinding(before.sessionID, before.source)
+    await bindSessionToLoop(before.sessionID, loopID, "execution")
     const loop = await BlueprintLoopStore.updateStatus(scopeID, loopID, {
       status: "running",
       userPrompt: normalized ?? null,
     })
-    await bindSessionToLoop(before.sessionID, loopID, "execution")
     void deliverFirstPrompt(before.sessionID, before, normalized).catch((err) => {
       log.error("failed to deliver BlueprintLoop start prompt", { loopID, error: err })
       BlueprintLoopStore.updateStatus(scopeID, loopID, {

--- a/packages/synergy/src/scope/runtime.ts
+++ b/packages/synergy/src/scope/runtime.ts
@@ -7,6 +7,7 @@ import { FileWatcher } from "@/file/watcher"
 import { LSP } from "@/lsp"
 import { Plugin } from "@/plugin"
 import { Vcs } from "@/project/vcs"
+import { SessionRecovery } from "@/session/recovery"
 import { Scope } from "."
 import { ScopeContext } from "./context"
 import { ScopedState } from "./scoped-state"
@@ -25,6 +26,9 @@ export namespace ScopeRuntime {
           fn: async () => {
             log.info("starting", { scopeID: scope.id, type: scope.type, directory: scope.directory })
             await Plugin.init()
+            await SessionRecovery.reconcileRuntimeState({ scopeID: scope.id, apply: true }).catch((error) => {
+              log.warn("session runtime recovery failed", { scopeID: scope.id, error })
+            })
             Format.init()
             await LSP.init()
             FileWatcher.init()

--- a/packages/synergy/src/server/global-runtime.ts
+++ b/packages/synergy/src/server/global-runtime.ts
@@ -11,6 +11,7 @@ import { FileWatcher } from "@/file/watcher"
 import { Scope } from "@/scope"
 import { ScopeContext } from "@/scope/context"
 import { Log } from "@/util/log"
+import { SessionRecovery } from "@/session/recovery"
 
 export namespace GlobalRuntime {
   const log = Log.create({ service: "global-runtime" })
@@ -23,6 +24,9 @@ export namespace GlobalRuntime {
         fn: async () => {
           log.info("starting")
           await Plugin.init()
+          await SessionRecovery.reconcileRuntimeState({ scopeID: Scope.home().id, apply: true }).catch((error) => {
+            log.warn("session runtime recovery failed", { scopeID: Scope.home().id, error })
+          })
           await startChannels()
           await HolosRuntime.init()
           FileWatcher.init()

--- a/packages/synergy/src/server/runtime.ts
+++ b/packages/synergy/src/server/runtime.ts
@@ -15,6 +15,7 @@ import { StartupReporter } from "../cli/startup-reporter"
 import { Flag } from "../flag/flag"
 import { GlobalRuntime } from "./global-runtime"
 import { Observability } from "../observability"
+import { Session } from "../session"
 
 const log = Log.create({ service: "server-runtime" })
 
@@ -350,6 +351,12 @@ function registerShutdown(
       phase = "kill running processes"
       await Observability.emit("shutdown.phase", { data: { phase } })
       await ProcessRegistry.killAllRunning()
+
+      phase = "flush session parts"
+      await Observability.emit("shutdown.phase", { data: { phase } })
+      await Session.flushPartWrites().catch((error) => {
+        log.warn("failed to flush session part writes", { error })
+      })
 
       phase = "stop global runtime"
       await Observability.emit("shutdown.phase", { data: { phase } })

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -453,6 +453,16 @@ export namespace SessionManager {
       }
       result[runtime.sessionID] = runtime.status
     }
+    if (scopeID) {
+      const { SessionRecovery } = await import("./recovery")
+      const recovered = await SessionRecovery.recoverableStatuses(scopeID).catch((error) => {
+        log.warn("failed to resolve recoverable session statuses", { scopeID, error })
+        return {}
+      })
+      for (const [sessionID, status] of Object.entries(recovered)) {
+        result[sessionID] ??= status
+      }
+    }
     return result
   }
 

--- a/packages/synergy/src/session/progress.ts
+++ b/packages/synergy/src/session/progress.ts
@@ -46,6 +46,17 @@ export namespace SessionProgress {
   }
 
   /**
+   * Resolve whether the given session still has a pending reply by loading its
+   * messages and delegating to {@link pendingReply}. Shared by session recovery
+   * and session working resolution.
+   */
+  export async function pendingReplyFor(input: { scopeID: string; sessionID: string }): Promise<boolean> {
+    const messages = await MessageV2.filterCompacted(MessageV2.stream(input)).catch(() => [] as MessageV2.WithParts[])
+    messages.sort((a, b) => a.info.id.localeCompare(b.info.id))
+    return pendingReply(messages)
+  }
+
+  /**
    * Determine whether the root message R still needs a model call.
    * Returns true if there exists a user message U with U.rootID === R.id
    * (or U itself if root) that does NOT have a terminal assistant after it.

--- a/packages/synergy/src/session/recovery.ts
+++ b/packages/synergy/src/session/recovery.ts
@@ -6,7 +6,13 @@ import { Storage } from "@/storage/storage"
 import { StoragePath } from "@/storage/path"
 import { SessionEndpoint } from "./endpoint"
 import { SessionNav, type ScopeNavIndex } from "./nav"
-import type { Info } from "./types"
+import type { Info, StatusInfo } from "./types"
+import { MessageV2 } from "./message-v2"
+import { SessionProgress } from "./progress"
+import { Session } from "./index"
+import { BlueprintLoopStore } from "../blueprint/loop-store"
+import type { Info as BlueprintLoopInfo } from "../blueprint/types"
+import { NoteStore } from "../note"
 
 export namespace SessionRecovery {
   export interface Location {
@@ -38,6 +44,350 @@ export namespace SessionRecovery {
     scanned: number
     repaired: number
     entries: Array<{ sessionID: string; scopeID: string; action: string }>
+  }
+
+  export interface RuntimeReconcileReport {
+    scopes: string[]
+    sessionsScanned: number
+    loopsScanned: number
+    changed: number
+    entries: Array<{ scopeID: string; sessionID?: string; noteID?: string; loopID?: string; action: string }>
+  }
+
+  const ACTIVE_LOOP_STATUSES = new Set<BlueprintLoopInfo["status"]>(["armed", "running", "waiting", "auditing"])
+  const TERMINAL_LOOP_STATUSES = new Set<BlueprintLoopInfo["status"]>(["completed", "failed", "cancelled"])
+
+  function isActiveLoop(loop: BlueprintLoopInfo | undefined) {
+    return !!loop && ACTIVE_LOOP_STATUSES.has(loop.status)
+  }
+
+  function isTerminalLoop(loop: BlueprintLoopInfo | undefined) {
+    return !!loop && TERMINAL_LOOP_STATUSES.has(loop.status)
+  }
+
+  function isWorkflowRecoveryCandidate(session: Info) {
+    return session.workflow?.kind === "lightloop" || session.workflow?.kind === "lattice"
+  }
+
+  function isSessionRecoveryCandidate(session: Info) {
+    if (session.time.archived) return false
+    return session.pendingReply === true || !!session.blueprint?.loopID || isWorkflowRecoveryCandidate(session)
+  }
+
+  async function scopeIDsForRuntimeRecovery(scopeID?: string): Promise<string[]> {
+    if (scopeID) return [scopeID]
+    const ids = new Set<string>()
+    for (const id of await Storage.scan(["sessions"]).catch(() => [])) ids.add(id)
+    for (const id of await Storage.scan(["blueprint_loops"]).catch(() => [])) ids.add(id)
+    return [...ids].sort()
+  }
+
+  async function sessionInfos(scopeID: string): Promise<Info[]> {
+    const sid = Identifier.asScopeID(scopeID)
+    const ids = await Storage.scan(StoragePath.sessionsRoot(sid)).catch(() => [])
+    if (ids.length === 0) return []
+    const keys = ids.map((id) => StoragePath.sessionInfo(sid, Identifier.asSessionID(id)))
+    const results = await Storage.readMany<Info>(keys)
+    return results.filter((item): item is Info => !!item && !!item.scope)
+  }
+
+  async function pendingReplyFor(scopeID: string, sessionID: string): Promise<boolean> {
+    const messages = await MessageV2.filterCompacted(MessageV2.stream({ scopeID, sessionID }))
+    messages.sort((a, b) => a.info.id.localeCompare(b.info.id))
+    return SessionProgress.pendingReply(messages)
+  }
+
+  function reportChange(
+    report: RuntimeReconcileReport,
+    input: { scopeID: string; sessionID?: string; noteID?: string; loopID?: string; action: string },
+  ) {
+    report.changed++
+    report.entries.push(input)
+  }
+
+  async function reconcilePendingReply(input: {
+    scopeID: string
+    session: Info
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    if (!input.session.pendingReply) return
+    const pendingReply = await pendingReplyFor(input.scopeID, input.session.id).catch(() => true)
+    if (pendingReply) return
+
+    if (input.apply) {
+      await Session.update(input.session.id, (draft) => {
+        draft.pendingReply = undefined
+      })
+    }
+    reportChange(input.report, {
+      scopeID: input.scopeID,
+      sessionID: input.session.id,
+      action: "pending_reply_cleared",
+    })
+  }
+
+  async function reconcileNoteActiveLoop(input: {
+    scopeID: string
+    loop: BlueprintLoopInfo
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    const note = await NoteStore.getAny(input.scopeID, input.loop.noteID).catch(() => undefined)
+    if (!note || note.kind !== "blueprint") return
+    if (note.blueprint?.activeLoopID === input.loop.id) return
+
+    if (input.apply) {
+      await NoteStore.updateAny(input.scopeID, input.loop.noteID, {
+        blueprint: { activeLoopID: input.loop.id },
+      })
+    }
+    reportChange(input.report, {
+      scopeID: input.scopeID,
+      loopID: input.loop.id,
+      action: "note_active_loop_restored",
+    })
+  }
+
+  async function clearNoteActiveLoop(input: {
+    scopeID: string
+    loop: BlueprintLoopInfo
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    const note = await NoteStore.getAny(input.scopeID, input.loop.noteID).catch(() => undefined)
+    if (!note || note.kind !== "blueprint" || note.blueprint?.activeLoopID !== input.loop.id) return
+
+    if (input.apply) {
+      await NoteStore.updateAny(input.scopeID, input.loop.noteID, {
+        blueprint: { activeLoopID: null },
+      })
+    }
+    reportChange(input.report, {
+      scopeID: input.scopeID,
+      loopID: input.loop.id,
+      action: "note_terminal_loop_cleared",
+    })
+  }
+
+  async function ensureSessionLoopBinding(input: {
+    scopeID: string
+    sessionID: string | undefined
+    loopID: string
+    loopRole: "execution" | "audit"
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    if (!input.sessionID) return
+    const session = await Storage.read<Info>(
+      StoragePath.sessionInfo(Identifier.asScopeID(input.scopeID), Identifier.asSessionID(input.sessionID)),
+    ).catch(() => undefined)
+    if (!session || session.time.archived) return
+    if (session.blueprint?.loopID === input.loopID && session.blueprint?.loopRole === input.loopRole) return
+
+    if (input.apply) {
+      await Session.update(input.sessionID, (draft) => {
+        draft.blueprint = { ...draft.blueprint, loopID: input.loopID, loopRole: input.loopRole }
+      })
+    }
+    reportChange(input.report, {
+      scopeID: input.scopeID,
+      sessionID: input.sessionID,
+      loopID: input.loopID,
+      action: `session_${input.loopRole}_loop_restored`,
+    })
+  }
+
+  async function clearSessionLoopBinding(input: {
+    scopeID: string
+    sessionID: string | undefined
+    loopID: string
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    if (!input.sessionID) return
+    const session = await Storage.read<Info>(
+      StoragePath.sessionInfo(Identifier.asScopeID(input.scopeID), Identifier.asSessionID(input.sessionID)),
+    ).catch(() => undefined)
+    if (!session || session.blueprint?.loopID !== input.loopID) return
+
+    if (input.apply) {
+      await Session.update(input.sessionID, (draft) => {
+        draft.blueprint = { ...draft.blueprint, loopID: undefined, loopRole: undefined }
+      })
+    }
+    reportChange(input.report, {
+      scopeID: input.scopeID,
+      sessionID: input.sessionID,
+      loopID: input.loopID,
+      action: "session_terminal_loop_cleared",
+    })
+  }
+
+  async function reconcileSessionBlueprintReference(input: {
+    scopeID: string
+    session: Info
+    loops: Map<string, BlueprintLoopInfo>
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    const loopID = input.session.blueprint?.loopID
+    if (!loopID) return
+    const loop = input.loops.get(loopID)
+    if (isActiveLoop(loop)) return
+
+    if (input.apply) {
+      await Session.update(input.session.id, (draft) => {
+        draft.blueprint = { ...draft.blueprint, loopID: undefined, loopRole: undefined }
+      })
+    }
+    reportChange(input.report, {
+      scopeID: input.scopeID,
+      sessionID: input.session.id,
+      loopID,
+      action: loop ? "session_inactive_loop_cleared" : "session_missing_loop_cleared",
+    })
+  }
+
+  async function reconcileNoteBlueprintReferences(input: {
+    scopeID: string
+    loops: Map<string, BlueprintLoopInfo>
+    apply: boolean
+    report: RuntimeReconcileReport
+  }) {
+    const notes = await NoteStore.list(input.scopeID, "all").catch(() => [])
+    for (const note of notes) {
+      if (note.kind !== "blueprint") continue
+      const loopID = note.blueprint?.activeLoopID
+      if (!loopID) continue
+      const loop = input.loops.get(loopID)
+      if (isActiveLoop(loop)) continue
+
+      if (input.apply) {
+        await NoteStore.updateAny(input.scopeID, note.id, {
+          blueprint: { activeLoopID: null },
+        })
+      }
+      reportChange(input.report, {
+        scopeID: input.scopeID,
+        noteID: note.id,
+        loopID,
+        action: loop ? "note_inactive_loop_cleared" : "note_missing_loop_cleared",
+      })
+    }
+  }
+
+  async function reconcileRuntimeScope(input: { scopeID: string; apply: boolean; report: RuntimeReconcileReport }) {
+    const [sessions, loops] = await Promise.all([
+      sessionInfos(input.scopeID),
+      BlueprintLoopStore.list(input.scopeID).catch(() => [] as BlueprintLoopInfo[]),
+    ])
+    input.report.sessionsScanned += sessions.length
+    input.report.loopsScanned += loops.length
+
+    const loopsByID = new Map(loops.map((loop) => [loop.id, loop]))
+    const sessionsByID = new Map(sessions.map((session) => [session.id, session]))
+    const sessionCandidates = new Map<string, Info>()
+    for (const session of sessions) {
+      if (isSessionRecoveryCandidate(session)) sessionCandidates.set(session.id, session)
+    }
+
+    for (const loop of loops) {
+      if (isActiveLoop(loop)) {
+        await reconcileNoteActiveLoop({ ...input, loop })
+        await ensureSessionLoopBinding({
+          ...input,
+          sessionID: loop.sessionID,
+          loopID: loop.id,
+          loopRole: "execution",
+        })
+        if (loop.status === "auditing") {
+          await ensureSessionLoopBinding({
+            ...input,
+            sessionID: loop.auditSessionID,
+            loopID: loop.id,
+            loopRole: "audit",
+          })
+        }
+      } else if (isTerminalLoop(loop)) {
+        await clearNoteActiveLoop({ ...input, loop })
+        await clearSessionLoopBinding({ ...input, sessionID: loop.sessionID, loopID: loop.id })
+        await clearSessionLoopBinding({ ...input, sessionID: loop.auditSessionID, loopID: loop.id })
+      }
+      const execution = sessionsByID.get(loop.sessionID)
+      if (execution) sessionCandidates.set(execution.id, execution)
+      if (loop.auditSessionID) {
+        const audit = sessionsByID.get(loop.auditSessionID)
+        if (audit) sessionCandidates.set(audit.id, audit)
+      }
+    }
+
+    for (const session of sessionCandidates.values()) {
+      await reconcilePendingReply({ ...input, session })
+      await reconcileSessionBlueprintReference({ ...input, session, loops: loopsByID })
+    }
+    await reconcileNoteBlueprintReferences({ ...input, loops: loopsByID })
+  }
+
+  export async function reconcileRuntimeState(
+    input: {
+      scopeID?: string
+      apply?: boolean
+    } = {},
+  ): Promise<RuntimeReconcileReport> {
+    const report: RuntimeReconcileReport = {
+      scopes: await scopeIDsForRuntimeRecovery(input.scopeID),
+      sessionsScanned: 0,
+      loopsScanned: 0,
+      changed: 0,
+      entries: [],
+    }
+    for (const scopeID of report.scopes) {
+      await reconcileRuntimeScope({ scopeID, apply: input.apply === true, report }).catch((error) => {
+        report.entries.push({ scopeID, action: `scope_reconcile_failed:${String(error)}` })
+      })
+    }
+    return report
+  }
+
+  export async function recoverableStatuses(scopeID: string): Promise<Record<string, StatusInfo>> {
+    const { resolve, toStatus } = await import("./working")
+    const [sessions, loops] = await Promise.all([
+      sessionInfos(scopeID),
+      BlueprintLoopStore.list(scopeID).catch(() => [] as BlueprintLoopInfo[]),
+    ])
+    const sessionsByID = new Map(sessions.map((session) => [session.id, session]))
+    const candidates = new Map<string, Info>()
+    const activeLoopSessionIDs = new Set<string>()
+    for (const session of sessions) {
+      if (isSessionRecoveryCandidate(session)) candidates.set(session.id, session)
+    }
+    for (const loop of loops) {
+      if (!isActiveLoop(loop)) continue
+      const execution = sessionsByID.get(loop.sessionID)
+      if (execution) {
+        candidates.set(execution.id, execution)
+        activeLoopSessionIDs.add(execution.id)
+      }
+      if (loop.auditSessionID) {
+        const audit = sessionsByID.get(loop.auditSessionID)
+        if (audit) {
+          candidates.set(audit.id, audit)
+          activeLoopSessionIDs.add(audit.id)
+        }
+      }
+    }
+
+    const result: Record<string, StatusInfo> = {}
+    for (const session of candidates.values()) {
+      const working = await resolve(session.id).catch(() => undefined)
+      if (working) {
+        result[session.id] = toStatus(working)
+      } else if (activeLoopSessionIDs.has(session.id)) {
+        result[session.id] = { type: "recovering", description: "BlueprintLoop interrupted" }
+      }
+    }
+    return result
   }
 
   export async function resolve(input: { sessionID: string; scopeID?: string }): Promise<Location> {

--- a/packages/synergy/src/session/recovery.ts
+++ b/packages/synergy/src/session/recovery.ts
@@ -7,10 +7,9 @@ import { StoragePath } from "@/storage/path"
 import { SessionEndpoint } from "./endpoint"
 import { SessionNav, type ScopeNavIndex } from "./nav"
 import type { Info, StatusInfo } from "./types"
-import { MessageV2 } from "./message-v2"
 import { SessionProgress } from "./progress"
 import { Session } from "./index"
-import { BlueprintLoopStore } from "../blueprint/loop-store"
+import { BlueprintLoopStore, isActiveLoopStatus } from "../blueprint/loop-store"
 import type { Info as BlueprintLoopInfo } from "../blueprint/types"
 import { NoteStore } from "../note"
 
@@ -54,11 +53,10 @@ export namespace SessionRecovery {
     entries: Array<{ scopeID: string; sessionID?: string; noteID?: string; loopID?: string; action: string }>
   }
 
-  const ACTIVE_LOOP_STATUSES = new Set<BlueprintLoopInfo["status"]>(["armed", "running", "waiting", "auditing"])
   const TERMINAL_LOOP_STATUSES = new Set<BlueprintLoopInfo["status"]>(["completed", "failed", "cancelled"])
 
   function isActiveLoop(loop: BlueprintLoopInfo | undefined) {
-    return !!loop && ACTIVE_LOOP_STATUSES.has(loop.status)
+    return !!loop && isActiveLoopStatus(loop.status)
   }
 
   function isTerminalLoop(loop: BlueprintLoopInfo | undefined) {
@@ -91,12 +89,6 @@ export namespace SessionRecovery {
     return results.filter((item): item is Info => !!item && !!item.scope)
   }
 
-  async function pendingReplyFor(scopeID: string, sessionID: string): Promise<boolean> {
-    const messages = await MessageV2.filterCompacted(MessageV2.stream({ scopeID, sessionID }))
-    messages.sort((a, b) => a.info.id.localeCompare(b.info.id))
-    return SessionProgress.pendingReply(messages)
-  }
-
   function reportChange(
     report: RuntimeReconcileReport,
     input: { scopeID: string; sessionID?: string; noteID?: string; loopID?: string; action: string },
@@ -112,7 +104,10 @@ export namespace SessionRecovery {
     report: RuntimeReconcileReport
   }) {
     if (!input.session.pendingReply) return
-    const pendingReply = await pendingReplyFor(input.scopeID, input.session.id).catch(() => true)
+    const pendingReply = await SessionProgress.pendingReplyFor({
+      scopeID: input.scopeID,
+      sessionID: input.session.id,
+    }).catch(() => true)
     if (pendingReply) return
 
     if (input.apply) {

--- a/packages/synergy/src/session/working.ts
+++ b/packages/synergy/src/session/working.ts
@@ -7,12 +7,10 @@ import { StoragePath } from "@/storage/path"
 import { Identifier } from "@/id/id"
 import { Scope } from "@/scope"
 import { SessionProgress } from "./progress"
-import { BlueprintLoopStore } from "../blueprint/loop-store"
+import { isActiveLoopStatus, BlueprintLoopStore } from "../blueprint/loop-store"
 import { LatticeStore } from "../lattice/store"
 
 const log = Log.create({ service: "session.working" })
-
-const ACTIVE_BLUEPRINT_LOOP_STATUSES = new Set(["armed", "running", "waiting", "auditing"])
 
 export async function resolve(sessionID: string): Promise<WorkingInfo | undefined> {
   const runtime = SessionManager.getRuntime(sessionID)
@@ -49,7 +47,7 @@ export async function resolve(sessionID: string): Promise<WorkingInfo | undefine
     break
   }
 
-  if (session.pendingReply && (await pendingReplyFor(scopeID, sessionID))) {
+  if (session.pendingReply && (await SessionProgress.pendingReplyFor({ scopeID, sessionID }))) {
     log.info("detected recovering session (pending reply)", { sessionID })
     return { status: "recovering" }
   }
@@ -70,13 +68,7 @@ async function hasActiveBlueprintLoop(input: { session: Info; scopeID: Identifie
   const loopID = input.session.blueprint?.loopID
   if (!loopID) return false
   const loop = await BlueprintLoopStore.get(input.scopeID, loopID).catch(() => undefined)
-  return !!loop && ACTIVE_BLUEPRINT_LOOP_STATUSES.has(loop.status)
-}
-
-async function pendingReplyFor(scopeID: string, sessionID: string): Promise<boolean> {
-  const messages = await MessageV2.filterCompacted(MessageV2.stream({ scopeID, sessionID })).catch(() => [])
-  messages.sort((a, b) => a.info.id.localeCompare(b.info.id))
-  return SessionProgress.pendingReply(messages)
+  return !!loop && isActiveLoopStatus(loop.status)
 }
 
 export function toStatus(working: WorkingInfo): StatusInfo {

--- a/packages/synergy/src/session/working.ts
+++ b/packages/synergy/src/session/working.ts
@@ -1,13 +1,18 @@
 import { Log } from "@/util/log"
 import { SessionManager } from "./manager"
-import type { StatusInfo, WorkingInfo } from "./types"
+import type { Info, StatusInfo, WorkingInfo } from "./types"
 import { MessageV2 } from "./message-v2"
 import { Storage } from "@/storage/storage"
 import { StoragePath } from "@/storage/path"
 import { Identifier } from "@/id/id"
 import { Scope } from "@/scope"
+import { SessionProgress } from "./progress"
+import { BlueprintLoopStore } from "../blueprint/loop-store"
+import { LatticeStore } from "../lattice/store"
 
 const log = Log.create({ service: "session.working" })
+
+const ACTIVE_BLUEPRINT_LOOP_STATUSES = new Set(["armed", "running", "waiting", "auditing"])
 
 export async function resolve(sessionID: string): Promise<WorkingInfo | undefined> {
   const runtime = SessionManager.getRuntime(sessionID)
@@ -20,9 +25,19 @@ export async function resolve(sessionID: string): Promise<WorkingInfo | undefine
   if (!session) return undefined
   const scopeID = Identifier.asScopeID((session.scope as Scope).id)
   const sid = Identifier.asSessionID(sessionID)
+
+  if (await hasActiveWorkflow({ session, scopeID })) {
+    log.info("detected recovering session (workflow)", { sessionID, workflow: session.workflow?.kind })
+    return { status: "recovering" }
+  }
+
+  if (await hasActiveBlueprintLoop({ session, scopeID })) {
+    log.info("detected recovering session (blueprint loop)", { sessionID, loopID: session.blueprint?.loopID })
+    return { status: "recovering" }
+  }
+
   const messageIDs = await Storage.scan(StoragePath.sessionMessagesRoot(scopeID, sid)).catch(() => [] as string[])
-  for (let i = messageIDs.length - 1; i >= 0; i--) {
-    const mid = messageIDs[i]
+  for (const mid of messageIDs.sort().reverse()) {
     const info = await Storage.read<MessageV2.Info>(
       StoragePath.messageInfo(scopeID, sid, mid as Identifier.MessageID),
     ).catch(() => undefined)
@@ -33,7 +48,35 @@ export async function resolve(sessionID: string): Promise<WorkingInfo | undefine
     }
     break
   }
+
+  if (session.pendingReply && (await pendingReplyFor(scopeID, sessionID))) {
+    log.info("detected recovering session (pending reply)", { sessionID })
+    return { status: "recovering" }
+  }
+
   return undefined
+}
+
+async function hasActiveWorkflow(input: { session: Info; scopeID: Identifier.ScopeID }): Promise<boolean> {
+  const workflow = input.session.workflow
+  if (!workflow) return false
+  if (workflow.kind === "lightloop") return true
+  if (workflow.kind !== "lattice") return false
+  const run = await LatticeStore.getOrUndefined(input.scopeID, input.session.id).catch(() => undefined)
+  return run?.status === "active" || run?.status === "paused"
+}
+
+async function hasActiveBlueprintLoop(input: { session: Info; scopeID: Identifier.ScopeID }): Promise<boolean> {
+  const loopID = input.session.blueprint?.loopID
+  if (!loopID) return false
+  const loop = await BlueprintLoopStore.get(input.scopeID, loopID).catch(() => undefined)
+  return !!loop && ACTIVE_BLUEPRINT_LOOP_STATUSES.has(loop.status)
+}
+
+async function pendingReplyFor(scopeID: string, sessionID: string): Promise<boolean> {
+  const messages = await MessageV2.filterCompacted(MessageV2.stream({ scopeID, sessionID })).catch(() => [])
+  messages.sort((a, b) => a.info.id.localeCompare(b.info.id))
+  return SessionProgress.pendingReply(messages)
 }
 
 export function toStatus(working: WorkingInfo): StatusInfo {

--- a/packages/synergy/test/session/recovery.test.ts
+++ b/packages/synergy/test/session/recovery.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test"
+import { BlueprintLoopStore } from "../../src/blueprint/loop-store"
+import { Identifier } from "../../src/id/id"
+import { LatticeStore } from "../../src/lattice/store"
+import { NoteStore } from "../../src/note"
+import { ScopeContext } from "../../src/scope/context"
+import { Session } from "../../src/session"
+import { SessionManager } from "../../src/session/manager"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionRecovery } from "../../src/session/recovery"
+import * as SessionWorking from "../../src/session/working"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function assertExists<T>(value: T | undefined): asserts value is T {
+  if (value === undefined) throw new Error("expected defined value")
+}
+
+async function createPendingUserMessage(sessionID: string) {
+  return Session.updateMessage({
+    id: Identifier.ascending("message"),
+    sessionID,
+    role: "user",
+    agent: "test",
+    model: { providerID: "test-provider", modelID: "test-model" },
+    time: { created: Date.now() },
+  })
+}
+
+async function createIncompleteAssistant(sessionID: string) {
+  const user = await createPendingUserMessage(sessionID)
+  return Session.updateMessage({
+    id: Identifier.ascending("message"),
+    sessionID,
+    role: "assistant",
+    parentID: user.id,
+    time: { created: Date.now() },
+    modelID: "test-model",
+    providerID: "test-provider",
+    path: { cwd: process.cwd(), root: process.cwd() },
+    mode: "test",
+    agent: "test",
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  })
+}
+
+async function createBlueprintNote() {
+  return NoteStore.create({
+    title: "Restart-safe Blueprint",
+    kind: "blueprint",
+    blueprint: {
+      description: "Recover loop references after restart.",
+    },
+  })
+}
+
+describe("SessionRecovery.reconcileRuntimeState", () => {
+  test("clears stale pendingReply and preserves a genuine pending reply", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const stale = await Session.create({})
+        await Session.update(stale.id, (draft) => {
+          draft.pendingReply = true
+        })
+
+        const pending = await Session.create({})
+        await createPendingUserMessage(pending.id)
+        await Session.update(pending.id, (draft) => {
+          draft.pendingReply = true
+        })
+
+        const report = await SessionRecovery.reconcileRuntimeState({
+          scopeID: ScopeContext.current.scope.id,
+          apply: true,
+        })
+
+        expect(report.changed).toBeGreaterThanOrEqual(1)
+        expect((await Session.get(stale.id)).pendingReply).toBeUndefined()
+        expect((await Session.get(pending.id)).pendingReply).toBe(true)
+      },
+    })
+  })
+
+  test("keeps incomplete assistant turns as recovering without abort repair", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const assistant = await createIncompleteAssistant(session.id)
+        await Session.update(session.id, (draft) => {
+          draft.pendingReply = true
+        })
+
+        await SessionRecovery.reconcileRuntimeState({
+          scopeID: ScopeContext.current.scope.id,
+          apply: true,
+        })
+
+        const refreshed = await Session.get(session.id)
+        expect(refreshed.pendingReply).toBe(true)
+
+        const messages = await Session.messages({ sessionID: session.id, raw: true })
+        const assistantMessage = messages.find((message) => message.info.id === assistant.id)
+        assertExists(assistantMessage)
+        expect((assistantMessage.info as MessageV2.Assistant).time.completed).toBeUndefined()
+
+        const statuses = await SessionManager.listStatuses(ScopeContext.current.scope.id)
+        expect(statuses[session.id]).toEqual({ type: "recovering" })
+      },
+    })
+  })
+
+  test("restores active BlueprintLoop note and execution session bindings", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const note = await createBlueprintNote()
+        const loop = await BlueprintLoopStore.create({
+          noteID: note.id,
+          noteVersion: note.version,
+          title: note.title,
+          sessionID: session.id,
+          runMode: "current",
+        })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+        await NoteStore.update(ScopeContext.current.scope.id, note.id, {
+          blueprint: { activeLoopID: null },
+        })
+
+        await SessionRecovery.reconcileRuntimeState({
+          scopeID: ScopeContext.current.scope.id,
+          apply: true,
+        })
+
+        const refreshedSession = await Session.get(session.id)
+        const refreshedNote = await NoteStore.get(ScopeContext.current.scope.id, note.id)
+        expect(refreshedSession.blueprint).toEqual({ loopID: loop.id, loopRole: "execution" })
+        expect(refreshedNote.blueprint?.activeLoopID).toBe(loop.id)
+
+        const statuses = await SessionManager.listStatuses(ScopeContext.current.scope.id)
+        expect(statuses[session.id]).toEqual({ type: "recovering" })
+      },
+    })
+  })
+
+  test("clears dangling terminal BlueprintLoop note and session references", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const note = await createBlueprintNote()
+        const loop = await BlueprintLoopStore.create({
+          noteID: note.id,
+          noteVersion: note.version,
+          title: note.title,
+          sessionID: session.id,
+          runMode: "current",
+        })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "completed" })
+        await Session.update(session.id, (draft) => {
+          draft.blueprint = { loopID: loop.id, loopRole: "execution" }
+        })
+        await NoteStore.update(ScopeContext.current.scope.id, note.id, {
+          blueprint: { activeLoopID: loop.id },
+        })
+
+        await SessionRecovery.reconcileRuntimeState({
+          scopeID: ScopeContext.current.scope.id,
+          apply: true,
+        })
+
+        const refreshedSession = await Session.get(session.id)
+        const refreshedNote = await NoteStore.get(ScopeContext.current.scope.id, note.id)
+        expect(refreshedSession.blueprint?.loopID).toBeUndefined()
+        expect(refreshedSession.blueprint?.loopRole).toBeUndefined()
+        expect(refreshedNote.blueprint?.activeLoopID).toBeUndefined()
+      },
+    })
+  })
+
+  test("projects active Lattice workflow sessions as recovering without kicking continuation", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const run = await LatticeStore.reset({ sessionID: session.id, mode: "auto", goal: "Recover only" })
+        await Session.update(session.id, (draft) => {
+          draft.workflow = {
+            kind: "lattice",
+            runID: run.id,
+            mode: run.mode,
+            firstBlueprintStarted: run.firstBlueprintStarted,
+          }
+        })
+
+        const status = await SessionWorking.resolve(session.id)
+        expect(status).toEqual({ status: "recovering" })
+        const runtime = SessionManager.getRuntime(session.id)
+        expect(runtime?.abort).toBeUndefined()
+        expect(runtime?.status).toEqual({ type: "idle" })
+      },
+    })
+  })
+})

--- a/packages/synergy/test/session/recovery.test.ts
+++ b/packages/synergy/test/session/recovery.test.ts
@@ -213,3 +213,202 @@ describe("SessionRecovery.reconcileRuntimeState", () => {
     })
   })
 })
+
+describe("SessionRecovery.recoverableStatuses", () => {
+  test("returns recovering statuses for sessions with active BlueprintLoops", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const note = await createBlueprintNote()
+        const loop = await BlueprintLoopStore.create({
+          noteID: note.id,
+          noteVersion: note.version,
+          title: note.title,
+          sessionID: session.id,
+          runMode: "current",
+        })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+
+        const statuses = await SessionRecovery.recoverableStatuses(ScopeContext.current.scope.id)
+        expect(statuses[session.id]).toEqual({ type: "recovering", description: "BlueprintLoop interrupted" })
+      },
+    })
+  })
+
+  test("returns empty record when no sessions need recovery", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const statuses = await SessionRecovery.recoverableStatuses(ScopeContext.current.scope.id)
+        expect(Object.keys(statuses)).toHaveLength(0)
+      },
+    })
+  })
+
+  test("includes audit session when loop is auditing", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const execSession = await Session.create({})
+        const auditSession = await Session.create({})
+        const note = await createBlueprintNote()
+        const loop = await BlueprintLoopStore.create({
+          noteID: note.id,
+          noteVersion: note.version,
+          title: note.title,
+          sessionID: execSession.id,
+          runMode: "current",
+        })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, {
+          status: "auditing",
+          auditSessionID: auditSession.id,
+        })
+
+        const statuses = await SessionRecovery.recoverableStatuses(ScopeContext.current.scope.id)
+        expect(statuses[execSession.id]).toEqual({ type: "recovering", description: "BlueprintLoop interrupted" })
+        expect(statuses[auditSession.id]).toEqual({ type: "recovering", description: "BlueprintLoop interrupted" })
+      },
+    })
+  })
+})
+
+describe("SessionRecovery BlueprintLoop audit binding", () => {
+  test("restores audit session binding when loop is auditing", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const execSession = await Session.create({})
+        const auditSession = await Session.create({})
+        const note = await createBlueprintNote()
+        const loop = await BlueprintLoopStore.create({
+          noteID: note.id,
+          noteVersion: note.version,
+          title: note.title,
+          sessionID: execSession.id,
+          runMode: "current",
+        })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, {
+          status: "auditing",
+          auditSessionID: auditSession.id,
+        })
+
+        // Wipe both session bindings to simulate crash before bind occurred
+        await Session.update(execSession.id, (draft) => {
+          draft.blueprint = undefined
+        })
+        await Session.update(auditSession.id, (draft) => {
+          draft.blueprint = undefined
+        })
+        await NoteStore.update(ScopeContext.current.scope.id, note.id, {
+          blueprint: { activeLoopID: null },
+        })
+
+        await SessionRecovery.reconcileRuntimeState({
+          scopeID: ScopeContext.current.scope.id,
+          apply: true,
+        })
+
+        const refreshedExec = await Session.get(execSession.id)
+        const refreshedAudit = await Session.get(auditSession.id)
+        const refreshedNote = await NoteStore.get(ScopeContext.current.scope.id, note.id)
+        expect(refreshedExec.blueprint).toEqual({ loopID: loop.id, loopRole: "execution" })
+        expect(refreshedAudit.blueprint).toEqual({ loopID: loop.id, loopRole: "audit" })
+        expect(refreshedNote.blueprint?.activeLoopID).toBe(loop.id)
+      },
+    })
+  })
+})
+
+describe("SessionProgress.pendingReplyFor", () => {
+  test("returns false when session has no messages", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const { SessionProgress } = await import("../../src/session/progress")
+        const session = await Session.create({})
+        const result = await SessionProgress.pendingReplyFor({
+          scopeID: ScopeContext.current.scope.id,
+          sessionID: session.id,
+        })
+        expect(result).toBe(false)
+      },
+    })
+  })
+
+  test("returns true for session with pending user and no terminal assistant", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const { SessionProgress } = await import("../../src/session/progress")
+        const session = await Session.create({})
+        await createPendingUserMessage(session.id)
+        const result = await SessionProgress.pendingReplyFor({
+          scopeID: ScopeContext.current.scope.id,
+          sessionID: session.id,
+        })
+        expect(result).toBe(true)
+      },
+    })
+  })
+})
+
+describe("SessionWorking resolution after restart", () => {
+  test("returns recovering for lightloop session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        await Session.update(session.id, (draft) => {
+          draft.workflow = { kind: "lightloop", taskDescription: "Recovery test" }
+        })
+
+        const result = await SessionWorking.resolve(session.id)
+        assertExists(result)
+        expect(result.status).toBe("recovering")
+
+        // Verify no runtime was spun up
+        const runtime = SessionManager.getRuntime(session.id)
+        expect(runtime?.abort).toBeUndefined()
+      },
+    })
+  })
+
+  test("returns recovering for active BlueprintLoop session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const note = await createBlueprintNote()
+        const loop = await BlueprintLoopStore.create({
+          noteID: note.id,
+          noteVersion: note.version,
+          title: note.title,
+          sessionID: session.id,
+          runMode: "current",
+        })
+        await BlueprintLoopStore.updateStatus(ScopeContext.current.scope.id, loop.id, { status: "running" })
+        await Session.update(session.id, (draft) => {
+          draft.blueprint = { loopID: loop.id, loopRole: "execution" }
+        })
+
+        const result = await SessionWorking.resolve(session.id)
+        assertExists(result)
+        expect(result.status).toBe("recovering")
+
+        const runtime = SessionManager.getRuntime(session.id)
+        expect(runtime?.abort).toBeUndefined()
+      },
+    })
+  })
+})

--- a/packages/synergy/test/tool/bash-github-token.test.ts
+++ b/packages/synergy/test/tool/bash-github-token.test.ts
@@ -55,7 +55,8 @@ test("local bash injects stored GH_TOKEN only for GitHub CLI commands", async ()
   await using tmp = await tmpdir({ git: true })
   const shell = Shell.acceptable()
   const usesBash = /(?:^|[\\/])bash(?:\.exe)?$/i.test(shell)
-  const printTokenOrMissing = usesBash
+  const usesPosixShell = process.platform !== "win32" || usesBash
+  const printTokenOrMissing = usesPosixShell
     ? "printf '%s' \"${GH_TOKEN:-missing}\""
     : "if defined GH_TOKEN (<nul set /p dummy=%GH_TOKEN%) else (<nul set /p dummy=missing)"
   const chainedTokenCommand = `gh && ${printTokenOrMissing}`

--- a/script/workflow-check.ts
+++ b/script/workflow-check.ts
@@ -11,8 +11,10 @@ const ZIZMOR_VERSION = "1.26.1"
 const ACTIONLINT_INSTALLER = `https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash`
 
 try {
-  await $`bash -c ${`mkdir -p "${tempDir}" && bash <(curl -sSfL "${ACTIONLINT_INSTALLER}") "${ACTIONLINT_VERSION}" "${tempDir}"`}`
-  await $`${path.join(tempDir, "actionlint")} -color`
+  const actionlint = (await hasCommand("actionlint"))
+    ? "actionlint"
+    : await downloadActionlint(ACTIONLINT_VERSION, tempDir)
+  await $`${actionlint} -color`
 } catch (error) {
   console.error(
     "actionlint failed or could not be downloaded. Install actionlint locally or ensure network access, then rerun bun run workflow:check.",
@@ -40,4 +42,9 @@ async function hasCommand(command: string) {
   } catch {
     return false
   }
+}
+
+async function downloadActionlint(version: string, targetDir: string) {
+  await $`bash -c ${`mkdir -p "${targetDir}" && bash <(curl -sSfL "${ACTIONLINT_INSTALLER}") "${version}" "${targetDir}"`}`
+  return path.join(targetDir, "actionlint")
 }


### PR DESCRIPTION
## What does this PR do?

Implements restart-safe session runtime state recovery without automatically continuing interrupted work.

- Adds a `SessionRecovery.reconcileRuntimeState()` pass on global/scope startup.
- Projects durable `recovering` statuses through existing `SessionManager.listStatuses()` / session status sync.
- Reconciles active and terminal BlueprintLoop note/session bindings, including crash windows around loop start.
- Refetches open note details on reconnect so Blueprint state resurfaces in Notes.
- Flushes buffered streaming part writes during graceful shutdown.
- Keeps Cortex out of this change.

## Why?

After backend/app restarts, persisted runtime state could partially disappear from the frontend even though durable session, Blueprint, workflow, or pending reply state still existed. This makes reconnect/reload restore the interrupted state consistently while leaving Continue/Start/Stop as explicit user actions.

## How was it tested?

- `bun run workflow:check`
- `bun run secrets:check`
- `bun run quality:quick`
- `cd packages/synergy && bun test test/tool/bash-github-token.test.ts test/session/working.test.ts test/session/recovery.test.ts test/server/blueprint-route.test.ts`
- `bun turbo test` (5206 pass, 1 skip, 0 fail)
- pre-push hook on push/force-push: format, lint, typecheck, monorepo check

## Checklist

- [x] `bun run quality:quick` passes
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] `bun run package:check` passes if package exports, build output, release logic, or publishable packages changed
- [x] `bun run workflow:check` passes if `.github/workflows/**`, GitHub Actions config, or CI helper scripts changed
- [x] `bun run secrets:check` passes locally or CI Gitleaks covers the change if auth, provider, channel, config, or credential examples changed
- [x] SDK regenerated if server routes or schemas changed (not needed; no route/schema change)
- [x] Documentation, AGENTS, and `.synergy` help updated if developer workflow, quality tooling, commands, or contributor rules changed
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included