### PR TITLE
fix(cortex): defer parent task notifications until turn ends

### DIFF
--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -25,6 +25,7 @@ export namespace Cortex {
 
   const tasks: Map<string, CortexTypes.Task> = new Map()
   const taskWaiters: Map<string, Set<{ resolve: (task: CortexTypes.Task) => void; timeout: Timer }>> = new Map()
+  const deferredParentNotifications = new Map<string, Set<string>>()
   const taskRuns: Map<string, Promise<void>> = new Map()
   const acquiredTasks = new Set<string>()
   let progressUpdateTimer: Timer | undefined
@@ -486,10 +487,15 @@ export namespace Cortex {
       taskWaiters.delete(taskID)
       log.info("task result delivered to waiters, skipping mail", { taskID, waiterCount: waiters.size })
     } else if (task.notifyParentOnComplete !== false) {
-      // Always enqueue the completion mail. SessionManager.deliver already queues
-      // when the parent is mid-turn, so skipping here permanently lost background
-      // task results (#550).
-      notifyParentSession(task)
+      // Background/auto-background tasks rely on this mail to re-enter the parent
+      // after the current turn ends (#548/#550). If the parent is mid-turn, defer
+      // until release() so we do not permanently drop the wake or force an
+      // immediate mid-turn re-entry (#244).
+      if (SessionManager.isRunning(task.parentSessionID)) {
+        deferParentNotification(task)
+      } else {
+        void notifyParentSession(task)
+      }
     } else {
       log.info("task parent notification suppressed", { taskID })
     }
@@ -533,7 +539,49 @@ export namespace Cortex {
     }
   }
 
