### PR TITLE
refactor(workflow): make worktree isolation optional

### DIFF
--- a/.synergy/skill/find-logs/SKILL.md
+++ b/.synergy/skill/find-logs/SKILL.md
@@ -72,8 +72,8 @@ Static code inspection establishes hypotheses. It is not sufficient evidence for
 
 When the task authorizes code changes and existing evidence cannot distinguish the hypotheses:
 
-1. Load `architecture` to identify the ownership boundary, then create or reuse a task-owned worktree according to `git-guide`. Never instrument the primary/shared checkout.
-2. Load `develop-synergy`; start the worktree with a new isolated `SYNERGY_HOME` and explicit free ports. Never reuse, restart, or mutate the backend carrying the current task.
+1. Load `architecture` to identify the ownership boundary, then inspect the current checkout according to `git-guide`. Temporary instrumentation may be edited there when it preserves unrelated work; use a task-owned worktree when concurrent changes need isolation.
+2. Load `develop-synergy`; start the source checkout with a new isolated `SYNERGY_HOME` and explicit free ports. Never reuse, restart, or mutate the backend carrying the current task.
 3. Reproduce the original behavior before editing when possible. Record the exact action, expected invariant, observed state, server start time, and a narrow log/trace window.
 4. Add the smallest temporary observation that separates the hypotheses: structured logs around state transitions, counters, timing, assertions, or a focused diagnostic endpoint/test. Prefer the owning domain's `Log.create({ service: ... })` pattern and log identifiers or derived metadata instead of payload contents.
 5. Restart only the isolated backend when required, repeat the same reproduction, and compare the before/after event sequence. Inspect persisted state and frontend/runtime state only at the boundary relevant to the hypothesis.

--- a/.synergy/skill/git-guide/SKILL.md
+++ b/.synergy/skill/git-guide/SKILL.md
@@ -18,13 +18,14 @@ git log --oneline -8
 
 Classify the current checkout before changing files:
 
-- Continue when it is a task-owned worktree already on the correct topic branch.
-- Enter and reuse an existing worktree for later changes to the same branch.
-- If the current directory is the primary, shared, or otherwise pre-existing checkout, create or enter a task worktree before editing.
+- Direct edits are allowed in the current checkout. Preserve unrelated dirty and untracked files regardless of whether it is the primary checkout or a worktree.
+- Continue in a task-owned worktree when it already owns the correct branch, and reuse it for later changes to that branch.
+- Treat primary, shared, and otherwise pre-existing checkouts as potentially concurrent. Do not switch branches or rebase them unless the user explicitly requests that operation.
+- A user may create or use a topic branch directly in the primary checkout. Use a task-owned worktree when concurrent work needs branch or file isolation, not as a prerequisite for every change.
 
-Never run `git checkout` or `git switch` in a shared or pre-existing checkout. A branch change affects every session using that working directory. Never switch branches, commit, rebase, or push from the primary checkout, even when it currently happens to be on a topic branch.
+Branch switches and rebases change repository state observed by every session sharing a checkout. Before an explicitly requested switch or rebase, inspect the branch and dirty state and stop if unrelated concurrent work makes the operation unsafe.
 
-Create a topic branch and worktree from the verified development base when no matching worktree exists. By default, put task worktrees under the repository checkout's project-local `.synergy/worktrees/` directory with a short filesystem-safe task slug:
+When isolation is useful and no matching worktree exists, create a topic branch and worktree from the verified development base. By default, put task worktrees under the repository checkout's project-local `.synergy/worktrees/` directory with a short filesystem-safe task slug:
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -37,14 +38,14 @@ git worktree add -b synergy/<topic> "$WORKTREE_ROOT/$TASK_SLUG" origin/dev
 
 This is `<repository>/.synergy/worktrees/<task-slug>`, not the installation or runtime home under `SYNERGY_HOME`. Use a different worktree location only when the user explicitly requests it. If the default path is unavailable, stop and ask rather than silently creating the worktree elsewhere.
 
