### PR TITLE
fix: build plugin before app in dev prepare, add bare-import alias in vite

### DIFF
--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -11,11 +11,25 @@ const virtuaSolidEntry = path.join(path.dirname(virtuaPackagePath), "lib/solid/i
 
 const sdkRoot = path.resolve(fileURLToPath(new URL("../sdk/js", import.meta.url)))
 const pluginRoot = path.resolve(fileURLToPath(new URL("../plugin", import.meta.url)))
-const pluginDistComplete =
-  fs.existsSync(path.join(pluginRoot, "dist/index.js")) &&
-  fs.existsSync(path.join(pluginRoot, "dist/artifact.js")) &&
-  fs.existsSync(path.join(pluginRoot, "dist/ids.js")) &&
-  fs.existsSync(path.join(pluginRoot, "dist/permissions.js"))
+// Check all exported subpaths, not just the first four — the package.json
+// exports map has 15 subpaths and we need the dist to be fully complete.
+const pluginExports = [
+  "index.js",
+  "tool.js",
+  "display.js",
+  "hooks.js",
+  "permissions.js",
+  "ids.js",
+  "policy.js",
+  "paths.js",
+  "artifact.js",
+  "market.js",
+  "spec.js",
+  "version.js",
+  "shell.js",
+  "ui.js",
+]
+const pluginDistComplete = pluginExports.every((f) => fs.existsSync(path.join(pluginRoot, "dist", f)))
 
 const sdkGenSourceExists =
   fs.existsSync(path.join(sdkRoot, "src/gen/sdk.gen.ts")) &&
@@ -42,9 +56,16 @@ function sdkAliases() {
   ]
 }
 
