### PR TITLE
fix(provider): rebuild requests for auth retries

### DIFF
--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -364,21 +364,24 @@ export namespace ProviderAuthRecovery {
 
   export function wrapFetch(providerID: string, fetchFn: FetchLike = fetch): FetchLike {
     if (handledFetches.has(fetchFn)) return fetchFn
-    const wrapped: FetchLike = (input, init) =>
-      execute({
+    const wrapped: FetchLike = (input, init) => {
+      const template = new Request(input, init)
+      return execute({
         providerID,
         request: async () => {
           const selected = await Auth.select(providerID)
-          const headers = new Headers(init?.headers)
+          const request = template.clone()
+          const headers = new Headers(request.headers)
           if (selected?.auth.type === "api") {
             const key = selected.auth.key
             if (headers.has("authorization")) headers.set("authorization", `Bearer ${key}`)
             if (headers.has("x-api-key")) headers.set("x-api-key", key)
             if (headers.has("api-key")) headers.set("api-key", key)
           }
-          return fetchFn(input, { ...init, headers })
+          return fetchFn(request, { ...init, body: undefined, headers })
         },
       })
+    }
     handledFetches.add(wrapped)
     return wrapped
   }

--- a/packages/synergy/test/provider/auth-recovery.test.ts
+++ b/packages/synergy/test/provider/auth-recovery.test.ts
@@ -113,6 +113,31 @@ test("a lone API key is invalidated only after a confirmed rejection", async () 
   )
 })
 
+test("a lone API key confirmation retry preserves request headers and body", async () => {
+  await Auth.set("test-api-confirm", { type: "api", key: "valid" })
+  const bodies: string[] = []
+  const authorizations: string[] = []
+  let requests = 0
+  const transport = ProviderAuthRecovery.wrapFetch("test-api-confirm", async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    bodies.push(await request.text())
+    authorizations.push(new Headers(init?.headers ?? request.headers).get("authorization") ?? "")
+    return new Response(null, { status: ++requests === 1 ? 401 : 200 })
+  })
+
+  const response = await transport(
+    new Request("https://provider.test/v1/messages", {
+      method: "POST",
+      headers: { Authorization: "Bearer stale" },
+      body: JSON.stringify({ prompt: "hello" }),
+    }),
+  )
+
+  expect(response.status).toBe(200)
+  expect(bodies).toEqual(['{"prompt":"hello"}', '{"prompt":"hello"}'])
+  expect(authorizations).toEqual(["Bearer valid", "Bearer valid"])
+})
+
 test("generic SDK transport rewrites common API-key headers when selecting a backup", async () => {
   await Auth.set("test-wrapped-api", { type: "api", key: "primary" })
   await Auth.addToPool("test-wrapped-api", "backup", { type: "api", key: "backup" })


### PR DESCRIPTION
## Summary
- rebuild provider requests for each authentication retry so POST bodies remain readable
- preserve request headers while rotating API credentials
- retain transport options such as proxy and signal without reusing the original body
- add regression coverage for a 401 confirmation retry with authorization and JSON body

## Test plan
- `bun test test/provider`
- `bun run quality:quick`