-Worktrees are branch-isolation tools, not something to recreate for every edit or every feature. One task branch should keep using its existing worktree. After entering it, inspect status again; do not assume it is clean.
+Worktrees are optional branch- and file-isolation tools, not something to recreate for every edit or every feature. One task branch should keep using its existing worktree. After entering it, inspect status again; do not assume it is clean.
 
 If task changes already exist in a shared checkout, do not stash, reset, clean, or switch that checkout to move them. Create a new task worktree and deliberately migrate only task-owned changes, leaving unrelated and untracked user work untouched.
 
 ## Protect Branches and Scope
 
 - Never push directly to the protected `dev` or `main` branches.
-- Commit repository changes on a topic branch and open a pull request against `dev`.
+- Local commits on `dev` or `main` are permitted when the user requests them, but they advance a potentially shared branch. Publish through a topic branch and open a pull request against `dev`.
 - The release workflow is the only path from `dev` to `main`.
 - Inspect `git status` before editing, staging, committing, rebasing, or publishing.
 - Preserve unrelated dirty and untracked files. Stage only explicit files owned by the current task.
@@ -88,8 +89,8 @@ Project-relative source paths such as `packages/synergy/src/tool/read.ts` are al
 
 ## Push and Open a PR
 
-1. Confirm the current directory is the task worktree and the current branch is its topic branch.
-2. Push only that topic branch; never push `dev` or `main` directly.
+1. Confirm the current branch is a non-protected topic branch and inspect the exact push target. Publication does not require a worktree.
+2. Push only the topic branch; never push `dev` or `main` directly.
 3. Open the pull request against `dev`.
 4. Use project-relative paths and redacted evidence in the PR body.
 5. State the summary and exact test commands. Do not claim checks that were not run.
@@ -103,28 +104,28 @@ gh issue comment <number> --body-file /synergy/note/<note-id>
 
 Do not interpolate Note contents into a shell command or pass them to an option that executes the file as code.
 
-The `autonomous` profile permits ordinary remote publication from worktrees and denies remote writes from the shared checkout. Enter the task worktree before pushing or creating a pull request. This capability boundary does not replace the user's authorization to publish.
+The `autonomous` profile permits ordinary topic-branch and pull-request publication from either the primary checkout or a worktree. Protected-branch pushes and broader remote mutations remain `shell_remote_write` and are denied. This capability boundary does not replace the user's authorization to publish.
 
 ## GitHub CLI Permission Matrix
 
 The permission system classifies `gh` commands before applying the active control profile. The table shows the base profile decision before user rules, approval cache, SmartAllow, GitHub authorization, or ordinary runtime failures.
 
-| Command                              | Capability             | Guarded  | Autonomous                  | Full Access |
-| ------------------------------------ | ---------------------- | -------- | --------------------------- | ----------- |
-| `gh pr view/list/status/checks/diff` | `shell_read`           | ✅ allow | ✅ allow                    | ✅ allow    |
-| `gh pr create`                       | `shell_remote_publish` | ⚠️ ask   | ✅ allow in a task worktree | ✅ allow    |
-| `gh pr comment` / `gh pr review`     | `shell_remote_publish` | ⚠️ ask   | ✅ allow in a task worktree | ✅ allow    |
-| `gh pr edit` / `gh pr ready`         | `shell_remote_write`   | ⚠️ ask   | ❌ deny                     | ✅ allow    |
-| `gh issue view/list/status`          | `shell_read`           | ✅ allow | ✅ allow                    | ✅ allow    |
-| `gh issue create/comment`            | `shell_remote_publish` | ⚠️ ask   | ✅ allow in a task worktree | ✅ allow    |
-| `gh issue edit/close/reopen`         | `shell_remote_write`   | ⚠️ ask   | ❌ deny                     | ✅ allow    |
-| `gh pr merge/close/reopen`           | `shell_destructive`    | ⚠️ ask   | ❌ deny                     | ✅ allow    |
+| Command                              | Capability             | Guarded  | Autonomous | Full Access |
+| ------------------------------------ | ---------------------- | -------- | ---------- | ----------- |
+| `gh pr view/list/status/checks/diff` | `shell_read`           | ✅ allow | ✅ allow   | ✅ allow    |
+| `gh pr create`                       | `shell_remote_publish` | ⚠️ ask   | ✅ allow   | ✅ allow    |
+| `gh pr comment` / `gh pr review`     | `shell_remote_publish` | ⚠️ ask   | ✅ allow   | ✅ allow    |
+| `gh pr edit` / `gh pr ready`         | `shell_remote_write`   | ⚠️ ask   | ❌ deny    | ✅ allow    |
+| `gh issue view/list/status`          | `shell_read`           | ✅ allow | ✅ allow   | ✅ allow    |
+| `gh issue create/comment`            | `shell_remote_publish` | ⚠️ ask   | ✅ allow   | ✅ allow    |
+| `gh issue edit/close/reopen`         | `shell_remote_write`   | ⚠️ ask   | ❌ deny    | ✅ allow    |
+| `gh pr merge/close/reopen`           | `shell_destructive`    | ⚠️ ask   | ❌ deny    | ✅ allow    |
 
