### PR TITLE
feat(bash): materialize reviewed Notes as virtual files

### DIFF
--- a/.synergy/skill/git-guide/SKILL.md
+++ b/.synergy/skill/git-guide/SKILL.md
@@ -93,6 +93,18 @@ bun run quality:quick   # format:check + lint + typecheck + monorepo:check + pac
 
 ## Pull Request Rules
 
+### Reviewed outbound content
+
+When a PR body, issue body, commit message, or other outbound text needs user review, use a Note as the editable intermediate artifact. After the user has reviewed or edited it, pass the Note to a file-consuming command through the local Bash virtual path:
+
+```bash
+gh pr create --body-file /synergy/note/<note-id>
+gh issue comment 123 --body-file /synergy/note/<note-id>
+git commit -F /synergy/note/<note-id>
+```
+
+Do not interpolate Note content into the command. Local Bash materializes the virtual path as a private, owner-readable file for the lifetime of the process and grants the sandbox read access to its staging directory, so shell metacharacters in the Note remain file content. The receiving CLI still owns the semantics of the file it reads; do not pass a Note to an option that executes or interprets the file as code. Synergy Link commands remain remote and receive virtual paths unchanged.
+
 ### 1. Create PRs from a worktree only
 
 Never `gh pr create` from the main checkout. Use `worktree_enter` first.

--- a/packages/synergy/AGENTS.md
+++ b/packages/synergy/AGENTS.md
@@ -83,7 +83,7 @@ sandbox/
 | Config schema    | `src/config/schema.ts`                | Defines `SandboxConfig` (`enabled`, `fallbackPolicy`)                          |
 | Control profile  | `src/control-profile/profiles.ts`     | Resolves sandbox mode per profile (`workspace_write`, `none`, fallback)        |
 | Enforcement gate | `src/enforcement/gate.ts`             | Exposes resolved sandbox mode from the active profile                          |
-| Tool resolver    | `src/session/tool-resolver.ts`        | Calls `prepareWrapper()` before shell execution, manages fallback policy       |
+| Tool resolver    | `src/session/tool-resolver.ts`        | Defers wrapping until local Bash preprocessing; manages fallback policy        |
 | Sandbox detector | `src/enforcement/sandbox-detector.ts` | Scans command output for OS-level denial patterns (EACCES, read-only FS, etc.) |
 | API route        | `src/server/control-profile-route.ts` | Exposes `/sandbox/status` endpoint for platform availability                   |
 

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -44,6 +44,7 @@ import { PluginToolId } from "../plugin/ids.js"
 import type { PluginApprovalRecord } from "../plugin/consent/approval-store.js"
 import { capabilityNonBypassable } from "@ericsanchezok/synergy-util/capability"
 import { PerformanceMetrics } from "@/performance/metrics"
