### PR TITLE
fix(enforcement): add jq to SAFE_COMMANDS for read-only shell classification

### DIFF
--- a/packages/synergy/src/enforcement/shell-safety.ts
+++ b/packages/synergy/src/enforcement/shell-safety.ts
@@ -1,4 +1,4 @@
-const SAFE_COMMANDS = new Set(["pwd", "ls", "cat", "head", "tail", "wc", "grep", "rg", "true"])
+const SAFE_COMMANDS = new Set(["pwd", "ls", "cat", "head", "tail", "wc", "grep", "rg", "jq", "true"])
 
 const GIT_TAXONOMY: Map<string, BashRisk> = new Map([
   // ── read_only ──────────────────────────────────────────────

--- a/packages/synergy/test/enforcement/shell-safety.test.ts
+++ b/packages/synergy/test/enforcement/shell-safety.test.ts
@@ -439,6 +439,7 @@ describe("ShellSafety isReadOnly", () => {
     expect(ShellSafety.isReadOnly("pwd")).toBe(true)
     expect(ShellSafety.isReadOnly("head -5 myfile")).toBe(true)
     expect(ShellSafety.isReadOnly("wc -l input.txt")).toBe(true)
+    expect(ShellSafety.isReadOnly("jq -r '.key' input.json")).toBe(true)
   })
 
   test("git read-only commands classified via taxonomy, not isReadOnly", () => {


### PR DESCRIPTION
## Summary
- Added `jq` to `SAFE_COMMANDS` in the shell safety classifier, treating it as a read-only data processing tool alongside `grep`, `rg`, `cat`, etc.
- Added test coverage for `jq` as an `isReadOnly` command.

## Why
`jq` is a pure JSON query/filter tool that only reads stdin or files and writes to stdout. Without this change, `jq` commands are classified as `"shell"` rather than `"shell_read"`, which causes a downstream misclassification: in `gate.ts:734`, the `writeCapable` flag is set to `true` for all non-`shell_read` commands, meaning all absolute paths in the command (including read-only file arguments) get classified as `file_external_write`. In `autonomous` mode, `file_external_write` is denied, blocking legitimate data analysis workflows.

## Test
- `bun test test/enforcement/shell-safety.test.ts` — all 213 tests pass