-Outside a worktree, Synergy upgrades `shell_remote_publish` to `shell_remote_write`; Autonomous therefore denies publication from the shared checkout. Unknown write-capable `gh` subcommands default to `shell_remote_write`. Full Access silently allows permission-system capabilities but does not override task authorization, protected-branch rules, GitHub permissions, validation failures, or network/runtime errors.
+Checkout type does not change ordinary `shell_remote_publish` into `shell_remote_write`. Unknown write-capable `gh` subcommands default to `shell_remote_write`. Full Access silently allows permission-system capabilities but does not override task authorization, protected-branch rules, GitHub permissions, validation failures, or network/runtime errors.
 
 ## Rebase or Recover
 
-Rebase only inside the feature worktree after confirming the branch and dirty state. Stop on conflicts, preserve both owners' intent, and rerun affected tests. Do not use `reset --hard`, checkout-based file destruction, force push, or hook bypass without explicit user authority and a reviewed recovery plan.
+Do not rebase a shared or pre-existing checkout unless the user explicitly requests it. Before any rebase, confirm the branch and dirty state; stop on conflicts, preserve both owners' intent, and rerun affected tests. Do not use `reset --hard`, checkout-based file destruction, force push, or hook bypass without explicit user authority and a reviewed recovery plan.
 
 ## Read History
 
@@ -142,4 +143,4 @@ Tie conclusions to the current implementation; history explains intent but does 
 
 ## Handoff
 
-Report the worktree/branch, files staged or committed, commit hash if created, checks run, push/PR result if requested, and any preserved unrelated changes.
+Report the checkout and branch, whether a worktree was used, files staged or committed, commit hash if created, checks run, push/PR result if requested, and any preserved unrelated changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,14 @@ The project-local `architecture` skill provides the code-tracing workflow. It li
 
 The primary checkout, pre-existing checkouts, and active Synergy runtime may be shared by concurrent sessions.
 
-- Inspect `git status` and the worktree list before editing. Repository changes must happen in a task-owned worktree on a topic branch; if the current directory is a primary, shared, or otherwise pre-existing checkout, create or enter the task worktree first.
-- Never run `git checkout` or `git switch`, commit, rebase, or push in the primary/shared checkout. A branch change affects every session using that directory.
-- Reuse a task's existing worktree when it is already on the correct branch; worktrees isolate branches but do not need to be recreated for every edit or feature.
-- Never push directly to protected `dev` or `main`. Publish only the task topic branch and open its PR against `dev`; the release workflow is the only path from `dev` to `main`.
+- Inspect `git status`, the current branch, and the worktree list before editing or performing Git operations. Direct edits in the current checkout are allowed; preserve unrelated dirty and untracked files.
+- Do not run `git checkout`, `git switch`, or rebase a shared or pre-existing checkout unless the user explicitly requests that operation. These commands change repository state observed by every session using that directory.
+- A user may choose to create or use a topic branch directly in the primary checkout. Use a task-owned worktree when concurrent work needs branch or file isolation, not as a prerequisite for every repository change; reuse an existing task worktree when it already owns the branch.
+- Stage and commit only when the user requests it. Local commits on `dev` or `main` are permitted, but they advance a potentially shared branch and must never be pushed directly.
+- Never push directly to protected `dev` or `main`. Publish a topic branch and open its PR against `dev`; the release workflow is the only path from `dev` to `main`.
 - Preserve unrelated dirty and untracked files. Inspect status again before staging and stage only explicit files owned by the current task.
 - Do not use destructive Git commands, force pushes, or hook bypasses without explicit user authority and a reviewed recovery plan.
