### PR TITLE
feat: add provider auth self-healing and attention UI

### DIFF
--- a/.synergy/skill/develop-synergy/SKILL.md
+++ b/.synergy/skill/develop-synergy/SKILL.md
@@ -117,13 +117,13 @@ mkdir -p "/tmp/synergy-dev-$(git branch --show-current)"
 
 ### Step 3: Copy config from main environment
 
-This avoids re-configuring API keys, providers, models, and agents:
+This avoids re-configuring provider settings, models, and agents:
 
 ```bash
 cp -r ~/.synergy/config /tmp/synergy-dev/.synergy/config
 ```
 
-This copies all domain config files (`00-general.jsonc` through `120-runtime.jsonc`) including your provider auth, model preferences, and custom agents.
+This copies all domain config files (`00-general.jsonc` through `120-runtime.jsonc`), including provider configuration, model preferences, and custom agents. Stored credentials remain isolated in `.synergy/data/auth/provider-auth.json` and are not copied by this command. Authentication-recovery tests should seed only the fixture credentials they need inside the isolated `SYNERGY_HOME`; never copy or overwrite the live credential store implicitly.
 
 ### Step 4: Choose ports that don't conflict with any running instance
 
@@ -182,5 +182,5 @@ rm -rf /tmp/synergy-dev
 
 - **Forgetting `SYNERGY_HOME`**: without it, the dev instance uses `~/.synergy/` and hits `AlreadyRunningError`
 - **Port conflicts across worktrees**: if you have multiple worktrees each running a dev instance, 4097/3001 will be taken by the first one. Always run the scan in Step 1 before picking ports.
-- **Missing config**: without copying config, the dev instance has no API keys and can't call models
+- **Missing credentials**: copying config does not copy the provider credential store. Seed an isolated fixture or connect the provider explicitly when a test must make authenticated model calls.
 - **`bun dev send` without `SYNERGY_HOME`**: sends to the main instance's server — usually what you want for normal use, but use `SYNERGY_HOME` if testing CLI changes in isolation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ SYNERGY_HOME=/tmp/synergy-dev bun dev web --server-port 4097 --app-port 3001
 Rules:
 
 - Always use explicit `--server-port` and `--app-port` that differ from the running instance
-- Always copy `~/.synergy/config` into the isolated directory (avoids reconfiguring API keys)
+- Always copy `~/.synergy/config` into the isolated directory (preserves provider settings without copying the separate credential store)
 - Never run `synergy stop` or `kill` on the main instance process
 
 The `develop-synergy` skill (`skill(name: "develop-synergy")`) has the full workflow.

