### PR TITLE
fix: propagate SmartAllow skip reason to denial metadata, include tool args in copy

### DIFF
--- a/packages/synergy/src/control-profile/approval.ts
+++ b/packages/synergy/src/control-profile/approval.ts
@@ -41,11 +41,7 @@ export interface ApprovalMetadata {
     executionStartedAt?: number
     approvalWaitMs?: number
   }
-  smartAllow?: {
-    risk: string
-    reason: string
-    confidence: number
-  }
+  smartAllow?: { risk: string; reason: string; confidence: number } | { skipped: true; reason: string }
 }
 
 function riskForCapability(capability: string): RiskLevel {

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -643,7 +643,12 @@ export namespace ToolResolver {
       // should be visible both in the error message AND the frontend audit tooltip.
       const diagnosticReason = envelope.refusal?.reason ?? decision.reason
       const metadata = ApprovalPolicy.metadata(approval, decision, "auto_denied")
-      const smartAllow = (ctx.extra as any).smartAllowRisk
+      let smartAllow: ApprovalMetadata["smartAllow"] | undefined
+      if ((ctx.extra as any).smartAllowRisk) {
+        smartAllow = (ctx.extra as any).smartAllowRisk
+      } else if (!smartAllowEligible) {
+        smartAllow = { skipped: true, reason: "Non-bypassable capability" }
+      }
       await setApprovalMetadata(ctx, { ...metadata, reason: diagnosticReason, ...(smartAllow ? { smartAllow } : {}) })
       throw new EnforcementError.PolicyDenied(diagnosticReason, decision.capabilities, envelope.profileId)
     }
@@ -651,7 +656,12 @@ export namespace ToolResolver {
     if (profile.profileId === "autonomous" && decision.action === "ask") {
       const diagnosticReason = envelope.refusal?.reason ?? decision.reason
       const metadata = ApprovalPolicy.metadata(approval, { ...decision, action: "deny" }, "auto_denied")
-      const smartAllow = (ctx.extra as any).smartAllowRisk
+      let smartAllow: ApprovalMetadata["smartAllow"] | undefined
+      if ((ctx.extra as any).smartAllowRisk) {
+        smartAllow = (ctx.extra as any).smartAllowRisk
+      } else if (!smartAllowEligible) {
+        smartAllow = { skipped: true, reason: "Non-bypassable capability" }
+      }
       await setApprovalMetadata(ctx, { ...metadata, reason: diagnosticReason, ...(smartAllow ? { smartAllow } : {}) })
       throw new EnforcementError.PolicyDenied(diagnosticReason, decision.capabilities, envelope.profileId)
     }

--- a/packages/ui/src/components/error-card.tsx
+++ b/packages/ui/src/components/error-card.tsx
@@ -28,8 +28,9 @@ export function ErrorCard(props: ErrorCardProps) {
   const [local] = splitProps(props, ["error", "compact", "input"])
   const parsed = () => parseError(local.error)
   const inputText = () => (local.input ? JSON.stringify(local.input, null, 2) : null)
+  const copyText = () => (inputText() ? `${local.error}\n\nInput:\n${inputText()}` : local.error)
   const copy = createCopyController({
-    text: () => local.error,
+    text: copyText,
     copyLabel: "Copy error",
     failureDescription: "Unable to copy the error.",
   })


### PR DESCRIPTION
## Summary
- SmartAllow denials in autonomous mode were not surfacing the skip reason in the denial metadata shown to users
- Tool invocation args were missing from the denial copy, making it hard to understand *what* was blocked

## Test
CI covers the change via existing smartallow/permission test suites.