### PR TITLE
Compact message flow error cards

### DIFF
--- a/packages/app/PRODUCT.md
+++ b/packages/app/PRODUCT.md
@@ -94,6 +94,8 @@ When the current running assistant step has no visible message part yet, the tim
 
 Tool audit icons are a quiet exception rail, not a status badge on every tool card. Show them for pending user approval, user decisions, denials, sandbox blocks, and notable autonomous or smart auto-approvals. Hide ordinary low-risk and Guarded baseline auto-approvals so read/search/tool plumbing does not compete with the work itself. The server approval metadata is the source of truth for audit visibility; the UI should not infer visibility from risk or mode.
 
+Message-flow errors should remain compact by default: show a single-line error preview in a neutral workbench row with a restrained critical marker, and place the complete error text, tool input, and copy action in the shared grounded details dialog. Raw diagnostics should not expand inline and dominate the surrounding session work.
+
 User prompts inside a turn may render as a compact right-aligned bubble with matching prompt attachments, but the turn header, tool/result timeline, media results, and diffs must keep their workbench-width timeline structure and original part order.
 Turn-level file changes summarize in the message flow; detailed file diff inspection belongs in the session Review workbench surface.
 

--- a/packages/ui/src/components/error-card-content.ts
+++ b/packages/ui/src/components/error-card-content.ts
@@ -1,0 +1,17 @@
+export function errorPreview(error: string) {
+  const line = error
+    .replace(/^error:\s*/i, "")
+    .split(/\r?\n/)
+    .find((item) => item.trim().length > 0)
+
+  return line?.trim() || "Unknown error"
+}
+
+export function errorInputText(input?: Record<string, unknown>) {
+  return input ? JSON.stringify(input, null, 2) : undefined
+}
+
+export function errorDetailsText(error: string, input?: Record<string, unknown>) {
+  const inputText = errorInputText(input)
+  return inputText ? `${error}\n\nInput:\n${inputText}` : error
+}

--- a/packages/ui/src/components/error-card.css
+++ b/packages/ui/src/components/error-card.css
@@ -1,12 +1,41 @@
+[data-component="card"].error-card-shell {
+  padding: 0;
+  overflow: hidden;
+  background-color: var(--workbench-card-bg, var(--surface-raised-base));
+  border-color: color-mix(
+    in oklch,
+    var(--border-critical-base) 34%,
+    var(--workbench-border, var(--border-weaker-base))
+  );
+  color: var(--text-base);
+}
+
 [data-component="error-card"] {
+  width: 100%;
+  min-width: 0;
   display: flex;
-  align-items: start;
+  align-items: center;
   gap: 8px;
-  padding: 4px 0;
+  min-height: 42px;
+  padding: 8px 10px 8px 12px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
+
+  &:hover {
+    background: var(--workbench-card-bg-hover, var(--surface-raised-base-hover));
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px var(--border-focus);
+  }
 
   [data-slot="icon-svg"] {
     color: var(--icon-critical-base);
-    margin-top: 4px;
     flex-shrink: 0;
   }
 
@@ -15,76 +44,70 @@
     min-width: 0;
   }
 
-  [data-slot="error-card-title"] {
-    font-weight: var(--font-weight-medium);
-    color: var(--text-on-critical-base);
-    white-space: nowrap;
-  }
-
   [data-slot="error-card-message"] {
-    color: var(--text-on-critical-weak);
-    max-height: 240px;
-    overflow-y: auto;
-    word-break: break-word;
+    color: var(--text-base);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     display: block;
   }
 