-- Stage, commit, push, open a PR, or mutate external systems only when the user requests that action.
+- Push, open a PR, or mutate external systems only when the user requests that action.
 - Keep local/runtime paths, session or Scope IDs, logs, credentials, private endpoints, and internal config out of commit messages, PR bodies, comments, and reviews. Project-relative source paths are allowed. Every agent-created commit must use a concise conventional type and end with `Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>`.
 - Never stop, restart, signal, or modify the `SYNERGY_HOME` of the Synergy instance carrying the current task.
 - Run source changes in an isolated second home with explicit alternate ports. Load `develop-synergy` for the exact workflow.

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -129,9 +129,9 @@ Frontend code should use `createSynergyClient()` and generated methods for inter
 
 The development branch is `dev`; `main` is updated by the release workflow. All pull requests target `dev`.
 
-Make repository changes in a task-owned worktree on a topic branch. Do not run `git checkout` or `git switch`, edit, commit, rebase, or publish from the primary/shared checkout. Create or enter the task worktree first, then inspect its status. Reuse that worktree for later changes to the same branch rather than creating a new worktree for every edit.
+Repository changes may be made directly in the current checkout. Treat primary and pre-existing checkouts as potentially shared: preserve unrelated work, and do not switch branches or rebase unless the user explicitly requests it. Use a task-owned worktree when concurrent development needs branch or file isolation, not as a prerequisite for every edit, and reuse an existing task worktree when it already owns the branch.
 
-Never push `dev` or `main` directly. Push only the task topic branch and open its pull request against `dev`; the release workflow is the only path from `dev` to `main`. Preserve unrelated changes, stage explicit task files, and keep local paths, runtime identifiers, logs, credentials, and internal configuration out of commit and GitHub text. See `git-guide` for the commit template, mandatory agent co-author footer, and publication workflow.
+Stage and commit only when requested. Local commits on `dev` or `main` are allowed, but never push either protected branch directly. Push a topic branch and open its pull request against `dev`; the release workflow is the only path from `dev` to `main`. Preserve unrelated changes, stage explicit task files, and keep local paths, runtime identifiers, logs, credentials, and internal configuration out of commit and GitHub text. See `git-guide` for the commit template, mandatory agent co-author footer, and publication workflow.
 
 Keep changes focused, update migrations for persisted schema changes, and update current-state docs plus relevant `.synergy/skill` workflows whenever an agent-facing command, path, tool, or procedure changes.
 

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -699,14 +699,6 @@ export namespace EnforcementGate {
           risk = "shell"
         }
 