-const pluginAliases = pluginDistComplete
-  ? []
-  : [{ find: /^@ericsanchezok\/synergy-plugin\/([^/]+)$/, replacement: path.join(pluginRoot, "src/$1.ts") }]
+function pluginAliasEntries() {
+  if (pluginDistComplete) return []
+  // Resolve source files directly when dist is missing (dev server, no prepare run).
+  return [
+    // Bare import: @ericsanchezok/synergy-plugin
+    { find: /^@ericsanchezok\/synergy-plugin$/, replacement: path.join(pluginRoot, "src/index.ts") },
+    // Subpath imports: @ericsanchezok/synergy-plugin/tool, /display, etc.
+    { find: /^@ericsanchezok\/synergy-plugin\/([^/]+)$/, replacement: path.join(pluginRoot, "src/$1.ts") },
+  ]
+}
 
 /**
  * @type {import("vite").PluginOption}
@@ -65,7 +86,7 @@ export default [
               replacement: fileURLToPath(new URL("./src", import.meta.url)),
             },
             ...sdkAliases(),
-            ...pluginAliases,
+            ...pluginAliasEntries(),
           ],
         },
         worker: {

--- a/packages/synergy/test/script/dev.test.ts
+++ b/packages/synergy/test/script/dev.test.ts
@@ -53,13 +53,13 @@ describe("dev orchestrator planner", () => {
 
     expect(plan.kind).toBe("run")
     expect(plan.mode).toBe("serial")
-    expect(plan.processes.map((process) => process.label)).toEqual(["install", "build", "desktop"])
-    expect(plan.processes[2]?.env).toMatchObject({
+    expect(plan.processes.map((process) => process.label)).toEqual(["install", "build:plugin", "build", "desktop"])
+    expect(plan.processes[3]?.env).toMatchObject({
       BUN_BIN: "/bun",
       SYNERGY_DESKTOP_CHANNEL: "dev",
       SYNERGY_DESKTOP_SERVER_MODE: "managed",
     })
-    expect(plan.processes[2]?.env).not.toHaveProperty("SYNERGY_DESKTOP_APP_URL")
+    expect(plan.processes[3]?.env).not.toHaveProperty("SYNERGY_DESKTOP_APP_URL")
   })
 
   test("plans managed desktop with app build even when app/dist already exists", async () => {
@@ -73,15 +73,15 @@ describe("dev orchestrator planner", () => {
 
       expect(plan.kind).toBe("run")
       expect(plan.mode).toBe("serial")
-      expect(plan.processes.map((process) => process.label)).toEqual(["build", "desktop"])
-      expect(plan.processes[0]?.command).toEqual(["/bun", "run", "build"])
-      expect(plan.processes[0]?.cwd).toBe(path.join(repoRoot, "packages", "app"))
-      expect(plan.processes[1]?.env).toMatchObject({
+      expect(plan.processes.map((process) => process.label)).toEqual(["build:plugin", "build", "desktop"])
+      expect(plan.processes[1]?.command).toEqual(["/bun", "run", "build"])
+      expect(plan.processes[1]?.cwd).toBe(path.join(repoRoot, "packages", "app"))
+      expect(plan.processes[2]?.env).toMatchObject({
         BUN_BIN: "/bun",
         SYNERGY_DESKTOP_CHANNEL: "dev",
         SYNERGY_DESKTOP_SERVER_MODE: "managed",
       })
-      expect(plan.processes[1]?.env).not.toHaveProperty("SYNERGY_DESKTOP_APP_URL")
+      expect(plan.processes[2]?.env).not.toHaveProperty("SYNERGY_DESKTOP_APP_URL")
     } finally {
       await rm(repoRoot, { recursive: true, force: true })
     }

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -10,7 +10,7 @@ const DEFAULT_HOSTNAME = "127.0.0.1"
 const DEFAULT_APP_HOST = "127.0.0.1"
 
 export interface DevProcessSpec {
-  label: "server" | "app" | "desktop" | "send" | "build" | "install" | "generate" | "sandbox"
+  label: "server" | "app" | "desktop" | "send" | "build" | "install" | "generate" | "sandbox" | "build:plugin"
   command: string[]
   cwd: string
   env?: Record<string, string | undefined>
@@ -68,6 +68,7 @@ function directories(repoRoot: string) {
   return {
     app: path.join(repoRoot, "packages", "app"),
     desktop: path.join(repoRoot, "packages", "desktop"),
+    plugin: path.join(repoRoot, "packages", "plugin"),
     synergy: path.join(repoRoot, "packages", "synergy"),
   }
 }
@@ -341,6 +342,7 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
       const dependenciesInstalled = fs.existsSync(path.join(repoRoot, "node_modules"))
       const processes: DevProcessSpec[] = [
         ...(dependenciesInstalled ? [] : [{ label: "install" as const, command: [bunPath, "install"], cwd: repoRoot }]),
+        { label: "build:plugin", command: [bunPath, "run", "build"], cwd: dirs.plugin },
         { label: "build", command: [bunPath, "run", "build"], cwd: dirs.app },
         desktopProcess({ repoRoot, bunPath, mode: "managed" }),
       ]
@@ -600,6 +602,9 @@ async function runPrepare(repoRoot: string, bunPath: string): Promise<number> {
   const initial = await runSerial([
     { label: "install", command: [bunPath, "install"], cwd: repoRoot },
     { label: "generate", command: [bunPath, "./script/generate.ts"], cwd: repoRoot },
+    // Build plugin (and its util dependency) before app so Vite can resolve
+    // @ericsanchezok/synergy-plugin from its `dist/` exports map.
+    { label: "build:plugin", command: [bunPath, "run", "build"], cwd: dirs.plugin },
     { label: "build", command: [bunPath, "run", "build"], cwd: dirs.app },
   ])
   if (initial !== 0) return initial


### PR DESCRIPTION
## Summary

- `bun dev prepare` now builds `packages/plugin` before `packages/app`, so Vite can resolve `@ericsanchezok/synergy-plugin` from its `dist/` exports map instead of failing with "Failed to resolve entry for package"
- `vite.js` now includes a bare import alias for `@ericsanchezok/synergy-plugin` (not just subpath imports), so the dev server (`bun dev app`) works without dist present
- `vite.js` checks all 14 exported subpaths for dist completeness, not just 4
- Managed desktop (`bun dev desktop --managed`) also builds plugin before app
- Extracted `pluginAliasEntries()` function matching the existing `sdkAliases()` pattern

## What changed

### `script/dev.ts`
- Added `plugin` to `directories()` return value
- Added `build:plugin` step in `runPrepare()` — runs `bun run build` in `packages/plugin` after `generate` and before `build` (app)
- Added `build:plugin` step in the managed desktop pipeline
- Added `"build:plugin"` to `DevProcessSpec.label` union

### `packages/app/vite.js`
- Full 14-subpath dist completeness check (was only 4)
- New bare import alias: `@ericsanchezok/synergy-plugin` → `src/index.ts`
- Extracted `pluginAliasEntries()` function (was inline ternary)
- Subpath alias regex unchanged but now part of the extracted function

## Verification

- Prettier format check: ✓
- Pre-push hooks (typecheck + sherif): ✓
- All changes are in the dev tooling layer — no runtime behavior impact

Fixes #517

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>