+import { BashVirtualPath } from "@/tool/bash/virtual-path"
 
 export interface Capability {
   class: string
@@ -762,7 +763,9 @@ export namespace EnforcementGate {
           classifyPathCapability(caps, args.workdir, pathOptions)
         }
 
-        const pathCandidates = [...extractAbsolutePaths(command), ...extractShellPathArguments(command, cwd)]
+        const pathCandidates = [...extractAbsolutePaths(command), ...extractShellPathArguments(command, cwd)].filter(
+          (candidate) => !BashVirtualPath.isShellCandidate(candidate),
+        )
         // shell_read → known read-only (cat, ls, grep, git log, etc.)
         // shell / shell_destructive → write-capable (builds, scripts, destructive ops)
         const writeCapable = risk !== "shell_read"

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -28,7 +28,7 @@ import type { SessionProcessor } from "./processor"
 import { ScopeContext } from "@/scope/context"
 import { EnforcementGate, type Capability } from "@/enforcement/gate"
 import { SandboxBackend } from "@/sandbox/backend"
-import type { SandboxExecutionWrapper } from "@/sandbox/backend"
+import type { BashSandboxPrepare } from "@/tool/bash/shared"
 import type { ResolvedProfile } from "@/control-profile/types"
 import { EnforcementError } from "@/enforcement/errors"
 import { Config } from "@/config/config"
@@ -1392,16 +1392,9 @@ export namespace ToolResolver {
                 using toolTimer = log.time("tool.execute", { tool: item.id, callID: options.toolCallId })
 
                 // ── Sandbox wrapping for bash ──────────────────────────
-                let sandboxWrapper: SandboxExecutionWrapper | undefined
                 if (item.id === "bash") {
                   const sandbox = gate.getSandbox()
                   if (sandbox.mode !== "none" && !shouldBypassShellSandbox(ctx)) {
-                    await toolTrace.phase("tool.sandbox.prepare", "sandbox prepare", {
-                      mode: sandbox.mode,
-                      backend: sandbox.backend,
-                      fallback: sandbox.fallback,
-                    })
-                    const bashCommand = ((args as Record<string, any>)?.command as string) ?? ""
                     // Register externally-approved roots into the gate so the
                     // policy engine can aggregate them with auto-approved paths.
                     const extRoots = approvedExternalRoots(ctx)
@@ -1409,33 +1402,35 @@ export namespace ToolResolver {
                       gate.registerApprovedPaths(extRoots, extRoots, false)
                     }
                     const sandboxPolicy = gate.getSandboxPolicy()
-                    sandboxWrapper = SandboxBackend.prepareWrapper({
-                      command: "/bin/sh",
-                      args: ["-c", bashCommand],
-                      workspace,
-                      sandboxMode: sandbox.mode,
-                      extraReadRoots: [synergyRoot, ...trustedRoots, ...extRoots],
-                      extraWritableRoots: sandboxPolicy?.fileSystem.writableRoots ?? [],
-                      protectedPaths: sandboxPolicy?.fileSystem.protectedPaths,
-                      dataDenyRoots: sandboxPolicy?.fileSystem.dataDenyRoots,
-                      backend: sandbox.backend,
-                    })
-                    if (sandboxWrapper.skipReason) {
-                      if (sandbox.fallback === "deny") {
-                        throw new Error(`Sandbox required but unavailable: ${sandboxWrapper.skipReason}`)
+                    const sandboxPrepare: BashSandboxPrepare = async (input) => {
+                      await toolTrace?.phase("tool.sandbox.prepare", "sandbox prepare", {
+                        mode: sandbox.mode,
+                        backend: sandbox.backend,
+                        fallback: sandbox.fallback,
+                      })
+                      const wrapper = SandboxBackend.prepareWrapper({
+                        command: "/bin/sh",
+                        args: ["-c", input.command],
+                        workspace,
+                        sandboxMode: sandbox.mode,
+                        extraReadRoots: [synergyRoot, ...trustedRoots, ...extRoots, ...input.extraReadRoots],
+                        extraWritableRoots: sandboxPolicy?.fileSystem.writableRoots ?? [],
+                        protectedPaths: sandboxPolicy?.fileSystem.protectedPaths,
+                        dataDenyRoots: sandboxPolicy?.fileSystem.dataDenyRoots,
+                        backend: sandbox.backend,
+                      })
+                      if (wrapper.skipReason && sandbox.fallback !== "deny") {
+                        log.warn("sandbox.unavailable", { skipReason: wrapper.skipReason })
                       }
-                      // warn fallback: log warning and surface in context for bash tool to include in output
-                      log.warn("sandbox.unavailable", { skipReason: sandboxWrapper.skipReason })
-                      ;(toolCtx.extra as any).sandboxWarning = sandboxWrapper.skipReason
+                      await toolTrace?.phase("tool.sandbox.prepared", "sandbox prepared", {
+                        skipReason: wrapper.skipReason,
+                        command: wrapper.command,
+                        args: wrapper.args,
+                      })
+                      return wrapper
                     }
-                    // Store wrapper in context for bash tool to use
-                    ;(toolCtx.extra as any).sandboxWrapper = sandboxWrapper
+                    ;(toolCtx.extra as any).sandboxPrepare = sandboxPrepare
                     ;(toolCtx.extra as any).sandboxFallback = sandbox.fallback
-                    await toolTrace.phase("tool.sandbox.prepared", "sandbox prepared", {
-                      skipReason: sandboxWrapper.skipReason,
-                      command: sandboxWrapper.command,
-                      args: sandboxWrapper.args,
-                    })
                   }
                 }
 

--- a/packages/synergy/src/tool/bash.txt
+++ b/packages/synergy/src/tool/bash.txt
@@ -33,6 +33,10 @@ Usage notes:
   - When targeting a remote `synergy-link` host with `linkID`, open a remote collaboration session first using the `connect` tool. Remote bash does not implicitly create sessions.
   - Remote linkIDs always start with `link_` (e.g. `"link_abc123"`). Any other value will be rejected.
 
+  - For outbound text that the user should review before it is published (for example a PR body, issue body, commit message, or channel message), draft it as a Note and let the user edit the Note first. Local bash commands can then pass `/synergy/note/<note-id>` as a file argument, for example `gh pr create --body-file /synergy/note/<note-id>` or `git commit -F /synergy/note/<note-id>`.
+  - Prefer a command's file-input option over command substitution. The virtual path keeps the Note content out of shell parsing, permission patterns, and the visible command while preserving the command's normal approval boundary.
+  - Note virtual paths are materialized only for local bash execution. A remote Synergy Link command receives the virtual path unchanged.
+
   - Use `background` (boolean) to run a command in the background immediately; it returns a processId for use with the process tool.
   - Use `yieldSeconds` to delay before auto-backgrounding a command that runs longer than the given number of seconds. Default is 10. If the command completes before yieldSeconds, it returns normally.
   - After backgrounding, use the `process` tool to monitor/interact (list, poll, log, write, send-keys, kill).

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -18,6 +18,8 @@ import type { BashResult } from "./shared"
 import { Observability } from "@/observability"
 import { ToolTimeout } from "../timeout"
 import { GitHubProvider } from "@/provider/github"
+import { BashVirtualFile } from "./virtual-file"
+import type { BashSandboxPrepare } from "./shared"
 
 /**
  * Derive a human-readable abort reason from an AbortSignal's .reason.
@@ -180,8 +182,10 @@ export const LocalBashBackend = {
       throw new Error("Failed to parse command")
     }
     const patterns = new Set<string>()
+    let virtualFileReferences: BashVirtualFile.Reference[] = []
 
     try {
+      virtualFileReferences = BashVirtualFile.references(tree.rootNode)
       for (const node of tree.rootNode.descendantsOfType("command")) {
         if (!node) continue
         const command = []
@@ -242,10 +246,8 @@ export const LocalBashBackend = {
       })
     }
 
-    const sandboxWrapper =
-      (ctx.extra as any)?.shellBypassSandbox === true ? undefined : (ctx.extra as any)?.sandboxWrapper
     const sandboxFallback = (ctx.extra as any)?.sandboxFallback as "deny" | "warn" | "allow" | undefined
-    const sandboxWarning = (ctx.extra as any)?.sandboxWarning as string | undefined
+    let sandboxWarning: string | undefined
     const warnOutput = (base: string) => (sandboxWarning ? `[Sandbox unavailable: ${sandboxWarning}]\n\n${base}` : base)
     const withAttachments = async (result: BashResult): Promise<BashResult> => {
       if (AttachmentDiscovery.shouldSkip(params.command)) return result
@@ -313,22 +315,64 @@ export const LocalBashBackend = {
         })
       }
     }
-    // ── ProcessRegistry setup (shared across both paths) ──────────
-    regProc = ProcessRegistry.create({
-      command: params.command,
-      description: params.description,
-      cwd,
-    })
-    await trace("bash.process.registered", {
-      processId: regProc.id,
-    })
 
-    ctx.metadata({
-      metadata: {
-        output: "",
-        description: params.description,
-      },
+    const materialized = await BashVirtualFile.materialize({
+      command: params.command,
+      references: virtualFileReferences,
+      scopeID: ScopeContext.current.scope.id,
     })
+    const sandboxPrepare = (ctx.extra as { sandboxPrepare?: BashSandboxPrepare } | undefined)?.sandboxPrepare
+    let sandboxWrapper: Awaited<ReturnType<BashSandboxPrepare>> | undefined
+    let artifactsCleaned = false
+    const cleanupExecutionArtifacts = () => {
+      if (artifactsCleaned) return
+      artifactsCleaned = true
+      if (sandboxWrapper?.tempPath) {
+        SandboxBackend.cleanupTemp(sandboxWrapper.tempPath)
+      }
+      materialized.cleanup()
+    }
+
+    try {
+      if ((ctx.extra as any)?.shellBypassSandbox !== true) {
+        sandboxWrapper = await sandboxPrepare?.({
+          command: materialized.command,
+          extraReadRoots: materialized.extraReadRoots,
+        })
+      }
+      sandboxWarning = sandboxWrapper?.skipReason
+    } catch (error) {
+      cleanupExecutionArtifacts()
+      throw error
+    }
+
+    // ── ProcessRegistry setup (shared across both paths) ──────────
+    try {
+      regProc = ProcessRegistry.create({
+        command: params.command,
+        description: params.description,
+        cwd,
+      })
+    } catch (error) {
+      cleanupExecutionArtifacts()
+      throw error
+    }
+    try {
+      await trace("bash.process.registered", {
+        processId: regProc.id,
+      })
+
+      ctx.metadata({
+        metadata: {
+          output: "",
+          description: params.description,
+        },
+      })
+    } catch (error) {
+      ProcessRegistry.remove(regProc.id)
+      cleanupExecutionArtifacts()
+      throw error
+    }
 
     const METADATA_THROTTLE_MS = 500
     let metadataTimer: ReturnType<typeof setTimeout> | null = null
@@ -386,7 +430,7 @@ export const LocalBashBackend = {
             fallback: sandboxFallback,
           })
         }
-        child = spawn(params.command, {
+        child = spawn(materialized.command, {
           shell,
           cwd,
           env: sandboxEnv,
@@ -396,9 +440,7 @@ export const LocalBashBackend = {
       }
     } catch (e: unknown) {
       ProcessRegistry.remove(regProc.id)
-      if (sandboxWrapper?.tempPath) {
-        SandboxBackend.cleanupTemp(sandboxWrapper.tempPath)
-      }
+      cleanupExecutionArtifacts()
       await trace(
         "bash.child.error",
         {
@@ -467,9 +509,7 @@ export const LocalBashBackend = {
       exited = true
       cleanupAllTimers()
       ProcessRegistry.remove(regProc.id)
-      if (sandboxWrapper?.tempPath) {
-        SandboxBackend.cleanupTemp(sandboxWrapper.tempPath)
-      }
+      cleanupExecutionArtifacts()
       void trace(
         "bash.child.error",
         {
@@ -501,9 +541,7 @@ export const LocalBashBackend = {
       } else {
         ProcessRegistry.remove(regProc.id)
       }
-      if (sandboxWrapper?.tempPath) {
-        SandboxBackend.cleanupTemp(sandboxWrapper.tempPath)
-      }
+      cleanupExecutionArtifacts()
       void trace("bash.child.exit", {
         exitCode: code,
         exitSignal: signal,

--- a/packages/synergy/src/tool/bash/shared.ts
+++ b/packages/synergy/src/tool/bash/shared.ts
@@ -1,6 +1,7 @@
 import { SynergyLinkBash } from "@ericsanchezok/synergy-link-protocol"
 import type { Tool } from "../tool"
 import type { MessageV2 } from "@/session/message-v2"
+import type { SandboxExecutionWrapper } from "@/sandbox/backend"
 
 export type BashParams = SynergyLinkBash.ExecutePayload & {
   linkID?: string
@@ -19,6 +20,13 @@ export interface BashResult {
 }
 
 export type BashContext = Tool.Context<BashMetadata>
+
+export interface BashSandboxPrepareInput {
+  command: string
+  extraReadRoots: string[]
+}
+
+export type BashSandboxPrepare = (input: BashSandboxPrepareInput) => Promise<SandboxExecutionWrapper>
 
 export const MAX_METADATA_LENGTH = 30_000
 

--- a/packages/synergy/src/tool/bash/virtual-file.ts
+++ b/packages/synergy/src/tool/bash/virtual-file.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs"
+import { chmod, mkdtemp, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import type { Node } from "web-tree-sitter"
+import { NoteMarkdown, NoteStore } from "../../note"
+import { BashVirtualPath } from "./virtual-path"
+
+export namespace BashVirtualFile {
+  export interface Reference {
+    startIndex: number
+    endIndex: number
+    provider: BashVirtualPath.Provider
+    id: string
+  }
+
+  export interface Materialization {
+    command: string
+    extraReadRoots: string[]
+    cleanup(): void
+  }
+
+  interface Provider {
+    extension: string
+    read(scopeID: string, id: string): Promise<string>
+  }
+
+  const providers = {
+    note: {
+      extension: ".md",
+      async read(scopeID, id) {
+        const note = await NoteStore.getAny(scopeID, id)
+        return NoteMarkdown.toMarkdown(note.content)
+      },
+    },
+  } satisfies Record<BashVirtualPath.Provider, Provider>
+
+  export function references(root: Node): Reference[] {
+    const result: Reference[] = []
+    for (const node of root.descendantsOfType(["word", "string", "raw_string"])) {
+      if (!node) continue
+      const parsed = parseCandidate(node.type, node.text)
+      if (!parsed) continue
+      result.push({
+        startIndex: node.startIndex + parsed.startOffset,
+        endIndex: node.startIndex + parsed.endOffset,
+        provider: parsed.provider,
+        id: parsed.id,
+      })
+    }
+    return result
+  }
+
+  export async function materialize(input: {
+    command: string
+    references: Reference[]
+    scopeID: string
+    tempRoot?: string
+  }): Promise<Materialization> {
+    if (input.references.length === 0) {
+      return { command: input.command, extraReadRoots: [], cleanup() {} }
+    }
+
+    const tempDir = await mkdtemp(path.join(input.tempRoot ?? os.tmpdir(), "synergy-bash-files-"))
+    let cleaned = false
+    const cleanup = () => {
+      if (cleaned) return
+      cleaned = true
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+      } catch {}
+    }
+
+    try {
+      await chmod(tempDir, 0o700)
+      const unique = new Map<string, Reference>()
+      for (const reference of input.references) {
+        unique.set(`${reference.provider}:${reference.id}`, reference)
+      }
+
+      const paths = new Map<string, string>()
+      let index = 0
+      for (const [key, reference] of unique.entries()) {
+        const provider = providers[reference.provider]
+        const content = await provider.read(input.scopeID, reference.id)
+        const filepath = path.join(tempDir, `${index++}${provider.extension}`)
+        await writeFile(filepath, content, { encoding: "utf-8", flag: "wx", mode: 0o600 })
+        await chmod(filepath, 0o400)
+        paths.set(key, filepath)
+      }
+
+      let command = input.command
+      for (const reference of input.references.toSorted((left, right) => right.startIndex - left.startIndex)) {
+        const filepath = paths.get(`${reference.provider}:${reference.id}`)
+        if (!filepath) throw new Error(`Bash virtual file was not materialized: ${reference.provider}:${reference.id}`)
+        command = command.slice(0, reference.startIndex) + shellQuote(filepath) + command.slice(reference.endIndex)
+      }
+
+      return { command, extraReadRoots: [tempDir], cleanup }
+    } catch (error) {
+      cleanup()
+      throw error
+    }
+  }
+
+  function parseCandidate(nodeType: string, text: string) {
+    if (nodeType === "string" || nodeType === "raw_string") {
+      const value = text.slice(1, -1)
+      const matched = matchProvider(value)
+      if (!matched) return
+      return { ...matched, startOffset: 0, endOffset: text.length }
+    }
+
+    const valueStart = text.lastIndexOf("=") + 1
+    const matched = matchProvider(text.slice(valueStart))
+    if (!matched) return
+    return { ...matched, startOffset: valueStart, endOffset: text.length }
+  }
+
+  function matchProvider(value: string) {
+    const matched = BashVirtualPath.match(value)
+    if (!matched) return
+    return { provider: matched.provider, id: matched.id }
+  }
+
+  function shellQuote(value: string) {
+    return `'${value.replaceAll("'", `'"'"'`)}'`
+  }
+}

--- a/packages/synergy/src/tool/bash/virtual-path.ts
+++ b/packages/synergy/src/tool/bash/virtual-path.ts
@@ -1,0 +1,27 @@
+export namespace BashVirtualPath {
+  const providerPatterns = {
+    note: /^\/synergy\/note\/(nte_[A-Za-z0-9_-]+)$/,
+  } as const
+
+  export type Provider = keyof typeof providerPatterns
+
+  export interface Match {
+    provider: Provider
+    id: string
+  }
+
+  export function match(value: string): Match | undefined {
+    for (const [provider, pattern] of Object.entries(providerPatterns) as [Provider, RegExp][]) {
+      const id = pattern.exec(value)?.[1]
+      if (id) return { provider, id }
+    }
+  }
+
+  export function is(value: string): boolean {
+    return match(value) !== undefined
+  }
+
+  export function isShellCandidate(value: string): boolean {
+    return is(value.replace(/[`)]+$/, ""))
+  }
+}

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -246,6 +246,31 @@ describe("EnforcementGate path classification", () => {
 // 2. Shell classification
 // ------------------------------------------------------------------
 describe("EnforcementGate shell classification", () => {
+  test("keeps reserved note virtual paths inside the bash boundary", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+    })
+
+    for (const command of [
+      "gh pr create --body-file /synergy/note/nte_reviewed",
+      'gh pr create --body "$(cat /synergy/note/nte_reviewed)"',
+      'gh pr create --body "`cat /synergy/note/nte_reviewed`"',
+    ]) {
+      const result = gate.classify("bash", {
+        command,
+        workdir: "/Users/test/synergy-control-profile",
+      })
+
+      expect(result.capabilities.some((cap: any) => cap.class === "shell_remote_publish")).toBe(true)
+      expect(
+        result.capabilities.some(
+          (cap: any) => cap.class === "file_external_read" || cap.class === "file_external_write",
+        ),
+      ).toBe(false)
+    }
+  })
+
   test("simple ls within workspace is classified as shell_read", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test/synergy-control-profile",

--- a/packages/synergy/test/tool/bash-note-virtual-path.test.ts
+++ b/packages/synergy/test/tool/bash-note-virtual-path.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  SynergyLinkBash,
+  SynergyLinkClient,
+  SynergyLinkProcess,
+  SynergyLinkSession,
+} from "@ericsanchezok/synergy-link-protocol"
+import { mkdir, readdir, stat } from "node:fs/promises"
+import path from "node:path"
+import { NoteMarkdown, NoteStore } from "../../src/note"
+import { ProcessRegistry } from "../../src/process/registry"
+import { ScopeContext } from "../../src/scope/context"
+import { BashTool } from "../../src/tool/bash"
+import { BashVirtualFile } from "../../src/tool/bash/virtual-file"
+import { SynergyLinkExecution } from "../../src/tool/synergy-link-execution"
+import { Shell } from "../../src/util/shell"
+import { tmpdir } from "../fixture/fixture"
+
+const baseContext = {
+  sessionID: "test",
+  messageID: "",
+  callID: "",
+  agent: "test-strategist",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+  extra: { shellBypassSandbox: true },
+} as any
+
+async function withNote<T>(markdown: string, fn: (noteID: string, root: string) => Promise<T>) {
+  await using tmp = await tmpdir({ git: true })
+  return ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const note = await NoteStore.create({
+        title: "Bash virtual file",
+        content: NoteMarkdown.fromMarkdown(markdown),
+      })
+      return fn(note.id, tmp.path)
+    },
+  })
+}
+
+async function waitForFinished(processID: string) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const finished = ProcessRegistry.getFinished(processID)
+    if (finished) return finished
+    await Bun.sleep(10)
+  }
+  throw new Error(`Process did not finish: ${processID}`)
+}
+
+describe("bash note virtual paths", () => {
+  test("passes note markdown as file bytes without evaluating shell syntax", async () => {
+    await withNote(
+      "safe\n$(touch should-not-run)\n`touch should-not-run-either`\n; touch still-not-code",
+      async (noteID, root) => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: `cat /synergy/note/${noteID}`,
+            description: "Read reviewed note",
+          },
+          baseContext,
+        )
+
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("$(touch should-not-run)")
+        expect(await Bun.file(`${root}/should-not-run`).exists()).toBe(false)
+        expect(await Bun.file(`${root}/should-not-run-either`).exists()).toBe(false)
+        expect(await Bun.file(`${root}/still-not-code`).exists()).toBe(false)
+      },
+    )
+  })
+
+  test("supports quoted paths and multiple reviewed notes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const left = await NoteStore.create({ title: "Left", content: NoteMarkdown.fromMarkdown("left") })
+        const right = await NoteStore.create({ title: "Right", content: NoteMarkdown.fromMarkdown("right") })
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command:
+              `cat '/synergy/note/${left.id}' && cat \"/synergy/note/${right.id}\" && ` +
+              `diff /synergy/note/${left.id} /synergy/note/${left.id}`,
+            description: "Consume reviewed notes",
+          },
+          baseContext,
+        )
+
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("left")
+        expect(result.output).toContain("right")
+      },
+    })
+  })
+
+  test("preserves non-ASCII command text before a virtual path", async () => {
+    await withNote("reviewed", async (noteID) => {
+      const bash = await BashTool.init()
+      const result = await bash.execute(
+        {
+          command: `printf '你好\\n' && cat /synergy/note/${noteID}`,
+          description: "Consume a reviewed note after Unicode text",
+        },
+        baseContext,
+      )
+
+      expect(result.metadata.exit).toBe(0)
+      expect(result.output).toContain("你好")
+      expect(result.output).toContain("reviewed")
+    })
+  })
+
+  test("does not resolve virtual-looking text in shell comments", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: "printf ok # /synergy/note/nte_missing",
+            description: "Print literal text",
+          },
+          baseContext,
+        )
+
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toBe("ok")
+      },
+    })
+  })
+
+  test("fails before spawning when a referenced note does not exist", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const bash = await BashTool.init()
+        const marker = `${tmp.path}/spawned`
+        const tempRoot = path.join(tmp.path, "staging")
+        await mkdir(tempRoot)
+        await expect(
+          bash.execute(
+            {
+              command: `touch ${JSON.stringify(marker)} && cat /synergy/note/nte_missing`,
+              description: "Consume missing note",
+            },
+            baseContext,
+          ),
+        ).rejects.toThrow("Note not found: nte_missing")
+        expect(await Bun.file(marker).exists()).toBe(false)
+
+        const command = "/synergy/note/nte_missing"
+        await expect(
+          BashVirtualFile.materialize({
+            command,
+            references: [{ startIndex: 0, endIndex: command.length, provider: "note", id: "nte_missing" }],
+            scopeID: ScopeContext.current.scope.id,
+            tempRoot,
+          }),
+        ).rejects.toThrow("Note not found: nte_missing")
+        expect(await readdir(tempRoot)).toEqual([])
+      },
+    })
+  })
+
+  test("removes private materialized files after foreground execution", async () => {
+    await withNote("reviewed", async (noteID) => {
+      const bash = await BashTool.init()
+      const result = await bash.execute(
+        {
+          command: `printf %s /synergy/note/${noteID}`,
+          description: "Inspect staged note path",
+        },
+        baseContext,
+      )
+      const materializedPath = result.output.trim()
+
+      expect(materializedPath).not.toContain("/synergy/note/")
+      expect(await Bun.file(materializedPath).exists()).toBe(false)
+    })
+  })
+
+  test("quotes materialized paths without changing shell argument boundaries", async () => {
+    await withNote("reviewed", async (noteID, root) => {
+      const tempRoot = path.join(root, "temp with ' quote")
+      await mkdir(tempRoot)
+      const virtualPath = `/synergy/note/${noteID}`
+      const command = `cat ${virtualPath}`
+      const materialized = await BashVirtualFile.materialize({
+        command,
+        references: [
+          {
+            startIndex: command.indexOf(virtualPath),
+            endIndex: command.length,
+            provider: "note",
+            id: noteID,
+          },
+        ],
+        scopeID: ScopeContext.current.scope.id,
+        tempRoot,
+      })
+      try {
+        const result = Bun.spawnSync([Shell.acceptable(), "-c", materialized.command], {
+          cwd: root,
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout.toString()).toContain("reviewed")
+      } finally {
+        materialized.cleanup()
+      }
+    })
+  })
+
+  test("isolates concurrent materializations of the same note", async () => {
+    await withNote("reviewed", async (noteID) => {
+      const bash = await BashTool.init()
+      const execute = () =>
+        bash.execute(
+          {
+            command: `printf %s /synergy/note/${noteID}`,
+            description: "Inspect concurrent note path",
+          },
+          baseContext,
+        )
+      const [left, right] = await Promise.all([execute(), execute()])
+      const leftPath = left.output.trim()
+      const rightPath = right.output.trim()
+
+      expect(leftPath).not.toBe(rightPath)
+      expect(await Bun.file(leftPath).exists()).toBe(false)
+      expect(await Bun.file(rightPath).exists()).toBe(false)
+    })
+  })
+
+  test("keeps files for background consumers and removes them on process exit", async () => {
+    await withNote("reviewed", async (noteID) => {
+      const bash = await BashTool.init()
+      const result = await bash.execute(
+        {
+          command: `printf '%s\\n' /synergy/note/${noteID}; sleep 0.2`,
+          description: "Keep reviewed note available",
+          yieldSeconds: 0.02,
+        },
+        baseContext,
+      )
+      const processID = result.metadata.processId
+      expect(processID).toBeString()
+
+      const running = ProcessRegistry.get(processID!)
+      const materializedPath = running?.output.trim()
+      expect(materializedPath).toBeString()
+      expect(await Bun.file(materializedPath!).exists()).toBe(true)
+      if (process.platform !== "win32") {
+        expect((await stat(materializedPath!)).mode & 0o777).toBe(0o400)
+        expect((await stat(path.dirname(materializedPath!))).mode & 0o777).toBe(0o700)
+      }
+
+      const finished = await waitForFinished(processID!)
+      expect(finished.command).toContain(`/synergy/note/${noteID}`)
+      expect(await Bun.file(materializedPath!).exists()).toBe(false)
+      ProcessRegistry.remove(processID!)
+    })
+  })
+
+  test("reads the latest user-edited note after command approval", async () => {
+    await withNote("draft", async (noteID) => {
+      const bash = await BashTool.init()
+      const result = await bash.execute(
+        {
+          command: `cat /synergy/note/${noteID}`,
+          description: "Read approved note revision",
+        },
+        {
+          ...baseContext,
+          ask: async () => {
+            const current = await NoteStore.getAny(ScopeContext.current.scope.id, noteID)
+            await NoteStore.update(ScopeContext.current.scope.id, noteID, {
+              expectedVersion: current.version,
+              content: NoteMarkdown.fromMarkdown("user-reviewed"),
+            })
+          },
+          extra: {
+            sandboxPrepare: async (input: { command: string }) => ({
+              command: Shell.acceptable(),
+              args: ["-c", input.command],
+              sandboxed: false,
+            }),
+          },
+        },
+      )
+
+      expect(result.metadata.exit).toBe(0)
+      expect(result.output).toContain("user-reviewed")
+      expect(result.output).not.toContain("draft")
+    })
+  })
+
+  test("prepares the sandbox from the materialized command and read-only staging root", async () => {
+    await withNote("sandboxed", async (noteID) => {
+      const bash = await BashTool.init()
+      let prepared: { command: string; extraReadRoots: string[] } | undefined
+      const result = await bash.execute(
+        {
+          command: `cat /synergy/note/${noteID}`,
+          description: "Read sandboxed note",
+        },
+        {
+          ...baseContext,
+          extra: {
+            sandboxPrepare: async (input: { command: string; extraReadRoots: string[] }) => {
+              prepared = input
+              return {
+                command: Shell.acceptable(),
+                args: ["-c", input.command],
+                sandboxed: false,
+              }
+            },
+            sandboxFallback: "deny",
+          },
+        },
+      )
+
+      expect(result.metadata.exit).toBe(0)
+      expect(result.output).toContain("sandboxed")
+      expect(prepared?.command).not.toContain("/synergy/note/")
+      expect(prepared?.extraReadRoots).toHaveLength(1)
+    })
+  })
+
+  test("cleans staged files when setup fails before the child is spawned", async () => {
+    await withNote("reviewed", async (noteID) => {
+      const bash = await BashTool.init()
+      let stagingRoot: string | undefined
+
+      await expect(
+        bash.execute(
+          {
+            command: `cat /synergy/note/${noteID}`,
+            description: "Fail after staging",
+          },
+          {
+            ...baseContext,
+            metadata: () => {
+              throw new Error("metadata unavailable")
+            },
+            extra: {
+              sandboxPrepare: async (input: { command: string; extraReadRoots: string[] }) => {
+                stagingRoot = input.extraReadRoots[0]
+                return {
+                  command: Shell.acceptable(),
+                  args: ["-c", input.command],
+                  sandboxed: false,
+                }
+              },
+            },
+          },
+        ),
+      ).rejects.toThrow("metadata unavailable")
+
+      expect(stagingRoot).toBeString()
+      expect(await Bun.file(stagingRoot!).exists()).toBe(false)
+    })
+  })
+
+  test("leaves remote Link commands virtual and does not materialize local files", async () => {
+    let forwarded: SynergyLinkBash.ExecutePayload | undefined
+    let prepared = false
+    const client: SynergyLinkClient.ExecutionClient = {
+      async executeBash(_linkID, input) {
+        forwarded = input
+        return { title: "Remote", metadata: { backend: "remote", exit: 0 }, output: "remote" }
+      },
+      async executeProcess(): Promise<SynergyLinkProcess.Result> {
+        throw new Error("unexpected process execution")
+      },
+      async executeSession(): Promise<SynergyLinkSession.Result> {
+        throw new Error("unexpected session execution")
+      },
+    }
+    SynergyLinkExecution.setClient(client)
+    SynergyLinkExecution.upsertSession({
+      linkID: "link_test",
+      targetAgentID: "remote-agent",
+      sessionID: "session_test",
+      status: "opened",
+      openedAt: Date.now(),
+      lastUsedAt: Date.now(),
+    })
+
+    try {
+      const bash = await BashTool.init()
+      const command = "cat /synergy/note/nte_remote"
+      const result = await bash.execute(
+        { command, description: "Read remote note path", linkID: "link_test" },
+        {
+          ...baseContext,
+          extra: {
+            sandboxPrepare: async () => {
+              prepared = true
+              throw new Error("local sandbox should not be prepared")
+            },
+          },
+        },
+      )
+
+      expect(result.metadata.backend).toBe("remote")
+      expect(forwarded?.command).toBe(command)
+      expect(prepared).toBe(false)
+    } finally {
+      SynergyLinkExecution.setClient(null)
+    }
+  })
+})

--- a/packages/synergy/test/tool/bash.test.ts
+++ b/packages/synergy/test/tool/bash.test.ts
@@ -491,7 +491,7 @@ describe("tool.bash permissions", () => {
     })
   })
 
-  test("uses direct execution after profile approval instead of an existing sandbox wrapper", async () => {
+  test("uses direct execution after profile approval without preparing a sandbox", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
       scope: await tmp.scope(),
@@ -501,10 +501,8 @@ describe("tool.bash permissions", () => {
           ...ctx,
           extra: {
             shellBypassSandbox: true,
-            sandboxWrapper: {
-              command: "false",
-              args: [],
-              sandboxed: true,
+            sandboxPrepare: async () => {
+              throw new Error("sandbox should not be prepared")
             },
           },
         }


### PR DESCRIPTION
## What

Add local Bash support for `/synergy/note/<id>` as a virtual, read-only file path. This enables the complete workflow:

1. an agent drafts outbound content in a Note;
2. the user reviews or edits that Note in Synergy;
3. the agent passes the reviewed content directly to a file-consuming CLI, such as:

```bash
gh pr create --body-file /synergy/note/<note-id>
gh issue comment 123 --body-file /synergy/note/<note-id>
git commit -F /synergy/note/<note-id>
```

The Bash schema, Note APIs, permission model, and remote Synergy Link protocol remain unchanged.

## First-principles goal

Outbound text is often both sensitive and consequential: PR bodies, issue reports, commit messages, and channel messages can contain private context and create external side effects. The user should be able to inspect and edit the exact text as a first-class Synergy artifact before an agent publishes it.

A Note is the review boundary. Bash is only the transport boundary. Note bytes therefore must not be copied into a shell command, a permission pattern, process metadata, or a SmartAllow prompt. The implementation materializes the latest reviewed Note as a file immediately before local process execution and gives the receiving CLI a filename, not an interpolated shell string.

## Design

- Reuse the existing tree-sitter Bash parse and resolve only exact `word`, `string`, or `raw_string` arguments. Quoted paths and `--flag=/synergy/note/...` work; comments and unrelated substrings are not rewritten.
- Keep the original command for enforcement, approval, traces, attachment policy, and process metadata. Only the child execution command receives physical paths.
- Materialize unique Note references in a random `mkdtemp` directory under the OS temp root. The directory is `0700`; files are created with `wx`, finalized as `0400`, and use numeric names so Note IDs are not exposed in physical filenames.
- POSIX-quote every generated physical path before inserting it into the parsed command. Paths containing spaces or apostrophes remain one shell argument.
- Defer sandbox wrapper creation until after materialization, then add the private staging directory as a read root. This fixes the ordering problem where an eager wrapper would still contain the unresolved command and deny the generated temp path.
- Tie cleanup to the actual child lifecycle. Foreground, background, spawn failure, sandbox/setup failure, and child error/exit all share one idempotent cleanup path.
- Resolve the Note after command approval, so an edit made during the review/approval flow is the content consumed by the command.
- Leave remote Synergy Link commands untouched. They receive the virtual path unchanged and never create local staging files.

The virtual-path definition exposes a typed provider registry. Adding a future provider requires both a supported path pattern and a materializer; TypeScript prevents those two registries from drifting.

## Shell-injection and data-exposure analysis

This closes the shell-injection path for Note content:

- Note Markdown is written as file bytes and is never concatenated into the command. `$()`, backticks, semicolons, quotes, newlines, and redirects inside the Note remain data.
- Generated paths are random, created inside a private directory, shell-quoted, and created exclusively with `wx`. A predictable PID-based `/var/tmp` name cannot be pre-created or replaced with a symlink.
- The Note ID is validated by the reserved virtual-path grammar and is not used as a physical filename.
- `/synergy/note/...` is excluded only from local filesystem boundary classification. The original command still retains its real capability: for example, `gh pr create` remains `shell_remote_publish`, while network, destructive, protected-path, and remote-execution capabilities are unchanged.

Important retained boundaries:

- The receiving CLI owns the semantics of the file it reads. Safe uses are data/file-input options such as `--body-file` and `-F`; callers must not pass a Note to an option that executes or interprets the file as code.
- A hard process crash or `SIGKILL` can leave a private temp directory behind. Normal failures and background completion are cleaned; crash residue remains owner-only and follows the OS temp lifecycle.
- This feature does not change Note persistence or access control. It prevents shell parsing and predictable temp-file exposure; it does not turn Notes into an encrypted secret store.

## Why the original sketch needed changes

- Regex replacement would rewrite comments, heredoc-like text, prefixes, and quoted contexts without understanding shell argument boundaries.
- `/var/tmp/synergy-note-<pid>-<id>` is predictable. A PID does not isolate concurrent async Bash calls in one server process and leaves a symlink/overwrite race.
- A broad `/var/tmp` file has weaker confidentiality and persistence characteristics than a random private directory in the OS temp root.
- The existing sandbox wrapper was built before local Bash execution. Replacing the command afterward would not update the wrapper or grant access to the staged file.
- Skipping cleanup for background commands would intentionally retain sensitive outbound content. Cleanup must follow child exit instead.
- `note_read` presentation limits do not cap the size of persisted Note content, so the implementation does not rely on that assumption.

## Tests

Added coverage for:

- shell metacharacters remaining inert file bytes;
- quoted, duplicate, multiple, missing, and non-ASCII-prefixed paths;
- comments remaining untouched;
- private permissions and shell-safe physical paths;
- concurrent calls receiving different staging paths;
- foreground, background, materialization, setup, spawn, and exit cleanup;
- latest user edit after approval;
- deferred sandbox preparation with the staged read root;
- remote Link passthrough;
- enforcement retaining publish capabilities without false external-path capabilities.

Verification:

- `bun run quality:quick` — passed
- `bun run secrets:check` — passed
- focused Bash, enforcement, and sandbox suites — 320 passed, 0 failed
- new virtual-path suite — 13 passed, 0 failed
- full package suite — 5,233 passed, 1 skipped, 20 failed because parallel tests share and corrupt the global config environment (`.../.synergy/config\0`); the affected files pass independently (41 passed, 0 failed)
- `bun run test:changed` reproduces the same repository-level parallel environment issue: 2,129 passed and the same 20 initialization tests failed

## Documentation

- Document the reviewed outbound-content workflow in the Bash tool guidance and Git development skill.
- Update the core runtime agent guide to reflect deferred sandbox wrapping.
