### PR TITLE
fix(provider): support Codex Request bodies

### DIFF
--- a/packages/synergy/src/provider/codex.ts
+++ b/packages/synergy/src/provider/codex.ts
@@ -689,6 +689,12 @@ export namespace CodexProvider {
     }
   }
 
+  async function codexRequestBody(input: RequestInfo | URL, init?: RequestInit) {
+    if (init?.body !== undefined) return init.body
+    if (!(input instanceof Request) || !input.body) return undefined
+    return input.clone().text()
+  }
+
   export async function codexFetch(input: RequestInfo | URL, init?: RequestInit) {
     const access = await resolveToken({ refreshIfExpiring: true })
     if (!access) {
@@ -700,23 +706,27 @@ export namespace CodexProvider {
       })
     }
 
-    const headers = new Headers(init?.headers)
+    const headers = new Headers(input instanceof Request ? input.headers : init?.headers)
+    if (input instanceof Request && init?.headers) {
+      for (const [key, value] of new Headers(init.headers)) headers.set(key, value)
+    }
     headers.set("Authorization", `Bearer ${access}`)
     for (const [key, value] of Object.entries(codexHeaders(access))) {
       headers.set(key, value)
     }
 
-    const rewritten = rewriteCodexBody(init?.body)
+    const rewritten = rewriteCodexBody(await codexRequestBody(input, init))
     if (rewritten.promptCacheKey) {
       headers.set("session_id", rewritten.promptCacheKey)
       headers.set("x-client-request-id", rewritten.promptCacheKey)
     }
 
-    return fetch(input, {
+    const requestInit: RequestInit = {
       ...init,
       headers,
-      body: rewritten.body,
-    })
+    }
+    if (rewritten.body !== undefined) requestInit.body = rewritten.body
+    return fetch(input, requestInit)
   }
 
   export async function saveImportedToken(token: TokenPayload) {

--- a/packages/synergy/test/agenda/bootstrap.test.ts
+++ b/packages/synergy/test/agenda/bootstrap.test.ts
@@ -15,15 +15,19 @@ import { tmpdir } from "../fixture/fixture"
 const originalTestHome = process.env.SYNERGY_TEST_HOME
 
 afterEach(async () => {
+  const currentHome = process.env.SYNERGY_TEST_HOME
+  const rootToClean = currentHome !== originalTestHome ? Global.Path.root : undefined
+
   if (originalTestHome === undefined) delete process.env.SYNERGY_TEST_HOME
   else process.env.SYNERGY_TEST_HOME = originalTestHome
 
-  await fs.rm(Global.Path.root, { recursive: true, force: true }).catch(() => {})
+  if (rootToClean) await fs.rm(rootToClean, { recursive: true, force: true }).catch(() => {})
 })
 
 function withAnima(autonomy: boolean, fn: () => Promise<void>) {
   return async () => {
     await using tmp = await tmpdir()
+    process.env.SYNERGY_TEST_HOME = path.join(tmp.path, "home")
     await fs.mkdir(Global.Path.config, { recursive: true })
     await Bun.write(path.join(Global.Path.config, "synergy.jsonc"), JSON.stringify({ library: { autonomy } }))
 

--- a/packages/synergy/test/provider/codex.test.ts
+++ b/packages/synergy/test/provider/codex.test.ts
@@ -256,6 +256,49 @@ test("codexFetch rewrites authorization, Codex headers, session headers, and req
   expect(body.max_output_tokens).toBeUndefined()
 })
 
+test("codexFetch rewrites Request input bodies", async () => {
+  const token = accessToken({ accountID: "acct_request" })
+  await Auth.set(CodexProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: token,
+    refresh: "refresh-request",
+    expires: nowSeconds() + 60 * 60,
+  })
+
+  let captured: { input: RequestInfo | URL; init?: RequestInit } | undefined
+  globalThis.fetch = asFetch(async (input, init) => {
+    captured = { input, init }
+    return jsonResponse({ ok: true })
+  })
+
+  const request = new Request("https://chatgpt.com/backend-api/codex/responses", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer stale",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-5.6-sol",
+      input: "hello",
+      prompt_cache_key: "session-request",
+      max_output_tokens: 123,
+    }),
+  })
+
+  await CodexProvider.codexFetch(request)
+
+  expect(captured?.input).toBe(request)
+  const headers = new Headers(captured?.init?.headers)
+  expect(headers.get("authorization")).toBe(`Bearer ${token}`)
+  expect(headers.get("chatgpt-account-id")).toBe("acct_request")
+  expect(headers.get("session_id")).toBe("session-request")
+  expect(headers.get("x-client-request-id")).toBe("session-request")
+
+  const body = JSON.parse(String(captured?.init?.body))
+  expect(body.prompt_cache_key).toBe("session-request")
+  expect(body.max_output_tokens).toBeUndefined()
+})
+
 test("fetchModelIDs sorts visible Codex models and sends Codex headers", async () => {
   const token = accessToken({ accountID: "acct_models" })
   const ids = await CodexProvider.fetchModelIDs(token, async (input, init) => {


### PR DESCRIPTION
## Summary
- make openai-codex body rewriting work when the transport passes a Request object
- preserve Request and init headers while applying Codex auth headers
- add regression coverage for removing max_output_tokens from Request bodies
- isolate agenda bootstrap test homes so the full suite does not delete shared test state

## Root cause
The provider transport normalizes requests to Request objects. The Codex fetch adapter only inspected init.body, so max_output_tokens generated by @ai-sdk/openai was forwarded to the Codex backend, which rejects it.

## Validation
- bun run quality
- 5256 passed, 1 skipped, 0 failed
- pre-push checks passed