### PR TITLE
feat: add max and ultra thinking intensity variants for GPT-5.6

### DIFF
--- a/packages/synergy/src/provider/transform.ts
+++ b/packages/synergy/src/provider/transform.ts
@@ -391,7 +391,7 @@ export namespace ProviderTransform {
   }
 
   const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
-  const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+  const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh", "max", "ultra"]
 
   export function variants(model: Provider.Model): Record<string, Record<string, any>> {
     if (!model.capabilities.reasoning) return {}
@@ -426,6 +426,15 @@ export namespace ProviderTransform {
         if (id.includes("gpt-5-") || id === "gpt-5") {
           azureEfforts.unshift("minimal")
         }
+        if (model.release_date >= "2025-11-13") {
+          azureEfforts.unshift("none")
+        }
+        if (model.release_date >= "2025-12-04") {
+          azureEfforts.push("xhigh")
+        }
+        if (model.release_date >= "2026-07-01") {
+          azureEfforts.push("max", "ultra")
+        }
         return Object.fromEntries(
           azureEfforts.map((effort) => [
             effort,
@@ -450,6 +459,9 @@ export namespace ProviderTransform {
           }
           if (model.release_date >= "2025-12-04") {
             arr.push("xhigh")
+          }
+          if (model.release_date >= "2026-07-01") {
+            arr.push("max", "ultra")
           }
           return arr
         })

--- a/packages/synergy/test/provider/transform.test.ts
+++ b/packages/synergy/test/provider/transform.test.ts
@@ -1111,6 +1111,66 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
+
+    test("azure gpt-5 with release_date >= 2025-11-13 includes 'none' effort", () => {
+      const model = createMockModel({
+        id: "gpt-5",
+        providerID: "azure",
+        api: {
+          id: "gpt-5",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+        release_date: "2025-11-14",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high"])
+    })
+
+    test("azure gpt-5 with release_date >= 2025-12-04 includes 'xhigh' effort", () => {
+      const model = createMockModel({
+        id: "gpt-5",
+        providerID: "azure",
+        api: {
+          id: "gpt-5",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+        release_date: "2025-12-05",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+    })
+
+    test("azure gpt-5 with release_date >= 2026-07-01 includes 'max' and 'ultra'", () => {
+      const model = createMockModel({
+        id: "gpt-5",
+        providerID: "azure",
+        api: {
+          id: "gpt-5",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+        release_date: "2026-07-02",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"])
+    })
+
+    test("azure gpt-5 before 2026-07-01 does not include 'max' or 'ultra'", () => {
+      const model = createMockModel({
+        id: "gpt-5",
+        providerID: "azure",
+        api: {
+          id: "gpt-5",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+        release_date: "2026-06-30",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+    })
   })
 
   describe("@ai-sdk/openai", () => {
@@ -1209,6 +1269,33 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  describe("@ai-sdk/anthropic", () => {
+    test("returns high and max with thinking config", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-4",
+        providerID: "anthropic",
+        api: {
+          id: "claude-4",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["high", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "enabled",
+          budgetTokens: 4095,
+        },
+      })
+      expect(result.max).toEqual({
+        thinking: {
+          type: "enabled",
+          budgetTokens: 8191,
+        },
+      })
+    })
+  })
   describe("@ai-sdk/amazon-bedrock", () => {
     test("returns WIDELY_SUPPORTED_EFFORTS with reasoningConfig", () => {
       const model = createMockModel({

--- a/packages/synergy/test/provider/transform.test.ts
+++ b/packages/synergy/test/provider/transform.test.ts
@@ -922,7 +922,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"])
       expect(result.low).toEqual({ reasoning: { effort: "low" } })
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
@@ -938,7 +938,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"])
     })
 
     test("grok-4 returns OPENAI_EFFORTS with reasoning", () => {
@@ -952,7 +952,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"])
     })
   })
 
@@ -968,7 +968,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"])
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
     })
@@ -1177,33 +1177,35 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
     })
-  })
 
-  describe("@ai-sdk/anthropic", () => {
-    test("returns high and max with thinking config", () => {
+    test("models after 2026-07-01 include 'max' and 'ultra' efforts", () => {
       const model = createMockModel({
-        id: "anthropic/claude-4",
-        providerID: "anthropic",
+        id: "openai/gpt-5-chat",
+        providerID: "openai",
         api: {
-          id: "claude-4",
-          url: "https://api.anthropic.com",
-          npm: "@ai-sdk/anthropic",
+          id: "gpt-5-chat",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
         },
+        release_date: "2026-07-02",
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["high", "max"])
-      expect(result.high).toEqual({
-        thinking: {
-          type: "enabled",
-          budgetTokens: 4095,
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"])
+    })
+
+    test("openai models before 2026-07-01 do not include 'max' or 'ultra'", () => {
+      const model = createMockModel({
+        id: "openai/gpt-5-chat",
+        providerID: "openai",
+        api: {
+          id: "gpt-5-chat",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
         },
+        release_date: "2026-06-30",
       })
-      expect(result.max).toEqual({
-        thinking: {
-          type: "enabled",
-          budgetTokens: 8191,
-        },
-      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
     })
   })
 


### PR DESCRIPTION
## Summary

- Add `max` and `ultra` reasoning effort variants for GPT-5.6 OpenAI models, released ~2026-07
- Update `OPENAI_EFFORTS` constant in `transform.ts` to include the new levels
- Add `release_date >= "2026-07-01"` threshold for `@ai-sdk/openai` path
- Sync Azure (`@ai-sdk/azure`) path with same threshold, plus backfill missing `"none"`/`"xhigh"` thresholds that existed in OpenAI path but not Azure
- OpenRouter and Gateway paths auto-benefit from the `OPENAI_EFFORTS` constant
- Add comprehensive tests for both OpenAI and Azure paths with boundary coverage

## Changes

- `packages/synergy/src/provider/transform.ts` — effort variant logic for all OpenAI providers
- `packages/synergy/test/provider/transform.test.ts` — 7 new tests, 4 updated

## Verification

- Existing tests updated to expect new variants where applicable
- Boundary tests confirm pre-2026-07 models do NOT get `max`/`ultra`
- Azure path tests for all three release_date thresholds (`none`, `xhigh`, `max`/`ultra`)
- Closes #522