--- a/README.md
+++ b/README.md
@@ -332,13 +332,15 @@ Use `synergy auth login` or the Web UI's **Connect provider** dialog to connect 
 ~/.synergy/data/auth/provider-auth.json
 ```
 
-Synergy resolves providers from a built-in provider profile registry, an optional signed remote catalog, `models.dev` metadata, live model discovery, and user config overrides. The remote catalog is data-only and must verify with the configured Ed25519 public key before Synergy uses it; provider-specific auth and transport behavior comes from built-in code or explicitly installed plugins, not remote executable code.
+Synergy resolves providers from a built-in provider profile registry, an optional signed remote catalog, `models.dev` metadata, live model discovery, and user config overrides. The remote catalog is data-only and must verify with the configured Ed25519 public key before Synergy uses it; provider-specific auth and transport behavior comes from built-in code or explicitly installed plugins, not remote executable code. Static and live catalogs use separate cache entries, so opening an offline provider list cannot suppress a later account-backed model refresh.
 
-`openai-codex` is the built-in OpenAI Codex provider for ChatGPT/Codex subscription login. It uses a ChatGPT/Codex device-code sign-in and the Codex backend, then exposes account-visible Codex models such as `gpt-5.4-mini` in `synergy models openai-codex` and the model picker. This is separate from the normal `openai` provider: OpenAI Platform API keys still use `openai` and follow Platform API billing.
+`openai-codex` is the built-in OpenAI Codex provider for ChatGPT/Codex subscription login. It uses a ChatGPT/Codex device-code sign-in and the Codex backend, then exposes every account-visible model returned by live discovery in `synergy models openai-codex` and the model picker. Account model slugs are not constrained by a static version allowlist. This is separate from the normal `openai` provider: OpenAI Platform API keys still use `openai` and follow Platform API billing.
 
 Synergy also supports subscription-style provider profiles such as Claude Pro/Max OAuth, GitHub Copilot, MiniMax OAuth, and usage-aware providers such as OpenRouter. Run `synergy auth usage [provider]` to inspect quota or credit snapshots when a provider exposes a reliable endpoint. Providers without a reliable usage endpoint report usage as unavailable.
 
-When `CODEX_HOME` or `~/.codex/auth.json` exists, the CLI can copy valid Codex CLI credentials into Synergy. Synergy does not share or write back to the Codex CLI auth file, so refresh-token rotation stays isolated between the two tools.
+Provider authentication is validated only by real model, usage, and model-discovery requests; Synergy does not periodically probe third-party accounts. A rejected OAuth request refreshes once and retries once, concurrent refreshes are coalesced, and credential pools preserve backup entries. Rate limits remain quota state rather than sign-in failures, while timeouts, network failures, 5xx responses, and unclassified 403 responses leave credential health unchanged. If recovery cannot restore access, Sidebar, Providers, Usage, and GitHub Settings show one shared recovery state instead of a raw HTTP status. Environment-backed credentials direct the user to update the server environment; stored OAuth and API-key credentials provide reconnect or replacement actions.
+
+When `CODEX_HOME` or `~/.codex/auth.json` exists, the CLI can explicitly copy valid Codex CLI credentials into Synergy. Synergy never re-imports, shares, or writes back to the Codex CLI auth file automatically, so refresh-token rotation stays isolated between the two tools.
 
 ### Project instruction files
 

--- a/packages/app/PRODUCT.md
+++ b/packages/app/PRODUCT.md
@@ -65,7 +65,11 @@ Model settings should keep role routing and quick-switcher visibility together i
 
 Provider settings should behave like a connection workspace, not a config editor. Keep provider discovery, selected-provider detail, and login flows together in the Providers page; provider quota, billing, and account-health details belong in Usage. The provider list should scroll inside its own column so the selected detail remains anchored. Do not expose raw provider allow/deny text lists in the primary settings UI.
 
+Provider authentication uses one product-facing health model across Sidebar, Providers, Usage, GitHub, and model availability. A refreshable OAuth access-token expiry remains connected; only a confirmed rejection that cannot recover becomes action required. Rate limits remain temporary availability state, and transient network or server failures offer retry without changing authentication health. Needs attention is mutually exclusive with Recommended, Connected, and Available to connect, and raw failure codes stay in diagnostics rather than primary copy.
+
 Usage settings should read as compact account summaries, not a wide report. Keep refresh controls inside the content flow, label quota windows with user-facing durations such as a 5-hour window, show provider reset timing inline with each quota row when available, and avoid stretching quota rows across the full modal width.
+
+The Sidebar footer contains one non-dismissible Attention rail above the account hub. Product updates retain their own state machine, while a pure selector combines update presentation with provider-auth health. Active download, install, or restart work wins; provider action-required state follows; update failures and ready updates follow after that. Multiple rejected providers aggregate into one stable notice, and resolving the underlying state removes it without a toast or dismissal preference.
 
 Integration settings such as MCP and Email should present connection management, not protocol debugging. Use compact status rows, plain task labels, and grouped connection fields that explain what Synergy will do with the connection. Keep local command, remote endpoint, SMTP, and IMAP details secondary to the user's intent: add tools, send mail, or read mail.
 
@@ -166,6 +170,8 @@ Product UI icons must use semantic tokens rather than raw Lucide literals. Each 
 Treat brand assets as a hierarchy, not interchangeable decoration. SII is the institutional parent, Holos is the organization and platform behind Synergy, and Synergy is the product. The Synergy product icon is the canonical app, favicon, notification, social, and external-attribution icon; Holos wordmarks may identify the backing organization/platform layer in the app shell and account surfaces, and SII marks should only identify the institute layer.
 
 Provider discovery should use provider profile metadata for explanatory copy and external sign-up CTAs. Settings may curate a short Recommended provider set for product guidance; custom providers remain standard alphabetical entries unless they declare metadata.
+
+Online account model discovery accepts future model slugs without a client allowlist. When live discovery cannot be verified because of a transient failure, stable fallback models may remain visible but must be labeled as a fallback catalog; authentication rejection instead makes the provider unavailable and routes to recovery.
 
 Clarifying question prompts are decision surfaces, not tool-output cards. They should use a solid outer shell, filled option rows, quiet step chips, clear disabled primary actions, and only the minimum icons needed to show disclosure or selection state.
 

--- a/packages/app/src/components/note-panel.tsx
+++ b/packages/app/src/components/note-panel.tsx
@@ -378,6 +378,7 @@ function RunMenu(props: {
     const list: ModelOption[] = []
     for (const provider of data.all) {
       if (!data.connected.includes(provider.id)) continue
+      if (data.runtimeAvailability?.[provider.id]?.available === false) continue
       for (const [modelId, model] of Object.entries(provider.models)) {
         list.push({
           kind: "model",

--- a/packages/app/src/components/provider/ProviderConnectionFlow.tsx
+++ b/packages/app/src/components/provider/ProviderConnectionFlow.tsx
@@ -20,6 +20,7 @@ export { compareProviderIDs, providerConnectCopy } from "./provider-recommendati
 export function ProviderConnectionFlow(props: {
   providerID: string
   providerName?: string
+  intent?: "connect" | "recover"
   connectedOverride?: boolean
   completeDescription?: string
   iconID?: string
@@ -109,13 +110,12 @@ export function ProviderConnectionFlow(props: {
   })
 
   async function complete() {
-    await globalSDK.client.global.dispose()
-    await globalSync.refreshAllConfigs()
+    await globalSync.refreshProviders()
     await props.onComplete?.()
     showToast({
       type: "success",
       icon: "circle-check",
-      title: `${providerName()} connected`,
+      title: `${providerName()} ${props.intent === "recover" ? "reconnected" : "connected"}`,
       description: props.completeDescription ?? `${providerName()} models are now available to use.`,
     })
   }
@@ -166,8 +166,12 @@ export function ProviderConnectionFlow(props: {
           <Match when={store.methodIndex === undefined}>
             <div class="provider-method-list">
               <div class="provider-flow-intro">
-                <div class="provider-flow-eyebrow">{connected() ? "Credential refresh" : "Connection method"}</div>
-                <div class="provider-flow-heading">{connected() ? "Refresh credentials" : "Choose how to connect"}</div>
+                <div class="provider-flow-eyebrow">
+                  {props.intent === "recover" ? "Account recovery" : "Connection method"}
+                </div>
+                <div class="provider-flow-heading">
+                  {props.intent === "recover" ? "Reconnect or replace credentials" : "Choose how to connect"}
+                </div>
               </div>
               <For each={methods()}>
                 {(item, index) => (
@@ -232,7 +236,9 @@ export function ProviderConnectionFlow(props: {
                 <form onSubmit={handleSubmit} class="provider-api-form">
                   <div class="provider-step-header">
                     <div class="provider-flow-eyebrow">API key</div>
-                    <div class="provider-flow-heading">Add a {providerName()} key</div>
+                    <div class="provider-flow-heading">
+                      {props.intent === "recover" ? "Replace" : "Add"} a {providerName()} key
+                    </div>
                     <p>Use a key from your provider account to make this provider available in Synergy.</p>
                   </div>
                   <Show when={providerCTA(props.providerID, profiles())}>

--- a/packages/app/src/components/provider/provider-auth-presentation.test.ts
+++ b/packages/app/src/components/provider/provider-auth-presentation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test"
+import {
+  providerNeedsAction,
+  providerRecoveryCopy,
+  providerStatusLabel,
+  providerUsageStatusLabel,
+} from "./provider-auth-presentation"
+
+describe("provider auth presentation", () => {
+  test("durable action-required and immediate usage rejection share one decision", () => {
+    expect(providerNeedsAction({ providerID: "a", status: "action_required" })).toBe(true)
+    expect(
+      providerNeedsAction(undefined, {
+        providerID: "a",
+        status: "error",
+        fetchedAt: new Date(0).toISOString(),
+        windows: [],
+        details: [],
+        reloginRequired: true,
+      }),
+    ).toBe(true)
+  })
+
+  test("exhaustion never turns a stale usage hint into a login prompt", () => {
+    expect(
+      providerNeedsAction(
+        { providerID: "a", status: "exhausted" },
+        {
+          providerID: "a",
+          status: "error",
+          fetchedAt: new Date(0).toISOString(),
+          windows: [],
+          details: [],
+          reloginRequired: true,
+        },
+      ),
+    ).toBe(false)
+    expect(providerStatusLabel({ providerID: "a", status: "exhausted" })).toBe("Temporarily unavailable")
+  })
+
+  test("recovery copy distinguishes environment, API-key, and OAuth actions", () => {
+    expect(
+      providerRecoveryCopy(
+        "GitHub",
+        { providerID: "github", status: "action_required", recovery: "update_environment" },
+        ["GH_TOKEN", "GITHUB_TOKEN"],
+      ),
+    ).toContain("GH_TOKEN or GITHUB_TOKEN")
+    expect(
+      providerRecoveryCopy("OpenRouter", {
+        providerID: "openrouter",
+        status: "action_required",
+        authKind: "api_key",
+      }),
+    ).toContain("Replace")
+    expect(providerRecoveryCopy("OpenAI Codex", { providerID: "openai-codex", status: "action_required" })).toContain(
+      "Reconnect",
+    )
+  })
+
+  test("usage badges distinguish rejection, exhaustion, and transient failure", () => {
+    const snapshot = (status: "available" | "unavailable" | "error", reloginRequired = false) => ({
+      providerID: "a",
+      status,
+      fetchedAt: new Date(0).toISOString(),
+      windows: [],
+      details: [],
+      reloginRequired,
+    })
+    expect(providerUsageStatusLabel(undefined, snapshot("error", true))).toBe("Sign-in required")
+    expect(providerUsageStatusLabel({ providerID: "a", status: "exhausted" }, snapshot("error"))).toBe(
+      "Temporarily unavailable",
+    )
+    expect(providerUsageStatusLabel({ providerID: "a", status: "connected" }, snapshot("error"))).toBe("Retry")
+  })
+})

--- a/packages/app/src/components/provider/provider-auth-presentation.ts
+++ b/packages/app/src/components/provider/provider-auth-presentation.ts
@@ -1,0 +1,71 @@
+import type {
+  AccountUsageSnapshot,
+  ProviderAuthHealth,
+  ProviderRuntimeAvailability,
+} from "@ericsanchezok/synergy-sdk/client"
+
+export function providerNeedsAction(health?: ProviderAuthHealth, usageSnapshot?: AccountUsageSnapshot) {
+  if (health?.status === "action_required") return true
+  if (health?.status === "exhausted") return false
+  return usageSnapshot?.reloginRequired === true
+}
+
+export function providerStatusLabel(health?: ProviderAuthHealth, availability?: ProviderRuntimeAvailability): string {
+  if (health?.status === "action_required") {
+    if (health.recovery === "update_environment") return "Update environment"
+    if (health.authKind === "api_key") return "Replace credentials"
+    return "Sign-in required"
+  }
+  if (health?.status === "exhausted") return "Temporarily unavailable"
+  if (availability?.reason === "fallback_unverified") return "Fallback catalog"
+  if (health?.status === "connected") return availability?.available === false ? "Unavailable" : "Connected"
+  return "Not connected"
+}
+
+export function providerRecoveryCopy(
+  providerName: string,
+  health?: ProviderAuthHealth,
+  environment: string[] = [],
+): string {
+  if (health?.recovery === "update_environment") {
+    const names = environment.length > 0 ? environment.join(" or ") : "the configured environment variable"
+    return `${providerName} rejected credentials from ${names}. Update the environment and restart the server.`
+  }
+  if (health?.authKind === "api_key") {
+    return `${providerName} rejected this API key. Replace it to restore models and usage.`
+  }
+  return `${providerName} rejected these credentials. Reconnect to restore models and usage.`
+}
+
+export function providerRecoveryTarget(providerID: string) {
+  return providerID === "github"
+    ? ({ section: "github" as const, providerID } satisfies ProviderRecoveryTarget)
+    : ({ section: "providers" as const, providerID } satisfies ProviderRecoveryTarget)
+}
+
+export function providerAuthTone(health?: ProviderAuthHealth) {
+  if (health?.status === "action_required") return "warning" as const
+  if (health?.status === "exhausted") return "muted" as const
+  if (health?.status === "connected") return "success" as const
+  return "muted" as const
+}
+
+export function providerRecoveryActionLabel(health?: ProviderAuthHealth) {
+  if (health?.recovery === "update_environment") return "View setup"
+  if (health?.authKind === "api_key") return "Replace credentials"
+  return "Reconnect"
+}
+
+export function providerUsageStatusLabel(health?: ProviderAuthHealth, snapshot?: AccountUsageSnapshot) {
+  if (providerNeedsAction(health, snapshot)) return health ? providerStatusLabel(health) : "Sign-in required"
+  if (health?.status === "exhausted") return "Temporarily unavailable"
+  if (snapshot?.status === "error") return "Retry"
+  if (snapshot?.status === "unavailable") return "Unavailable"
+  if (snapshot?.status === "available") return "Available"
+  return providerStatusLabel(health)
+}
+
+export type ProviderRecoveryTarget = {
+  section: "providers" | "github"
+  providerID?: string
+}

--- a/packages/app/src/components/provider/provider-recommendation.ts
+++ b/packages/app/src/components/provider/provider-recommendation.ts
@@ -4,6 +4,8 @@ export type ProviderRecommendationMetadata = {
   displayName?: string
   description?: string
   signupUrl?: string
+  authKind?: string
+  environment?: string[]
   recommendation?: {
     level: "featured" | "recommended" | "standard"
     rank?: number

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -123,6 +123,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
     const list: ProviderModel[] = []
     for (const provider of data.all) {
       if (!data.connected.includes(provider.id)) continue
+      if (data.runtimeAvailability?.[provider.id]?.available === false) continue
       for (const [modelId, model] of Object.entries(provider.models) as [
         string,
         { name: string; variants?: Record<string, unknown> },
@@ -165,14 +166,9 @@ export function SettingsPanel(props: SettingsPanelProps) {
         id: provider.id,
         name: provider.name,
         connected: data.connected.includes(provider.id),
-        available: availability?.available ?? data.connected.includes(provider.id),
         modelCount: availability?.modelCount ?? Object.keys(provider.models).length,
-        authStatus: health?.status,
-        availabilityReason: availability?.reason,
-        reloginRequired: health?.reloginRequired,
-        cooldownUntil: health?.cooldownUntil,
-        resetAt: health?.resetAt,
-        failureCode: health?.failureCode,
+        health,
+        availability,
         profile: data.profiles?.[provider.id],
       }
     })

--- a/packages/app/src/components/settings/panels/GitHubPanel.tsx
+++ b/packages/app/src/components/settings/panels/GitHubPanel.tsx
@@ -1,4 +1,4 @@
-import type { GitHubAuthStatus } from "@ericsanchezok/synergy-sdk/client"
+import type { GitHubAuthStatus, ProviderAuthHealth } from "@ericsanchezok/synergy-sdk/client"
 import { Button } from "@ericsanchezok/synergy-ui/button"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
@@ -8,6 +8,11 @@ import { ProviderConnectionFlow } from "@/components/provider/ProviderConnection
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { SettingsPage, SettingsSection } from "../components/SettingsPrimitives"
+import {
+  providerNeedsAction,
+  providerRecoveryCopy,
+  providerStatusLabel,
+} from "@/components/provider/provider-auth-presentation"
 
 export function GitHubPanel() {
   const globalSDK = useGlobalSDK()
@@ -18,15 +23,29 @@ export function GitHubPanel() {
   })
 
   const connected = createMemo(() => status()?.status === "connected")
-  const statusLabel = createMemo(() => githubStatusLabel(status()))
+  const effectiveHealth = createMemo<ProviderAuthHealth | undefined>(() => {
+    const health = globalSync.data.provider.authHealth?.github
+    if (health?.status === "action_required") return health
+    if (status()?.status !== "invalid") return health
+    return {
+      providerID: "github",
+      status: "action_required",
+      recovery: status()?.source === "env" ? "update_environment" : "reconnect",
+      source: status()?.source,
+      authKind: status()?.authKind,
+    }
+  })
+  const needsAction = createMemo(() => providerNeedsAction(effectiveHealth()))
+  const statusLabel = createMemo(() =>
+    needsAction() ? providerStatusLabel(effectiveHealth()) : githubStatusLabel(status()),
+  )
 
   async function refreshStatus() {
-    await Promise.all([refetch(), globalSync.refreshAllConfigs()])
+    await Promise.all([refetch(), globalSync.refreshProviders()])
   }
 
   async function logout() {
     await globalSDK.client.auth.githubLogout({}, { throwOnError: true })
-    await globalSDK.client.global.dispose()
     await refreshStatus()
     showToast({ type: "warning", title: "GitHub disconnected", description: "Stored GitHub credentials were removed." })
   }
@@ -64,6 +83,15 @@ export function GitHubPanel() {
         </div>
       </SettingsSection>
 
+      <Show when={needsAction()}>
+        <SettingsSection title="Action required">
+          <div class="providers-auth-warning" role="status">
+            <Icon name={getSemanticIcon("providers.reconnect")} size="small" />
+            <span>{providerRecoveryCopy("GitHub", effectiveHealth(), ["GH_TOKEN", "GITHUB_TOKEN"])}</span>
+          </div>
+        </SettingsSection>
+      </Show>
+
       <Show when={status()?.account}>
         {(account) => (
           <SettingsSection title="Account">
@@ -75,32 +103,50 @@ export function GitHubPanel() {
                 </p>
               </div>
             </div>
-            <Show when={account().url}>
-              <div class="providers-connect-actions">
-                <a class="provider-auth-link" href={account().url} target="_blank" rel="noreferrer">
-                  <span>Open GitHub profile</span>
-                  <Icon name={getSemanticIcon("action.open")} size="small" />
-                </a>
+            <div class="providers-connect-actions">
+              <Show when={account().url}>
+                {(url) => (
+                  <a class="provider-auth-link" href={url()} target="_blank" rel="noreferrer">
+                    <span>Open GitHub profile</span>
+                    <Icon name={getSemanticIcon("action.open")} size="small" />
+                  </a>
+                )}
+              </Show>
+              <Show when={status()?.source === "store"}>
                 <button type="button" class="provider-auth-link" onClick={logout}>
                   <span>Log out</span>
                   <Icon name={getSemanticIcon("account.logout")} size="small" />
                 </button>
-              </div>
-            </Show>
+              </Show>
+            </div>
           </SettingsSection>
         )}
       </Show>
 
-      <SettingsSection>
-        <ProviderConnectionFlow
-          providerID="github"
-          providerName="GitHub"
-          connectedOverride={connected()}
-          skipAutoAdvance
-          completeDescription="GitHub credentials are ready for GitHub CLI-backed actions."
-          onComplete={refreshStatus}
-        />
-      </SettingsSection>
+      <Show
+        when={status()?.source !== "env"}
+        fallback={
+          <SettingsSection title="Environment credentials">
+            <p class="providers-connect-copy">
+              {needsAction()
+                ? "Update GH_TOKEN or GITHUB_TOKEN in the Synergy server environment, then restart the server and refresh this page."
+                : "GitHub is connected through GH_TOKEN or GITHUB_TOKEN in the Synergy server environment."}
+            </p>
+          </SettingsSection>
+        }
+      >
+        <SettingsSection>
+          <ProviderConnectionFlow
+            providerID="github"
+            providerName="GitHub"
+            intent={needsAction() ? "recover" : "connect"}
+            connectedOverride={connected()}
+            skipAutoAdvance
+            completeDescription="GitHub credentials are ready for GitHub CLI-backed actions."
+            onComplete={refreshStatus}
+          />
+        </SettingsSection>
+      </Show>
     </SettingsPage>
   )
 }

--- a/packages/app/src/components/settings/panels/ProvidersPanel.test.ts
+++ b/packages/app/src/components/settings/panels/ProvidersPanel.test.ts
@@ -39,8 +39,6 @@ describe("Providers panel UI contract", () => {
     expect(providersPanel).toContain('"openrouter"')
     expect(providersPanel).toContain('"openai-codex"')
     expect(providersPanel).toContain('"zhipu-ai-coding-plan"')
-    expect(providersPanel).toContain("filter((provider) => SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id))")
-    expect(providersPanel).toContain("provider.connected && !SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id)")
     expect(providersPanel).not.toContain("isRecommendedProvider")
   })
 

--- a/packages/app/src/components/settings/panels/ProvidersPanel.tsx
+++ b/packages/app/src/components/settings/panels/ProvidersPanel.tsx
@@ -1,4 +1,8 @@
-import type { ProviderAuthResponse } from "@ericsanchezok/synergy-sdk/client"
+import type {
+  ProviderAuthHealth,
+  ProviderAuthResponse,
+  ProviderRuntimeAvailability,
+} from "@ericsanchezok/synergy-sdk/client"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { ProviderIcon } from "@ericsanchezok/synergy-ui/provider-icon"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
@@ -11,6 +15,14 @@ import {
   type ProviderRecommendationMetadata,
 } from "@/components/provider/provider-recommendation"
 import { SettingsPage } from "../components/SettingsPrimitives"
+import {
+  providerNeedsAction,
+  providerAuthTone,
+  providerRecoveryActionLabel,
+  providerRecoveryCopy,
+  providerStatusLabel,
+} from "@/components/provider/provider-auth-presentation"
+import { groupProviderConnections } from "./provider-groups"
 
 const SETTINGS_RECOMMENDED_PROVIDER_IDS = [
   "deepseek",
@@ -28,14 +40,9 @@ export type ProviderConnectionSummary = {
   id: string
   name: string
   connected: boolean
-  available: boolean
   modelCount: number
-  authStatus?: string
-  availabilityReason?: string
-  reloginRequired?: boolean
-  cooldownUntil?: number
-  resetAt?: number
-  failureCode?: string
+  health?: ProviderAuthHealth
+  availability?: ProviderRuntimeAvailability
   profile?: ProviderRecommendationMetadata
 }
 
@@ -64,21 +71,18 @@ export function ProvidersPanel(props: {
     if (!q) return summaries()
     return summaries().filter((provider) => `${provider.name} ${provider.id}`.toLowerCase().includes(q))
   })
+  const groups = createMemo(() => groupProviderConnections(filtered(), SETTINGS_RECOMMENDED_PROVIDER_RANK))
   const recommended = createMemo(() =>
-    filtered()
-      .filter((provider) => SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id))
-      .sort((a, b) => settingsRecommendedRank(a.id) - settingsRecommendedRank(b.id)),
+    groups().recommended.sort((a, b) => settingsRecommendedRank(a.id) - settingsRecommendedRank(b.id)),
   )
-  const connected = createMemo(() =>
-    filtered().filter((provider) => provider.connected && !SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id)),
-  )
-  const other = createMemo(() =>
-    filtered().filter((provider) => !SETTINGS_RECOMMENDED_PROVIDER_RANK.has(provider.id) && !provider.connected),
-  )
+  const needsAttention = () => groups().needsAttention
+  const connected = () => groups().connected
+  const other = () => groups().other
   const selected = createMemo(() => {
     const current = selectedID()
     return (
       summaries().find((provider) => provider.id === current) ??
+      needsAttention()[0] ??
       recommended()[0] ??
       connected()[0] ??
       other()[0] ??
@@ -86,13 +90,8 @@ export function ProvidersPanel(props: {
     )
   })
 
-  function statusLabel(provider: ProviderConnectionSummary) {
-    if (provider.authStatus === "dead") return "Relogin"
-    if (provider.authStatus === "exhausted") return "Exhausted"
-    if (provider.authStatus === "expired") return "Expired"
-    if (provider.connected) return provider.available ? "Connected" : "Unavailable"
-    return "Not connected"
-  }
+  const statusLabel = (provider: ProviderConnectionSummary) =>
+    providerStatusLabel(provider.health, provider.availability)
 
   return (
     <SettingsPage title="Providers" description="Connect model providers and manage runtime availability.">
@@ -112,6 +111,13 @@ export function ProvidersPanel(props: {
               when={filtered().length > 0}
               fallback={<div class="providers-list-empty">No providers match this search.</div>}
             >
+              <ProviderGroup
+                title="Needs attention"
+                providers={needsAttention()}
+                selectedID={selected()?.id}
+                onSelect={setSelectedID}
+                statusLabel={statusLabel}
+              />
               <ProviderGroup
                 title="Recommended"
                 providers={recommended()}
@@ -162,7 +168,8 @@ export function ProvidersPanel(props: {
                   </div>
                   <span
                     class="ds-inline-badge"
-                    classList={{ "ds-inline-badge-muted": !provider().connected || !provider().available }}
+                    classList={{ "ds-inline-badge-muted": providerAuthTone(provider().health) === "muted" }}
+                    data-auth-tone={providerAuthTone(provider().health)}
                   >
                     {statusLabel(provider())}
                   </span>
@@ -174,24 +181,52 @@ export function ProvidersPanel(props: {
                   <Show when={props.authMethods[provider().id]?.length}>
                     <span>{props.authMethods[provider().id].map((method) => method.label).join(", ")}</span>
                   </Show>
-                  <Show when={provider().failureCode}>
-                    <span>{provider().failureCode}</span>
-                  </Show>
-                  <Show when={provider().availabilityReason && provider().availabilityReason !== "connected"}>
-                    <span>{provider().availabilityReason?.replace(/_/g, " ")}</span>
+                  <Show when={provider().availability?.reason && provider().availability?.reason !== "connected"}>
+                    <span>{provider().availability?.reason?.replace(/_/g, " ")}</span>
                   </Show>
                 </div>
 
+                <Show when={providerNeedsAction(provider().health)}>
+                  <div class="providers-auth-warning" role="status">
+                    <Icon name={getSemanticIcon("providers.reconnect")} size="small" />
+                    <span>
+                      {providerRecoveryCopy(provider().name, provider().health, provider().profile?.environment)}
+                    </span>
+                  </div>
+                </Show>
+
                 <div class="providers-connect-section">
                   <div>
-                    <div class="providers-connect-title">{provider().connected ? "Account" : "Connect"}</div>
+                    <div class="providers-connect-title">
+                      {providerNeedsAction(provider().health)
+                        ? providerRecoveryActionLabel(provider().health)
+                        : provider().connected
+                          ? "Account"
+                          : "Connect"}
+                    </div>
                     <p class="providers-connect-copy">
-                      {provider().connected
-                        ? "Credentials are connected. Use Usage for quota and billing details."
-                        : "Choose a sign-in method. Synergy will make available models selectable after connection."}
+                      {providerNeedsAction(provider().health)
+                        ? "Choose a recovery method. Existing backup credentials remain available."
+                        : provider().connected
+                          ? "Credentials are connected. Use Usage for quota and billing details."
+                          : "Choose a sign-in method. Synergy will make available models selectable after connection."}
                     </p>
                   </div>
-                  <ProviderConnectionFlow providerID={provider().id} compact />
+                  <Show
+                    when={provider().health?.recovery !== "update_environment"}
+                    fallback={
+                      <p class="providers-connect-copy">
+                        Update the server environment, restart Synergy, then refresh this page. Environment values are
+                        never overwritten by Settings.
+                      </p>
+                    }
+                  >
+                    <ProviderConnectionFlow
+                      providerID={provider().id}
+                      intent={providerNeedsAction(provider().health) ? "recover" : "connect"}
+                      compact
+                    />
+                  </Show>
                 </div>
               </div>
             )}
@@ -234,7 +269,8 @@ function ProviderGroup(props: {
               </div>
               <span
                 class="ds-inline-badge"
-                classList={{ "ds-inline-badge-muted": !provider.connected || !provider.available }}
+                classList={{ "ds-inline-badge-muted": providerAuthTone(provider.health) === "muted" }}
+                data-auth-tone={providerAuthTone(provider.health)}
               >
                 {props.statusLabel(provider)}
               </span>

--- a/packages/app/src/components/settings/panels/UsagePanel.tsx
+++ b/packages/app/src/components/settings/panels/UsagePanel.tsx
@@ -1,4 +1,4 @@
-import type { AccountUsageSnapshot } from "@ericsanchezok/synergy-sdk/client"
+import type { AccountUsageSnapshot, ProviderAuthHealth } from "@ericsanchezok/synergy-sdk/client"
 import { Button } from "@ericsanchezok/synergy-ui/button"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { ProviderIcon } from "@ericsanchezok/synergy-ui/provider-icon"
@@ -17,6 +17,12 @@ import {
   nextUsageReset,
   usageWindowMeterPercent,
 } from "./UsagePanel.model"
+import {
+  providerNeedsAction,
+  providerRecoveryActionLabel,
+  providerRecoveryCopy,
+  providerUsageStatusLabel,
+} from "@/components/provider/provider-auth-presentation"
 
 const USAGE_FIRST_PROVIDER_IDS = ["openai-codex", "anthropic", "github-copilot", "openrouter", "openai"]
 
@@ -37,13 +43,24 @@ export function UsagePanel(props: { onConnectProvider: (providerID?: string) => 
       { id: b, name: providerName(b) },
     )
   const usageCapableIDs = createMemo(() => {
-    const ids = new Set([...USAGE_FIRST_PROVIDER_IDS, ...Object.keys(usage() ?? {})])
+    const attentionIDs = Object.values(globalSync.data.provider.authHealth ?? {})
+      .filter((health) => health.status === "action_required")
+      .map((health) => health.providerID)
+    const ids = new Set([...USAGE_FIRST_PROVIDER_IDS, ...Object.keys(usage() ?? {}), ...attentionIDs])
     return [...ids].filter((id) => providers().some((provider) => provider.id === id)).sort(sortProviderIDs)
   })
-  const unconnected = createMemo(() => usageCapableIDs().filter((id) => !connected().has(id)))
+  const needsAttention = createMemo(() =>
+    usageCapableIDs()
+      .filter((id) => providerNeedsAction(globalSync.data.provider.authHealth?.[id], usage()?.[id]))
+      .map((id) => ({ providerID: id, snapshot: usage()?.[id] })),
+  )
+  const attentionIDs = createMemo(() => new Set(needsAttention().map((item) => item.providerID)))
+  const unconnected = createMemo(() =>
+    usageCapableIDs().filter((id) => !connected().has(id) && !attentionIDs().has(id)),
+  )
   const connectedUsage = createMemo(() =>
     usageCapableIDs()
-      .filter((id) => connected().has(id))
+      .filter((id) => connected().has(id) && !attentionIDs().has(id))
       .map((id) => ({ providerID: id, snapshot: usage()?.[id] }))
       .sort((a, b) => sortProviderIDs(a.providerID, b.providerID)),
   )
@@ -75,6 +92,12 @@ export function UsagePanel(props: { onConnectProvider: (providerID?: string) => 
               <span class="usage-overview-value">{unconnected().length}</span>
               <span class="usage-overview-label">Available to connect</span>
             </div>
+            <Show when={needsAttention().length > 0}>
+              <div class="usage-overview-metric">
+                <span class="usage-overview-value">{needsAttention().length}</span>
+                <span class="usage-overview-label">Needs attention</span>
+              </div>
+            </Show>
             <Show when={nextReset()}>
               {(reset) => (
                 <div class="usage-overview-metric" title={reset().title}>
@@ -105,6 +128,42 @@ export function UsagePanel(props: { onConnectProvider: (providerID?: string) => 
             </Button>
           </div>
         </div>
+
+        <Show when={usage.error}>
+          <div class="usage-request-error" role="alert">
+            <Icon name={getSemanticIcon("state.error")} size="small" />
+            <span>Usage data could not be loaded.</span>
+            <Button type="button" variant="secondary" size="small" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Show>
+
+        <SettingsSection
+          title="Needs attention"
+          description="These accounts were rejected and remain here until their credentials are recovered."
+        >
+          <SettingsEntityList
+            isEmpty={needsAttention().length === 0}
+            emptyTitle="No provider accounts need attention"
+            emptyDescription="Credential recovery actions will appear here when a provider rejects a request."
+          >
+            <div class="usage-panel-list">
+              <For each={needsAttention()}>
+                {(item) => (
+                  <UsageProviderPanel
+                    providerID={item.providerID}
+                    providerName={providerName(item.providerID)}
+                    snapshot={item.snapshot}
+                    health={globalSync.data.provider.authHealth?.[item.providerID]}
+                    environment={globalSync.data.provider.profiles?.[item.providerID]?.environment}
+                    onConnect={() => props.onConnectProvider(item.providerID)}
+                  />
+                )}
+              </For>
+            </div>
+          </SettingsEntityList>
+        </SettingsSection>
 
         <SettingsSection
           title="Connectable providers"
@@ -159,10 +218,8 @@ export function UsagePanel(props: { onConnectProvider: (providerID?: string) => 
                       providerID={item.providerID}
                       providerName={providerName(item.providerID)}
                       snapshot={item.snapshot}
-                      reloginRequired={globalSync.data.provider.authHealth?.[item.providerID]?.reloginRequired}
-                      cooldownUntil={globalSync.data.provider.authHealth?.[item.providerID]?.cooldownUntil}
-                      resetAt={globalSync.data.provider.authHealth?.[item.providerID]?.resetAt}
-                      status={globalSync.data.provider.authHealth?.[item.providerID]?.status}
+                      health={globalSync.data.provider.authHealth?.[item.providerID]}
+                      environment={globalSync.data.provider.profiles?.[item.providerID]?.environment}
                       onConnect={() => props.onConnectProvider(item.providerID)}
                     />
                   )}
@@ -180,12 +237,12 @@ function UsageProviderPanel(props: {
   providerID: string
   providerName: string
   snapshot?: AccountUsageSnapshot
-  reloginRequired?: boolean
-  cooldownUntil?: number
-  resetAt?: number
-  status?: string
+  health?: ProviderAuthHealth
+  environment?: string[]
   onConnect: () => void
 }) {
+  const needsAction = createMemo(() => providerNeedsAction(props.health, props.snapshot))
+  const badge = createMemo(() => providerUsageStatusLabel(props.health, props.snapshot))
   return (
     <div class="usage-provider-panel">
       <div class="usage-provider-panel-head">
@@ -197,24 +254,24 @@ function UsageProviderPanel(props: {
           </div>
         </div>
         <span class="ds-inline-badge" classList={{ "ds-inline-badge-muted": props.snapshot?.status !== "available" }}>
-          {props.snapshot?.status ?? props.status ?? "connected"}
+          {badge()}
         </span>
       </div>
 
-      <Show when={props.reloginRequired}>
+      <Show when={needsAction()}>
         <div class="usage-warning-row">
-          <Icon name={getSemanticIcon("state.warning")} size="small" />
-          <span>Relogin required.</span>
+          <Icon name={getSemanticIcon("providers.reconnect")} size="small" />
+          <span>{providerRecoveryCopy(props.providerName, props.health, props.environment)}</span>
           <Button type="button" variant="secondary" size="small" onClick={props.onConnect}>
-            Reconnect
+            {providerRecoveryActionLabel(props.health)}
           </Button>
         </div>
       </Show>
 
-      <Show when={props.cooldownUntil}>
+      <Show when={props.health?.cooldownUntil}>
         {(value) => <div class="usage-muted-row">Cooldown until {formatUnix(value())}</div>}
       </Show>
-      <Show when={props.resetAt}>
+      <Show when={props.health?.resetAt}>
         {(value) => <div class="usage-muted-row">Provider renews {formatUnix(value())}</div>}
       </Show>
 

--- a/packages/app/src/components/settings/panels/provider-groups.test.ts
+++ b/packages/app/src/components/settings/panels/provider-groups.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { groupProviderConnections } from "./provider-groups"
+
+describe("provider settings groups", () => {
+  test("every provider appears in exactly one group and attention wins over recommendation", () => {
+    const groups = groupProviderConnections(
+      [
+        {
+          id: "openai-codex",
+          connected: false,
+          health: { providerID: "openai-codex", status: "action_required" as const },
+        },
+        { id: "openrouter", connected: true, health: { providerID: "openrouter", status: "connected" as const } },
+        { id: "anthropic", connected: true },
+        { id: "deepseek", connected: false },
+        { id: "custom", connected: false },
+      ],
+      new Set(["openai-codex", "openrouter", "deepseek"]),
+    )
+
+    expect(groups.needsAttention.map((provider) => provider.id)).toEqual(["openai-codex"])
+    expect(groups.recommended.map((provider) => provider.id)).toEqual(["openrouter", "deepseek"])
+    expect(groups.connected.map((provider) => provider.id)).toEqual(["anthropic"])
+    expect(groups.other.map((provider) => provider.id)).toEqual(["custom"])
+    expect(Object.values(groups).flat()).toHaveLength(5)
+  })
+})

--- a/packages/app/src/components/settings/panels/provider-groups.ts
+++ b/packages/app/src/components/settings/panels/provider-groups.ts
@@ -1,0 +1,32 @@
+import type { ProviderAuthHealth } from "@ericsanchezok/synergy-sdk/client"
+import { providerNeedsAction } from "@/components/provider/provider-auth-presentation"
+
+export type GroupableProvider = {
+  id: string
+  connected: boolean
+  health?: ProviderAuthHealth
+}
+
+export function groupProviderConnections<T extends GroupableProvider>(
+  providers: T[],
+  recommended: { has(providerID: string): boolean },
+) {
+  const result = {
+    needsAttention: [] as T[],
+    recommended: [] as T[],
+    connected: [] as T[],
+    other: [] as T[],
+  }
+  for (const provider of providers) {
+    if (providerNeedsAction(provider.health)) {
+      result.needsAttention.push(provider)
+    } else if (recommended.has(provider.id)) {
+      result.recommended.push(provider)
+    } else if (provider.connected) {
+      result.connected.push(provider)
+    } else {
+      result.other.push(provider)
+    }
+  }
+  return result
+}

--- a/packages/app/src/components/settings/settings-panel.css
+++ b/packages/app/src/components/settings/settings-panel.css
@@ -2273,6 +2273,10 @@
   white-space: nowrap;
 }
 
+.ds-inline-badge[data-auth-tone="warning"] {
+  color: var(--icon-warning-base);
+}
+
 .providers-detail-meta {
   display: flex;
   flex-wrap: wrap;
@@ -2287,6 +2291,30 @@
   background: color-mix(in oklch, var(--border-base) 20%, transparent);
   font-size: var(--settings-type-caption-size);
   line-height: var(--settings-type-caption-line-height);
+}
+
+.providers-auth-warning,
+.usage-request-error {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px;
+  border-radius: 9px;
+  color: var(--text-base);
+  background: color-mix(in oklch, var(--icon-warning-base) 12%, var(--settings-card-bg));
+  font-size: var(--settings-type-body-size);
+  line-height: var(--settings-type-body-line-height);
+}
+
+.providers-auth-warning > span,
+.usage-request-error > span,
+.usage-warning-row > span {
+  min-width: 0;
+  flex: 1;
+}
+
+.usage-request-error {
+  background: color-mix(in oklch, var(--icon-critical-base) 10%, var(--settings-panel-bg));
 }
 
 .provider-auth-link {

--- a/packages/app/src/components/sidebar/app-attention.test.ts
+++ b/packages/app/src/components/sidebar/app-attention.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import type { ProviderAuthHealth } from "@ericsanchezok/synergy-sdk/client"
+import { selectAppAttention } from "./app-attention"
+
+const hiddenUpdate = {
+  visible: false,
+  title: "",
+  detail: "",
+  actionLabel: null,
+  action: null,
+  progress: null,
+  tone: "neutral" as const,
+  busy: false,
+}
+
+function auth(providerID: string): ProviderAuthHealth {
+  return { providerID, status: "action_required", recovery: "reconnect" }
+}
+
+describe("app attention selector", () => {
+  test("an active updater stays above provider authentication", () => {
+    const notice = selectAppAttention({
+      productUpdate: {
+        ...hiddenUpdate,
+        visible: true,
+        title: "Downloading Synergy",
+        tone: "active",
+        progress: 40,
+      },
+      authHealth: { anthropic: auth("anthropic") },
+      providerNames: { anthropic: "Anthropic" },
+    })
+    expect(notice?.source).toBe("product-update")
+    expect(notice?.priority).toBe(400)
+  })
+
+  test("authentication is above update failures and ready updates", () => {
+    for (const tone of ["error", "ready"] as const) {
+      const notice = selectAppAttention({
+        productUpdate: { ...hiddenUpdate, visible: true, title: "Update", tone, action: "check" },
+        authHealth: { "openai-codex": auth("openai-codex") },
+        providerNames: { "openai-codex": "OpenAI Codex" },
+      })
+      expect(notice?.source).toBe("provider-auth")
+    }
+  })
+
+  test("multiple providers aggregate into one stable notice", () => {
+    const notice = selectAppAttention({
+      productUpdate: hiddenUpdate,
+      authHealth: { github: auth("github"), anthropic: auth("anthropic"), "openai-codex": auth("openai-codex") },
+      providerNames: {},
+    })
+    expect(notice?.title).toBe("3 providers need attention")
+    expect(notice?.action).toEqual({ type: "open-settings", section: "providers" })
+  })
+
+  test("a single provider focuses its recovery target and GitHub routes to GitHub settings", () => {
+    const codex = selectAppAttention({
+      productUpdate: hiddenUpdate,
+      authHealth: { "openai-codex": auth("openai-codex") },
+      providerNames: { "openai-codex": "OpenAI Codex" },
+    })
+    expect(codex?.action).toEqual({
+      type: "open-settings",
+      section: "providers",
+      providerID: "openai-codex",
+    })
+
+    const github = selectAppAttention({
+      productUpdate: hiddenUpdate,
+      authHealth: { github: auth("github") },
+      providerNames: { github: "GitHub" },
+    })
+    expect(github?.action).toEqual({ type: "open-settings", section: "github" })
+  })
+})

--- a/packages/app/src/components/sidebar/app-attention.ts
+++ b/packages/app/src/components/sidebar/app-attention.ts
@@ -1,0 +1,77 @@
+import type { ProviderAuthHealth } from "@ericsanchezok/synergy-sdk/client"
+import type { SemanticIconTokenName } from "@ericsanchezok/synergy-ui/semantic-icon"
+import type { ProductUpdateNotice } from "@/context/product-update"
+import { providerNeedsAction, providerRecoveryTarget } from "@/components/provider/provider-auth-presentation"
+
+export type AppAttentionNotice = {
+  id: string
+  source: "product-update" | "provider-auth"
+  priority: number
+  tone: "active" | "warning" | "ready" | "error"
+  title: string
+  detail: string
+  actionLabel?: string
+  progress?: number
+  busy?: boolean
+  iconToken: SemanticIconTokenName
+  action: { type: "product-update" } | { type: "open-settings"; section: "providers" | "github"; providerID?: string }
+}
+
+export function selectAppAttention(input: {
+  productUpdate: ProductUpdateNotice
+  authHealth: Record<string, ProviderAuthHealth>
+  providerNames: Record<string, string>
+}): AppAttentionNotice | undefined {
+  const candidates = [productUpdateAttention(input.productUpdate), providerAuthAttention(input)].filter(
+    (notice): notice is AppAttentionNotice => !!notice,
+  )
+  return candidates.sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id))[0]
+}
+
+function productUpdateAttention(notice: ProductUpdateNotice): AppAttentionNotice | undefined {
+  if (!notice.visible) return undefined
+  const priority = notice.tone === "active" ? 400 : notice.tone === "error" ? 200 : 100
+  return {
+    id: "product-update",
+    source: "product-update",
+    priority,
+    tone: notice.tone === "neutral" ? "ready" : notice.tone,
+    title: notice.title,
+    detail: notice.detail,
+    actionLabel: notice.actionLabel ?? undefined,
+    progress: notice.progress ?? undefined,
+    busy: notice.busy || !notice.action,
+    iconToken: notice.action === "install" ? "product.update.install" : "product.update",
+    action: { type: "product-update" },
+  }
+}
+
+function providerAuthAttention(input: {
+  authHealth: Record<string, ProviderAuthHealth>
+  providerNames: Record<string, string>
+}): AppAttentionNotice | undefined {
+  const affected = Object.values(input.authHealth)
+    .filter((health) => providerNeedsAction(health))
+    .sort((a, b) => a.providerID.localeCompare(b.providerID))
+  if (affected.length === 0) return undefined
+
+  const first = affected[0]
+  const firstName = input.providerNames[first.providerID] ?? first.providerID
+  const single = affected.length === 1
+  const target = single ? providerRecoveryTarget(first.providerID) : { section: "providers" as const }
+  return {
+    id: `provider-auth:${affected.map((health) => health.providerID).join(",")}`,
+    source: "provider-auth",
+    priority: 300,
+    tone: "warning",
+    title: single ? `${firstName} needs sign-in` : `${affected.length} providers need attention`,
+    detail: single ? "Reconnect to restore models and usage." : "Review rejected credentials in Settings.",
+    actionLabel: single && first.recovery === "update_environment" ? "Review" : "Reconnect",
+    iconToken: "providers.reconnect",
+    action: {
+      type: "open-settings",
+      section: target.section,
+      ...(single && target.section === "providers" ? { providerID: first.providerID } : {}),
+    },
+  }
+}

--- a/packages/app/src/components/sidebar/sidebar.css
+++ b/packages/app/src/components/sidebar/sidebar.css
@@ -678,14 +678,14 @@
   display: none;
 }
 
-/* ===== Product update notice ===== */
+/* ===== App attention notice ===== */
 
-.sb-update-notice {
+.sb-attention-notice {
   flex-shrink: 0;
   padding: 6px 8px 0;
 }
 
-.sb-update-button {
+.sb-attention-button {
   display: flex;
   align-items: center;
   gap: 9px;
@@ -702,15 +702,15 @@
     opacity 150ms;
 }
 
-.sb-update-button:not(:disabled):hover {
+.sb-attention-button:not(:disabled):hover {
   background: var(--sb-active-bg);
 }
 
-.sb-update-button:disabled {
+.sb-attention-button:disabled {
   cursor: default;
 }
 
-.sb-update-icon {
+.sb-attention-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -722,7 +722,7 @@
   background: color-mix(in srgb, var(--text-base) 8%, transparent);
 }
 
-.sb-update-copy {
+.sb-attention-copy {
   display: flex;
   flex: 1;
   min-width: 0;
@@ -730,7 +730,7 @@
   gap: 2px;
 }
 
-.sb-update-title {
+.sb-attention-title {
   font-size: var(--font-size-small);
   font-weight: 600;
   color: var(--text-strong);
@@ -739,7 +739,7 @@
   text-overflow: ellipsis;
 }
 
-.sb-update-detail {
+.sb-attention-detail {
   font-size: var(--font-size-x-small);
   font-weight: 500;
   color: var(--text-weak);
@@ -748,14 +748,14 @@
   text-overflow: ellipsis;
 }
 
-.sb-update-action {
+.sb-attention-action {
   flex-shrink: 0;
   font-size: var(--font-size-x-small);
   font-weight: 650;
   color: var(--text-base);
 }
 
-.sb-update-progress {
+.sb-attention-progress {
   height: 3px;
   margin: 5px 2px 0;
   overflow: hidden;
@@ -763,43 +763,52 @@
   background: color-mix(in srgb, var(--text-base) 12%, transparent);
 }
 
-.sb-update-progress span {
+.sb-attention-progress span {
   display: block;
-  width: var(--sb-update-progress);
+  width: var(--sb-attention-progress);
   height: 100%;
   border-radius: inherit;
   background: var(--text-base);
   transition: width 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.sb-update-notice[data-tone="ready"] .sb-update-icon {
+.sb-attention-notice[data-tone="ready"] .sb-attention-icon {
   color: var(--icon-success-base);
   background: color-mix(in srgb, var(--icon-success-base) 14%, transparent);
 }
 
-.sb-update-notice[data-tone="ready"] .sb-update-progress span {
+.sb-attention-notice[data-tone="ready"] .sb-attention-progress span {
   background: var(--icon-success-base);
 }
 
-.sb-update-notice[data-tone="active"] .sb-update-icon {
+.sb-attention-notice[data-tone="active"] .sb-attention-icon {
   color: var(--icon-base);
   background: color-mix(in srgb, var(--icon-base) 14%, transparent);
 }
 
-.sb-update-notice[data-tone="active"] .sb-update-progress span {
+.sb-attention-notice[data-tone="active"] .sb-attention-progress span {
   background: var(--icon-base);
 }
 
-.sb-update-notice[data-tone="error"] .sb-update-icon {
+.sb-attention-notice[data-tone="error"] .sb-attention-icon {
   color: var(--icon-critical-base);
   background: color-mix(in srgb, var(--icon-critical-base) 14%, transparent);
 }
 
-.sb-update-notice[data-tone="error"] .sb-update-progress span {
+.sb-attention-notice[data-tone="error"] .sb-attention-progress span {
   background: var(--icon-critical-base);
 }
 
-.sb-update-notice--collapsed {
+.sb-attention-notice[data-tone="warning"] .sb-attention-icon {
+  color: var(--icon-warning-base);
+  background: color-mix(in srgb, var(--icon-warning-base) 14%, transparent);
+}
+
+.sb-attention-notice[data-tone="warning"] .sb-attention-progress span {
+  background: var(--icon-warning-base);
+}
+
+.sb-attention-notice--collapsed {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -807,7 +816,7 @@
   padding: 6px 8px 0;
 }
 
-.sb-update-notice--collapsed .sb-update-button {
+.sb-attention-notice--collapsed .sb-attention-button {
   width: 32px;
   min-height: 32px;
   justify-content: center;
@@ -815,13 +824,13 @@
   border-radius: 8px;
 }
 
-.sb-update-notice--collapsed .sb-update-progress {
+.sb-attention-notice--collapsed .sb-attention-progress {
   width: 32px;
   margin: 4px 0 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .sb-update-progress span {
+  .sb-attention-progress span {
     transition: none;
   }
 }

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -25,6 +25,7 @@ import { useProductUpdate } from "@/context/product-update"
 import { useHolosAgentActions } from "@/components/holos/agent-actions"
 import { SettingsDialog } from "@/components/settings"
 import { listNavigation, subscribeNavigation, type NavigationEntry } from "@/plugin"
+import { selectAppAttention, type AppAttentionNotice } from "./app-attention"
 import {
   resolveSessionVisualState,
   scopeKeyForNavEntry,
@@ -74,6 +75,7 @@ export function Sidebar(props: SidebarProps) {
   const location = useLocation()
   const params = useParams()
   const { pickProjectDirectories } = useProjectDirectoryPicker()
+  const productUpdate = useProductUpdate()
 
   const isExpanded = () => layout.sidebar.opened()
   const isDark = () => theme.mode() === "dark"
@@ -89,6 +91,33 @@ export function Sidebar(props: SidebarProps) {
     entry.active?.(location.pathname) ?? location.pathname === entry.path
   const navigationIcon = (entry: NavigationEntry) =>
     entry.icon ?? (entry.iconToken ? getSemanticIcon(entry.iconToken) : getSemanticIcon("plugins.main"))
+  const providerNames = createMemo(() =>
+    Object.fromEntries([
+      ...globalSync.data.provider.all.map((provider) => [provider.id, provider.name]),
+      ["github", "GitHub"],
+    ]),
+  )
+  const attention = createMemo(() =>
+    selectAppAttention({
+      productUpdate: productUpdate.notice(),
+      authHealth: globalSync.data.provider.authHealth ?? {},
+      providerNames: providerNames(),
+    }),
+  )
+
+  const runAttentionAction = (notice: AppAttentionNotice) => {
+    const action = notice.action
+    if (action.type === "product-update") {
+      void productUpdate.runNoticeAction()
+      return
+    }
+    dialog.show(() => (
+      <SettingsDialog
+        initialTab={action.section}
+        providerFocusID={action.section === "providers" ? action.providerID : undefined}
+      />
+    ))
+  }
 
   const [recentSectionOpen, setRecentSectionOpen] = createSignal(true)
   const [homeSectionOpen, setHomeSectionOpen] = createSignal(false)
@@ -568,7 +597,7 @@ export function Sidebar(props: SidebarProps) {
         </div>
       </Show>
 
-      <SidebarUpdateNotice isExpanded={isExpanded()} />
+      <SidebarAttentionNotice notice={attention()} isExpanded={isExpanded()} onAction={runAttentionAction} />
 
       {/* Bottom: Agent Hub */}
       <SidebarAgentHub isExpanded={isExpanded()} globalSDK={globalSDK} />
@@ -611,49 +640,51 @@ export function Sidebar(props: SidebarProps) {
   )
 }
 
-function SidebarUpdateNotice(props: { isExpanded: boolean }) {
-  const update = useProductUpdate()
-  const notice = update.notice
-  const icon = () =>
-    notice().action === "install" ? getSemanticIcon("product.update.install") : getSemanticIcon("product.update")
-
+function SidebarAttentionNotice(props: {
+  notice?: AppAttentionNotice
+  isExpanded: boolean
+  onAction: (notice: AppAttentionNotice) => void
+}) {
   return (
-    <Show when={notice().visible}>
-      <div
-        classList={{
-          "sb-update-notice": true,
-          "sb-update-notice--collapsed": !props.isExpanded,
-        }}
-        data-tone={notice().tone}
-        aria-live="polite"
-      >
-        <Tooltip value={`${notice().title}${notice().detail ? ` — ${notice().detail}` : ""}`} placement="right">
-          <button
-            type="button"
-            class="sb-update-button"
-            disabled={!notice().action || notice().busy}
-            onClick={() => void update.runNoticeAction()}
-          >
-            <span class="sb-update-icon">
-              <Icon name={icon()} size="small" />
-            </span>
-            <Show when={props.isExpanded}>
-              <span class="sb-update-copy">
-                <span class="sb-update-title">{notice().title}</span>
-                <span class="sb-update-detail">{notice().detail}</span>
+    <Show when={props.notice}>
+      {(notice) => (
+        <div
+          classList={{
+            "sb-attention-notice": true,
+            "sb-attention-notice--collapsed": !props.isExpanded,
+          }}
+          data-tone={notice().tone}
+          aria-live="polite"
+        >
+          <Tooltip value={`${notice().title}${notice().detail ? ` — ${notice().detail}` : ""}`} placement="right">
+            <button
+              type="button"
+              class="sb-attention-button"
+              aria-label={`${notice().title}${notice().detail ? `. ${notice().detail}` : ""}`}
+              disabled={notice().busy}
+              onClick={() => props.onAction(notice())}
+            >
+              <span class="sb-attention-icon">
+                <Icon name={getSemanticIcon(notice().iconToken)} size="small" />
               </span>
-              <Show when={notice().actionLabel}>
-                <span class="sb-update-action">{notice().busy ? "Working..." : notice().actionLabel}</span>
+              <Show when={props.isExpanded}>
+                <span class="sb-attention-copy">
+                  <span class="sb-attention-title">{notice().title}</span>
+                  <span class="sb-attention-detail">{notice().detail}</span>
+                </span>
+                <Show when={notice().actionLabel}>
+                  <span class="sb-attention-action">{notice().busy ? "Working..." : notice().actionLabel}</span>
+                </Show>
               </Show>
-            </Show>
-          </button>
-        </Tooltip>
-        <Show when={notice().progress != null}>
-          <div class="sb-update-progress" aria-hidden="true">
-            <span style={{ "--sb-update-progress": `${notice().progress ?? 0}%` }} />
-          </div>
-        </Show>
-      </div>
+            </button>
+          </Tooltip>
+          <Show when={notice().progress != null}>
+            <div class="sb-attention-progress" aria-hidden="true">
+              <span style={{ "--sb-attention-progress": `${notice().progress ?? 0}%` }} />
+            </div>
+          </Show>
+        </div>
+      )}
     </Show>
   )
 }

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -815,6 +815,14 @@ function createGlobalSync() {
       bootstrap()
       return
     }
+    if (event?.type === "provider.auth.updated") {
+      const health = event.properties.health
+      setGlobalStore("provider", "authHealth", health.providerID, reconcile(health))
+      for (const state of Object.values(children)) {
+        state[1]("provider", "authHealth", health.providerID, reconcile(health))
+      }
+      return
+    }
     if (event?.type === "scope.updated") {
       const result = Binary.search(globalStore.scope, event.properties.id, (s) => s.id)
       if (event.properties.time?.archived) {
@@ -1434,6 +1442,7 @@ function createGlobalSync() {
     loadGlobalAgenda,
     refreshConfig,
     refreshAllConfigs,
+    refreshProviders: () => refreshTargeted(["provider"]),
     scope: {
       loadSessions,
       loadAgenda,

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -15,7 +15,12 @@ export function useProviders() {
     }
     return globalSync.data.provider
   })
-  const connected = createMemo(() => providers().all.filter((p) => providers().connected.includes(p.id)))
+  const connected = createMemo(() =>
+    providers().all.filter((provider) => {
+      if (!providers().connected.includes(provider.id)) return false
+      return providers().runtimeAvailability?.[provider.id]?.available ?? true
+    }),
+  )
   const popular = createMemo(() => providers().all.filter((p) => isRecommendedProvider(providers().profiles, p.id)))
   return {
     all: createMemo(() => providers().all),

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -229,6 +229,17 @@ config(input, output) {
 
 If a transform empties `output.system`, Synergy restores the original system prompt.
 
+### Provider authentication recovery
+
+Provider profiles may implement `classifyError` and `refreshAuth`. These hooks run in the shared provider request pipeline for model calls and live discovery:
+
+- `classifyError` should return a classification only for a confirmed credential rejection or rate limit. Do not classify a generic 403, timeout, network error, or 5xx response as a credential failure.
+- Set `reloginRequired: true` only when the credential itself has been rejected. Set `exhausted: true` for quota or rate limits and include `cooldownUntil` or `resetAt` when known.
+- `refreshAuth` receives the current credential and returns one replacement credential. It must not persist credentials, mutate the pool, retry the business request, or implement an unbounded refresh loop; Synergy serializes refreshes, updates the selected pool entry, and performs the single request retry.
+- A plugin without `classifyError` keeps its original error response. In particular, Synergy does not guess that an unclassified plugin 403 is an authentication failure.
+
+Auth and error response bodies are never included in public provider-health events. Keep classifier output machine-readable and free of tokens, keys, and upstream response bodies.
+
 ## Plugin Input
 
 `init(input)` receives runtime services scoped to the active Synergy Scope:

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3831,6 +3831,8 @@ export type ProviderAuthError = {
   data: {
     providerID: string
     message: string
+    failureCode?: string
+    actionRequired?: boolean
   }
 }
 
@@ -4405,16 +4407,18 @@ export type ProviderProfileMetadata = {
   displayName?: string
   description?: string
   signupUrl?: string
+  authKind?: string
+  environment?: Array<string>
   recommendation?: ProviderRecommendation
 }
 
 export type ProviderAuthHealth = {
   providerID: string
-  status: "connected" | "not_configured" | "expired" | "exhausted" | "dead"
+  status: "connected" | "not_configured" | "exhausted" | "action_required"
+  recovery?: "reconnect" | "update_environment"
   authKind?: string
   source?: string
   updatedAt?: number
-  reloginRequired?: boolean
   cooldownUntil?: number
   resetAt?: number
   failureCode?: string
@@ -4423,7 +4427,14 @@ export type ProviderAuthHealth = {
 export type ProviderRuntimeAvailability = {
   providerID: string
   available: boolean
-  reason?: "connected" | "not_connected" | "disabled" | "no_models"
+  reason?:
+    | "connected"
+    | "not_connected"
+    | "disabled"
+    | "no_models"
+    | "authentication_required"
+    | "exhausted"
+    | "fallback_unverified"
   healthCheck?: "models" | "none"
   modelCount: number
 }
@@ -5932,6 +5943,13 @@ export type EventScopeRuntimeDisposed = {
   }
 }
 
+export type EventProviderAuthUpdated = {
+  type: "provider.auth.updated"
+  properties: {
+    health: ProviderAuthHealth
+  }
+}
+
 export type EventInstallationUpdated = {
   type: "installation.updated"
   properties: {
@@ -5987,6 +6005,15 @@ export type EventMcpFailed = {
   properties: {
     server: string
     error: string
+  }
+}
+
+export type EventRuntimeReloaded = {
+  type: "runtime.reloaded"
+  properties: {
+    executed: Array<RuntimeReloadTarget>
+    cascaded: Array<RuntimeReloadTarget>
+    changedFields: Array<string>
   }
 }
 
@@ -6266,15 +6293,6 @@ export type EventFileEdited = {
   }
 }
 
-export type EventRuntimeReloaded = {
-  type: "runtime.reloaded"
-  properties: {
-    executed: Array<RuntimeReloadTarget>
-    cascaded: Array<RuntimeReloadTarget>
-    changedFields: Array<string>
-  }
-}
-
 export type EventDagUpdated = {
   type: "dag.updated"
   properties: {
@@ -6494,6 +6512,7 @@ export type Event =
   | EventScopeUpdated
   | EventScopeRemoved
   | EventScopeRuntimeDisposed
+  | EventProviderAuthUpdated
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
   | EventConfigUpdated
@@ -6502,6 +6521,7 @@ export type Event =
   | EventMcpResourcesChanged
   | EventMcpReady
   | EventMcpFailed
+  | EventRuntimeReloaded
   | EventMessageUpdated
   | EventMessageRemoved
   | EventMessagePartUpdated
@@ -6538,7 +6558,6 @@ export type Event =
   | EventLspClientDiagnostics
   | EventLspUpdated
   | EventFileEdited
-  | EventRuntimeReloaded
   | EventDagUpdated
   | EventTodoUpdated
   | EventAgendaItemCreated

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2065,6 +2065,16 @@
                       }
                     }
                   },
+                  "pinned": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "archived": {
                     "anyOf": [
                       {
@@ -20589,6 +20599,9 @@
               }
             }
           },
+          "pinned": {
+            "type": "number"
+          },
           "time": {
             "type": "object",
             "properties": {
@@ -26501,6 +26514,12 @@
               },
               "message": {
                 "type": "string"
+              },
+              "failureCode": {
+                "type": "string"
+              },
+              "actionRequired": {
+                "type": "boolean"
               }
             },
             "required": ["providerID", "message"]
@@ -28224,6 +28243,15 @@
           "signupUrl": {
             "type": "string"
           },
+          "authKind": {
+            "type": "string"
+          },
+          "environment": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "recommendation": {
             "$ref": "#/components/schemas/ProviderRecommendation"
           }
@@ -28239,7 +28267,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["connected", "not_configured", "expired", "exhausted", "dead"]
+            "enum": ["connected", "not_configured", "exhausted", "action_required"]
+          },
+          "recovery": {
+            "type": "string",
+            "enum": ["reconnect", "update_environment"]
           },
           "authKind": {
             "type": "string"
@@ -28249,9 +28281,6 @@
           },
           "updatedAt": {
             "type": "number"
-          },
-          "reloginRequired": {
-            "type": "boolean"
           },
           "cooldownUntil": {
             "type": "number"
@@ -28276,7 +28305,15 @@
           },
           "reason": {
             "type": "string",
-            "enum": ["connected", "not_connected", "disabled", "no_models"]
+            "enum": [
+              "connected",
+              "not_connected",
+              "disabled",
+              "no_models",
+              "authentication_required",
+              "exhausted",
+              "fallback_unverified"
+            ]
           },
           "healthCheck": {
             "type": "string",
@@ -32889,6 +32926,25 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.provider.auth.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "provider.auth.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "health": {
+                "$ref": "#/components/schemas/ProviderAuthHealth"
+              }
+            },
+            "required": ["health"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "Event.installation.updated": {
         "type": "object",
         "properties": {
@@ -33042,6 +33098,40 @@
               }
             },
             "required": ["server", "error"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.runtime.reloaded": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "runtime.reloaded"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "executed": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RuntimeReloadTarget"
+                }
+              },
+              "cascaded": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RuntimeReloadTarget"
+                }
+              },
+              "changedFields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["executed", "cascaded", "changedFields"]
           }
         },
         "required": ["type", "properties"]
@@ -33821,40 +33911,6 @@
         },
         "required": ["type", "properties"]
       },
-      "Event.runtime.reloaded": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "runtime.reloaded"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "executed": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RuntimeReloadTarget"
-                }
-              },
-              "cascaded": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/RuntimeReloadTarget"
-                }
-              },
-              "changedFields": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": ["executed", "cascaded", "changedFields"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
       "Event.dag.updated": {
         "type": "object",
         "properties": {
@@ -34463,6 +34519,9 @@
             "$ref": "#/components/schemas/Event.scope.runtime.disposed"
           },
           {
+            "$ref": "#/components/schemas/Event.provider.auth.updated"
+          },
+          {
             "$ref": "#/components/schemas/Event.installation.updated"
           },
           {
@@ -34485,6 +34544,9 @@
           },
           {
             "$ref": "#/components/schemas/Event.mcp.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.runtime.reloaded"
           },
           {
             "$ref": "#/components/schemas/Event.message.updated"
@@ -34593,9 +34655,6 @@
           },
           {
             "$ref": "#/components/schemas/Event.file.edited"
-          },
-          {
-            "$ref": "#/components/schemas/Event.runtime.reloaded"
           },
           {
             "$ref": "#/components/schemas/Event.dag.updated"

--- a/packages/synergy/AGENTS.md
+++ b/packages/synergy/AGENTS.md
@@ -54,7 +54,7 @@ Do not bypass pre-push hooks. If a hook check fails, fix the root cause rather t
 - **Event sequencing**: `Bus.publish` stamps state events with a scope-monotonic `seq` + per-runtime `epoch` and journals them for `/event/replay`; mark high-frequency coalescible events (part deltas) `streaming` in `BusEvent.define` so they stay unsequenced. Scoped GET responses advertise the snapshot watermark via `x-synergy-seq`/`x-synergy-epoch`. See `docs/architecture/frontend-data-sync.md`.
 - **API Client**: When modifying server endpoints in `packages/synergy/src/server/server.ts`, run `./script/generate.ts` to regenerate the SDK.
 - **Provider framework**: Provider existence comes from the profile/catalog resolver, not directly from `models.dev`. Keep remote catalogs data-only and signature-verified; complex auth, transport, and usage behavior belongs in built-in strategies or explicitly installed plugins.
-- **Provider auth**: Keep `openai-codex` as the ChatGPT/Codex OAuth device-code provider. Do not mix it with the `openai` Platform API-key provider or share/write Codex CLI `auth.json` credentials directly. Runtime auth reads the provider auth store at `~/.synergy/data/auth/provider-auth.json`; imported auth files are handled by migrations only.
+- **Provider auth**: Keep `openai-codex` as the ChatGPT/Codex OAuth device-code provider. Do not mix it with the `openai` Platform API-key provider or share/write Codex CLI `auth.json` credentials directly. Runtime auth reads the provider auth store at `~/.synergy/data/auth/provider-auth.json`; imported auth files are handled by migrations only. Real provider requests drive authentication recovery and health transitions; do not add startup or periodic third-party credential probes.
 
 ### Sandbox Architecture
 

--- a/packages/synergy/src/provider/anthropic-oauth.ts
+++ b/packages/synergy/src/provider/anthropic-oauth.ts
@@ -3,6 +3,8 @@ import { AccountUsage } from "./usage"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin"
 import z from "zod"
+import { ProviderAuthRecovery } from "./auth-recovery"
+import type { ProviderProfile } from "./profile"
 
 export namespace AnthropicOAuthProvider {
   export const PROVIDER_ID = "anthropic"
@@ -170,8 +172,9 @@ export namespace AnthropicOAuthProvider {
   }
 
   export async function resolveToken(options?: { allowMissing?: boolean; fetch?: FetchLike }) {
-    const auth = await Auth.get(PROVIDER_ID)
-    if (!auth || auth.type !== "oauth") {
+    const selected = await Auth.select(PROVIDER_ID)
+    const auth = selected?.auth
+    if (!selected || !auth || auth.type !== "oauth") {
       if (options?.allowMissing) return undefined
       throw new AuthError({
         providerID: PROVIDER_ID,
@@ -183,10 +186,11 @@ export namespace AnthropicOAuthProvider {
     if (auth.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return auth.access
     try {
       return await Auth.withLock(`${PROVIDER_ID}:oauth-refresh`, async () => {
-        const latest = await Auth.get(PROVIDER_ID)
+        const latestSelected = await Auth.select(PROVIDER_ID)
+        const latest = latestSelected?.auth
         if (latest?.type === "oauth" && latest.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return latest.access
         const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch)
-        await Auth.set(
+        await Auth.replaceSelectedCredential(
           PROVIDER_ID,
           {
             type: "oauth",
@@ -194,7 +198,7 @@ export namespace AnthropicOAuthProvider {
             refresh: refreshed.refresh,
             expires: refreshed.expires,
           },
-          { source: "api" },
+          { credentialID: latestSelected?.credentialID ?? selected.credentialID },
         )
         return refreshed.access
       })
@@ -218,14 +222,19 @@ export namespace AnthropicOAuthProvider {
   }
 
   export async function anthropicFetch(input: RequestInfo | URL, init?: RequestInit) {
-    const token = await resolveToken()
-    const headers = new Headers(init?.headers)
-    headers.delete("x-api-key")
-    headers.delete("X-Api-Key")
-    for (const [key, value] of Object.entries(requestHeaders(token!))) {
-      headers.set(key, value)
-    }
-    return fetch(input, { ...init, headers })
+    return ProviderAuthRecovery.execute({
+      providerID: PROVIDER_ID,
+      request: async () => {
+        const token = await resolveToken()
+        const headers = new Headers(init?.headers)
+        headers.delete("x-api-key")
+        headers.delete("X-Api-Key")
+        for (const [key, value] of Object.entries(requestHeaders(token!))) headers.set(key, value)
+        return fetch(input, { ...init, headers })
+      },
+      refresh: refreshAuth,
+      classify: classifyError,
+    })
   }
 
   export async function fetchUsage(fetchFn: FetchLike = fetch): Promise<AccountUsage.Snapshot> {
@@ -236,14 +245,31 @@ export namespace AnthropicOAuthProvider {
         "Anthropic account limits are only available for OAuth-backed Claude accounts.",
       )
     }
-    const response = await fetchFn("https://api.anthropic.com/api/oauth/usage", {
-      headers: requestHeaders(token),
-      signal: AbortSignal.timeout(15_000),
+    const response = await ProviderAuthRecovery.execute({
+      providerID: PROVIDER_ID,
+      request: async () => {
+        const current = await resolveToken({ allowMissing: true, fetch: fetchFn })
+        if (!current) return new Response(null, { status: 401 })
+        return fetchFn("https://api.anthropic.com/api/oauth/usage", {
+          headers: requestHeaders(current),
+          signal: AbortSignal.timeout(15_000),
+        })
+      },
+      refresh: (auth) => refreshAuth(auth, fetchFn),
+      classify: classifyError,
+      throwOnActionRequired: false,
     })
     if (!response.ok) {
-      return AccountUsage.error(PROVIDER_ID, `Anthropic usage request failed with status ${response.status}.`, {
-        reloginRequired: response.status === 401 || response.status === 403,
-      })
+      const failure = classifyError({ status: response.status, body: await safeJson(response.clone()) })
+      if (failure?.reloginRequired) {
+        return AccountUsage.error(PROVIDER_ID, "Anthropic rejected these credentials. Reconnect to restore usage.", {
+          reloginRequired: true,
+        })
+      }
+      if (failure?.exhausted) {
+        return AccountUsage.unavailable(PROVIDER_ID, "Anthropic usage is temporarily rate limited.")
+      }
+      return AccountUsage.error(PROVIDER_ID, "Anthropic usage is temporarily unavailable.")
     }
     const payload = await safeJson(response)
     const windows = [
@@ -273,5 +299,29 @@ export namespace AnthropicOAuthProvider {
       windows,
       details,
     }
+  }
+
+  export async function refreshAuth(auth: Auth.Info, fetchFn: FetchLike = fetch): Promise<Auth.Info | undefined> {
+    if (auth.type !== "oauth") return undefined
+    const refreshed = await refreshOAuth(auth, fetchFn)
+    return {
+      type: "oauth",
+      access: refreshed.access,
+      refresh: refreshed.refresh,
+      expires: refreshed.expires,
+    }
+  }
+
+  export function classifyError(input: {
+    status?: number
+    body?: unknown
+  }): ProviderProfile.ClassifiedError | undefined {
+    const payload = input.body && typeof input.body === "object" ? (input.body as Record<string, any>) : {}
+    const type = String(payload.type ?? payload.error?.type ?? payload.error ?? "")
+    if (input.status === 429) return { code: type || "rate_limited", retryable: true, exhausted: true }
+    if (input.status === 401 || ["authentication_error", "invalid_token"].includes(type)) {
+      return { code: type || "credential_rejected", retryable: false, reloginRequired: true }
+    }
+    return undefined
   }
 }

--- a/packages/synergy/src/provider/api-key.ts
+++ b/packages/synergy/src/provider/api-key.ts
@@ -1,6 +1,7 @@
 import { Global } from "../global"
 import fs from "fs/promises"
 import z from "zod"
+import { ProviderAuthHealth } from "./auth-health"
 
 export namespace Auth {
   export const Oauth = z
@@ -287,6 +288,16 @@ export namespace Auth {
     await fs.rename(tmp, filename)
   }
 
+  async function mutateStore(providerID: string, mutate: (store: Store) => void | Promise<void>) {
+    await withLock("provider-auth-store:write", async () => {
+      const store = await readStore()
+      const previous = ProviderAuthHealth.fromEntry(providerID, store.credentials[providerID])
+      await mutate(store)
+      await writeStore(store)
+      await ProviderAuthHealth.commitStored(previous, providerID, store.credentials[providerID])
+    })
+  }
+
   export async function migrateLegacy(input?: { backup?: boolean }): Promise<{ migrated: boolean; count: number }> {
     const oldFile = Bun.file(legacyFilepath())
     if (!(await oldFile.exists())) return { migrated: false, count: 0 }
@@ -374,37 +385,72 @@ export namespace Auth {
   }
 
   export async function set(key: string, info: Info, options?: { source?: Source }) {
-    const store = await readStore()
-    const primary = poolEntryFromInfo(key, info, options?.source)
-    store.credentials[key] = {
-      ...entryFromInfo(key, info, options?.source),
-      pool: [primary],
-    }
-    await writeStore(store)
+    await mutateStore(key, (store) => {
+      const primary = poolEntryFromInfo(key, info, options?.source)
+      store.credentials[key] = {
+        ...entryFromInfo(key, info, options?.source),
+        pool: [primary],
+      }
+    })
   }
 
   export async function addToPool(providerID: string, credentialID: string, info: Info, options?: { source?: Source }) {
-    const store = await readStore()
-    const existing = store.credentials[providerID]
-    const next = poolEntryFromInfo(credentialID, info, options?.source)
-    if (!existing) {
-      store.credentials[providerID] = {
-        ...entryFromInfo(providerID, info, options?.source),
-        pool: [next],
+    await mutateStore(providerID, (store) => {
+      const existing = store.credentials[providerID]
+      const next = poolEntryFromInfo(credentialID, info, options?.source)
+      if (!existing) {
+        store.credentials[providerID] = {
+          ...entryFromInfo(providerID, info, options?.source),
+          pool: [next],
+        }
+        return
       }
-      await writeStore(store)
-      return
-    }
-    const pool = materializePool(existing).filter((item) => item.id !== credentialID)
-    existing.pool = [...pool, next]
-    existing.updatedAt = Date.now()
-    await writeStore(store)
+      const pool = materializePool(existing).filter((item) => item.id !== credentialID)
+      existing.pool = [...pool, next]
+      existing.updatedAt = Date.now()
+    })
+  }
+
+  export async function replaceSelectedCredential(
+    providerID: string,
+    info: Info,
+    options?: { credentialID?: string; source?: Source },
+  ) {
+    await mutateStore(providerID, (store) => {
+      const existing = store.credentials[providerID]
+      if (!existing) {
+        const credentialID = options?.credentialID ?? providerID
+        store.credentials[providerID] = {
+          ...entryFromInfo(providerID, info, options?.source),
+          pool: [poolEntryFromInfo(credentialID, info, options?.source)],
+        }
+        return
+      }
+
+      const selectedID = options?.credentialID ?? selectPoolEntry(existing)?.id ?? providerID
+      const pool = materializePool(existing)
+      const current = pool.find((item) => item.id === selectedID)
+      const replacement = poolEntryFromInfo(selectedID, info, options?.source ?? current?.source ?? existing.source)
+      existing.pool = pool.some((item) => item.id === selectedID)
+        ? pool.map((item) => (item.id === selectedID ? replacement : item))
+        : [...pool, replacement]
+      existing.updatedAt = Date.now()
+
+      if (selectedID === providerID) {
+        const primary = entryFromInfo(providerID, info, options?.source ?? current?.source ?? existing.source)
+        existing.authKind = primary.authKind
+        existing.tokens = primary.tokens
+        existing.expiresAt = primary.expiresAt
+        existing.metadata = primary.metadata
+        existing.source = primary.source
+      }
+    })
   }
 
   export async function remove(key: string) {
-    const store = await readStore()
-    delete store.credentials[key]
-    await writeStore(store)
+    await mutateStore(key, (store) => {
+      delete store.credentials[key]
+    })
   }
 
   export async function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
@@ -428,44 +474,44 @@ export namespace Auth {
     providerID: string,
     input: { failureCode: string; cooldownUntil?: number; resetAt?: number; credentialID?: string },
   ) {
-    const store = await readStore()
-    const entry = store.credentials[providerID]
-    if (!entry) return
-    const selected = input.credentialID ?? selectPoolEntry(entry)?.id
-    const pool = materializePool(entry)
-    entry.pool = pool.map((item) =>
-      item.id === selected
-        ? {
-            ...item,
-            status: "exhausted" as const,
-            failureCode: input.failureCode,
-            cooldownUntil: input.cooldownUntil,
-            resetAt: input.resetAt,
-            updatedAt: Date.now(),
-          }
-        : item,
-    )
-    entry.updatedAt = Date.now()
-    await writeStore(store)
+    await mutateStore(providerID, (store) => {
+      const entry = store.credentials[providerID]
+      if (!entry) return
+      const selected = input.credentialID ?? selectPoolEntry(entry)?.id
+      const pool = materializePool(entry)
+      entry.pool = pool.map((item) =>
+        item.id === selected
+          ? {
+              ...item,
+              status: "exhausted" as const,
+              failureCode: input.failureCode,
+              cooldownUntil: input.cooldownUntil,
+              resetAt: input.resetAt,
+              updatedAt: Date.now(),
+            }
+          : item,
+      )
+      entry.updatedAt = Date.now()
+    })
   }
 
   export async function markDead(providerID: string, failureCode: string, input?: { credentialID?: string }) {
-    const store = await readStore()
-    const entry = store.credentials[providerID]
-    if (!entry) return
-    const selected = input?.credentialID ?? selectPoolEntry(entry)?.id
-    const pool = materializePool(entry)
-    entry.pool = pool.map((item) =>
-      item.id === selected
-        ? {
-            ...item,
-            status: "dead" as const,
-            failureCode,
-            updatedAt: Date.now(),
-          }
-        : item,
-    )
-    entry.updatedAt = Date.now()
-    await writeStore(store)
+    await mutateStore(providerID, (store) => {
+      const entry = store.credentials[providerID]
+      if (!entry) return
+      const selected = input?.credentialID ?? selectPoolEntry(entry)?.id
+      const pool = materializePool(entry)
+      entry.pool = pool.map((item) =>
+        item.id === selected
+          ? {
+              ...item,
+              status: "dead" as const,
+              failureCode,
+              updatedAt: Date.now(),
+            }
+          : item,
+      )
+      entry.updatedAt = Date.now()
+    })
   }
 }

--- a/packages/synergy/src/provider/auth-health.ts
+++ b/packages/synergy/src/provider/auth-health.ts
@@ -1,0 +1,142 @@
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { ScopeContext } from "@/scope/context"
+import z from "zod"
+import type { Auth } from "./api-key"
+
+export namespace ProviderAuthHealth {
+  export const Info = z
+    .object({
+      providerID: z.string(),
+      status: z.enum(["connected", "not_configured", "exhausted", "action_required"]),
+      recovery: z.enum(["reconnect", "update_environment"]).optional(),
+      authKind: z.string().optional(),
+      source: z.string().optional(),
+      updatedAt: z.number().optional(),
+      cooldownUntil: z.number().optional(),
+      resetAt: z.number().optional(),
+      failureCode: z.string().optional(),
+    })
+    .meta({ ref: "ProviderAuthHealth" })
+  export type Info = z.infer<typeof Info>
+
+  export const Event = {
+    Updated: BusEvent.define(
+      "provider.auth.updated",
+      z.object({
+        health: Info,
+      }),
+    ),
+  }
+
+  const observations = new Map<string, Info>()
+
+  function nowSeconds() {
+    return Math.floor(Date.now() / 1000)
+  }
+
+  function recovery(source: string | undefined): Info["recovery"] {
+    return source === "env" ? "update_environment" : "reconnect"
+  }
+
+  function usable(item: Auth.PoolEntry, now = nowSeconds()) {
+    if (item.status === "dead") return false
+    if (item.status === "active") return true
+    const cooldownActive = item.cooldownUntil !== undefined && item.cooldownUntil > now
+    const resetActive = item.resetAt !== undefined && item.resetAt > now
+    return !cooldownActive && !resetActive
+  }
+
+  function storedHealth(providerID: string, entry: Auth.StoreEntry | undefined): Info {
+    if (!entry) return { providerID, status: "not_configured" }
+
+    const pool = entry.pool ?? []
+    if (pool.length === 0 || pool.some((item) => usable(item))) {
+      return {
+        providerID,
+        status: "connected",
+        authKind: entry.authKind,
+        source: entry.source,
+        updatedAt: entry.updatedAt,
+      }
+    }
+
+    const dead = pool.find((item) => item.status === "dead")
+    if (dead && pool.every((item) => item.status === "dead")) {
+      return {
+        providerID,
+        status: "action_required",
+        recovery: recovery(dead.source ?? entry.source),
+        authKind: dead.authKind ?? entry.authKind,
+        source: dead.source ?? entry.source,
+        updatedAt: dead.updatedAt ?? entry.updatedAt,
+        failureCode: dead.failureCode,
+      }
+    }
+
+    const exhausted = pool.find((item) => item.status === "exhausted")
+    if (exhausted) {
+      return {
+        providerID,
+        status: "exhausted",
+        authKind: exhausted.authKind ?? entry.authKind,
+        source: exhausted.source ?? entry.source,
+        updatedAt: exhausted.updatedAt ?? entry.updatedAt,
+        cooldownUntil: exhausted.cooldownUntil,
+        resetAt: exhausted.resetAt,
+        failureCode: exhausted.failureCode,
+      }
+    }
+
+    return {
+      providerID,
+      status: "action_required",
+      recovery: recovery(entry.source),
+      authKind: entry.authKind,
+      source: entry.source,
+      updatedAt: entry.updatedAt,
+    }
+  }
+
+  export function fromEntry(providerID: string, entry: Auth.StoreEntry | undefined): Info {
+    return observations.get(providerID) ?? storedHealth(providerID, entry)
+  }
+
+  export function observe(input: Info) {
+    const previous = observations.get(input.providerID)
+    const next = Info.parse({ ...input, updatedAt: input.updatedAt ?? Date.now() })
+    observations.set(input.providerID, next)
+    return publishIfChanged(previous, next)
+  }
+
+  export function clearObservation(providerID: string, entry?: Auth.StoreEntry) {
+    const previous = observations.get(providerID)
+    if (!previous) return Promise.resolve()
+    observations.delete(providerID)
+    return publishIfChanged(previous, storedHealth(providerID, entry))
+  }
+
+  export function commitStored(previous: Info, providerID: string, entry?: Auth.StoreEntry) {
+    observations.delete(providerID)
+    return publishIfChanged(previous, storedHealth(providerID, entry))
+  }
+
+  function comparable(info: Info) {
+    return {
+      providerID: info.providerID,
+      status: info.status,
+      recovery: info.recovery,
+      authKind: info.authKind,
+      source: info.source,
+      cooldownUntil: info.cooldownUntil,
+      resetAt: info.resetAt,
+      failureCode: info.failureCode,
+    }
+  }
+
+  async function publishIfChanged(previous: Info | undefined, next: Info) {
+    if (previous && JSON.stringify(comparable(previous)) === JSON.stringify(comparable(next))) return
+    if (!ScopeContext.tryScope()) return
+    await Bus.publish(Event.Updated, { health: next })
+  }
+}

--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -1,0 +1,387 @@
+import { RuntimeReload } from "@/runtime/reload"
+import { ScopeContext } from "@/scope/context"
+import { NamedError } from "@ericsanchezok/synergy-util/error"
+import z from "zod"
+import { Auth } from "./api-key"
+import { ProviderAuthHealth } from "./auth-health"
+import { ProviderProfile } from "./profile"
+
+export namespace ProviderAuthRecovery {
+  type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+  export interface ExecuteInput {
+    providerID: string
+    request: () => Promise<Response>
+    refresh?: (auth: Auth.Info) => Promise<Auth.Info | undefined>
+    recoverWithoutCredential?: () => Promise<boolean>
+    classify?: (input: {
+      providerID: string
+      status?: number
+      error?: unknown
+      body?: unknown
+    }) => ProviderProfile.ClassifiedError | undefined
+    reloadOnTransition?: boolean
+    throwOnActionRequired?: boolean
+  }
+
+  export const Error = NamedError.create(
+    "ProviderAuthenticationRequiredError",
+    z.object({
+      providerID: z.string(),
+      failureCode: z.string(),
+      actionRequired: z.literal(true),
+      message: z.string(),
+    }),
+  )
+
+  const handledFetches = new WeakSet<FetchLike>()
+
+  function fingerprint(auth: Auth.Info) {
+    switch (auth.type) {
+      case "oauth":
+        return `${auth.type}:${auth.access}:${auth.refresh}:${JSON.stringify(auth.metadata ?? {})}`
+      case "api":
+        return `${auth.type}:${auth.key}:${JSON.stringify(auth.metadata ?? {})}`
+      case "wellknown":
+        return `${auth.type}:${auth.key}:${auth.token}`
+      case "holos":
+        return `${auth.type}:${auth.agentId}:${auth.agentSecret}`
+    }
+  }
+
+  async function responseBody(response: Response) {
+    try {
+      const text = await response.clone().text()
+      if (!text || text.length > 64 * 1024) return undefined
+      return JSON.parse(text)
+    } catch {
+      return undefined
+    }
+  }
+
+  function retryAfterSeconds(response: Response) {
+    const retryAfter = response.headers.get("retry-after")
+    const seconds = Number(retryAfter)
+    if (Number.isFinite(seconds) && seconds > 0) return Math.ceil(seconds)
+    if (retryAfter) {
+      const date = Date.parse(retryAfter)
+      if (Number.isFinite(date) && date > Date.now()) return Math.ceil((date - Date.now()) / 1000)
+    }
+    const milliseconds = Number(response.headers.get("retry-after-ms"))
+    if (Number.isFinite(milliseconds) && milliseconds > 0) return Math.ceil(milliseconds / 1000)
+    return undefined
+  }
+
+  function resetAt(response: Response) {
+    for (const name of ["x-ratelimit-reset", "x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"]) {
+      const value = Number(response.headers.get(name))
+      if (!Number.isFinite(value) || value <= 0) continue
+      return value > 10_000_000_000 ? Math.floor(value / 1000) : Math.floor(value)
+    }
+    return undefined
+  }
+
+  async function classify(input: ExecuteInput, response: Response) {
+    const body = await responseBody(response)
+    const profile = ProviderProfile.get(input.providerID)
+    const classified =
+      input.classify?.({ providerID: input.providerID, status: response.status, body }) ??
+      profile?.classifyError?.({ providerID: input.providerID, status: response.status, body })
+    if (classified) {
+      if (!classified.exhausted) return classified
+      const retryAfter = retryAfterSeconds(response)
+      return {
+        ...classified,
+        cooldownUntil:
+          classified.cooldownUntil ?? (retryAfter ? Math.floor(Date.now() / 1000) + retryAfter : undefined),
+        resetAt: classified.resetAt ?? resetAt(response),
+      }
+    }
+    if (response.status === 401 && profile?.origin !== "plugin") {
+      return {
+        code: "credential_rejected",
+        retryable: false,
+        reloginRequired: true,
+      } satisfies ProviderProfile.ClassifiedError
+    }
+    if (response.status === 429) {
+      const retryAfter = retryAfterSeconds(response)
+      return {
+        code: "rate_limited",
+        retryable: true,
+        exhausted: true,
+        cooldownUntil: retryAfter ? Math.floor(Date.now() / 1000) + retryAfter : undefined,
+        resetAt: resetAt(response),
+      } satisfies ProviderProfile.ClassifiedError
+    }
+    return undefined
+  }
+
+  function requiresRelogin(error: unknown) {
+    if (!error || typeof error !== "object") return false
+    const data = (error as { data?: { reloginRequired?: unknown } }).data
+    return data?.reloginRequired === true
+  }
+
+  async function reloadProvider(reason: string, enabled: boolean) {
+    if (!enabled || !ScopeContext.tryScope()) return
+    await RuntimeReload.reload({ targets: ["provider"], reason })
+  }
+
+  function runtimeCredential(providerID: string) {
+    const profile = ProviderProfile.get(providerID)
+    const usesEnvironment = profile?.env?.some((name) => !!process.env[name]?.trim()) === true
+    return {
+      source: usesEnvironment ? "env" : profile?.origin === "plugin" ? "plugin" : "runtime",
+      recovery: usesEnvironment ? ("update_environment" as const) : ("reconnect" as const),
+      authKind: profile?.authKind,
+    }
+  }
+
+  async function markSuccess(providerID: string) {
+    const entry = (await Auth.entries())[providerID]
+    if (entry) {
+      await ProviderAuthHealth.clearObservation(providerID, entry)
+      return
+    }
+    const runtime = runtimeCredential(providerID)
+    await ProviderAuthHealth.observe({
+      providerID,
+      status: "connected",
+      source: runtime.source,
+      authKind: runtime.authKind,
+    })
+  }
+
+  async function markFailure(
+    input: ExecuteInput,
+    selected: Awaited<ReturnType<typeof Auth.select>>,
+    failure: ProviderProfile.ClassifiedError,
+  ) {
+    const runtime = runtimeCredential(input.providerID)
+    if (failure.exhausted) {
+      if (selected) {
+        await Auth.markExhausted(input.providerID, {
+          credentialID: selected.credentialID,
+          failureCode: failure.code,
+          cooldownUntil: failure.cooldownUntil,
+          resetAt: failure.resetAt,
+        })
+      } else {
+        await ProviderAuthHealth.observe({
+          providerID: input.providerID,
+          status: "exhausted",
+          source: runtime.source,
+          authKind: runtime.authKind,
+          failureCode: failure.code,
+          cooldownUntil: failure.cooldownUntil,
+          resetAt: failure.resetAt,
+        })
+      }
+      await reloadProvider(`provider auth exhausted: ${input.providerID}`, input.reloadOnTransition !== false)
+      return
+    }
+    if (!failure.reloginRequired) return
+    if (selected) {
+      await Auth.markDead(input.providerID, failure.code, { credentialID: selected.credentialID })
+    } else {
+      await ProviderAuthHealth.observe({
+        providerID: input.providerID,
+        status: "action_required",
+        recovery: runtime.recovery,
+        source: runtime.source,
+        authKind: runtime.authKind,
+        failureCode: failure.code,
+      })
+    }
+    await reloadProvider(`provider auth rejected: ${input.providerID}`, input.reloadOnTransition !== false)
+  }
+
+  async function refresh(input: ExecuteInput, selected: NonNullable<Awaited<ReturnType<typeof Auth.select>>>) {
+    const profile = ProviderProfile.get(input.providerID)
+    const refresh =
+      input.refresh ??
+      (profile?.refreshAuth
+        ? (auth: Auth.Info) => profile.refreshAuth!({ providerID: input.providerID, auth })
+        : undefined)
+    if (!refresh) return false
+
+    return Auth.withLock(`${input.providerID}:${selected.credentialID}:rejected-refresh`, async () => {
+      const latest = await Auth.select(input.providerID)
+      if (!latest) return false
+      if (latest.credentialID !== selected.credentialID || fingerprint(latest.auth) !== fingerprint(selected.auth)) {
+        return true
+      }
+      const next = await refresh(selected.auth)
+      if (!next) return false
+      await Auth.replaceSelectedCredential(input.providerID, next, {
+        credentialID: selected.credentialID,
+      })
+      return true
+    })
+  }
+
+  async function finishFailure(
+    input: ExecuteInput,
+    response: Response,
+    failure: ProviderProfile.ClassifiedError,
+  ): Promise<Response> {
+    if (!failure.reloginRequired || input.throwOnActionRequired === false) return response
+    await throwActionRequired(input, failure)
+    return response
+  }
+
+  async function throwActionRequired(input: ExecuteInput, failure: ProviderProfile.ClassifiedError) {
+    const entry = (await Auth.entries())[input.providerID]
+    const health = ProviderAuthHealth.fromEntry(input.providerID, entry)
+    if (health.status !== "action_required") return
+    throw new Error({
+      providerID: input.providerID,
+      failureCode: health.failureCode ?? failure.code,
+      actionRequired: true,
+      message: "These credentials were rejected. Reconnect the provider to restore models and usage.",
+    })
+  }
+
+  function classifiedThrownError(error: unknown): ProviderProfile.ClassifiedError | undefined {
+    if (!requiresRelogin(error)) return undefined
+    return {
+      code: (error as { data?: { code?: string } }).data?.code ?? "credential_rejected",
+      retryable: false,
+      reloginRequired: true,
+    }
+  }
+
+  function isMissingCredentialError(error: unknown) {
+    if (!error || typeof error !== "object") return false
+    const code = (error as { data?: { code?: unknown } }).data?.code
+    return typeof code === "string" && code.endsWith("_missing")
+  }
+
+  async function retryOnce(input: ExecuteInput) {
+    try {
+      const response = await input.request()
+      if (response.ok) {
+        await markSuccess(input.providerID)
+        return response
+      }
+      const failure = await classify(input, response)
+      if (failure) await markFailure(input, await Auth.select(input.providerID), failure)
+      return failure ? finishFailure(input, response, failure) : response
+    } catch (error) {
+      const failure = classifiedThrownError(error)
+      if (!failure) throw error
+      const selected = await Auth.select(input.providerID)
+      const entry = (await Auth.entries())[input.providerID]
+      if (isMissingCredentialError(error) && !entry) throw error
+      await markFailure(input, selected, failure)
+      if (input.throwOnActionRequired !== false) await throwActionRequired(input, failure)
+      throw error
+    }
+  }
+
+  async function retryWithBackup(
+    input: ExecuteInput,
+    rejectedCredentialID: string,
+    original: Response,
+    failure: ProviderProfile.ClassifiedError,
+  ) {
+    const backup = await Auth.select(input.providerID)
+    if (!backup || backup.credentialID === rejectedCredentialID) return finishFailure(input, original, failure)
+    return retryOnce(input)
+  }
+
+  export async function execute(input: ExecuteInput) {
+    let first: Response
+    try {
+      first = await input.request()
+    } catch (error) {
+      const failure = classifiedThrownError(error)
+      if (!failure) throw error
+      const selected = await Auth.select(input.providerID)
+      const entry = (await Auth.entries())[input.providerID]
+      if (isMissingCredentialError(error) && !entry) throw error
+      await markFailure(input, selected, failure)
+      const backup = await Auth.select(input.providerID)
+      if (selected && backup && backup.credentialID !== selected.credentialID) {
+        return retryOnce(input)
+      }
+      if (input.throwOnActionRequired !== false) await throwActionRequired(input, failure)
+      throw error
+    }
+    if (first.ok) {
+      await markSuccess(input.providerID)
+      return first
+    }
+
+    const firstFailure = await classify(input, first)
+    if (!firstFailure) return first
+    if (firstFailure.exhausted) {
+      await markFailure(input, await Auth.select(input.providerID), firstFailure)
+      return first
+    }
+    if (!firstFailure.reloginRequired) return first
+
+    const selected = await Auth.select(input.providerID)
+    if (!selected) {
+      if (input.recoverWithoutCredential) {
+        try {
+          if (await input.recoverWithoutCredential()) {
+            return retryOnce(input)
+          }
+        } catch (error) {
+          if (!requiresRelogin(error)) return first
+        }
+      }
+      await markFailure(input, selected, firstFailure)
+      return finishFailure(input, first, firstFailure)
+    }
+
+    let refreshed = false
+    try {
+      refreshed = await refresh(input, selected)
+    } catch (error) {
+      if (!requiresRelogin(error)) return first
+      const failure = {
+        code: (error as { data?: { code?: string } }).data?.code ?? firstFailure.code,
+        retryable: false,
+        reloginRequired: true,
+      } satisfies ProviderProfile.ClassifiedError
+      await markFailure(input, selected, failure)
+      return retryWithBackup(input, selected.credentialID, first, failure)
+    }
+
+    if (!refreshed) {
+      await markFailure(input, selected, firstFailure)
+      return retryWithBackup(input, selected.credentialID, first, firstFailure)
+    }
+
+    return retryOnce(input)
+  }
+
+  export function wrapFetch(providerID: string, fetchFn: FetchLike = fetch): FetchLike {
+    if (handledFetches.has(fetchFn)) return fetchFn
+    const wrapped: FetchLike = (input, init) =>
+      execute({
+        providerID,
+        request: async () => {
+          const selected = await Auth.select(providerID)
+          const headers = new Headers(init?.headers)
+          if (selected?.auth.type === "api") {
+            const key = selected.auth.key
+            if (headers.has("authorization")) headers.set("authorization", `Bearer ${key}`)
+            if (headers.has("x-api-key")) headers.set("x-api-key", key)
+            if (headers.has("api-key")) headers.set("api-key", key)
+          }
+          return fetchFn(input, { ...init, headers })
+        },
+      })
+    handledFetches.add(wrapped)
+    return wrapped
+  }
+
+  export function handled(fetchFn: FetchLike): FetchLike {
+    handledFetches.add(fetchFn)
+    return fetchFn
+  }
+}

--- a/packages/synergy/src/provider/auth.ts
+++ b/packages/synergy/src/provider/auth.ts
@@ -14,8 +14,17 @@ import { MiniMaxProvider } from "./minimax"
 import { GitHubProvider } from "./github"
 import { registerBuiltinProviderProfiles } from "./builtin"
 import { Provider } from "./provider"
+import { RuntimeReload } from "@/runtime/reload"
 
 export namespace ProviderAuth {
+  async function reloadProvider(reason: string) {
+    if (ScopeContext.tryScope()) {
+      await RuntimeReload.reload({ targets: ["provider"], reason })
+      return
+    }
+    await Provider.reload()
+  }
+
   const state = ScopedState.create(async () => {
     registerBuiltinProviderProfiles()
     const pluginMethods = pipe(
@@ -196,7 +205,7 @@ export namespace ProviderAuth {
         },
         { source },
       )
-      await Provider.reload()
+      await reloadProvider(`provider credentials connected: ${saveProvider}`)
       return true
     }
     await Auth.set(
@@ -209,7 +218,7 @@ export namespace ProviderAuth {
       },
       { source },
     )
-    await Provider.reload()
+    await reloadProvider(`provider credentials connected: ${saveProvider}`)
     return true
   }
 
@@ -274,7 +283,7 @@ export namespace ProviderAuth {
         },
         { source: "web" },
       )
-      await Provider.reload()
+      await reloadProvider(`provider credentials connected: ${input.providerID}`)
     },
   )
 

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -12,6 +12,7 @@ import { iife } from "@/util/iife"
 import { SYNERGY_REFERER } from "@/holos/constants"
 import type { AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
+import { ProviderAuthRecovery } from "./auth-recovery"
 
 let registered = false
 
@@ -77,7 +78,7 @@ export function registerBuiltinProviderProfiles() {
       return {
         apiKey: "synergy-codex-oauth",
         baseURL: CodexProvider.runtimeBaseURL(),
-        fetch: CodexProvider.codexFetch,
+        fetch: ProviderAuthRecovery.handled(CodexProvider.codexFetch),
         setCacheKey: true,
       }
     },
@@ -92,6 +93,8 @@ export function registerBuiltinProviderProfiles() {
       return CodexProvider.fetchModelCatalog(access, input.fetch)
     },
     fetchUsage: (input) => CodexProvider.fetchUsage(input?.fetch),
+    refreshAuth: (input) => (input.auth ? CodexProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
+    classifyError: CodexProvider.classifyError,
   })
 
   ProviderProfile.register({
@@ -123,7 +126,7 @@ export function registerBuiltinProviderProfiles() {
       }
       return {
         apiKey: "synergy-anthropic-oauth",
-        fetch: AnthropicOAuthProvider.anthropicFetch,
+        fetch: ProviderAuthRecovery.handled(AnthropicOAuthProvider.anthropicFetch),
         headers: {
           "anthropic-beta":
             "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
@@ -131,6 +134,8 @@ export function registerBuiltinProviderProfiles() {
       }
     },
     fetchUsage: (input) => AnthropicOAuthProvider.fetchUsage(input?.fetch),
+    refreshAuth: (input) => (input.auth ? AnthropicOAuthProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
+    classifyError: AnthropicOAuthProvider.classifyError,
   })
 
   ProviderProfile.register({
@@ -178,7 +183,7 @@ export function registerBuiltinProviderProfiles() {
     runtimeOptions: async () => ({
       apiKey: "synergy-copilot",
       baseURL: CopilotProvider.BASE_URL,
-      fetch: CopilotProvider.copilotFetchFor("github-copilot"),
+      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor("github-copilot")),
     }),
     getModel: async ({ sdk, modelID }) => {
       if (modelID.toLowerCase().includes("claude")) {
@@ -186,13 +191,16 @@ export function registerBuiltinProviderProfiles() {
           name: "github-copilot",
           apiKey: "synergy-copilot",
           baseURL: CopilotProvider.BASE_URL,
-          fetch: CopilotProvider.copilotFetchFor("github-copilot") as typeof fetch,
+          fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor("github-copilot")) as typeof fetch,
         }).languageModel(modelID)
       }
       if (modelID.includes("codex") || modelID.startsWith("gpt-5")) return sdk.responses(modelID)
       return sdk.chat(modelID)
     },
     fetchModels: (input) => CopilotProvider.fetchModelIDs("github-copilot", input.fetch),
+    refreshAuth: (input) =>
+      input.auth ? CopilotProvider.refreshAuth("github-copilot", input.auth) : Promise.resolve(undefined),
+    classifyError: CopilotProvider.classifyError,
   })
 
   ProviderProfile.register({
@@ -209,7 +217,7 @@ export function registerBuiltinProviderProfiles() {
     runtimeOptions: async () => ({
       apiKey: "synergy-copilot-enterprise",
       baseURL: CopilotProvider.BASE_URL,
-      fetch: CopilotProvider.copilotFetchFor("github-copilot-enterprise"),
+      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor("github-copilot-enterprise")),
     }),
     getModel: async ({ sdk, modelID }) => {
       if (modelID.toLowerCase().includes("claude")) {
@@ -217,13 +225,18 @@ export function registerBuiltinProviderProfiles() {
           name: "github-copilot-enterprise",
           apiKey: "synergy-copilot-enterprise",
           baseURL: CopilotProvider.BASE_URL,
-          fetch: CopilotProvider.copilotFetchFor("github-copilot-enterprise") as typeof fetch,
+          fetch: ProviderAuthRecovery.handled(
+            CopilotProvider.copilotFetchFor("github-copilot-enterprise"),
+          ) as typeof fetch,
         }).languageModel(modelID)
       }
       if (modelID.includes("codex") || modelID.startsWith("gpt-5")) return sdk.responses(modelID)
       return sdk.chat(modelID)
     },
     fetchModels: (input) => CopilotProvider.fetchModelIDs("github-copilot-enterprise", input.fetch),
+    refreshAuth: (input) =>
+      input.auth ? CopilotProvider.refreshAuth("github-copilot-enterprise", input.auth) : Promise.resolve(undefined),
+    classifyError: CopilotProvider.classifyError,
   })
 
   ProviderProfile.register({
@@ -497,8 +510,10 @@ export function registerBuiltinProviderProfiles() {
     runtimeOptions: async () => ({
       apiKey: "synergy-minimax-oauth",
       baseURL: MiniMaxProvider.GLOBAL_INFERENCE,
-      fetch: MiniMaxProvider.minimaxFetch,
+      fetch: ProviderAuthRecovery.handled(MiniMaxProvider.minimaxFetch),
     }),
+    refreshAuth: (input) => (input.auth ? MiniMaxProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
+    classifyError: MiniMaxProvider.classifyError,
   })
 
   ProviderProfile.register({

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -53,8 +53,9 @@ export namespace ProviderCatalog {
     .strict()
   type RemoteCatalog = z.infer<typeof RemoteCatalog>
 
-  let inFlight: Promise<Record<string, ModelsDev.Provider>> | undefined
-  let memoryCache: { value: Record<string, ModelsDev.Provider>; createdAt: number } | undefined
+  const inFlight = new Map<string, Promise<Record<string, ModelsDev.Provider>>>()
+  const memoryCache = new Map<string, { value: Record<string, ModelsDev.Provider>; createdAt: number }>()
+  const liveDiscovery = new Map<string, "verified" | "fallback">()
 
   function fallbackModel(provider: ModelsDev.Provider, modelID: string): ModelsDev.Model {
     return {
@@ -274,7 +275,11 @@ export namespace ProviderCatalog {
       log.warn("failed to fetch live provider models", { providerID: profile.id, error })
       live = []
     }
-    if (!live.length) return provider
+    if (!live.length) {
+      liveDiscovery.set(profile.id, "fallback")
+      return provider
+    }
+    liveDiscovery.set(profile.id, "verified")
     const source = modelsDev[profile.modelsDevProviderID ?? profile.id]
     const npm = profile.aiSdkPackage ?? source?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible"
     const next: ModelsDev.Provider = { ...provider, models: {} }
@@ -298,14 +303,24 @@ export namespace ProviderCatalog {
     includeLive?: boolean
     forceRefresh?: boolean
   }): Promise<Record<string, ModelsDev.Provider>> {
-    if (!input?.forceRefresh && memoryCache && Date.now() - memoryCache.createdAt < DEFAULT_CACHE_TTL_MS) {
-      return memoryCache.value
+    const key = cacheKey(input)
+    const cached = memoryCache.get(key)
+    if (!input?.forceRefresh && cached && Date.now() - cached.createdAt < DEFAULT_CACHE_TTL_MS) {
+      return cached.value
     }
-    if (!input?.forceRefresh && inFlight) return inFlight
-    inFlight = doResolve(input).finally(() => {
-      inFlight = undefined
+    const pending = inFlight.get(key)
+    if (!input?.forceRefresh && pending) return pending
+    let request: Promise<Record<string, ModelsDev.Provider>>
+    request = doResolve(input).finally(() => {
+      if (inFlight.get(key) === request) inFlight.delete(key)
     })
-    return inFlight
+    inFlight.set(key, request)
+    return request
+  }
+
+  function cacheKey(input?: { config?: unknown; includeLive?: boolean }) {
+    const providerCatalog = (input?.config as { providerCatalog?: unknown } | undefined)?.providerCatalog ?? {}
+    return JSON.stringify({ includeLive: input?.includeLive === true, providerCatalog })
   }
 
   async function doResolve(input?: {
@@ -368,19 +383,21 @@ export namespace ProviderCatalog {
       }
     }
 
-    memoryCache = { value: result, createdAt: Date.now() }
+    memoryCache.set(cacheKey(input), { value: result, createdAt: Date.now() })
     return result
   }
 
   async function registerPluginProfiles() {
     const { Plugin } = await import("../plugin")
     const allHooks = await Plugin.allHooks().catch(() => [])
+    ProviderProfile.clearPluginProfiles()
     for (const hooks of allHooks) {
       const values = Array.isArray(hooks.provider) ? hooks.provider : hooks.provider ? [hooks.provider] : []
       for (const profile of values) {
         ProviderProfile.register({
           id: profile.id,
           name: profile.name,
+          origin: "plugin",
           aliases: profile.aliases,
           description: profile.description,
           signupUrl: profile.signupUrl,
@@ -425,7 +442,12 @@ export namespace ProviderCatalog {
   }
 
   export function reset() {
-    memoryCache = undefined
-    inFlight = undefined
+    memoryCache.clear()
+    inFlight.clear()
+    liveDiscovery.clear()
+  }
+
+  export function liveDiscoveryStatus(providerID: string) {
+    return liveDiscovery.get(providerID)
   }
 }

--- a/packages/synergy/src/provider/codex.ts
+++ b/packages/synergy/src/provider/codex.ts
@@ -10,6 +10,7 @@ import type { ModelsDev } from "./models"
 import type { ProviderProfile } from "./profile"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin"
 import { AccountUsage } from "./usage"
+import { ProviderAuthRecovery } from "./auth-recovery"
 
 export namespace CodexProvider {
   const log = Log.create({ service: "provider.codex" })
@@ -424,8 +425,9 @@ export namespace CodexProvider {
     allowMissing?: boolean
     fetch?: FetchLike
   }): Promise<string | undefined> {
-    const auth = await Auth.get(PROVIDER_ID)
-    if (!auth || auth.type !== "oauth") {
+    const selected = await Auth.select(PROVIDER_ID)
+    const auth = selected?.auth
+    if (!selected || !auth || auth.type !== "oauth") {
       if (options?.allowMissing) return undefined
       throw new AuthError({
         providerID: PROVIDER_ID,
@@ -445,7 +447,8 @@ export namespace CodexProvider {
 
     try {
       return await Auth.withLock(`${PROVIDER_ID}:oauth-refresh`, async () => {
-        const latest = await Auth.get(PROVIDER_ID)
+        const latestSelected = await Auth.select(PROVIDER_ID)
+        const latest = latestSelected?.auth
         if (latest?.type === "oauth" && !options?.forceRefresh) {
           const latestExpires = accessTokenExpiresAt(latest.access) ?? latest.expires
           const latestShouldRefresh =
@@ -456,7 +459,7 @@ export namespace CodexProvider {
 
         const refreshSource = latest?.type === "oauth" ? latest : auth
         const refreshed = await refreshOAuth(refreshSource, options?.fetch)
-        await Auth.set(
+        await Auth.replaceSelectedCredential(
           PROVIDER_ID,
           {
             type: "oauth",
@@ -464,7 +467,7 @@ export namespace CodexProvider {
             refresh: refreshed.refresh,
             expires: refreshed.expires,
           },
-          { source: "api" },
+          { credentialID: latestSelected?.credentialID ?? selected.credentialID },
         )
         return refreshed.access
       })
@@ -609,13 +612,24 @@ export namespace CodexProvider {
   }
 
   async function fetchModelPayload(accessToken: string, fetchFn: FetchLike = fetch) {
-    const response = await fetchFn(`${baseURL()}/models?client_version=1.0.0`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: "application/json",
-        ...codexHeaders(accessToken),
+    const response = await ProviderAuthRecovery.execute({
+      providerID: PROVIDER_ID,
+      request: async () => {
+        const current =
+          (await resolveToken({ allowMissing: true, fetch: fetchFn }).catch(() => undefined)) ?? accessToken
+        return fetchFn(`${baseURL()}/models?client_version=1.0.0`, {
+          headers: {
+            Authorization: `Bearer ${current}`,
+            Accept: "application/json",
+            ...codexHeaders(current),
+          },
+          signal: AbortSignal.timeout(10_000),
+        })
       },
-      signal: AbortSignal.timeout(10_000),
+      refresh: (auth) => refreshAuth(auth, fetchFn),
+      classify: classifyError,
+      reloadOnTransition: false,
+      throwOnActionRequired: false,
     })
     if (!response.ok) return []
     const payload = await safeJson(response)
@@ -690,33 +704,69 @@ export namespace CodexProvider {
   }
 
   export async function codexFetch(input: RequestInfo | URL, init?: RequestInit) {
-    const access = await resolveToken({ refreshIfExpiring: true })
-    if (!access) {
-      throw new AuthError({
-        providerID: PROVIDER_ID,
-        code: "codex_auth_missing",
-        message: "No Codex credentials stored. Run `synergy auth login` and choose OpenAI Codex.",
-        reloginRequired: true,
-      })
-    }
+    return ProviderAuthRecovery.execute({
+      providerID: PROVIDER_ID,
+      request: async () => {
+        const access = await resolveToken({ refreshIfExpiring: true })
+        if (!access) {
+          throw new AuthError({
+            providerID: PROVIDER_ID,
+            code: "codex_auth_missing",
+            message: "No Codex credentials stored. Run `synergy auth login` and choose OpenAI Codex.",
+            reloginRequired: true,
+          })
+        }
 
-    const headers = new Headers(init?.headers)
-    headers.set("Authorization", `Bearer ${access}`)
-    for (const [key, value] of Object.entries(codexHeaders(access))) {
-      headers.set(key, value)
-    }
+        const headers = new Headers(init?.headers)
+        headers.set("Authorization", `Bearer ${access}`)
+        for (const [key, value] of Object.entries(codexHeaders(access))) {
+          headers.set(key, value)
+        }
 
-    const rewritten = rewriteCodexBody(init?.body)
-    if (rewritten.promptCacheKey) {
-      headers.set("session_id", rewritten.promptCacheKey)
-      headers.set("x-client-request-id", rewritten.promptCacheKey)
-    }
+        const rewritten = rewriteCodexBody(init?.body)
+        if (rewritten.promptCacheKey) {
+          headers.set("session_id", rewritten.promptCacheKey)
+          headers.set("x-client-request-id", rewritten.promptCacheKey)
+        }
 
-    return fetch(input, {
-      ...init,
-      headers,
-      body: rewritten.body,
+        return fetch(input, {
+          ...init,
+          headers,
+          body: rewritten.body,
+        })
+      },
+      refresh: async (auth) => {
+        return refreshAuth(auth)
+      },
+      classify: classifyError,
     })
+  }
+
+  export function classifyError(input: {
+    status?: number
+    body?: unknown
+  }): ProviderProfile.ClassifiedError | undefined {
+    const payload = input.body && typeof input.body === "object" ? (input.body as Record<string, any>) : {}
+    const code = errorCode(payload) ?? (input.status === 401 ? "credential_rejected" : undefined)
+    if (input.status === 429) {
+      return { code: code ?? "rate_limited", retryable: true, exhausted: true }
+    }
+    const rejected =
+      input.status === 401 ||
+      ["token_invalidated", "invalid_token", "invalid_grant", "refresh_token_reused"].includes(code ?? "")
+    if (rejected) return { code: code ?? "credential_rejected", retryable: false, reloginRequired: true }
+    return undefined
+  }
+
+  export async function refreshAuth(auth: Auth.Info, fetchFn: FetchLike = fetch): Promise<Auth.Info | undefined> {
+    if (auth.type !== "oauth") return undefined
+    const refreshed = await refreshOAuth(auth, fetchFn)
+    return {
+      type: "oauth",
+      access: refreshed.access,
+      refresh: refreshed.refresh,
+      expires: refreshed.expires,
+    }
   }
 
   export async function saveImportedToken(token: TokenPayload) {
@@ -750,25 +800,39 @@ export namespace CodexProvider {
     }
     let response: Response
     try {
-      response = await fetchFn(usageURL(), {
-        headers: {
-          Authorization: `Bearer ${access}`,
-          Accept: "application/json",
-          "User-Agent": "codex-cli",
-          ...codexHeaders(access),
+      response = await ProviderAuthRecovery.execute({
+        providerID: PROVIDER_ID,
+        request: async () => {
+          const current =
+            (await resolveToken({ refreshIfExpiring: true, allowMissing: true, fetch: fetchFn })) ?? access
+          return fetchFn(usageURL(), {
+            headers: {
+              Authorization: `Bearer ${current}`,
+              Accept: "application/json",
+              "User-Agent": "codex-cli",
+              ...codexHeaders(current),
+            },
+            signal: AbortSignal.timeout(15_000),
+          })
         },
-        signal: AbortSignal.timeout(15_000),
+        refresh: (auth) => refreshAuth(auth, fetchFn),
+        classify: classifyError,
+        throwOnActionRequired: false,
       })
     } catch {
       return AccountUsage.error(PROVIDER_ID, "OpenAI Codex usage request failed.")
     }
     if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
-        return AccountUsage.error(PROVIDER_ID, `Codex usage request failed with status ${response.status}.`, {
+      const failure = await classifyError({ status: response.status, body: await safeJson(response.clone()) })
+      if (failure?.reloginRequired) {
+        return AccountUsage.error(PROVIDER_ID, "OpenAI rejected these credentials. Reconnect to restore usage.", {
           reloginRequired: true,
         })
       }
-      return AccountUsage.error(PROVIDER_ID, `Codex usage request failed with status ${response.status}.`)
+      if (failure?.exhausted) {
+        return AccountUsage.unavailable(PROVIDER_ID, "OpenAI Codex usage is temporarily rate limited.")
+      }
+      return AccountUsage.error(PROVIDER_ID, "OpenAI Codex usage is temporarily unavailable.")
     }
     const payload = await safeJson(response)
     const rateLimit = payload.rate_limit ?? {}

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -2,6 +2,8 @@ import { Auth } from "./api-key"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin"
 import z from "zod"
+import { ProviderAuthRecovery } from "./auth-recovery"
+import type { ProviderProfile } from "./profile"
 
 export namespace CopilotProvider {
   export const PROVIDER_ID = "github-copilot"
@@ -14,6 +16,7 @@ export namespace CopilotProvider {
   export const API_TOKEN_REFRESH_MARGIN_SECONDS = 120
 
   type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+  const runtimeTokens = new Map<string, { githubToken: string; token: string; expiresAt: number }>()
 
   export const AuthError = NamedError.create(
     "CopilotAuthError",
@@ -134,10 +137,16 @@ export namespace CopilotProvider {
     return undefined
   }
 
-  export async function exchangeToken(providerID = PROVIDER_ID, fetchFn: FetchLike = fetch) {
-    const auth = await Auth.get(providerID)
+  export function clearApiToken(providerID = PROVIDER_ID) {
+    runtimeTokens.delete(providerID)
+  }
+
+  export async function exchangeToken(providerID = PROVIDER_ID, fetchFn: FetchLike = fetch, force = false) {
+    const selected = await Auth.select(providerID)
+    const auth = selected?.auth
     const metadata = auth?.metadata ?? {}
     if (
+      !force &&
       auth?.type === "api" &&
       typeof metadata.copilotApiToken === "string" &&
       typeof metadata.copilotApiTokenExpires === "number" &&
@@ -154,16 +163,34 @@ export namespace CopilotProvider {
         reloginRequired: true,
       })
     }
+    const runtime = runtimeTokens.get(providerID)
+    if (
+      !force &&
+      runtime?.githubToken === githubToken &&
+      runtime.expiresAt > nowSeconds() + API_TOKEN_REFRESH_MARGIN_SECONDS
+    ) {
+      return runtime.token
+    }
     return Auth.withLock(`${providerID}:copilot-token`, async () => {
-      const latest = await Auth.get(providerID)
+      const latestSelected = await Auth.select(providerID)
+      const latest = latestSelected?.auth
       const latestMetadata = latest?.metadata ?? {}
       if (
+        !force &&
         latest?.type === "api" &&
         typeof latestMetadata.copilotApiToken === "string" &&
         typeof latestMetadata.copilotApiTokenExpires === "number" &&
         latestMetadata.copilotApiTokenExpires > nowSeconds() + API_TOKEN_REFRESH_MARGIN_SECONDS
       ) {
         return latestMetadata.copilotApiToken
+      }
+      const latestRuntime = runtimeTokens.get(providerID)
+      if (
+        !force &&
+        latestRuntime?.githubToken === githubToken &&
+        latestRuntime.expiresAt > nowSeconds() + API_TOKEN_REFRESH_MARGIN_SECONDS
+      ) {
+        return latestRuntime.token
       }
       const response = await fetchFn(TOKEN_EXCHANGE_URL, {
         headers: {
@@ -193,51 +220,105 @@ export namespace CopilotProvider {
       }
       const expires = Number(payload.expires_at)
       const expiresAt = Number.isFinite(expires) && expires > 0 ? expires : nowSeconds() + 25 * 60
-      await Auth.set(
-        providerID,
-        {
-          type: "api",
-          key: githubToken,
-          metadata: {
-            ...(latest?.metadata ?? auth?.metadata ?? {}),
-            copilotApiToken: payload.token,
-            copilotApiTokenExpires: expiresAt,
+      if (latestSelected && latest?.type === "api") {
+        await Auth.replaceSelectedCredential(
+          providerID,
+          {
+            type: "api",
+            key: githubToken,
+            metadata: {
+              ...(latest.metadata ?? auth?.metadata ?? {}),
+              copilotApiToken: payload.token,
+              copilotApiTokenExpires: expiresAt,
+            },
           },
-        },
-        { source: "api" },
-      )
+          { credentialID: latestSelected.credentialID, source: latestSelected.poolEntry?.source ?? "api" },
+        )
+      } else {
+        runtimeTokens.set(providerID, { githubToken, token: payload.token, expiresAt })
+      }
       return payload.token
     })
   }
 
   export function copilotFetchFor(providerID = PROVIDER_ID) {
     return async (input: RequestInfo | URL, init?: RequestInit) => {
-      const token = await exchangeToken(providerID).catch(() => exchangeToken(PROVIDER_ID))
-      const headers = new Headers(init?.headers)
-      headers.set("Authorization", `Bearer ${token}`)
-      headers.set("User-Agent", USER_AGENT)
-      headers.set("Editor-Version", EDITOR_VERSION)
-      headers.set("Copilot-Integration-Id", "vscode-chat")
-      return fetch(input, { ...init, headers })
+      return ProviderAuthRecovery.execute({
+        providerID,
+        request: async () => {
+          const token = await exchangeToken(providerID)
+          const headers = new Headers(init?.headers)
+          headers.set("Authorization", `Bearer ${token}`)
+          headers.set("User-Agent", USER_AGENT)
+          headers.set("Editor-Version", EDITOR_VERSION)
+          headers.set("Copilot-Integration-Id", "vscode-chat")
+          return fetch(input, { ...init, headers })
+        },
+        refresh: (auth) => refreshAuth(providerID, auth),
+        recoverWithoutCredential: async () => {
+          clearApiToken(providerID)
+          await exchangeToken(providerID, fetch, true)
+          return true
+        },
+        classify: classifyError,
+      })
     }
   }
 
   export const copilotFetch = copilotFetchFor(PROVIDER_ID)
 
   export async function fetchModelIDs(providerID = PROVIDER_ID, fetchFn: FetchLike = fetch): Promise<string[]> {
-    const token = await exchangeToken(providerID, fetchFn)
-    const response = await fetchFn(`${BASE_URL}/models`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-        "User-Agent": USER_AGENT,
-        "Editor-Version": EDITOR_VERSION,
+    const response = await ProviderAuthRecovery.execute({
+      providerID,
+      request: async () => {
+        const token = await exchangeToken(providerID, fetchFn)
+        return fetchFn(`${BASE_URL}/models`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+            "User-Agent": USER_AGENT,
+            "Editor-Version": EDITOR_VERSION,
+          },
+          signal: AbortSignal.timeout(15_000),
+        })
       },
-      signal: AbortSignal.timeout(15_000),
+      refresh: (auth) => refreshAuth(providerID, auth, fetchFn),
+      recoverWithoutCredential: async () => {
+        clearApiToken(providerID)
+        await exchangeToken(providerID, fetchFn, true)
+        return true
+      },
+      classify: classifyError,
+      reloadOnTransition: false,
+      throwOnActionRequired: false,
     })
     if (!response.ok) return []
     const payload = await safeJson(response)
     const data = Array.isArray(payload.data) ? payload.data : Array.isArray(payload.models) ? payload.models : []
     return data.map((item) => item?.id).filter((id): id is string => typeof id === "string" && !!id)
+  }
+
+  export async function refreshAuth(
+    providerID: string,
+    auth: Auth.Info,
+    fetchFn: FetchLike = fetch,
+  ): Promise<Auth.Info | undefined> {
+    if (auth.type !== "api") return undefined
+    clearApiToken(providerID)
+    await exchangeToken(providerID, fetchFn, true)
+    return (await Auth.select(providerID))?.auth ?? auth
+  }
+
+  export function classifyError(input: {
+    status?: number
+    body?: unknown
+  }): ProviderProfile.ClassifiedError | undefined {
+    const payload = input.body && typeof input.body === "object" ? (input.body as Record<string, any>) : {}
+    const code = String(payload.error?.code ?? payload.error ?? payload.code ?? "")
+    if (input.status === 429) return { code: code || "rate_limited", retryable: true, exhausted: true }
+    if (input.status === 401 || ["invalid_token", "bad_credentials"].includes(code)) {
+      return { code: code || "github_token_rejected", retryable: false, reloginRequired: true }
+    }
+    return undefined
   }
 }

--- a/packages/synergy/src/provider/github.ts
+++ b/packages/synergy/src/provider/github.ts
@@ -2,6 +2,7 @@ import { Auth } from "./api-key"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin"
 import z from "zod"
+import { ProviderAuthHealth } from "./auth-health"
 
 export namespace GitHubProvider {
   export const PROVIDER_ID = "github"
@@ -76,9 +77,9 @@ export namespace GitHubProvider {
     })
     if (!response.ok) {
       throw new AuthError({
-        code: response.status === 401 || response.status === 403 ? "github_token_invalid" : "github_user_failed",
+        code: response.status === 401 ? "github_token_invalid" : "github_user_failed",
         message: `GitHub account lookup failed with status ${response.status}.`,
-        reloginRequired: response.status === 401 || response.status === 403,
+        reloginRequired: response.status === 401,
       })
     }
     return accountFromPayload(await safeJson(response))
@@ -234,21 +235,23 @@ export namespace GitHubProvider {
   export async function status(fetchFn: FetchLike = fetch): Promise<Status> {
     const resolved = await resolveToken()
     if (!resolved) return { providerID: PROVIDER_ID, status: "not_configured" }
-    if (resolved.account) {
-      return {
-        providerID: PROVIDER_ID,
-        status: "connected",
-        source: resolved.source,
-        authKind: resolved.authKind,
-        account: resolved.account,
-        updatedAt: resolved.updatedAt,
-      }
-    }
     const account = await fetchAccount(resolved.token, fetchFn).catch((error) => {
       if (AuthError.isInstance(error) && error.data.reloginRequired) return "invalid" as const
       return undefined
     })
     if (account === "invalid") {
+      if (resolved.source === "store") {
+        const selected = await Auth.select(PROVIDER_ID)
+        await Auth.markDead(PROVIDER_ID, "github_token_invalid", { credentialID: selected?.credentialID })
+      } else {
+        await ProviderAuthHealth.observe({
+          providerID: PROVIDER_ID,
+          status: "action_required",
+          recovery: "update_environment",
+          source: "env",
+          failureCode: "github_token_invalid",
+        })
+      }
       return {
         providerID: PROVIDER_ID,
         status: "invalid",
@@ -267,6 +270,16 @@ export namespace GitHubProvider {
         updatedAt: resolved.updatedAt,
         failureCode: "github_account_lookup_failed",
       }
+    }
+    if (resolved.source === "store") {
+      await ProviderAuthHealth.clearObservation(PROVIDER_ID, (await Auth.entries())[PROVIDER_ID])
+    } else {
+      await ProviderAuthHealth.observe({
+        providerID: PROVIDER_ID,
+        status: "connected",
+        source: "env",
+        authKind: "api_key",
+      })
     }
     return {
       providerID: PROVIDER_ID,

--- a/packages/synergy/src/provider/minimax.ts
+++ b/packages/synergy/src/provider/minimax.ts
@@ -2,6 +2,8 @@ import { Auth } from "./api-key"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin"
 import z from "zod"
+import { ProviderAuthRecovery } from "./auth-recovery"
+import type { ProviderProfile } from "./profile"
 
 export namespace MiniMaxProvider {
   export const PROVIDER_ID = "minimax-oauth"
@@ -177,8 +179,9 @@ export namespace MiniMaxProvider {
   }
 
   export async function resolveToken(options?: { allowMissing?: boolean; fetch?: FetchLike }) {
-    const auth = await Auth.get(PROVIDER_ID)
-    if (!auth || auth.type !== "oauth") {
+    const selected = await Auth.select(PROVIDER_ID)
+    const auth = selected?.auth
+    if (!selected || !auth || auth.type !== "oauth") {
       if (options?.allowMissing) return undefined
       throw new AuthError({
         providerID: PROVIDER_ID,
@@ -190,10 +193,11 @@ export namespace MiniMaxProvider {
     if (auth.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return auth.access
     try {
       return await Auth.withLock(`${PROVIDER_ID}:oauth-refresh`, async () => {
-        const latest = await Auth.get(PROVIDER_ID)
+        const latestSelected = await Auth.select(PROVIDER_ID)
+        const latest = latestSelected?.auth
         if (latest?.type === "oauth" && latest.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return latest.access
         const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch)
-        await Auth.set(
+        await Auth.replaceSelectedCredential(
           PROVIDER_ID,
           {
             type: "oauth",
@@ -201,7 +205,7 @@ export namespace MiniMaxProvider {
             refresh: refreshed.refresh,
             expires: refreshed.expires,
           },
-          { source: "api" },
+          { credentialID: latestSelected?.credentialID ?? selected.credentialID },
         )
         return refreshed.access
       })
@@ -215,9 +219,40 @@ export namespace MiniMaxProvider {
   }
 
   export async function minimaxFetch(input: RequestInfo | URL, init?: RequestInit) {
-    const token = await resolveToken()
-    const headers = new Headers(init?.headers)
-    headers.set("Authorization", `Bearer ${token}`)
-    return fetch(input, { ...init, headers })
+    return ProviderAuthRecovery.execute({
+      providerID: PROVIDER_ID,
+      request: async () => {
+        const token = await resolveToken()
+        const headers = new Headers(init?.headers)
+        headers.set("Authorization", `Bearer ${token}`)
+        return fetch(input, { ...init, headers })
+      },
+      refresh: refreshAuth,
+      classify: classifyError,
+    })
+  }
+
+  export async function refreshAuth(auth: Auth.Info, fetchFn: FetchLike = fetch): Promise<Auth.Info | undefined> {
+    if (auth.type !== "oauth") return undefined
+    const refreshed = await refreshOAuth(auth, fetchFn)
+    return {
+      type: "oauth",
+      access: refreshed.access,
+      refresh: refreshed.refresh,
+      expires: refreshed.expires,
+    }
+  }
+
+  export function classifyError(input: {
+    status?: number
+    body?: unknown
+  }): ProviderProfile.ClassifiedError | undefined {
+    const payload = input.body && typeof input.body === "object" ? (input.body as Record<string, any>) : {}
+    const code = String(payload.error?.code ?? payload.error ?? payload.base_resp?.status_code ?? "")
+    if (input.status === 429) return { code: code || "rate_limited", retryable: true, exhausted: true }
+    if (input.status === 401 || ["invalid_token", "1004", "2049"].includes(code)) {
+      return { code: code || "credential_rejected", retryable: false, reloginRequired: true }
+    }
+    return undefined
   }
 }

--- a/packages/synergy/src/provider/profile.ts
+++ b/packages/synergy/src/provider/profile.ts
@@ -49,6 +49,8 @@ export namespace ProviderProfile {
       displayName: z.string().optional(),
       description: z.string().optional(),
       signupUrl: z.string().optional(),
+      authKind: z.string().optional(),
+      environment: z.array(z.string()).optional(),
       recommendation: Recommendation.optional(),
     })
     .strict()
@@ -93,6 +95,7 @@ export namespace ProviderProfile {
   export interface Profile {
     id: string
     name: string
+    origin?: "builtin" | "plugin"
     aliases?: string[]
     displayName?: string
     description?: string
@@ -151,6 +154,15 @@ export namespace ProviderProfile {
     return [...profiles.values()]
   }
 
+  export function clearPluginProfiles() {
+    for (const [providerID, profile] of profiles) {
+      if (profile.origin === "plugin") profiles.delete(providerID)
+    }
+    for (const [alias, providerID] of aliases) {
+      if (!profiles.has(providerID)) aliases.delete(alias)
+    }
+  }
+
   export function canonicalID(providerID: string): string {
     return aliases.get(providerID) ?? providerID
   }
@@ -162,6 +174,8 @@ export namespace ProviderProfile {
       ...(profile.displayName ? { displayName: profile.displayName } : {}),
       ...(profile.description ? { description: profile.description } : {}),
       ...(profile.signupUrl ? { signupUrl: profile.signupUrl } : {}),
+      ...(profile.authKind ? { authKind: profile.authKind } : {}),
+      ...(profile.env?.length ? { environment: profile.env } : {}),
       ...(profile.recommendation ? { recommendation: profile.recommendation } : {}),
     }
   }

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -42,6 +42,7 @@ import { createVercel } from "@ai-sdk/vercel"
 import { ProviderTransform } from "./transform"
 import { ProviderCatalog } from "./catalog"
 import { ProviderProfile } from "./profile"
+import { ProviderAuthRecovery } from "./auth-recovery"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -209,7 +210,7 @@ export namespace Provider {
   }
 
   async function fetchWithProxyOptions(
-    fetchFn: typeof fetch,
+    fetchFn: ProviderProfile.FetchLike,
     input: RequestInfo | URL,
     init: RequestInit | undefined,
     proxyUrl: string | undefined,
@@ -709,18 +710,19 @@ export namespace Provider {
     delete options["proxy"]
     delete options["noProxy"]
 
+    const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch)
     const proxyFetch =
       proxyUrl || noProxy
-        ? (input: any, init?: any) => fetchWithProxyOptions(customFetch ?? fetch, input, init, proxyUrl, noProxy)
-        : customFetch
-    if (proxyFetch) options["fetch"] = proxyFetch
+        ? (input: any, init?: any) => fetchWithProxyOptions(authFetch, input, init, proxyUrl, noProxy)
+        : authFetch
+    options["fetch"] = proxyFetch
 
     const builtSDK = bundledFn({
       name: model.providerID,
       ...options,
     }) as SDK
 
-    if (proxyFetch) {
+    if (proxyUrl || noProxy) {
       const patchedSDK = new Proxy(builtSDK as object, {
         get(target, prop) {
           if (prop === "fetch") return proxyFetch
@@ -764,6 +766,7 @@ export namespace Provider {
       }
 
       const customFetch = options["fetch"]
+      const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch)
       const proxyUrl = options["proxy"] as string | undefined
       const noProxy = options["noProxy"] === true
       delete options["proxy"]
@@ -772,7 +775,7 @@ export namespace Provider {
       const DEFAULT_TIMEOUT_MS = 900_000
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
-        const fetchFn = customFetch ?? fetch
+        const fetchFn = authFetch
         const opts = init ?? {}
 
         const proxyUrlForRequest = proxyUrl

--- a/packages/synergy/src/provider/usage.ts
+++ b/packages/synergy/src/provider/usage.ts
@@ -1,4 +1,5 @@
 import { Auth } from "./api-key"
+import { ProviderAuthRecovery } from "./auth-recovery"
 import z from "zod"
 
 export namespace AccountUsage {
@@ -100,23 +101,35 @@ export namespace AccountUsage {
     if (!auth || auth.type !== "api") {
       return unavailable(providerID, "OpenRouter credits are only available for API-key credentials.")
     }
-    const headers = {
-      Authorization: `Bearer ${auth.key}`,
-      Accept: "application/json",
-    }
-    const [creditsResponse, keyResponse] = await Promise.all([
-      fetchFn("https://openrouter.ai/api/v1/credits", {
-        headers,
-        signal: AbortSignal.timeout(10_000),
-      }),
-      fetchFn("https://openrouter.ai/api/v1/key", {
-        headers,
-        signal: AbortSignal.timeout(10_000),
-      }).catch(() => undefined),
-    ])
+    const request = (url: string) =>
+      ProviderAuthRecovery.execute({
+        providerID,
+        request: async () => {
+          const current = await Auth.get(providerID)
+          if (current?.type !== "api") return new Response(null, { status: 401 })
+          return fetchFn(url, {
+            headers: {
+              Authorization: `Bearer ${current.key}`,
+              Accept: "application/json",
+            },
+            signal: AbortSignal.timeout(10_000),
+          })
+        },
+        throwOnActionRequired: false,
+      })
+    const creditsResponse = await request("https://openrouter.ai/api/v1/credits")
     if (!creditsResponse.ok) {
-      return error(providerID, `OpenRouter credits request failed with status ${creditsResponse.status}.`)
+      if (creditsResponse.status === 401) {
+        return error(providerID, "OpenRouter rejected this API key. Replace it to restore usage.", {
+          reloginRequired: true,
+        })
+      }
+      if (creditsResponse.status === 429) {
+        return unavailable(providerID, "OpenRouter usage is temporarily rate limited.")
+      }
+      return error(providerID, "OpenRouter usage is temporarily unavailable.")
     }
+    const keyResponse = await request("https://openrouter.ai/api/v1/key").catch(() => undefined)
     const creditsPayload = (await creditsResponse.json().catch(() => ({}))) as any
     const keyPayload = keyResponse?.ok ? ((await keyResponse.json().catch(() => ({}))) as any) : {}
     const credits = creditsPayload.data ?? {}

--- a/packages/synergy/src/server/provider.ts
+++ b/packages/synergy/src/server/provider.ts
@@ -10,120 +10,35 @@ import { ProviderAuth } from "../provider/auth"
 import { Log } from "../util/log"
 import { errors } from "./error"
 import { ProviderCatalog } from "@/provider/catalog"
+import { RuntimeReload } from "@/runtime/reload"
 import { ProviderUsage } from "@/provider/usage-service"
 import { AccountUsage } from "@/provider/usage"
 import { Auth } from "@/provider/api-key"
 import { ProviderProfile } from "@/provider/profile"
 import { GitHubProvider } from "@/provider/github"
+import { ProviderAuthHealth } from "@/provider/auth-health"
 
 const log = Log.create({ service: "provider" })
-
-const ProviderAuthHealth = z
-  .object({
-    providerID: z.string(),
-    status: z.enum(["connected", "not_configured", "expired", "exhausted", "dead"]),
-    authKind: z.string().optional(),
-    source: z.string().optional(),
-    updatedAt: z.number().optional(),
-    reloginRequired: z.boolean().optional(),
-    cooldownUntil: z.number().optional(),
-    resetAt: z.number().optional(),
-    failureCode: z.string().optional(),
-  })
-  .meta({ ref: "ProviderAuthHealth" })
 
 const ProviderRuntimeAvailability = z
   .object({
     providerID: z.string(),
     available: z.boolean(),
-    reason: z.enum(["connected", "not_connected", "disabled", "no_models"]).optional(),
+    reason: z
+      .enum([
+        "connected",
+        "not_connected",
+        "disabled",
+        "no_models",
+        "authentication_required",
+        "exhausted",
+        "fallback_unverified",
+      ])
+      .optional(),
     healthCheck: z.enum(["models", "none"]).optional(),
     modelCount: z.number(),
   })
   .meta({ ref: "ProviderRuntimeAvailability" })
-
-async function authHealth(
-  providerID: string,
-  entry: Auth.StoreEntry | undefined,
-): Promise<z.infer<typeof ProviderAuthHealth>> {
-  if (!entry) {
-    return {
-      providerID,
-      status: "not_configured",
-      reloginRequired: false,
-    }
-  }
-  const now = Date.now()
-  const selected = await Auth.select(providerID)
-  if (selected) {
-    const info = selected.auth
-    if (info.type === "oauth" && info.expires * 1000 <= now) {
-      return {
-        providerID,
-        status: "expired",
-        authKind: selected.poolEntry?.authKind ?? entry.authKind,
-        source: selected.poolEntry?.source ?? entry.source,
-        updatedAt: selected.poolEntry?.updatedAt ?? entry.updatedAt,
-        reloginRequired: false,
-      }
-    }
-    return {
-      providerID,
-      status: "connected",
-      authKind: selected.poolEntry?.authKind ?? entry.authKind,
-      source: selected.poolEntry?.source ?? entry.source,
-      updatedAt: selected.poolEntry?.updatedAt ?? entry.updatedAt,
-      reloginRequired: false,
-    }
-  }
-
-  const pool = entry.pool ?? []
-  const dead = pool.find((item) => item.status === "dead")
-  const exhausted = pool.find((item) => item.status === "exhausted")
-  if (dead && pool.every((item) => item.status === "dead")) {
-    return {
-      providerID,
-      status: "dead",
-      authKind: entry.authKind,
-      source: entry.source,
-      updatedAt: entry.updatedAt,
-      reloginRequired: true,
-      failureCode: dead.failureCode,
-    }
-  }
-  if (exhausted) {
-    return {
-      providerID,
-      status: "exhausted",
-      authKind: entry.authKind,
-      source: entry.source,
-      updatedAt: entry.updatedAt,
-      reloginRequired: false,
-      cooldownUntil: exhausted.cooldownUntil,
-      resetAt: exhausted.resetAt,
-      failureCode: exhausted.failureCode,
-    }
-  }
-  const info = Auth.infoFromEntry(entry)
-  if (info?.type === "oauth" && info.expires * 1000 <= now) {
-    return {
-      providerID,
-      status: "expired",
-      authKind: entry.authKind,
-      source: entry.source,
-      updatedAt: entry.updatedAt,
-      reloginRequired: false,
-    }
-  }
-  return {
-    providerID,
-    status: "connected",
-    authKind: entry.authKind,
-    source: entry.source,
-    updatedAt: entry.updatedAt,
-    reloginRequired: false,
-  }
-}
 
 export const ProviderRoute = new Hono()
   .get(
@@ -145,7 +60,7 @@ export const ProviderRoute = new Hono()
                   configProviders: z.array(z.string()),
                   catalogProviders: z.array(z.string()),
                   profiles: z.record(z.string(), ProviderProfile.Metadata),
-                  authHealth: z.record(z.string(), ProviderAuthHealth),
+                  authHealth: z.record(z.string(), ProviderAuthHealth.Info),
                   runtimeAvailability: z.record(z.string(), ProviderRuntimeAvailability),
                 }),
               ),
@@ -185,37 +100,77 @@ export const ProviderRoute = new Hono()
         ]),
       )
       const entries = await Auth.entries()
+      const healthProviderIDs = new Set([
+        ...Object.keys(providers),
+        ...Object.keys(entries),
+        GitHubProvider.PROVIDER_ID,
+      ])
       const authHealthByProvider = Object.fromEntries(
-        await Promise.all(
-          Object.values(providers).map(async (provider) => [
-            provider.id,
-            await authHealth(provider.id, entries[provider.id]),
-          ]),
-        ),
+        [...healthProviderIDs].map((providerID) => {
+          const health = ProviderAuthHealth.fromEntry(providerID, entries[providerID])
+          if (health.status !== "not_configured") return [providerID, health]
+          const provider = providers[providerID]
+          const profile = ProviderProfile.get(providerID)
+          const githubEnvironment =
+            providerID === GitHubProvider.PROVIDER_ID &&
+            !!(process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim())
+          const runtimeConnected = Object.prototype.hasOwnProperty.call(connected, providerID)
+          if (!runtimeConnected && !githubEnvironment) return [providerID, health]
+          const environment = provider?.env?.some((name) => !!process.env[name]?.trim()) || githubEnvironment
+          return [
+            providerID,
+            {
+              providerID,
+              status: "connected" as const,
+              authKind: profile?.authKind,
+              source: environment ? "env" : profile?.origin === "plugin" ? "plugin" : undefined,
+            },
+          ]
+        }),
       )
       const runtimeAvailability = mapValues(providers, (provider) => {
         const disabledProvider = disabled.has(provider.id)
         const modelCount = Object.keys(provider.models).length
+        const health = authHealthByProvider[provider.id]
+        const authenticationRequired = health?.status === "action_required"
+        const credentialExhausted = health?.status === "exhausted"
         const available =
-          !disabledProvider && Object.prototype.hasOwnProperty.call(connected, provider.id) && modelCount > 0
+          !disabledProvider &&
+          !authenticationRequired &&
+          !credentialExhausted &&
+          Object.prototype.hasOwnProperty.call(connected, provider.id) &&
+          modelCount > 0
         const profile = ProviderProfile.get(provider.id)
+        const fallbackUnverified = ProviderCatalog.liveDiscoveryStatus(provider.id) === "fallback"
         return {
           providerID: provider.id,
           available,
           reason: disabledProvider
             ? ("disabled" as const)
-            : modelCount === 0
-              ? ("no_models" as const)
-              : available
-                ? ("connected" as const)
-                : ("not_connected" as const),
+            : authenticationRequired
+              ? ("authentication_required" as const)
+              : credentialExhausted
+                ? ("exhausted" as const)
+                : modelCount === 0
+                  ? ("no_models" as const)
+                  : fallbackUnverified && available
+                    ? ("fallback_unverified" as const)
+                    : available
+                      ? ("connected" as const)
+                      : ("not_connected" as const),
           healthCheck: profile?.healthCheck ?? "models",
           modelCount,
         }
       })
+      const defaultModels = Object.fromEntries(
+        Object.entries(providers).flatMap(([providerID, provider]) => {
+          const model = Provider.sort(Object.values(provider.models))[0]
+          return model ? [[providerID, model.id]] : []
+        }),
+      )
       return c.json({
         all: Object.values(providers),
-        default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
+        default: defaultModels,
         connected: Object.keys(connected),
         configProviders,
         catalogProviders: Object.keys(filteredProviders),
@@ -337,7 +292,7 @@ export const ProviderRoute = new Hono()
     }),
     async (c) => {
       await GitHubProvider.remove()
-      await Provider.reload()
+      await RuntimeReload.reload({ targets: ["provider"], reason: "GitHub credentials removed" })
       return c.json(true)
     },
   )

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -10,6 +10,7 @@ import { fn } from "@/util/fn"
 import { Storage } from "@/storage/storage"
 import { StoragePath } from "@/storage/path"
 import { ProviderTransform } from "@/provider/transform"
+import { ProviderAuthRecovery } from "@/provider/auth-recovery"
 import { STATUS_CODES } from "http"
 import { iife } from "@/util/iife"
 import { type SystemError } from "bun"
@@ -87,6 +88,8 @@ export namespace MessageV2 {
     z.object({
       providerID: z.string(),
       message: z.string(),
+      failureCode: z.string().optional(),
+      actionRequired: z.boolean().optional(),
     }),
   )
   export const APIError = NamedError.create(
@@ -1238,6 +1241,16 @@ export namespace MessageV2 {
           {
             providerID: ctx.providerID,
             message: e.message,
+          },
+          { cause: e },
+        ).toObject()
+      case ProviderAuthRecovery.Error.isInstance(e):
+        return new MessageV2.AuthError(
+          {
+            providerID: e.data.providerID,
+            message: e.data.message,
+            failureCode: e.data.failureCode,
+            actionRequired: e.data.actionRequired,
           },
           { cause: e },
         ).toObject()

--- a/packages/synergy/test/provider/auth-recovery.test.ts
+++ b/packages/synergy/test/provider/auth-recovery.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { Auth } from "../../src/provider/api-key"
+import { ProviderAuthHealth } from "../../src/provider/auth-health"
+import { ProviderAuthRecovery } from "../../src/provider/auth-recovery"
+import { ProviderProfile } from "../../src/provider/profile"
+import { Bus } from "../../src/bus"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
+
+const PROVIDERS = [
+  "test-refresh",
+  "test-backup",
+  "test-wrapped-api",
+  "test-status",
+  "test-exhausted",
+  "test-env",
+  "test-missing",
+  "test-plugin-with-hooks",
+  "test-plugin-without-classifier",
+]
+
+async function reset() {
+  ProviderProfile.clearPluginProfiles()
+  for (const providerID of PROVIDERS) {
+    await Auth.remove(providerID).catch(() => {})
+    await ProviderAuthHealth.clearObservation(providerID)
+  }
+}
+
+beforeEach(reset)
+afterEach(reset)
+
+test("concurrent credential rejection performs one refresh and each request retries once", async () => {
+  await Auth.set("test-refresh", { type: "oauth", access: "old", refresh: "refresh", expires: 9999999999 })
+  let refreshes = 0
+  let requests = 0
+
+  const execute = () =>
+    ProviderAuthRecovery.execute({
+      providerID: "test-refresh",
+      request: async () => {
+        requests++
+        const auth = await Auth.get("test-refresh")
+        return new Response(null, { status: auth?.type === "oauth" && auth.access === "new" ? 200 : 401 })
+      },
+      refresh: async (auth) => {
+        refreshes++
+        await Promise.resolve()
+        return auth.type === "oauth" ? { ...auth, access: "new" } : undefined
+      },
+    })
+
+  const responses = await Promise.all([execute(), execute()])
+  expect(responses.map((response) => response.status)).toEqual([200, 200])
+  expect(refreshes).toBe(1)
+  expect(requests).toBe(4)
+})
+
+test("a rejected primary API key switches to a backup within the single retry budget", async () => {
+  await Auth.set("test-backup", { type: "api", key: "primary" })
+  await Auth.addToPool("test-backup", "backup", { type: "api", key: "backup" })
+  const keys: string[] = []
+
+  const response = await ProviderAuthRecovery.execute({
+    providerID: "test-backup",
+    request: async () => {
+      const auth = await Auth.get("test-backup")
+      const key = auth?.type === "api" ? auth.key : ""
+      keys.push(key)
+      return new Response(null, { status: key === "backup" ? 200 : 401 })
+    },
+  })
+
+  expect(response.status).toBe(200)
+  expect(keys).toEqual(["primary", "backup"])
+  expect((await Auth.select("test-backup"))?.credentialID).toBe("backup")
+  expect(ProviderAuthHealth.fromEntry("test-backup", (await Auth.entries())["test-backup"]).status).toBe("connected")
+})
+
+test("generic SDK transport rewrites common API-key headers when selecting a backup", async () => {
+  await Auth.set("test-wrapped-api", { type: "api", key: "primary" })
+  await Auth.addToPool("test-wrapped-api", "backup", { type: "api", key: "backup" })
+  const seen: string[] = []
+  const transport = ProviderAuthRecovery.wrapFetch("test-wrapped-api", async (_input, init) => {
+    const authorization = new Headers(init?.headers).get("authorization") ?? ""
+    seen.push(authorization)
+    return new Response(null, { status: authorization === "Bearer backup" ? 200 : 401 })
+  })
+
+  const response = await transport("https://provider.test/v1/messages", {
+    headers: { Authorization: "Bearer primary" },
+  })
+  expect(response.status).toBe(200)
+  expect(seen).toEqual(["Bearer primary", "Bearer backup"])
+})
+
+test("403, server failures, and network exceptions do not invalidate credentials without classification", async () => {
+  await Auth.set("test-status", { type: "api", key: "valid-until-proven-otherwise" })
+
+  for (const status of [403, 500, 503]) {
+    const response = await ProviderAuthRecovery.execute({
+      providerID: "test-status",
+      request: async () => new Response(null, { status }),
+    })
+    expect(response.status).toBe(status)
+    expect(await Auth.get("test-status")).toMatchObject({ type: "api" })
+  }
+
+  await expect(
+    ProviderAuthRecovery.execute({
+      providerID: "test-status",
+      request: async () => {
+        throw new TypeError("fetch failed")
+      },
+    }),
+  ).rejects.toThrow("fetch failed")
+  expect(await Auth.get("test-status")).toMatchObject({ type: "api" })
+})
+
+test("rate limits mark credentials exhausted with retry metadata and never refresh", async () => {
+  await Auth.set("test-exhausted", { type: "oauth", access: "access", refresh: "refresh", expires: 9999999999 })
+  let refreshes = 0
+  const reset = Math.floor(Date.now() / 1000) + 600
+  const response = await ProviderAuthRecovery.execute({
+    providerID: "test-exhausted",
+    request: async () =>
+      new Response(null, {
+        status: 429,
+        headers: { "retry-after": "120", "x-ratelimit-reset": String(reset) },
+      }),
+    refresh: async () => {
+      refreshes++
+      return undefined
+    },
+  })
+
+  expect(response.status).toBe(429)
+  expect(refreshes).toBe(0)
+  expect(ProviderAuthHealth.fromEntry("test-exhausted", (await Auth.entries())["test-exhausted"])).toMatchObject({
+    status: "exhausted",
+    resetAt: reset,
+  })
+})
+
+test("environment credential rejection is process-local and requests an environment update", async () => {
+  ProviderProfile.register({
+    id: "test-env",
+    name: "Test environment provider",
+    origin: "plugin",
+    env: ["SYNERGY_TEST_ENV_TOKEN"],
+    classifyError: ({ status }) =>
+      status === 401 ? { code: "test_env_rejected", retryable: false, reloginRequired: true } : undefined,
+  })
+  process.env.SYNERGY_TEST_ENV_TOKEN = "invalid"
+  try {
+    await expect(
+      ProviderAuthRecovery.execute({
+        providerID: "test-env",
+        request: async () => new Response(null, { status: 401 }),
+      }),
+    ).rejects.toMatchObject({ name: "ProviderAuthenticationRequiredError" })
+
+    expect((await Auth.entries())["test-env"]).toBeUndefined()
+    expect(ProviderAuthHealth.fromEntry("test-env", undefined)).toMatchObject({
+      status: "action_required",
+      recovery: "update_environment",
+    })
+
+    const recovered = await ProviderAuthRecovery.execute({
+      providerID: "test-env",
+      request: async () => new Response(null, { status: 200 }),
+    })
+    expect(recovered.status).toBe(200)
+    expect(ProviderAuthHealth.fromEntry("test-env", undefined)).toMatchObject({
+      status: "connected",
+      source: "env",
+    })
+    expect((await Auth.entries())["test-env"]).toBeUndefined()
+  } finally {
+    delete process.env.SYNERGY_TEST_ENV_TOKEN
+  }
+})
+
+test("a request that cannot start without credentials remains not configured", async () => {
+  const missing = Object.assign(new Error("No credentials configured"), {
+    data: {
+      code: "test_auth_missing",
+      reloginRequired: true,
+    },
+  })
+
+  await expect(
+    ProviderAuthRecovery.execute({
+      providerID: "test-missing",
+      request: async () => {
+        throw missing
+      },
+    }),
+  ).rejects.toBe(missing)
+  expect(ProviderAuthHealth.fromEntry("test-missing", undefined)).toEqual({
+    providerID: "test-missing",
+    status: "not_configured",
+  })
+})
+
+test("plugin classifier and refresh hooks run, while an unclassified plugin 401 remains untouched", async () => {
+  let classified = 0
+  let refreshed = 0
+  ProviderProfile.register({
+    id: "test-plugin-with-hooks",
+    name: "Test plugin",
+    origin: "plugin",
+    classifyError: ({ status }) => {
+      classified++
+      return status === 401 ? { code: "plugin_token_rejected", retryable: false, reloginRequired: true } : undefined
+    },
+    refreshAuth: async ({ auth }) => {
+      refreshed++
+      return auth?.type === "oauth" ? { ...auth, access: "plugin-new" } : undefined
+    },
+  })
+  await Auth.set("test-plugin-with-hooks", {
+    type: "oauth",
+    access: "plugin-old",
+    refresh: "plugin-refresh",
+    expires: 9999999999,
+  })
+
+  const recovered = await ProviderAuthRecovery.execute({
+    providerID: "test-plugin-with-hooks",
+    request: async () => {
+      const auth = await Auth.get("test-plugin-with-hooks")
+      return new Response(null, { status: auth?.type === "oauth" && auth.access === "plugin-new" ? 200 : 401 })
+    },
+  })
+  expect(recovered.status).toBe(200)
+  expect(classified).toBe(1)
+  expect(refreshed).toBe(1)
+
+  ProviderProfile.register({
+    id: "test-plugin-without-classifier",
+    name: "Unclassified plugin",
+    origin: "plugin",
+  })
+  await Auth.set("test-plugin-without-classifier", { type: "api", key: "plugin-key" })
+  const untouched = await ProviderAuthRecovery.execute({
+    providerID: "test-plugin-without-classifier",
+    request: async () => new Response(null, { status: 401 }),
+  })
+  expect(untouched.status).toBe(401)
+  expect(await Auth.get("test-plugin-without-classifier")).toMatchObject({ type: "api", key: "plugin-key" })
+})
+
+test("health events contain only public state and ignore connected token rotation", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const events: unknown[] = []
+      const unsubscribe = Bus.subscribe(ProviderAuthHealth.Event.Updated, (event) => events.push(event.properties))
+      try {
+        await Auth.set("test-refresh", { type: "api", key: "secret-primary" }, { source: "api" })
+        events.length = 0
+
+        await Auth.replaceSelectedCredential("test-refresh", { type: "api", key: "secret-rotated" }, { source: "api" })
+        expect(events).toEqual([])
+
+        await Auth.markDead("test-refresh", "credential_rejected")
+        expect(events).toHaveLength(1)
+        expect(events[0]).toEqual({
+          health: {
+            providerID: "test-refresh",
+            status: "action_required",
+            recovery: "reconnect",
+            authKind: "api_key",
+            source: "api",
+            updatedAt: expect.any(Number),
+            failureCode: "credential_rejected",
+          },
+        })
+        expect(JSON.stringify(events)).not.toContain("secret-primary")
+        expect(JSON.stringify(events)).not.toContain("secret-rotated")
+      } finally {
+        unsubscribe()
+      }
+    },
+  })
+})

--- a/packages/synergy/test/provider/codex.test.ts
+++ b/packages/synergy/test/provider/codex.test.ts
@@ -256,6 +256,71 @@ test("codexFetch rewrites authorization, Codex headers, session headers, and req
   expect(body.max_output_tokens).toBeUndefined()
 })
 
+test("codexFetch refreshes an invalidated access token and retries once", async () => {
+  const oldToken = accessToken({ accountID: "acct_old" })
+  const newToken = accessToken({ accountID: "acct_new" })
+  await Auth.set(CodexProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: oldToken,
+    refresh: "refresh-old",
+    expires: nowSeconds() + 60 * 60,
+  })
+
+  const calls: string[] = []
+  globalThis.fetch = asFetch(async (input, init) => {
+    const url = String(input)
+    calls.push(url)
+    if (url === CodexProvider.OAUTH_TOKEN_URL) {
+      return jsonResponse({ access_token: newToken, refresh_token: "refresh-new", expires_in: 3600 })
+    }
+    const authorization = new Headers(init?.headers).get("authorization")
+    if (authorization === `Bearer ${oldToken}`) {
+      return jsonResponse({ error: { code: "token_invalidated", message: "token invalidated" } }, { status: 401 })
+    }
+    expect(authorization).toBe(`Bearer ${newToken}`)
+    return jsonResponse({ ok: true })
+  })
+
+  const response = await CodexProvider.codexFetch("https://chatgpt.com/backend-api/codex/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "gpt-5.6-sol", input: "hello" }),
+  })
+
+  expect(response.status).toBe(200)
+  expect(calls.filter((url) => url === CodexProvider.OAUTH_TOKEN_URL)).toHaveLength(1)
+  expect(calls.filter((url) => url.endsWith("/responses"))).toHaveLength(2)
+  const stored = await Auth.get(CodexProvider.PROVIDER_ID)
+  expect(stored?.type === "oauth" ? stored.refresh : undefined).toBe("refresh-new")
+})
+
+test("codexFetch marks credentials dead when invalidated access cannot refresh", async () => {
+  const token = accessToken({ accountID: "acct_dead" })
+  await Auth.set(CodexProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: token,
+    refresh: "refresh-dead",
+    expires: nowSeconds() + 60 * 60,
+  })
+
+  globalThis.fetch = asFetch(async (input) => {
+    if (String(input) === CodexProvider.OAUTH_TOKEN_URL) {
+      return jsonResponse({ error: "invalid_grant", error_description: "refresh token revoked" }, { status: 400 })
+    }
+    return jsonResponse({ error: { code: "token_invalidated" } }, { status: 401 })
+  })
+
+  await expect(
+    CodexProvider.codexFetch("https://chatgpt.com/backend-api/codex/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.5", input: "hello" }),
+    }),
+  ).rejects.toMatchObject({
+    name: "ProviderAuthenticationRequiredError",
+    data: { providerID: CodexProvider.PROVIDER_ID, actionRequired: true },
+  })
+  expect(await Auth.get(CodexProvider.PROVIDER_ID)).toBeUndefined()
+})
+
 test("fetchModelIDs sorts visible Codex models and sends Codex headers", async () => {
   const token = accessToken({ accountID: "acct_models" })
   const ids = await CodexProvider.fetchModelIDs(token, async (input, init) => {
@@ -274,6 +339,20 @@ test("fetchModelIDs sorts visible Codex models and sends Codex headers", async (
   })
 
   expect(ids).toEqual(["gpt-5.4-mini", "gpt-5.5"])
+})
+
+test("fetchModelIDs preserves future account-visible model slugs", async () => {
+  const token = accessToken({ accountID: "acct_future" })
+  const ids = await CodexProvider.fetchModelIDs(token, async () =>
+    jsonResponse({
+      models: [
+        { slug: "gpt-5.6-sol", priority: 1 },
+        { slug: "future-codex-model", priority: 2 },
+      ],
+    }),
+  )
+
+  expect(ids).toEqual(["gpt-5.6-sol", "future-codex-model"])
 })
 
 test("fetchModelCatalog parses Codex context windows without filtering supported_in_api false", async () => {

--- a/packages/synergy/test/provider/framework.test.ts
+++ b/packages/synergy/test/provider/framework.test.ts
@@ -6,6 +6,7 @@ import { AnthropicOAuthProvider } from "../../src/provider/anthropic-oauth"
 import { ProviderCatalog } from "../../src/provider/catalog"
 import { CodexProvider } from "../../src/provider/codex"
 import { AccountUsage } from "../../src/provider/usage"
+import { ProviderAuthHealth } from "../../src/provider/auth-health"
 import { ProviderProfile } from "../../src/provider/profile"
 import { Plugin } from "../../src/plugin"
 
@@ -263,8 +264,14 @@ test("provider catalog live discovery supports model catalog metadata and legacy
   ])
   ProviderCatalog.reset()
 
-  const catalog = await ProviderCatalog.resolve({
+  const staticCatalog = await ProviderCatalog.resolve({
     forceRefresh: true,
+    includeLive: false,
+    config: { providerCatalog: { enabled: false, offlineCache: false } },
+  })
+  expect(Object.keys(staticCatalog["plugin-live-catalog-provider"].models)).toEqual(["static-model"])
+
+  const catalog = await ProviderCatalog.resolve({
     includeLive: true,
     config: { providerCatalog: { enabled: false, offlineCache: false } },
   })
@@ -440,6 +447,79 @@ test("provider auth pool skips exhausted and dead credentials", async () => {
     cooldownUntil: nowSeconds() - 1,
   })
   expect(await Auth.get("openrouter")).toEqual({ type: "api", key: "primary" })
+})
+
+test("provider auth health exposes product states without treating refreshable oauth expiry as failure", async () => {
+  const expired: Auth.StoreEntry = {
+    providerID: "openai-codex",
+    authKind: "oauth" as const,
+    tokens: { accessToken: "expired-access", refreshToken: "refresh-token" },
+    expiresAt: nowSeconds() - 60,
+    source: "web" as const,
+    updatedAt: Date.now(),
+    pool: [
+      {
+        id: "openai-codex",
+        status: "active" as const,
+        authKind: "oauth" as const,
+        tokens: { accessToken: "expired-access", refreshToken: "refresh-token" },
+        expiresAt: nowSeconds() - 60,
+        source: "web" as const,
+        updatedAt: Date.now(),
+      },
+    ],
+  }
+
+  expect(ProviderAuthHealth.fromEntry("openai-codex", expired)).toMatchObject({
+    providerID: "openai-codex",
+    status: "connected",
+  })
+
+  expired.pool![0].status = "dead"
+  expired.pool![0].failureCode = "token_invalidated"
+  expect(ProviderAuthHealth.fromEntry("openai-codex", expired)).toMatchObject({
+    providerID: "openai-codex",
+    status: "action_required",
+    recovery: "reconnect",
+    failureCode: "token_invalidated",
+  })
+})
+
+test("replacing a selected credential preserves backup pool entries", async () => {
+  await Auth.set("openai-codex", {
+    type: "oauth",
+    access: accessToken(),
+    refresh: "refresh-primary",
+    expires: nowSeconds() + 60,
+  })
+  await Auth.addToPool(
+    "openai-codex",
+    "backup",
+    {
+      type: "oauth",
+      access: accessToken(),
+      refresh: "refresh-backup",
+      expires: nowSeconds() + 120,
+    },
+    { source: "web" },
+  )
+
+  const selected = await Auth.select("openai-codex")
+  await Auth.replaceSelectedCredential(
+    "openai-codex",
+    {
+      type: "oauth",
+      access: accessToken(),
+      refresh: "refresh-rotated",
+      expires: nowSeconds() + 3600,
+    },
+    { credentialID: selected?.credentialID, source: "api" },
+  )
+
+  const entry = (await Auth.entries())["openai-codex"]
+  expect(entry.pool?.map((item) => item.id)).toEqual(["openai-codex", "backup"])
+  expect(entry.pool?.[0].tokens.refreshToken).toBe("refresh-rotated")
+  expect(entry.pool?.[1].tokens.refreshToken).toBe("refresh-backup")
 })
 
 test("usage windows normalize reset timestamps", () => {

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -131,6 +131,33 @@ test("anthropic oauth refresh rotates tokens and marks invalid grants dead", asy
   expect(await Auth.get(AnthropicOAuthProvider.PROVIDER_ID)).toBeUndefined()
 })
 
+test("anthropic request rejection refreshes once and retries with the rotated token", async () => {
+  await Auth.set(AnthropicOAuthProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: "anthropic-old",
+    refresh: "anthropic-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  let refreshes = 0
+  let requests = 0
+  globalThis.fetch = asFetch(async (input, init) => {
+    if (AnthropicOAuthProvider.OAUTH_TOKEN_URLS.some((url) => url === String(input))) {
+      refreshes++
+      return jsonResponse({ access_token: "anthropic-new", refresh_token: "anthropic-refresh-2", expires_in: 3600 })
+    }
+    requests++
+    const token = new Headers(init?.headers).get("authorization")
+    return token === "Bearer anthropic-new"
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ type: "authentication_error" }, { status: 401 })
+  })
+
+  const response = await AnthropicOAuthProvider.anthropicFetch("https://api.anthropic.com/v1/messages")
+  expect(response.status).toBe(200)
+  expect(refreshes).toBe(1)
+  expect(requests).toBe(2)
+})
+
 test("github copilot device login exchanges a GitHub token for Copilot models", async () => {
   const authorize = await CopilotProvider.authorizeDeviceCode(
     CopilotProvider.PROVIDER_ID,
@@ -323,4 +350,61 @@ test("minimax user-code oauth refreshes short tokens and injects bearer auth", a
     return jsonResponse({ ok: true })
   })
   await MiniMaxProvider.minimaxFetch("https://api.minimax.io/anthropic/v1/messages")
+})
+
+test("minimax request rejection recovers once and invalid refresh requires reconnect", async () => {
+  await Auth.set(MiniMaxProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: "minimax-old",
+    refresh: "minimax-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  let refreshes = 0
+  globalThis.fetch = asFetch(async (input, init) => {
+    if (String(input) === `${MiniMaxProvider.GLOBAL_BASE}/oauth/token`) {
+      refreshes++
+      return jsonResponse({ access_token: "minimax-new", refresh_token: "minimax-refresh-2", expired_in: 3600 })
+    }
+    return new Headers(init?.headers).get("authorization") === "Bearer minimax-new"
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ error: "invalid_token" }, { status: 401 })
+  })
+  expect((await MiniMaxProvider.minimaxFetch(`${MiniMaxProvider.GLOBAL_INFERENCE}/v1/messages`)).status).toBe(200)
+  expect(refreshes).toBe(1)
+
+  await Auth.set(MiniMaxProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: "minimax-rejected",
+    refresh: "minimax-invalid-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  globalThis.fetch = asFetch(async (input) =>
+    String(input) === `${MiniMaxProvider.GLOBAL_BASE}/oauth/token`
+      ? jsonResponse({ error: "invalid_grant" }, { status: 401 })
+      : jsonResponse({ error: "invalid_token" }, { status: 401 }),
+  )
+  await expect(MiniMaxProvider.minimaxFetch(`${MiniMaxProvider.GLOBAL_INFERENCE}/v1/messages`)).rejects.toMatchObject({
+    name: "ProviderAuthenticationRequiredError",
+  })
+})
+
+test("copilot clears a rejected API token, exchanges once, and retries", async () => {
+  await Auth.set(CopilotProvider.PROVIDER_ID, { type: "api", key: "github-device-token" })
+  let exchanges = 0
+  let requests = 0
+  globalThis.fetch = asFetch(async (input, init) => {
+    if (String(input) === CopilotProvider.TOKEN_EXCHANGE_URL) {
+      exchanges++
+      return jsonResponse({ token: `copilot-${exchanges}`, expires_at: nowSeconds() + 3600 })
+    }
+    requests++
+    return new Headers(init?.headers).get("authorization") === "Bearer copilot-2"
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ error: "invalid_token" }, { status: 401 })
+  })
+
+  const response = await CopilotProvider.copilotFetch("https://api.githubcopilot.com/chat/completions")
+  expect(response.status).toBe(200)
+  expect(exchanges).toBe(2)
+  expect(requests).toBe(2)
 })

--- a/packages/synergy/test/server/provider-route.test.ts
+++ b/packages/synergy/test/server/provider-route.test.ts
@@ -10,6 +10,7 @@ import { Provider } from "../../src/provider/provider"
 
 const originalCodexHome = process.env.CODEX_HOME
 const originalOpenAIAPIKey = process.env.OPENAI_API_KEY
+const originalFetch = globalThis.fetch
 let isolatedCodexHome: string | undefined
 
 function nowSeconds() {
@@ -46,6 +47,7 @@ function restoreOpenAIAPIKey() {
 }
 
 async function reset() {
+  globalThis.fetch = originalFetch
   if (isolatedCodexHome) await fs.rm(isolatedCodexHome, { recursive: true, force: true })
   isolatedCodexHome = path.join(os.tmpdir(), `synergy-provider-route-codex-${Math.random().toString(36).slice(2)}`)
   await fs.mkdir(isolatedCodexHome, { recursive: true })
@@ -57,6 +59,7 @@ async function reset() {
 
 beforeEach(reset)
 afterEach(async () => {
+  globalThis.fetch = originalFetch
   await Auth.remove(CodexProvider.PROVIDER_ID).catch(() => {})
   await Provider.reload()
   if (isolatedCodexHome) await fs.rm(isolatedCodexHome, { recursive: true, force: true })
@@ -73,6 +76,7 @@ test("/provider returns catalog, auth health, and runtime availability", async (
 
   expect(body.all.some((provider: any) => provider.id === CodexProvider.PROVIDER_ID)).toBe(true)
   expect(body.catalogProviders).toContain(CodexProvider.PROVIDER_ID)
+  expect(body.authHealth.github.providerID).toBe("github")
   expect(body.authHealth[CodexProvider.PROVIDER_ID]).toMatchObject({
     providerID: CodexProvider.PROVIDER_ID,
     status: "not_configured",
@@ -101,6 +105,39 @@ test("/provider returns catalog, auth health, and runtime availability", async (
         url: "https://openrouter.ai/keys",
       },
     },
+  })
+})
+
+test("usage rejection completes the durable auth-health transition before responding", async () => {
+  await Auth.set(CodexProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: accessToken(),
+    refresh: "revoked-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    if (String(input) === CodexProvider.OAUTH_TOKEN_URL) {
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      })
+    }
+    return new Response(JSON.stringify({ error: { code: "token_invalidated" } }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    })
+  }) as typeof fetch
+
+  const app = Server.App()
+  const usageResponse = await app.request(`/provider/${CodexProvider.PROVIDER_ID}/usage?scopeID=home`)
+  expect(usageResponse.status).toBe(200)
+  expect(await usageResponse.json()).toMatchObject({ status: "error", reloginRequired: true })
+
+  const providerResponse = await app.request("/provider")
+  const providers = await providerResponse.json()
+  expect(providers.authHealth[CodexProvider.PROVIDER_ID]).toMatchObject({
+    status: "action_required",
+    recovery: "reconnect",
   })
 })
 

--- a/packages/synergy/test/session/retry.test.ts
+++ b/packages/synergy/test/session/retry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 import { APICallError } from "ai"
+import { ProviderAuthRecovery } from "../../src/provider/auth-recovery"
 
 function apiError(headers?: Record<string, string>): MessageV2.APIError {
   return new MessageV2.APIError({
@@ -82,6 +83,26 @@ describe("session.retry.delay", () => {
 })
 
 describe("session.message-v2.fromError", () => {
+  test("preserves structured provider recovery metadata", () => {
+    const result = MessageV2.fromError(
+      new ProviderAuthRecovery.Error({
+        providerID: "openai-codex",
+        failureCode: "token_invalidated",
+        actionRequired: true,
+        message: "Reconnect the provider.",
+      }),
+      { providerID: "openai-codex" },
+    )
+
+    expect(MessageV2.AuthError.isInstance(result)).toBe(true)
+    expect((result as { data: Record<string, unknown> }).data).toEqual({
+      providerID: "openai-codex",
+      failureCode: "token_invalidated",
+      actionRequired: true,
+      message: "Reconnect the provider.",
+    })
+  })
+
   test.concurrent(
     "converts ECONNRESET socket errors to retryable APIError",
     async () => {

--- a/packages/ui/src/components/semantic-icon.tsx
+++ b/packages/ui/src/components/semantic-icon.tsx
@@ -29,6 +29,7 @@ export const SemanticIconToken = {
   "experience.main": "lightbulb",
   "agents.main": "users",
   "providers.main": "server",
+  "providers.reconnect": "shield-alert",
   "agenda.main": "calendar-clock",
 
   // Session runtime


### PR DESCRIPTION
## What does this PR do?

This turns provider authentication failures into one recoverable lifecycle shared by the runtime, API, SDK, Settings, and Sidebar.

### Backend authentication lifecycle

- Adds canonical `ProviderAuthHealth` states: `not_configured`, `connected`, `exhausted`, and `action_required`.
- Adds a sequenced, secret-free `provider.auth.updated` event and keeps environment/plugin observations process-local.
- Adds a bounded recovery executor used by provider transports, usage requests, and live model discovery.
- Activates existing `classifyError` and `refreshAuth` provider/plugin hooks.
- Refreshes at most once and retries the business request at most once; concurrent failures share a provider/credential refresh lock.
- Replaces only the selected pool credential during OAuth rotation, preserving backups, cooldowns, counters, and source metadata.
- Switches to a backup credential within the same retry budget when the selected credential is rejected.
- Distinguishes 401 credential rejection, classified 403 authentication errors, 429 exhaustion, and transient network/5xx failures.
- Covers OpenAI Codex, Anthropic OAuth, MiniMax OAuth, GitHub Copilot, GitHub integration, API-key providers, environment credentials, and plugin providers.
- Returns structured provider authentication errors to sessions without leaking tokens or upstream response bodies.

### Codex model discovery

- Routes Codex `/models` through the same recovery pipeline.
- Separates static and live provider-catalog caches so an earlier static `/provider` request cannot suppress later account model discovery.
- Preserves unknown future model slugs, including account-visible `gpt-5.6-*` models, without a version whitelist.
- Marks static fallback results as unverified instead of presenting them as confirmed account models.
- Keeps Codex CLI credential import explicit; recovery never silently re-imports CLI credentials.

### App Attention and Settings UX

- Replaces the update-only Sidebar rendering shell with a generic `SidebarAttentionNotice` while keeping `ProductUpdateContext` isolated.
- Selects one stable primary notice with the requested priority: active update, provider authentication, update failure, then update-ready.
- Aggregates multiple provider failures into one notice and routes single-provider/GitHub actions to the correct Settings target.
- Adds a shared provider-auth presentation layer used by Sidebar, Providers, Usage, and GitHub.
- Adds a mutually exclusive `Needs attention` Providers group and explicit recovery intent/copy for OAuth, API keys, imports, and environment variables.
- Splits Usage into needs-attention, connected, and connectable providers; 401, 429, and transient failures now have distinct actions and badges.
- Removes page-local `global.dispose()` refreshes in favor of targeted provider refresh plus the server runtime reload/event path.
- Adds the semantic `providers.reconnect` icon token, collapsed Sidebar tooltip/focus behavior, `aria-live`, and reduced-motion handling.

### API, SDK, docs, and cleanup

- Updates the provider health/runtime availability/session error schemas and regenerates the SDK.
- Updates README, product contract, plugin hook docs, package guidance, and the development skill.
- Removes the route-local health model, old `SidebarUpdateNotice`, old `sb-update-*` classes, duplicated recovery copy, and obsolete public `expired`/`dead` states.
- Keeps the credential store at schema v2, so no persistence migration or compatibility adapter is added.

## Why?

The reported Codex symptoms had two independent root causes:

1. Usage requests surfaced a raw 401 but did not produce durable, shared authentication state or a recovery entry point.
2. Static and live provider discovery shared one cache entry, so an earlier static provider request could leave OpenAI Codex showing the bundled GPT-5.5 catalog even when the account exposed newer models.

Treating this as a provider lifecycle rather than a Codex-only banner also prevents the same split behavior for Anthropic, MiniMax, Copilot, API-key providers, GitHub, and plugins.

## Edge cases and safety

- A naturally expired access token with a refresh token remains connected until a real request proves recovery failed.
- Missing credentials remain `not_configured`; they are not mislabeled as rejected credentials.
- Unclassified plugin 401/403 responses are left untouched; generic 403 responses never force re-login.
- Rate limits retain exhaustion/cooldown semantics and never show a sign-in action.
- Timeouts, DNS/network failures, and 5xx responses do not mutate authentication health.
- Environment failures are never written into the credential store and recovery copy points to the relevant environment configuration.
- Health events contain only public state and are suppressed for connected-to-connected token rotation.
- Providers with zero models no longer crash `/provider`; they report `no_models` and have no default model entry.

## How was it tested?

- `bun run quality:quick`
- `bun run deadcode`
- `bun run secrets:check`
- `bun dev build app`
- `git diff --check`
- Backend auth/provider/server/session/tool regression set: 120 passed, 0 failed.
- App provider presentation/grouping/attention/Settings regression set: 21 passed, 0 failed.
- UI semantic icon suite: 5 passed, 0 failed.

The repository-wide core invocation reached 5,240 passes and reproduced 20 existing full-process isolation failures, all with the same NUL-suffixed global config path pollution. Every affected file passes when run independently and in the 120-test feature regression set; this PR does not mix an unrelated test-runner/global-path refactor into the authentication change.

## Checklist

- [x] `bun run quality:quick` passes
- [x] Relevant narrow tests pass; commands/results are listed above
- [x] `bun run package:check` passes through `quality:quick`
- [x] Workflow files were not changed
- [x] `bun run secrets:check` passes
- [x] SDK regenerated after route/schema changes
- [x] README, PRODUCT, plugin docs, AGENTS, and `.synergy` help are updated
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, compatibility wrappers, or dead code are included