-  function notifyParentSession(task: CortexTypes.Task): void {
+  function deferParentNotification(task: CortexTypes.Task): void {
+    const parentSessionID = task.parentSessionID
+    const pending = deferredParentNotifications.get(parentSessionID) ?? new Set<string>()
+    if (pending.has(task.id)) return
+    pending.add(task.id)
+    deferredParentNotifications.set(parentSessionID, pending)
+    log.info("deferred parent notification until parent turn ends", {
+      taskID: task.id,
+      parentSessionID,
+    })
+  }
+
+  export async function flushDeferredParentNotifications(parentSessionID: string): Promise<void> {
+    const pending = deferredParentNotifications.get(parentSessionID)
+    if (!pending || pending.size === 0) return
+    deferredParentNotifications.delete(parentSessionID)
+
+    for (const taskID of pending) {
+      const task = tasks.get(taskID)
+      if (!task) {
+        log.info("skipped deferred parent notification for missing task", { taskID, parentSessionID })
+        continue
+      }
+      if (task.notifyParentOnComplete === false) {
+        log.info("skipped deferred parent notification: notifyParentOnComplete is false", {
+          taskID,
+          parentSessionID,
+        })
+        continue
+      }
+      if (!isTerminal(task.status)) {
+        log.info("skipped deferred parent notification for non-terminal task", {
+          taskID,
+          parentSessionID,
+          status: task.status,
+        })
+        continue
+      }
+      await notifyParentSession(task)
+    }
+  }
+
+  async function notifyParentSession(task: CortexTypes.Task): Promise<void> {
     const statusText = task.status === "error" ? "FAILED" : task.status === "cancelled" ? "CANCELLED" : "COMPLETED"
     const notification = [
       `[BACKGROUND TASK ${statusText}]`,
@@ -548,24 +596,26 @@ export namespace Cortex {
       .filter(Boolean)
       .join("\n")
 
-    void SessionManager.deliver({
-      target: task.parentSessionID,
-      mail: {
-        type: "user",
-        metadata: { source: "cortex", sourceSessionID: task.sessionID },
-        parts: [
-          {
-            id: Identifier.ascending("part"),
-            sessionID: task.parentSessionID,
-            messageID: Identifier.ascending("message"),
-            type: "text",
-            text: notification,
-          },
-        ],
-      },
-    }).catch((error) => {
+    try {
+      await SessionManager.deliver({
+        target: task.parentSessionID,
+        mail: {
+          type: "user",
+          metadata: { source: "cortex", sourceSessionID: task.sessionID },
+          parts: [
+            {
+              id: Identifier.ascending("part"),
+              sessionID: task.parentSessionID,
+              messageID: Identifier.ascending("message"),
+              type: "text",
+              text: notification,
+            },
+          ],
+        },
+      })
+    } catch (error) {
       log.error("failed to notify parent session", { taskID: task.id, parentSessionID: task.parentSessionID, error })
-    })
+    }
   }
 
   function isTerminal(status: CortexTypes.TaskStatus): boolean {
@@ -819,6 +869,7 @@ export namespace Cortex {
     tasks.clear()
     taskRuns.clear()
     acquiredTasks.clear()
+    deferredParentNotifications.clear()
     if (progressUpdateTimer) {
       clearTimeout(progressUpdateTimer)
       progressUpdateTimer = undefined

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -398,6 +398,9 @@ export namespace SessionManager {
       log.warn("failed to emit session update after release", { sessionID, error })
     })
 
+    const { Cortex } = await import("../cortex/manager")
+    await Cortex.flushDeferredParentNotifications(sessionID)
+
     if (await SessionInbox.hasRunnableItem(sessionID)) {
       scheduleWake(sessionID, "release")
     }

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -1119,7 +1119,7 @@ describe.serial("Cortex", () => {
       })
     })
 
-    test("still notifies parent when parent session is mid-turn", async () => {
+    test("defers parent notification until the mid-turn parent releases", async () => {
       await using tmp = await tmpdir({ git: true })
       await ScopeContext.provide({
         scope: await tmp.scope(),
@@ -1140,7 +1140,7 @@ describe.serial("Cortex", () => {
             const parentSession = await Session.create({})
             ;(SessionManager.isRunning as any) = mock((sessionID: string) => sessionID === parentSession.id)
             const task = await Cortex.launch({
-              description: "Notify mid-turn parent",
+              description: "Defer mid-turn parent notification",
               prompt: "Do something",
               agent: "developer",
               parentSessionID: parentSession.id,
@@ -1151,6 +1151,10 @@ describe.serial("Cortex", () => {
             const completed = await waitUntilCompleted(task.id)
 
             expect(completed?.status).toBe("completed")
+            expect(deliveries).toHaveLength(0)
+
+            await Cortex.flushDeferredParentNotifications(parentSession.id)
+
             expect(deliveries).toHaveLength(1)
             expect(deliveries[0].target).toBe(parentSession.id)
             expect(deliveries[0].mail.metadata?.source).toBe("cortex")

--- a/packages/synergy/test/session/manager.test.ts
+++ b/packages/synergy/test/session/manager.test.ts
@@ -4,11 +4,11 @@ import { Log } from "../../src/util/log"
 import { SessionManager } from "../../src/session/manager"
 import { Session } from "../../src/session"
 import { SessionEndpoint } from "../../src/session/endpoint"
+import { SessionInbox } from "../../src/session/inbox"
 import { tmpdir } from "../fixture/fixture"
 import { Channel } from "../../src/channel"
 import { Bus } from "../../src/bus"
 import { SessionEvent } from "../../src/session/event"
-
 Log.init({ print: false })
 
 describe("SessionManager.getSession", () => {
@@ -193,6 +193,137 @@ describe("SessionManager.getSession", () => {
           } finally {
             unsub()
             SessionManager.unregisterRuntime(session.id)
+          }
+        },
+      })
+    })
+
+    test("release flushes deferred cortex parent notifications before scheduling wake", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { Cortex } = await import("../../src/cortex/manager")
+          const { SessionInvoke } = await import("../../src/session/invoke")
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const originalDeliver = SessionManager.deliver
+          const originalIsRunning = SessionManager.isRunning
+          const originalLoop = SessionInvoke.loop
+          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          const wakes: string[] = []
+          let parentSessionID = ""
+
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              const parentID = "msg_cortex_parent"
+              const message = await Session.updateMessage({
+                id: "msg_cortex_assistant",
+                role: "assistant",
+                parentID,
+                rootID: parentID,
+                mode: "test",
+                agent: "developer",
+                path: {
+                  cwd: ScopeContext.current.directory,
+                  root: ScopeContext.current.directory,
+                },
+                cost: 0,
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  reasoning: 0,
+                  cache: { read: 0, write: 0 },
+                },
+                modelID: "test-model",
+                providerID: "test-provider",
+                time: {
+                  created: Date.now(),
+                  completed: Date.now(),
+                },
+                sessionID: input.sessionID,
+              })
+              const part = await Session.updatePart({
+                id: "prt_cortex_assistant",
+                messageID: message.id,
+                sessionID: input.sessionID,
+                type: "text",
+                text: "completed",
+              })
+              return { info: message, parts: [part] }
+            },
+          )
+          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+            deliveries.push(input)
+            if (typeof input.target === "string") {
+              await SessionInbox.enqueueMail({
+                sessionID: input.target,
+                mail: input.mail as any,
+              })
+            }
+          })
+          ;(SessionInvoke.loop as any) = mock(async (sessionID: string) => {
+            wakes.push(sessionID)
+          })
+
+          try {
+            const parentSession = await Session.create({})
+            parentSessionID = parentSession.id
+            const rootID = "msg_parent_root"
+            await Session.updateMessage({
+              id: rootID,
+              role: "user",
+              sessionID: parentSession.id,
+              time: { created: Date.now() },
+              agent: "synergy",
+              model: { providerID: "test-provider", modelID: "test-model" },
+              isRoot: true,
+              rootID,
+            } as any)
+            await Session.updatePart({
+              id: "prt_parent_root",
+              messageID: rootID,
+              sessionID: parentSession.id,
+              type: "text",
+              text: "parent root",
+            })
+            SessionManager.acquire(parentSession.id)
+            ;(SessionManager.isRunning as any) = mock((sessionID: string) => {
+              if (sessionID !== parentSession.id) return originalIsRunning(sessionID)
+              return !!SessionManager.getRuntime(sessionID)?.abort
+            })
+
+            const task = await Cortex.launch({
+              description: "Flush deferred parent notification",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: rootID,
+              model: { providerID: "test-provider", modelID: "test-model" },
+            })
+
+            for (let i = 0; i < 50; i++) {
+              const current = Cortex.get(task.id)
+              if (current?.status === "completed" || current?.status === "error") break
+              await Bun.sleep(10)
+            }
+
+            expect(deliveries).toHaveLength(0)
+            expect(SessionManager.isRunning(parentSession.id)).toBe(true)
+
+            await SessionManager.release(parentSession.id)
+            await Bun.sleep(20)
+
+            expect(deliveries).toHaveLength(1)
+            expect(deliveries[0].target).toBe(parentSession.id)
+            expect(deliveries[0].mail.metadata?.source).toBe("cortex")
+            expect(wakes).toContain(parentSession.id)
+          } finally {
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionManager.isRunning as any) = originalIsRunning
+            ;(SessionInvoke.loop as any) = originalLoop
+            if (parentSessionID) SessionManager.unregisterRuntime(parentSessionID)
+            Cortex.reset()
           }
         },
       })


### PR DESCRIPTION
## Summary
- Defer Cortex parent completion notifications while the parent session is mid-turn, then flush them on `SessionManager.release()`.
- Await deferred delivery so release can schedule wake from a populated inbox, fixing the #548 path where background/auto-backgrounded subagent results never re-enter the parent.
- Preserve #244 behavior by avoiding immediate mid-turn re-entry, while still guaranteeing the notification is not permanently dropped.

## Test plan
- [x] `cd packages/synergy && bun test test/cortex/manager.test.ts test/session/manager.test.ts test/session/inbox.test.ts test/tool/session-send.test.ts`
- [ ] Manual: start a session via `session_send`, launch `task(background=true)`, confirm parent resumes after subagent completion

Closes #548