-        // git push from the main checkout is never safe to auto-allow — even
-        // a "publishable" feature-branch push can land in the wrong remote.
-        // Upgrade to shell_remote_write (already denied in autonomous) on
-        // main; worktrees keep shell_remote_publish for normal workflow.
-        if (risk === "shell_remote_publish" && workspaceType !== "worktree") {
-          risk = "shell_remote_write"
-        }
-
         if (risk === "shell_hardline") {
           caps.push({
             class: "shell_hardline",

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -2873,6 +2873,32 @@ describe("security invariants: nonBypassable permission boundaries", () => {
     expect(caps.every((c: any) => c.nonBypassable === false)).toBe(true)
   })
 
+  test("autonomous allows an explicit topic-branch push from the main checkout", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "main",
+      profileId: "autonomous",
+    })
+
+    const envelope = gate.evaluate("bash", { command: "git push origin feature" })
+    expect(envelope.decision).toBe("allow")
+    expect(envelope.capabilities.some((cap: any) => cap.class === "shell_remote_publish")).toBe(true)
+    expect(envelope.capabilities.some((cap: any) => cap.class === "shell_remote_write")).toBe(false)
+  })
+
+  test("autonomous still denies an explicit protected-branch push from the main checkout", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "main",
+      profileId: "autonomous",
+    })
+
+    const envelope = gate.evaluate("bash", { command: "git push origin dev" })
+    expect(envelope.decision).toBe("deny")
+    expect(envelope.capabilities.some((cap: any) => cap.class === "shell_remote_write")).toBe(true)
+    expect(envelope.capabilities.some((cap: any) => cap.class === "shell_remote_publish")).toBe(false)
+  })
+
   test("classifyBashRisk shell_destructive path sets nonBypassable=true", async () => {
     const gate = await EnforcementGate.create({
       activeWorkspace: "/Users/test",


### PR DESCRIPTION
## Summary

Make worktree isolation an opt-in concurrency tool instead of a prerequisite for every repository edit.

This change allows agents to edit the active primary or pre-existing checkout while preserving the safeguards that matter for concurrent development:

- shared checkout branch switches and rebases still require explicit user direction
- staging, commits, pushes, and pull requests still require user authorization
- local commits on `dev` or `main` are allowed when requested, but direct pushes to either protected branch remain forbidden
- topic branches can be published from either the primary checkout or a worktree
- worktrees remain the recommended tool when branch or file isolation is actually needed

## First principles

The policy now separates two independent risks instead of treating every edit as equally dangerous.

### 1. Protect shared local state

Multiple agents can observe the same checkout. The disruptive operations are those that move or rewrite the checkout's shared branch and history state, especially `git checkout`, `git switch`, and rebase. Those operations can invalidate another agent's assumptions immediately, so they remain guarded and require explicit user direction in shared or pre-existing checkouts.

Ordinary file edits do not inherently require a second checkout. Requiring a worktree for every small documentation or source change adds setup cost without addressing a corresponding branch-state risk. Agents must still inspect status, preserve unrelated dirty and untracked files, and stage only task-owned paths.

### 2. Protect remote integration branches

The durable publication boundary is the remote `dev`/`main` branch, not the local directory in which work happened. A local commit is recoverable and may be moved onto a topic branch before publication. A direct protected-branch push bypasses review and affects every collaborator, so it remains forbidden.

The enforcement gate therefore continues to classify explicit protected-branch pushes and bare pushes from a protected current branch as `shell_remote_write`. Force pushes, ref deletion, ambiguous repository selectors, and other destructive forms retain their stricter classifications.

### 3. Match isolation cost to concurrency needs

Worktrees are still valuable when concurrent tasks need independent branches, indexes, or overlapping files. They are now optional isolation infrastructure rather than mandatory ceremony. A user can also choose to create a topic branch directly in the primary checkout and develop there over time.

## Implementation

- update the root agent policy and development reference to allow direct edits in the active checkout
- revise `git-guide` so checkout type no longer determines whether normal topic publication is allowed
- preserve explicit user authorization for shared-checkout branch switches and rebases
- allow temporary diagnostics instrumentation in the current checkout while retaining isolated runtime requirements
- remove the enforcement-gate rule that upgraded every main-checkout `shell_remote_publish` operation to `shell_remote_write`
- add behavioral coverage for allowed topic-branch publication and denied protected-branch publication from the main checkout

## Verification

- `bun test test/enforcement/gate.test.ts` — 215 passed
- `bun run skill:check` — 18 repository Skills validated
- `bun run package-guide:check` — 12 package guides validated
- pre-push repository checks:
  - Prettier
  - Oxlint
  - Turbo typecheck across all 12 packages
  - Sherif monorepo validation
