### PR TITLE
fix: bound server memory pressure and prevent WS client leaks

### DIFF
--- a/packages/synergy/src/cortex/concurrency.ts
+++ b/packages/synergy/src/cortex/concurrency.ts
@@ -1,4 +1,5 @@
 import { Log } from "../util/log"
+import { SessionMemoryPressure } from "../session/memory-pressure"
 
 export namespace CortexConcurrency {
   const log = Log.create({ service: "cortex.concurrency" })
@@ -7,41 +8,103 @@ export namespace CortexConcurrency {
   const queues: Map<string, Array<() => void>> = new Map()
 
   const DEFAULT_LIMIT = 8
+  // Healthy runs keep the historical per-agent limit without a tight global cap.
+  // Global throttling only engages under soft/critical memory pressure (#501).
+  const DEFAULT_GLOBAL_LIMIT = Number.POSITIVE_INFINITY
+  const SOFT_PRESSURE_GLOBAL_LIMIT = 4
+  const PRESSURE_GLOBAL_LIMIT = 2
+
+  let globalRunning = 0
+  let memoryProbe: (() => SessionMemoryPressure.Snapshot) | undefined
 
   export function getLimit(_key: string): number {
     return DEFAULT_LIMIT
   }
 
-  export async function acquire(key: string): Promise<void> {
-    const current = counts.get(key) ?? 0
-    const limit = getLimit(key)
+  export function getGlobalLimit(snapshot = currentMemorySnapshot()): number {
+    const configured = envNumber(process.env.SYNERGY_CORTEX_GLOBAL_CONCURRENCY)
+    const thresholds = SessionMemoryPressure.resolveThresholds(process.env, snapshot)
+    const critical =
+      snapshot.rssBytes >= thresholds.rssCriticalBytes ||
+      snapshot.arrayBuffersBytes >= thresholds.arrayBuffersCriticalBytes ||
+      (snapshot.cgroupCurrentBytes ?? 0) >= thresholds.cgroupCriticalBytes
+    if (critical) return configured ? Math.min(configured, PRESSURE_GLOBAL_LIMIT) : PRESSURE_GLOBAL_LIMIT
 
-    if (current < limit) {
-      counts.set(key, current + 1)
-      log.info("acquired", { key, current: current + 1, limit })
-      return
+    // Soft pressure: start throttling once we are halfway to the critical RSS /
+    // ArrayBuffer thresholds so parallel subagents do not race into the redline.
+    const softRss = thresholds.rssCriticalBytes * 0.5
+    const softArrayBuffers = thresholds.arrayBuffersCriticalBytes * 0.5
+    if (snapshot.rssBytes >= softRss || snapshot.arrayBuffersBytes >= softArrayBuffers) {
+      return configured ? Math.min(configured, SOFT_PRESSURE_GLOBAL_LIMIT) : SOFT_PRESSURE_GLOBAL_LIMIT
     }
+    return configured ?? DEFAULT_GLOBAL_LIMIT
+  }
 
-    log.info("queued", { key, queueSize: (queues.get(key)?.length ?? 0) + 1 })
-    return new Promise((resolve) => {
-      const queue = queues.get(key) ?? []
-      queue.push(resolve)
-      queues.set(key, queue)
-    })
+  export function setMemoryProbeForTest(probe?: () => SessionMemoryPressure.Snapshot) {
+    memoryProbe = probe
+  }
+
+  export async function acquire(key: string): Promise<void> {
+    while (true) {
+      const perAgent = counts.get(key) ?? 0
+      const perAgentLimit = getLimit(key)
+      const globalLimit = getGlobalLimit()
+
+      if (perAgent < perAgentLimit && globalRunning < globalLimit) {
+        counts.set(key, perAgent + 1)
+        globalRunning++
+        log.info("acquired", {
+          key,
+          current: perAgent + 1,
+          limit: perAgentLimit,
+          globalRunning,
+          globalLimit,
+        })
+        return
+      }
+
+      log.info("queued", {
+        key,
+        queueSize: (queues.get(key)?.length ?? 0) + 1,
+        perAgent,
+        perAgentLimit,
+        globalRunning,
+        globalLimit,
+      })
+      await new Promise<void>((resolve) => {
+        const queue = queues.get(key) ?? []
+        queue.push(resolve)
+        queues.set(key, queue)
+      })
+    }
   }
 
   export function release(key: string): void {
-    const queue = queues.get(key)
-    if (queue?.length) {
-      const next = queue.shift()!
-      log.info("released-to-waiting", { key, remaining: queue.length })
+    const current = counts.get(key) ?? 0
+    if (current > 0) {
+      counts.set(key, current - 1)
+      globalRunning = Math.max(0, globalRunning - 1)
+    }
+
+    // Prefer the same agent queue, then any other waiting agent, so a global
+    // slot freed under memory pressure can be reused by another agent.
+    const sameAgentQueue = queues.get(key)
+    if (sameAgentQueue?.length) {
+      const next = sameAgentQueue.shift()!
+      log.info("released-to-waiting", { key, remaining: sameAgentQueue.length, globalRunning })
       next()
       return
     }
 
-    const current = counts.get(key) ?? 1
-    counts.set(key, Math.max(0, current - 1))
-    log.info("released", { key, current: Math.max(0, current - 1) })
+    for (const [queuedKey, queue] of queues) {
+      if (!queue.length) continue
+      const next = queue.shift()!
+      log.info("released-to-waiting", { key: queuedKey, remaining: queue.length, globalRunning, from: key })
+      next()
+      return
+    }
+
+    log.info("released", { key, current: Math.max(0, current - 1), globalRunning })
   }
 
   export function status(): Record<string, { running: number; queued: number }> {
@@ -55,8 +118,28 @@ export namespace CortexConcurrency {
     return result
   }
 
+  export function globalStatus() {
+    return {
+      running: globalRunning,
+      limit: getGlobalLimit(),
+    }
+  }
+
   export function reset(): void {
     counts.clear()
     queues.clear()
+    globalRunning = 0
+    memoryProbe = undefined
+  }
+
+  function currentMemorySnapshot(): SessionMemoryPressure.Snapshot {
+    if (memoryProbe) return memoryProbe()
+    return SessionMemoryPressure.currentSnapshot()
+  }
+
+  function envNumber(value: string | undefined) {
+    if (!value) return undefined
+    const parsed = Number(value)
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined
   }
 }

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -486,11 +486,10 @@ export namespace Cortex {
       taskWaiters.delete(taskID)
       log.info("task result delivered to waiters, skipping mail", { taskID, waiterCount: waiters.size })
     } else if (task.notifyParentOnComplete !== false) {
-      if (SessionManager.isRunning(task.parentSessionID)) {
-        log.info("skipping parent notification: session is mid-turn", { taskID: task.id })
-      } else {
-        notifyParentSession(task)
-      }
+      // Always enqueue the completion mail. SessionManager.deliver already queues
+      // when the parent is mid-turn, so skipping here permanently lost background
+      // task results (#550).
+      notifyParentSession(task)
     } else {
       log.info("task parent notification suppressed", { taskID })
     }

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -908,29 +908,28 @@ export namespace Provider {
             }, timeoutMs as number).unref()
           }
 
+          let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
           const wrappedStream = new ReadableStream({
-            async start(controller) {
-              const reader = originalBody.getReader()
+            // Pull-based so provider bytes stay bounded by downstream demand
+            // (AI SDK / SessionProcessor). The previous eager start() pump could
+            // enqueue far ahead of a slow fanout path and inflate native buffers
+            // (#524 / #498).
+            async pull(controller) {
+              reader ??= originalBody.getReader()
               try {
-                while (true) {
-                  const { done, value } = await Promise.race([reader.read(), idleAborted])
-                  if (done) {
-                    if (idleTimer) clearTimeout(idleTimer)
-                    controller.close()
-                    break
-                  }
-                  resetIdle()
-                  controller.enqueue(value)
+                const { done, value } = await Promise.race([reader.read(), idleAborted])
+                if (done) {
+                  if (idleTimer) clearTimeout(idleTimer)
+                  controller.close()
+                  return
                 }
+                resetIdle()
+                controller.enqueue(value)
               } catch (err) {
                 if (idleTimer) clearTimeout(idleTimer)
                 controller.error(err)
                 try {
-                  reader.cancel(err).catch(() => {})
-                } catch {}
-              } finally {
-                try {
-                  reader.releaseLock()
+                  await reader.cancel(err)
                 } catch {}
               }
             },

--- a/packages/synergy/src/server/global-event-clients.ts
+++ b/packages/synergy/src/server/global-event-clients.ts
@@ -1,0 +1,222 @@
+import type { WSContext } from "hono/ws"
+import { Log } from "../util/log"
+
+export namespace GlobalEventClients {
+  const log = Log.create({ service: "server.global-event-clients" })
+
+  export type Mode = "full" | "delta"
+  export type SendResult = "sent" | "backpressured" | "dropped" | "closed" | "error"
+
+  export interface ClientState {
+    mode: Mode
+    ws: WSContext
+    raw?: unknown
+    connectedAt: number
+    lastSendAt?: number
+    lastBackpressureAt?: number
+    consecutiveBackpressure: number
+    droppedFrames: number
+    sentFrames: number
+  }
+
+  export interface RegistryOptions {
+    /** Max consecutive backpressure results before the client is closed. */
+    maxConsecutiveBackpressure?: number
+    /** If raw.bufferedAmount exceeds this, treat as backpressure. */
+    bufferedAmountLimit?: number
+    now?: () => number
+  }
+
+  export interface Registry {
+    size(): number
+    add(ws: WSContext, mode: Mode): void
+    remove(ws: WSContext): boolean
+    broadcast(encode: (mode: Mode) => string): {
+      clients: number
+      sent: number
+      dropped: number
+      removed: number
+    }
+    heartbeat(data: string): {
+      clients: number
+      sent: number
+      removed: number
+    }
+    clear(): void
+    clients(): IterableIterator<ClientState>
+  }
+
+  export function connectionKey(ws: WSContext): unknown {
+    // Hono's Bun adapter constructs a fresh WSContext wrapper per callback while
+    // keeping the underlying ServerWebSocket (`ws.raw`) stable. Prefer raw as the
+    // identity so open/close/error/message share one registry entry.
+    return (ws as { raw?: unknown }).raw ?? ws
+  }
+
+  export function createRegistry(options: RegistryOptions = {}): Registry {
+    const maxConsecutiveBackpressure = options.maxConsecutiveBackpressure ?? 32
+    const bufferedAmountLimit = options.bufferedAmountLimit ?? 8 * 1024 * 1024
+    const now = options.now ?? Date.now
+    const clients = new Map<unknown, ClientState>()
+
+    function add(ws: WSContext, mode: Mode) {
+      const key = connectionKey(ws)
+      const existing = clients.get(key)
+      if (existing) {
+        existing.ws = ws
+        existing.mode = mode
+        existing.raw = (ws as { raw?: unknown }).raw
+        return
+      }
+      clients.set(key, {
+        mode,
+        ws,
+        raw: (ws as { raw?: unknown }).raw,
+        connectedAt: now(),
+        consecutiveBackpressure: 0,
+        droppedFrames: 0,
+        sentFrames: 0,
+      })
+    }
+
+    function remove(ws: WSContext): boolean {
+      return clients.delete(connectionKey(ws))
+    }
+
+    function rawReadyState(client: ClientState): number | undefined {
+      const raw = client.raw as { readyState?: number } | undefined
+      if (raw && typeof raw.readyState === "number") return raw.readyState
+      // Hono snapshots readyState into WSContext construction options, so the
+      // wrapper value can be stale. Prefer raw when present.
+      try {
+        return client.ws.readyState
+      } catch {
+        return undefined
+      }
+    }
+
+    function rawBufferedAmount(client: ClientState): number | undefined {
+      const raw = client.raw as { bufferedAmount?: number } | undefined
+      return typeof raw?.bufferedAmount === "number" ? raw.bufferedAmount : undefined
+    }
+
+    function send(client: ClientState, data: string): SendResult {
+      const readyState = rawReadyState(client)
+      // 1 = OPEN in both browser and Bun ServerWebSocket conventions.
+      if (readyState !== undefined && readyState !== 1) return "closed"
+
+      const bufferedAmount = rawBufferedAmount(client)
+      if (bufferedAmount !== undefined && bufferedAmount > bufferedAmountLimit) {
+        client.consecutiveBackpressure++
+        client.lastBackpressureAt = now()
+        client.droppedFrames++
+        return "backpressured"
+      }
+
+      try {
+        const raw = client.raw as { send?: (data: string) => number | void } | undefined
+        if (raw && typeof raw.send === "function") {
+          const result = raw.send(data)
+          // Bun documents: -1 backpressure, 0 dropped/closed, >0 bytes sent.
+          if (typeof result === "number") {
+            if (result < 0) {
+              client.consecutiveBackpressure++
+              client.lastBackpressureAt = now()
+              client.droppedFrames++
+              return "backpressured"
+            }
+            if (result === 0) {
+              client.droppedFrames++
+              return "dropped"
+            }
+            client.consecutiveBackpressure = 0
+            client.sentFrames++
+            client.lastSendAt = now()
+            return "sent"
+          }
+        }
+
+        client.ws.send(data)
+        client.consecutiveBackpressure = 0
+        client.sentFrames++
+        client.lastSendAt = now()
+        return "sent"
+      } catch {
+        return "error"
+      }
+    }
+
+    function maybeEvict(key: unknown, client: ClientState, result: SendResult): boolean {
+      if (result === "closed" || result === "error" || result === "dropped") {
+        clients.delete(key)
+        return true
+      }
+      if (result === "backpressured" && client.consecutiveBackpressure >= maxConsecutiveBackpressure) {
+        try {
+          client.ws.close(1013, "websocket backpressure")
+        } catch {}
+        clients.delete(key)
+        log.warn("evicted websocket client under backpressure", {
+          consecutiveBackpressure: client.consecutiveBackpressure,
+          droppedFrames: client.droppedFrames,
+          mode: client.mode,
+        })
+        return true
+      }
+      return false
+    }
+
+    function broadcast(encode: (mode: Mode) => string) {
+      let sent = 0
+      let dropped = 0
+      let removed = 0
+      // Cache encodings once per mode for this event.
+      let fullData: string | undefined
+      let deltaData: string | undefined
+      const payloadFor = (mode: Mode) => {
+        if (mode === "full") {
+          fullData ??= encode("full")
+          return fullData
+        }
+        deltaData ??= encode("delta")
+        return deltaData
+      }
+
+      for (const [key, client] of clients) {
+        const result = send(client, payloadFor(client.mode))
+        if (result === "sent") sent++
+        else dropped++
+        if (maybeEvict(key, client, result)) removed++
+      }
+      return { clients: clients.size + removed, sent, dropped, removed }
+    }
+
+    function heartbeat(data: string) {
+      let sent = 0
+      let removed = 0
+      for (const [key, client] of clients) {
+        const result = send(client, data)
+        if (result === "sent") sent++
+        if (maybeEvict(key, client, result === "backpressured" ? "sent" : result)) {
+          // Heartbeats should not count toward streaming backpressure eviction.
+          // Only hard failures remove clients here.
+          if (result !== "backpressured") removed++
+        } else if (result === "backpressured") {
+          // Reset consecutive counter growth from heartbeats alone.
+          client.consecutiveBackpressure = Math.max(0, client.consecutiveBackpressure - 1)
+        }
+      }
+      return { clients: clients.size + removed, sent, removed }
+    }
+
+    return {
+      size: () => clients.size,
+      add,
+      remove,
+      broadcast,
+      heartbeat,
+      clear: () => clients.clear(),
+      clients: () => clients.values(),
+    }
+  }
+}

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -2,6 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { EventWire } from "./event-wire"
+import { GlobalEventClients } from "./global-event-clients"
 import { Log } from "../util/log"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
 import { Hono, type Context, type MiddlewareHandler, type Next } from "hono"
@@ -163,7 +164,7 @@ export namespace Server {
   let _appMounted = false
   let _globalEventBroadcastOff: (() => void) | undefined
   let _globalEventHeartbeatInterval: ReturnType<typeof setInterval> | undefined
-  let _globalEventClients: Map<any, "full" | "delta"> | undefined
+  let _globalEventClients: ReturnType<typeof GlobalEventClients.createRegistry> | undefined
 
   function isLoopbackOrigin(input: string) {
     try {
@@ -628,37 +629,23 @@ export namespace Server {
         .get(
           "/global/event/ws",
           (() => {
-            // client -> wire mode. "delta" clients opt into the compact streaming
-            // protocol (message.part.delta frames + periodic checkpoints, #350 D1);
-            // "full" clients receive the legacy full-part-on-every-delta stream.
-            const globalEventClients = new Map<any, "full" | "delta">()
+            // Track clients by stable raw socket identity. Hono's Bun adapter
+            // constructs a fresh WSContext wrapper per callback, so Map keys based
+            // on the wrapper leak across reconnects (#551). The registry also
+            // applies send backpressure limits so a slow UI cannot hard-stall the
+            // event loop (#524).
+            const globalEventClients = GlobalEventClients.createRegistry()
             // One encoder shared by all delta clients on this route: they receive
             // identical frames, so the checkpoint throttle is shared correctly.
             const wire = EventWire.createEncoder()
             const broadcastHandler = (event: any) => {
-              let fullData: string | undefined
-              const fullEncoding = () => {
-                if (fullData !== undefined) return fullData
-                fullData = JSON.stringify(event)
-                return fullData
-              }
-              // Compute the delta-mode encoding at most once per event (shared
-              // across all delta clients) instead of per-client stringify.
-              let deltaData: string | undefined
-              const deltaEncoding = () => {
-                if (deltaData !== undefined) return deltaData
+              globalEventClients.broadcast((mode) => {
+                if (mode === "full") return JSON.stringify(event)
                 const dp = wire.deltaPayload(event.payload)
-                deltaData =
-                  dp === event.payload ? fullEncoding() : JSON.stringify({ directory: event.directory, payload: dp })
-                return deltaData
-              }
-              for (const [client, mode] of globalEventClients) {
-                try {
-                  client.send(mode === "delta" ? deltaEncoding() : fullEncoding())
-                } catch {
-                  globalEventClients.delete(client)
-                }
-              }
+                return dp === event.payload
+                  ? JSON.stringify(event)
+                  : JSON.stringify({ directory: event.directory, payload: dp })
+              })
             }
             GlobalBus.on("event", broadcastHandler)
             _globalEventBroadcastOff = () => GlobalBus.off("event", broadcastHandler)
@@ -669,13 +656,7 @@ export namespace Server {
               },
             })
             const heartbeat = setInterval(() => {
-              for (const client of globalEventClients.keys()) {
-                try {
-                  client.send(heartbeatData)
-                } catch {
-                  globalEventClients.delete(client)
-                }
-              }
+              globalEventClients.heartbeat(heartbeatData)
             }, 30000)
             _globalEventHeartbeatInterval = heartbeat
             _globalEventClients = globalEventClients
@@ -684,7 +665,7 @@ export namespace Server {
               return {
                 onOpen(_event, ws) {
                   log.info("global event ws connected", { mode })
-                  globalEventClients.set(ws, mode)
+                  globalEventClients.add(ws, mode)
                   ws.send(
                     JSON.stringify({
                       payload: {
@@ -695,11 +676,11 @@ export namespace Server {
                   )
                 },
                 onClose(_event, ws) {
-                  globalEventClients.delete(ws)
+                  globalEventClients.remove(ws)
                   log.info("global event ws disconnected")
                 },
                 onError(_event, ws) {
-                  globalEventClients.delete(ws)
+                  globalEventClients.remove(ws)
                 },
                 onMessage(_event, ws) {
                   try {

--- a/packages/synergy/src/storage/storage.ts
+++ b/packages/synergy/src/storage/storage.ts
@@ -10,6 +10,9 @@ import { ObservabilityResources } from "@/observability/resources"
 
 export namespace Storage {
   const READ_MANY_CONCURRENCY = 32
+  // Successful duration samples are high-cardinality and previously amplified
+  // telemetry write load under UI polling (#343). Keep errors at 100%.
+  const STORAGE_DURATION_SAMPLE_RATE = 0.02
 
   export const NotFoundError = NamedError.create(
     "NotFoundError",
@@ -174,6 +177,7 @@ export namespace Storage {
         unit: "ms",
         module: "storage",
         labels: { operation, keyPrefix: key[0] ?? "root", status },
+        sampleRate: status === "error" ? 1 : STORAGE_DURATION_SAMPLE_RATE,
       })
       ObservabilityMetrics.record({
         name: "storage.operation.count",

--- a/packages/synergy/test/cortex/concurrency.test.ts
+++ b/packages/synergy/test/cortex/concurrency.test.ts
@@ -67,6 +67,32 @@ describe("CortexConcurrency", () => {
       expect(status["agent-a"].running).toBe(8)
       expect(status["agent-b"].running).toBe(8)
     })
+
+    test("global limit throttles across agents under memory pressure", async () => {
+      CortexConcurrency.setMemoryProbeForTest(() => ({
+        rssBytes: 10 * 1024 ** 3,
+        heapUsedBytes: 1,
+        heapTotalBytes: 1,
+        externalBytes: 1,
+        arrayBuffersBytes: 9 * 1024 ** 3,
+      }))
+
+      await CortexConcurrency.acquire("agent-a")
+      await CortexConcurrency.acquire("agent-b")
+
+      let resolved = false
+      const queued = CortexConcurrency.acquire("agent-c").then(() => {
+        resolved = true
+      })
+      await flushMicrotasks(4)
+      expect(resolved).toBe(false)
+      expect(CortexConcurrency.globalStatus().running).toBe(2)
+
+      CortexConcurrency.release("agent-a")
+      await queued
+      expect(resolved).toBe(true)
+      expect(CortexConcurrency.globalStatus().running).toBe(2)
+    })
   })
 
   describe("release", () => {

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -1119,6 +1119,50 @@ describe.serial("Cortex", () => {
       })
     })
 
+    test("still notifies parent when parent session is mid-turn", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const originalDeliver = SessionManager.deliver
+          const originalIsRunning = SessionManager.isRunning
+          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              return writeAssistantText(input.sessionID, "completed")
+            },
+          )
+          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+            deliveries.push(input)
+          })
+          try {
+            const parentSession = await Session.create({})
+            ;(SessionManager.isRunning as any) = mock((sessionID: string) => sessionID === parentSession.id)
+            const task = await Cortex.launch({
+              description: "Notify mid-turn parent",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: "msg_test01234567890abc",
+              model: { providerID: "test-provider", modelID: "test-model" },
+            })
+
+            const completed = await waitUntilCompleted(task.id)
+
+            expect(completed?.status).toBe("completed")
+            expect(deliveries).toHaveLength(1)
+            expect(deliveries[0].target).toBe(parentSession.id)
+            expect(deliveries[0].mail.metadata?.source).toBe("cortex")
+          } finally {
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionManager.isRunning as any) = originalIsRunning
+          }
+        },
+      })
+    })
+
     test("suppresses parent notification when notifyParentOnComplete is false", async () => {
       await using tmp = await tmpdir({ git: true })
       await ScopeContext.provide({

--- a/packages/synergy/test/server/global-event-clients.test.ts
+++ b/packages/synergy/test/server/global-event-clients.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { GlobalEventClients } from "../../src/server/global-event-clients"
+import type { WSContext } from "hono/ws"
+
+function fakeWs(input: {
+  raw?: { readyState?: number; bufferedAmount?: number; send?: (data: string) => number | void }
+  readyState?: number
+  send?: (data: string) => void
+  close?: (code?: number, reason?: string) => void
+}): WSContext {
+  return {
+    raw: input.raw,
+    readyState: input.readyState ?? input.raw?.readyState ?? 1,
+    send: input.send ?? (() => {}),
+    close: input.close ?? (() => {}),
+    url: null,
+    protocol: null,
+    binaryType: "arraybuffer",
+  } as unknown as WSContext
+}
+
+describe("GlobalEventClients", () => {
+  test("keys clients by stable raw socket across fresh WSContext wrappers", () => {
+    const registry = GlobalEventClients.createRegistry()
+    const raw = { readyState: 1, send: () => 4 }
+    const openWrapper = fakeWs({ raw })
+    const closeWrapper = fakeWs({ raw })
+
+    registry.add(openWrapper, "delta")
+    expect(registry.size()).toBe(1)
+
+    // Hono constructs a new WSContext per callback; identity must still match.
+    expect(GlobalEventClients.connectionKey(openWrapper)).toBe(raw)
+    expect(GlobalEventClients.connectionKey(closeWrapper)).toBe(raw)
+    expect(registry.remove(closeWrapper)).toBe(true)
+    expect(registry.size()).toBe(0)
+  })
+
+  test("falls back to the wrapper object when raw is unavailable", () => {
+    const registry = GlobalEventClients.createRegistry()
+    const wrapper = fakeWs({ readyState: 1 })
+    registry.add(wrapper, "full")
+    expect(registry.size()).toBe(1)
+    expect(registry.remove(wrapper)).toBe(true)
+    expect(registry.size()).toBe(0)
+  })
+
+  test("drops frames under backpressure and eventually evicts the client", () => {
+    const closed: Array<{ code?: number; reason?: string }> = []
+    const raw = {
+      readyState: 1,
+      bufferedAmount: 0,
+      send: () => -1 as number,
+    }
+    const registry = GlobalEventClients.createRegistry({ maxConsecutiveBackpressure: 3 })
+    registry.add(
+      fakeWs({
+        raw,
+        close: (code, reason) => closed.push({ code, reason }),
+      }),
+      "delta",
+    )
+
+    const first = registry.broadcast(() => "frame")
+    expect(first.sent).toBe(0)
+    expect(first.dropped).toBe(1)
+    expect(registry.size()).toBe(1)
+
+    registry.broadcast(() => "frame")
+    const third = registry.broadcast(() => "frame")
+    expect(third.removed).toBe(1)
+    expect(registry.size()).toBe(0)
+    expect(closed).toEqual([{ code: 1013, reason: "websocket backpressure" }])
+  })
+
+  test("removes clients whose raw socket is no longer open", () => {
+    const raw = {
+      readyState: 3,
+      send: () => {
+        throw new Error("should not send on closed socket")
+      },
+    }
+    const registry = GlobalEventClients.createRegistry()
+    registry.add(fakeWs({ raw, readyState: 1 }), "full")
+    const result = registry.broadcast(() => "payload")
+    expect(result.removed).toBe(1)
+    expect(registry.size()).toBe(0)
+  })
+
+  test("encodes full and delta payloads once per broadcast", () => {
+    const registry = GlobalEventClients.createRegistry()
+    const rawA = { readyState: 1, send: () => 1 }
+    const rawB = { readyState: 1, send: () => 1 }
+    registry.add(fakeWs({ raw: rawA }), "full")
+    registry.add(fakeWs({ raw: rawB }), "delta")
+
+    let fullEncodes = 0
+    let deltaEncodes = 0
+    registry.broadcast((mode) => {
+      if (mode === "full") {
+        fullEncodes++
+        return "FULL"
+      }
+      deltaEncodes++
+      return "DELTA"
+    })
+
+    expect(fullEncodes).toBe(1)
+    expect(deltaEncodes).toBe(1)
+  })
+})

--- a/packages/synergy/test/storage/storage-sampling.test.ts
+++ b/packages/synergy/test/storage/storage-sampling.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { ObservabilityConfig } from "../../src/observability/config"
+import { ObservabilityStore } from "../../src/observability/store"
+import { Storage } from "../../src/storage/storage"
+import { cleanupObservabilityHomes, resetObservabilityHome } from "../observability/fixture"
+
+beforeEach(() => {
+  resetObservabilityHome("synergy-storage-sampling-")
+  ObservabilityStore.open()
+})
+
+afterEach(() => {
+  cleanupObservabilityHomes()
+})
+
+describe.serial("storage telemetry sampling", () => {
+  test("samples successful storage durations while preserving counters and errors", async () => {
+    const originalRandom = Math.random
+    Math.random = () => 0.99
+    try {
+      await Storage.write(["perf", "sampled"], { count: 1 })
+      await expect(Storage.read(["perf", "missing-duration-sample"])).rejects.toThrow()
+      ObservabilityStore.flush()
+    } finally {
+      Math.random = originalRandom
+    }
+
+    const durationRows = ObservabilityStore.queryMetrics({ since: 0, names: ["storage.operation.duration"] })
+    const durationStatuses = new Set(durationRows.map((row) => JSON.parse(row.labels_json).status))
+    expect(durationStatuses).not.toContain("ok")
+    expect(durationStatuses).toContain("error")
+
+    const countRows = ObservabilityStore.queryMetrics({ since: 0, names: ["storage.operation.count"] })
+    const countStatuses = new Set(countRows.map((row) => JSON.parse(row.labels_json).status))
+    expect(countStatuses).toContain("ok")
+    expect(countStatuses).toContain("error")
+  })
+})


### PR DESCRIPTION
## Summary
- Stabilize global event WebSocket client identity on raw sockets so reconnects no longer leak stale clients and saturate CPU (`#551`).
- Add send backpressure handling/eviction for global event fanout and make provider response streaming pull-based (`#524`, `#498`).
- Restore storage duration telemetry sampling after the observability migration regression (`#343`).
- Always enqueue Cortex background-task completion mail, including when the parent is mid-turn (`#550`).
- Throttle global Cortex concurrency under soft/critical memory pressure while preserving the healthy per-agent limit (`#501`).

Closes #343
Closes #498
Closes #501
Closes #524
Closes #550
Closes #551

## Test plan
- [x] `cd packages/synergy && bun test test/server/global-event-clients.test.ts test/storage/storage-sampling.test.ts test/cortex/concurrency.test.ts test/cortex/manager.test.ts`
- [ ] `cd packages/synergy && bun run typecheck`
- [ ] `bun run quality:quick`
- [ ] Manual: open multiple UI windows, reconnect global event WS, confirm client count does not grow after disconnect
- [ ] Manual: complete a `task(background=true)` while parent is mid-turn and confirm inbox notification is delivered