-  [data-slot="error-card-copy"] {
+  [data-slot="error-card-details"] {
     flex-shrink: 0;
-    margin-top: 2px;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    border-radius: var(--radius-sm);
-    color: var(--icon-weak);
-    cursor: pointer;
-    opacity: 0;
-    transition:
-      opacity 150ms ease,
-      background-color 150ms ease;
-
-    &:hover {
-      background: var(--workbench-control-bg-hover, var(--surface-raised-base-hover));
-      color: var(--icon-base);
-    }
-
-    &[data-copy-state="copied"] {
-      color: var(--icon-success-base);
-    }
-
-    &[data-copy-state="failed"] {
-      color: var(--icon-critical-base);
-    }
-
-    &:disabled {
-      cursor: not-allowed;
-    }
-  }
-
-  &:hover [data-slot="error-card-copy"] {
-    opacity: 1;
-  }
-
-  &[data-compact] {
-    [data-slot="error-card-message"] {
-      max-height: 120px;
-    }
-  }
-
-  [data-slot="error-card-input"] {
-    margin-top: 6px;
-    padding: 6px 8px;
-    background: var(--surface-critical-subtle, rgba(239, 68, 68, 0.06));
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 11px;
-    line-height: 1.4;
+    gap: 2px;
     color: var(--text-weak);
-    max-height: 160px;
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+  }
+}
+
+[data-component="dialog"] [data-slot="dialog-content"].error-details-dialog {
+  [data-slot="dialog-body"] {
+    gap: 20px;
+  }
+
+  [data-slot="error-details-section"] {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  [data-slot="error-details-label"] {
+    color: var(--text-weak);
+    font-size: var(--type-ui-caption-size, 12px);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--type-ui-caption-line-height, 16px);
+  }
+
+  [data-slot="error-details-content"] {
+    max-height: 280px;
+    margin: 0;
     overflow: auto;
+    padding: 12px 14px;
+    border-radius: 10px;
+    background: var(--dialog-control-bg);
+    color: var(--text-base);
+    font-family: var(--font-family-mono);
+    font-size: var(--type-ui-caption-size, 12px);
+    line-height: var(--type-ui-body-line-height, 20px);
+    overflow-wrap: anywhere;
     white-space: pre-wrap;
-    word-break: break-all;
+  }
+
+  [data-slot="dialog-actions"] {
+    padding-top: 14px;
+    border-top: 1px solid var(--dialog-border-weak);
+  }
+
+  [data-copy-state="copied"] [data-slot="icon-svg"] {
+    color: var(--icon-success-base);
+  }
+
+  [data-copy-state="failed"] [data-slot="icon-svg"] {
+    color: var(--icon-critical-base);
   }
 }

--- a/packages/ui/src/components/error-card.tsx
+++ b/packages/ui/src/components/error-card.tsx
@@ -1,70 +1,82 @@
 import { Show, splitProps } from "solid-js"
+import { useDialog } from "../context/dialog"
+import { Button } from "./button"
 import { Card } from "./card"
 import { createCopyController } from "./clipboard"
+import { Dialog } from "./dialog"
+import { errorDetailsText, errorInputText, errorPreview } from "./error-card-content"
 import { Icon } from "./icon"
-import { Tooltip } from "./tooltip"
 import "./error-card.css"
 import { getSemanticIcon } from "./semantic-icon"
 
 export interface ErrorCardProps {
-  /** Full raw error text — copy button copies this exactly */
   error: string
-  /** Compact single-line mode for session-level errors. Default false. */
   compact?: boolean
-  /** Optional tool input args to display alongside the error */
   input?: Record<string, unknown>
 }
 
