### PR TITLE
fix(ui): render skipped SmartAllow audit reason

### DIFF
--- a/packages/ui/src/utils/approval-audit.ts
+++ b/packages/ui/src/utils/approval-audit.ts
@@ -20,11 +20,7 @@ interface ApprovalMeta {
   audit?: {
     visible?: boolean
   }
-  smartAllow?: {
-    risk?: string
-    reason?: string
-    confidence?: number
-  }
+  smartAllow?: { risk: string; reason: string; confidence: number } | { skipped: true; reason: string }
 }
 
 export interface ApprovalAudit {
@@ -107,6 +103,11 @@ function explain(status: string, mode?: string, risk?: string, reason?: string):
   }
 }
 
+function formatSmartAllow(smartAllow: NonNullable<ApprovalMeta["smartAllow"]>): string {
+  if ("skipped" in smartAllow) return `Smart allow skipped: ${smartAllow.reason}`
+  return `Smart allow: ${smartAllow.risk} risk, ${(smartAllow.confidence * 100).toFixed(0)}% confidence`
+}
+
 export function getApprovalAudit(approval: ApprovalMeta | null | undefined): ApprovalAudit {
   const empty: ApprovalAudit = { icon: null, iconClass: "", tooltip: "" }
   if (!approval) return empty
@@ -136,10 +137,7 @@ export function getApprovalAudit(approval: ApprovalMeta | null | undefined): App
   const riskAdj = risk ? (RISK_ADJECTIVE[risk] ?? risk) : null
   const line1 = riskAdj ? `${label} \u00b7 ${riskAdj} risk` : label
   const line2 = explain(status, mode, risk, reason)
-  const sa = approval.smartAllow
-  const saLine = sa
-    ? `Smart allow: ${sa.risk ?? "unknown"} risk, ${((sa.confidence ?? 0) * 100).toFixed(0)}% confidence`
-    : undefined
+  const saLine = approval.smartAllow ? formatSmartAllow(approval.smartAllow) : undefined
   const parts = [line1, line2, saLine].filter(Boolean) as string[]
   const tooltip = parts.join("\n")
 

--- a/packages/ui/test/approval-audit.test.ts
+++ b/packages/ui/test/approval-audit.test.ts
@@ -75,4 +75,28 @@ describe("getApprovalAudit", () => {
     expect(r.tooltip).toMatch(/^Auto approved · Medium risk/)
     expect(r.tooltip).toContain("\nCustom explanation here")
   })
+
+  test("tooltip includes evaluated SmartAllow risk and confidence", () => {
+    const r = getApprovalAudit({
+      status: "auto_allowed",
+      risk: "low",
+      audit: visible,
+      smartAllow: { risk: "low", reason: "Routine operation", confidence: 0.92 },
+    })
+
+    expect(r.tooltip).toContain("\nSmart allow: low risk, 92% confidence")
+  })
+
+  test("tooltip explains when SmartAllow evaluation was skipped", () => {
+    const r = getApprovalAudit({
+      status: "auto_denied",
+      risk: "high",
+      audit: visible,
+      smartAllow: { skipped: true, reason: "Non-bypassable capability" },
+    })
+
+    expect(r.tooltip).toContain("\nSmart allow skipped: Non-bypassable capability")
+    expect(r.tooltip).not.toContain("unknown risk")
+    expect(r.tooltip).not.toContain("0% confidence")
+  })
 })


### PR DESCRIPTION
## Summary

- align the frontend SmartAllow audit metadata with the backend evaluated/skipped union
- render the backend-provided reason when SmartAllow evaluation is skipped
- cover both evaluated and skipped tooltip semantics with focused regression tests

Closes #553

## Testing

- `bun test test/approval-audit.test.ts` (from `packages/ui`) — 13 passed
- changed-file Prettier check — passed
- `git diff --check` — passed

## Environment limitations

- package typecheck could not start because `tsgo` is not installed in this worktree
- the full UI suite reached 206 passing tests, then stopped because `solid-js` and `jsdom` are not installed in this worktree