### PR TITLE
fix(ui): show reasoning content when model produces no text part

### DIFF
--- a/packages/ui/src/components/session-turn-timeline.test.ts
+++ b/packages/ui/src/components/session-turn-timeline.test.ts
@@ -689,6 +689,81 @@ describe("session turn timeline", () => {
     expect(items[1]).toMatchObject({ kind: "part", part: { type: "text" } })
   })
 
+  test("promotes reasoning to text when completed turn has no text parts", () => {
+    const message = assistant("assistant-a")
+    const parts: PartType[] = [
+      {
+        id: "reasoning-a",
+        sessionID: "session",
+        messageID: message.id,
+        type: "reasoning",
+        text: "The user asked for a simple greeting.",
+      } as PartType,
+      {
+        id: "reasoning-b",
+        sessionID: "session",
+        messageID: message.id,
+        type: "reasoning",
+        text: "I should respond with 'Hello'.",
+      } as PartType,
+    ]
+
+    const items = collectSessionTurnTimelineItems([message], { [message.id]: parts }, false)
+
+    expect(items.map((item) => item.kind)).toEqual(["part", "part"])
+    expect(items[0]).toMatchObject({
+      kind: "part",
+      part: { type: "reasoning", text: "The user asked for a simple greeting." },
+    })
+    expect(items[1]).toMatchObject({
+      kind: "part",
+      part: { type: "reasoning", text: "I should respond with 'Hello'." },
+    })
+  })
+
+  test("keeps reasoning as reasoning while turn is still working", () => {
+    const message = assistant("assistant-a")
+    const parts: PartType[] = [
+      {
+        id: "reasoning-a",
+        sessionID: "session",
+        messageID: message.id,
+        type: "reasoning",
+        text: "Still thinking...",
+      } as PartType,
+    ]
+
+    const items = collectSessionTurnTimelineItems([message], { [message.id]: parts }, true)
+
+    expect(items.map((item) => item.kind)).toEqual(["reasoning"])
+  })
+
+  test("does not promote reasoning when there is a regular text part present", () => {
+    const message = assistant("assistant-a")
+    const parts: PartType[] = [
+      {
+        id: "reasoning-a",
+        sessionID: "session",
+        messageID: message.id,
+        type: "reasoning",
+        text: "I will greet the user.",
+      } as PartType,
+      {
+        id: "text-a",
+        sessionID: "session",
+        messageID: message.id,
+        type: "text",
+        text: "Hello!",
+      } as PartType,
+    ]
+
+    const items = collectSessionTurnTimelineItems([message], { [message.id]: parts }, false)
+
+    // reasoning stays hidden (not promoted), only text shows as part
+    expect(items.map((item) => item.kind)).toEqual(["part"])
+    expect(items[0]).toMatchObject({ kind: "part", part: { type: "text" } })
+  })
+
   test("renders compaction assistants as one event card while hiding streaming text", () => {
     const message = compactionAssistant("assistant-compaction")
     const streamingItems = collectSessionTurnTimelineItems(

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -220,10 +220,10 @@ export function shouldShowTurnUserChrome(
   return hasVisibleUserMessageContent(parts)
 }
 
-export function timelineKindForPart(part: PartType, working: boolean): SessionTurnTimelineItem["kind"] | undefined {
+export function timelineKindForPart(part: PartType, _working: boolean): SessionTurnTimelineItem["kind"] | undefined {
   if (part.type === "text") return part.text.trim() ? "part" : undefined
   if (part.type === "attachment") return resolveAttachmentPresentation(part).hidden ? undefined : "part"
-  if (part.type === "reasoning") return working && part.text.trim() ? "reasoning" : undefined
+  if (part.type === "reasoning") return part.text.trim() ? "reasoning" : undefined
   if (part.type === "compaction_recovery") return "part"
   if (part.type !== "tool") return undefined
   if (isActiveMediaGenerationToolPart(part)) return "media-pending"
@@ -263,6 +263,7 @@ export function collectSessionTurnTimelineItems(
       continue
     }
 
+    const msgStartIndex = items.length
     const hasCompactionRecovery = !!compactionRecovery
     for (const part of parts) {
       const kind = timelineKindForPart(part, working)
@@ -292,11 +293,36 @@ export function collectSessionTurnTimelineItems(
 
       items.push({ kind, message, part: part as TextPart | ToolPart | AttachmentPart })
     }
+
+    // When the turn is complete, hide reasoning items if there are visible
+    // text/tool/attachment items (standard behavior: final output supersedes
+    // thinking tokens). When there are no visible items — reasoning-only
+    // response — promote reasoning to "part" so content is not lost.
+    if (!working) {
+      const msgItems = items.slice(msgStartIndex)
+      const hasVisiblePart = msgItems.some((item) => item.kind !== "reasoning" && item.kind !== "compaction")
+      if (hasVisiblePart) {
+        // Remove reasoning items (thought tokens hidden by real output)
+        for (let i = items.length - 1; i >= msgStartIndex; i--) {
+          if (items[i]?.kind === "reasoning") items.splice(i, 1)
+        }
+      } else {
+        // Promote reasoning items to "part" so they display as text
+        for (let i = msgStartIndex; i < items.length; i++) {
+          if (items[i]?.kind === "reasoning") {
+            items[i] = {
+              kind: "part",
+              message: items[i].message,
+              part: items[i].part,
+            } as SessionTurnTimelineItem
+          }
+        }
+      }
+    }
   }
 
   return items
 }
-
 /** A non-root, visible user message rendered as an inline chip inside its turn. */
 export function isGuidedContextUserMessage(message: Pick<UserMessage, "isRoot" | "visible">): boolean {
   return message.isRoot === false && message.visible !== false
@@ -785,12 +811,24 @@ export function SessionTurn(
     const parts = data.store.part[last.id]
     if (!parts) return ""
     const texts: string[] = []
+    let hasTextPart = false
     for (const part of parts) {
       if (part.type !== "text") continue
+      hasTextPart = true
       const textPart = part as TextPart
       if (textPart.synthetic || textPart.origin === "system") continue
       const text = textPart.text?.trim()
       if (text) texts.push(text)
+    }
+    // Reasoning-only fallback: when the model produces no text parts,
+    // collect reasoning content so Copy Markdown is still available.
+    if (!hasTextPart && !working()) {
+      for (const part of parts) {
+        if (part.type === "reasoning") {
+          const text = (part as ReasoningPart).text?.trim()
+          if (text) texts.push(text)
+        }
+      }
     }
     return texts.join("\n\n")
   })


### PR DESCRIPTION
## Summary
- Fix regression where reasoning-only final responses from DeepSeek were completely hidden after turn completion
- Reasoning items now promote to "part" kind when no text/tool/attachment items exist in the completed turn
- Copy Markdown falls back to reasoning text when no text parts are present

## Root cause
Commit `f89bde97` removed the reasoning-to-text fallback that was originally added in `60ae63bc`.

## Changes
- `collectSessionTurnTimelineItems`: post-processing that hides reasoning when real output exists, but promotes it when there's nothing else
- `markdownText` memo: falls back to collecting reasoning text when no text parts exist
- Tests: 3 new test cases covering reasoning-only promotion, working state, and mixed reasoning+text

## Verification
- 33/33 timeline tests pass
- Existing test "hides completed-turn reasoning without moving later parts" still passes (unchanged behavior when text/tool output exists)

Closes #508