-function parseError(raw: string): { title: string | null; message: string } {
-  const stripped = raw.replace(/^error:\s*/i, "")
-  const colonSpace = stripped.indexOf(": ")
-  if (colonSpace > 0 && colonSpace < 30) {
-    return { title: stripped.slice(0, colonSpace), message: stripped.slice(colonSpace + 2) }
-  }
-  return { title: null, message: stripped }
-}
-
-export function ErrorCard(props: ErrorCardProps) {
-  const [local] = splitProps(props, ["error", "compact", "input"])
-  const parsed = () => parseError(local.error)
-  const inputText = () => (local.input ? JSON.stringify(local.input, null, 2) : null)
-  const copyText = () => (inputText() ? `${local.error}\n\nInput:\n${inputText()}` : local.error)
+function ErrorDetailsDialog(props: Pick<ErrorCardProps, "error" | "input">) {
   const copy = createCopyController({
-    text: copyText,
-    copyLabel: "Copy error",
-    failureDescription: "Unable to copy the error.",
+    text: () => errorDetailsText(props.error, props.input),
+    copyLabel: "Copy details",
+    copiedLabel: "Copied",
+    failureDescription: "Unable to copy the error details.",
+    copyIcon: getSemanticIcon("action.copy"),
+    copiedIcon: getSemanticIcon("state.success"),
+    failedIcon: getSemanticIcon("state.error"),
   })
 
   return (
-    <Card variant="error">
-      <div data-component="error-card" data-compact={local.compact ? "" : undefined}>
+    <Dialog title="Error details" size="wide" class="error-details-dialog">
+      <section data-slot="error-details-section">
+        <div data-slot="error-details-label">Error message</div>
+        <pre data-slot="error-details-content">{props.error}</pre>
+      </section>
+      <Show when={errorInputText(props.input)}>
+        {(input) => (
+          <section data-slot="error-details-section">
+            <div data-slot="error-details-label">Tool input</div>
+            <pre data-slot="error-details-content">{input()}</pre>
+          </section>
+        )}
+      </Show>
+      <div data-slot="dialog-actions">
+        <Button
+          type="button"
+          variant="secondary"
+          size="large"
+          icon={copy.icon()}
+          data-copy-state={copy.state()}
+          disabled={copy.disabled()}
+          onClick={() => void copy.copy()}
+        >
+          {copy.tooltip()}
+        </Button>
+      </div>
+    </Dialog>
+  )
+}
+
+export function ErrorCard(props: ErrorCardProps) {
+  const [local] = splitProps(props, ["error", "input"])
+  const dialog = useDialog()
+
+  const openDetails = () => {
+    dialog.show(() => <ErrorDetailsDialog error={local.error} input={local.input} />)
+  }
+
+  return (
+    <Card variant="error" class="error-card-shell">
+      <button type="button" data-component="error-card" onClick={openDetails}>
         <Icon name={getSemanticIcon("state.error")} size="small" />
         <div data-slot="error-card-content">
-          <Show when={local.compact}>
-            <span data-slot="error-card-message">{local.error}</span>
-          </Show>
-          <Show when={!local.compact}>
-            <Show when={parsed().title}>
-              <span data-slot="error-card-title">{parsed().title}</span>
-            </Show>
-            <span data-slot="error-card-message">{parsed().message}</span>
-            <Show when={inputText()}>
-              <pre data-slot="error-card-input">{inputText()}</pre>
-            </Show>
-          </Show>
+          <span data-slot="error-card-message">{errorPreview(local.error)}</span>
         </div>
-        <Tooltip value={copy.tooltip()} placement="top" gutter={4}>
-          <button
-            type="button"
-            data-slot="error-card-copy"
-            data-copy-state={copy.state()}
-            disabled={copy.disabled()}
-            onClick={() => void copy.copy()}
-          >
-            <Icon name={copy.icon()} size="small" />
-          </button>
-        </Tooltip>
-      </div>
+        <span data-slot="error-card-details">
+          View details
+          <Icon name={getSemanticIcon("navigation.expand")} size="small" />
+        </span>
+      </button>
     </Card>
   )
 }

--- a/packages/ui/test/error-card.test.ts
+++ b/packages/ui/test/error-card.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { errorDetailsText, errorPreview } from "../src/components/error-card-content"
+
+describe("ErrorCard", () => {
+  test("uses only the first error line in the message flow", () => {
+    const preview = errorPreview("oldString not found in content\n\nThe most similar lines are:\nprivate-token")
+
+    expect(preview).toBe("oldString not found in content")
+  })
+
+  test("preserves the complete error and tool input for the details dialog", () => {
+    expect(errorDetailsText("oldString not found", { oldString: "private-token" })).toBe(
+      'oldString not found\n\nInput:\n{\n  "oldString": "private-token"\n}',
+    )
+  })
+})


### PR DESCRIPTION
## What does this PR do?

- Replaces expanded message-flow error cards with a compact single-line preview.
- Opens complete error text and optional tool input in the shared grounded Dialog.
- Keeps copy feedback and icons on the shared clipboard and semantic-icon primitives.
- Documents the durable message-flow error treatment in the Web product contract.
- Adds coverage for preview truncation and complete details preservation.

## Why?

Raw tool and message errors could expand into large critical-colored blocks that dominated the session timeline and made recoverable failures look dangerous. The compact row keeps the failure visible without competing with the surrounding work, while the details dialog preserves all diagnostic information on demand.

## How was it tested?

- `bun test test/error-card.test.ts` from `packages/ui`
- `bun run --cwd packages/ui test`
- `bun run typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`
- Browser-verified both tool-level and message-level errors in an isolated Synergy instance, including truncation, dialog content, copy feedback, and dismissal.

## Checklist

- [x] `bun run quality:quick` passes
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] `bun run package:check` passes as part of `quality:quick`
- [x] Workflow validation is not applicable; no workflow files changed
- [x] Secret scanning changes are not applicable; no auth or credential surfaces changed
- [x] SDK regeneration is not applicable; no server routes or schemas changed
- [x] Product documentation was updated for the durable interaction rule
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included
