### PR TITLE
feat(ui): smooth terminal markdown crossfade after streaming (#364)

### DIFF
--- a/packages/ui/src/components/markdown-terminal-transition.ts
+++ b/packages/ui/src/components/markdown-terminal-transition.ts
@@ -1,0 +1,107 @@
+export const MARKDOWN_TERMINAL_CROSSFADE_MS = 280
+export const MARKDOWN_TERMINAL_CROSSFADE_MAX_CHARS = 20_000
+
+export type MarkdownTerminalTransitionMode = "instant" | "crossfade"
+
+export function markdownTerminalTransitionMode(input: {
+  hadStreamContent: boolean
+  markdownLength: number
+  prefersReducedMotion: boolean
+}): MarkdownTerminalTransitionMode {
+  if (!input.hadStreamContent) return "instant"
+  if (input.prefersReducedMotion) return "instant"
+  if (input.markdownLength > MARKDOWN_TERMINAL_CROSSFADE_MAX_CHARS) return "instant"
+  return "crossfade"
+}
+
+export function applyMarkdownTerminalCrossfade(input: {
+  container: HTMLElement
+  html: string
+  durationMs?: number
+  enhance?: (root: HTMLElement) => () => void
+  schedule?: (callback: () => void, ms: number) => number
+  cancel?: (id: number) => void
+  nextFrame?: (callback: () => void) => number
+  cancelFrame?: (id: number) => void
+  prefersReducedMotion?: boolean
+  markdownLength?: number
+  hadStreamContent?: boolean
+}) {
+  const mode = markdownTerminalTransitionMode({
+    hadStreamContent: input.hadStreamContent ?? Boolean(input.container.childNodes.length),
+    markdownLength: input.markdownLength ?? input.html.length,
+    prefersReducedMotion: input.prefersReducedMotion ?? false,
+  })
+
+  const schedule = input.schedule ?? ((callback, ms) => window.setTimeout(callback, ms))
+  const cancel = input.cancel ?? ((id) => window.clearTimeout(id))
+  const nextFrame = input.nextFrame ?? ((callback) => window.requestAnimationFrame(callback))
+  const cancelFrame = input.cancelFrame ?? ((id) => window.cancelAnimationFrame(id))
+  const durationMs = input.durationMs ?? MARKDOWN_TERMINAL_CROSSFADE_MS
+
+  let enhanceCleanup: (() => void) | undefined
+  let timeoutId: number | undefined
+  let frameId: number | undefined
+  let finished = false
+
+  const clearMotion = () => {
+    if (timeoutId !== undefined) {
+      cancel(timeoutId)
+      timeoutId = undefined
+    }
+    if (frameId !== undefined) {
+      cancelFrame(frameId)
+      frameId = undefined
+    }
+  }
+
+  const dispose = () => {
+    clearMotion()
+    enhanceCleanup?.()
+    enhanceCleanup = undefined
+  }
+
+  if (mode === "instant") {
+    input.container.replaceChildren()
+    input.container.innerHTML = input.html
+    enhanceCleanup = input.enhance?.(input.container)
+    return dispose
+  }
+
+  const previous = document.createElement("div")
+  previous.dataset.slot = "markdown-terminal-from"
+  previous.replaceChildren(...Array.from(input.container.childNodes))
+
+  const next = document.createElement("div")
+  next.dataset.slot = "markdown-terminal-to"
+  next.innerHTML = input.html
+
+  const stage = document.createElement("div")
+  stage.dataset.slot = "markdown-terminal-crossfade"
+  stage.append(previous, next)
+  input.container.replaceChildren(stage)
+
+  // Bind interactive controls on the terminal layer while the short crossfade plays.
+  // Moving these nodes into the container later preserves the same listeners.
+  enhanceCleanup = input.enhance?.(next)
+
+  // Ensure the outgoing stream layer is painted before the fade starts.
+  previous.getBoundingClientRect()
+  frameId = nextFrame(() => {
+    frameId = undefined
+    if (finished) return
+    stage.dataset.active = "true"
+    timeoutId = schedule(() => {
+      timeoutId = undefined
+      if (finished) return
+      finished = true
+      // Move the already-enhanced terminal nodes into place; do not re-parse HTML.
+      input.container.replaceChildren(...Array.from(next.childNodes))
+    }, durationMs)
+  })
+
+  return () => {
+    finished = true
+    dispose()
+  }
+}

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -369,6 +369,55 @@
   }
 }
 
+[data-component="markdown"] [data-slot="markdown-terminal-crossfade"] {
+  position: relative;
+  display: grid;
+  width: 100%;
+  min-width: 0;
+}
+
+[data-component="markdown"] [data-slot="markdown-terminal-from"],
+[data-component="markdown"] [data-slot="markdown-terminal-to"] {
+  grid-area: 1 / 1;
+  min-width: 0;
+  transition:
+    opacity 280ms ease,
+    transform 280ms ease;
+  will-change: opacity;
+}
+
+[data-component="markdown"] [data-slot="markdown-terminal-from"] {
+  opacity: 1;
+  z-index: 1;
+}
+
+[data-component="markdown"] [data-slot="markdown-terminal-to"] {
+  opacity: 0;
+  z-index: 2;
+  transform: translateY(2px);
+}
+
+[data-component="markdown"]
+  [data-slot="markdown-terminal-crossfade"][data-active="true"]
+  [data-slot="markdown-terminal-from"] {
+  opacity: 0;
+}
+
+[data-component="markdown"]
+  [data-slot="markdown-terminal-crossfade"][data-active="true"]
+  [data-slot="markdown-terminal-to"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-component="markdown"] [data-slot="markdown-terminal-from"],
+  [data-component="markdown"] [data-slot="markdown-terminal-to"] {
+    transition: none;
+    transform: none;
+  }
+}
+
 :root[data-color-scheme="light"] [data-component="markdown"] [data-slot="markdown-code-block"] {
   background-color: color-mix(in srgb, var(--surface-base) 92%, var(--surface-inset-base));
 }

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -8,6 +8,7 @@ import {
 import { ComponentProps, createEffect, createResource, onCleanup, splitProps } from "solid-js"
 import { copyTextToClipboard, type CopyState } from "./clipboard"
 import { sanitizeHtml } from "./markdown-sanitize"
+import { applyMarkdownTerminalCrossfade } from "./markdown-terminal-transition"
 import * as smd from "streaming-markdown"
 
 type Entry = MarkdownRenderEntry
@@ -245,15 +246,27 @@ export function Markdown(
   })
 
   // Terminal render: once the full-fidelity HTML resolves (and we are no longer
-  // streaming), finish any live parser and replace the streamed DOM in one shot,
-  // then run the one-time DOM enhancement (copy buttons, table wrap, katex copy).
+  // streaming), finish any live parser and crossfade from the streamed DOM into
+  // the one-shot high-fidelity tree. Enhancement (copy buttons, table wrap,
+  // katex copy) runs on the terminal content only once.
   createEffect(() => {
     if (local.streaming) return
     const rendered = html()
     if (!rendered || !isCurrentMarkdownRender(rendered, local.text)) return
+    const hadStreamContent = Boolean(stream) || container.childNodes.length > 0
     endStream()
-    container.innerHTML = rendered.html
-    const cleanup = enhanceMarkdown(container)
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const cleanup = applyMarkdownTerminalCrossfade({
+      container,
+      html: rendered.html,
+      enhance: (root) => enhanceMarkdown(root as HTMLDivElement),
+      prefersReducedMotion,
+      markdownLength: local.text.length,
+      hadStreamContent,
+    })
     onCleanup(cleanup)
   })
 

--- a/packages/ui/test/markdown-terminal-transition.test.ts
+++ b/packages/ui/test/markdown-terminal-transition.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test"
+import {
+  applyMarkdownTerminalCrossfade,
+  MARKDOWN_TERMINAL_CROSSFADE_MAX_CHARS,
+  MARKDOWN_TERMINAL_CROSSFADE_MS,
+  markdownTerminalTransitionMode,
+} from "../src/components/markdown-terminal-transition"
+
+type NodeLike = {
+  dataset: Record<string, string>
+  childNodes: NodeLike[]
+  html: string
+  text: string
+  append: (...nodes: NodeLike[]) => void
+  replaceChildren: (...nodes: NodeLike[]) => void
+  querySelector: (selector: string) => NodeLike | null
+  getAttribute: (name: string) => string | null
+  getBoundingClientRect: () => { width: number; height: number }
+  get innerHTML(): string
+  set innerHTML(value: string)
+  get textContent(): string
+  set textContent(value: string)
+}
+
+function createNode(html = "", text = html.replaceAll(/<[^>]+>/g, "")): NodeLike {
+  const dataset: Record<string, string> = {}
+  const node: NodeLike = {
+    dataset,
+    childNodes: [],
+    html,
+    text,
+    get innerHTML() {
+      return this.html
+    },
+    set innerHTML(value: string) {
+      this.html = value
+      this.text = value.replaceAll(/<[^>]+>/g, "")
+      // Represent the markup as a single leaf child without recursive parsing.
+      this.childNodes = value
+        ? [
+            {
+              ...createLeaf(value, this.text),
+            },
+          ]
+        : []
+    },
+    get textContent() {
+      if (this.childNodes.length > 0) return this.childNodes.map((child) => child.textContent).join("")
+      return this.text
+    },
+    set textContent(value: string) {
+      this.text = value
+      this.html = value
+      this.childNodes = []
+    },
+    append(...nodes: NodeLike[]) {
+      this.childNodes.push(...nodes)
+    },
+    replaceChildren(...nodes: NodeLike[]) {
+      this.childNodes = [...nodes]
+      this.html = nodes.map((child) => child.html || child.text).join("")
+      this.text = nodes.map((child) => child.text).join("")
+    },
+    querySelector(selector: string) {
+      const match = selector.match(/\[data-slot="([^"]+)"\]/)
+      if (!match) return null
+      const slot = match[1]!
+      const visit = (current: NodeLike): NodeLike | null => {
+        if (current.dataset.slot === slot) return current
+        for (const child of current.childNodes) {
+          const found = visit(child)
+          if (found) return found
+        }
+        return null
+      }
+      return visit(this)
+    },
+    getAttribute(name: string) {
+      if (name === "data-active") return this.dataset.active ?? null
+      if (name === "data-slot") return this.dataset.slot ?? null
+      return null
+    },
+    getBoundingClientRect() {
+      return { width: 1, height: 1 }
+    },
+  }
+  return node
+}
+
+function createLeaf(html: string, text: string): NodeLike {
+  const dataset: Record<string, string> = {}
+  return {
+    dataset,
+    childNodes: [],
+    html,
+    text,
+    get innerHTML() {
+      return this.html
+    },
+    set innerHTML(value: string) {
+      this.html = value
+      this.text = value.replaceAll(/<[^>]+>/g, "")
+    },
+    get textContent() {
+      return this.text
+    },
+    set textContent(value: string) {
+      this.text = value
+      this.html = value
+    },
+    append() {},
+    replaceChildren(...nodes: NodeLike[]) {
+      this.childNodes = [...nodes]
+      this.html = nodes.map((child) => child.html || child.text).join("")
+      this.text = nodes.map((child) => child.text).join("")
+    },
+    querySelector() {
+      return null
+    },
+    getAttribute() {
+      return null
+    },
+    getBoundingClientRect() {
+      return { width: 1, height: 1 }
+    },
+  }
+}
+
+;(globalThis as any).document = {
+  createElement() {
+    return createNode()
+  },
+}
+
+function createContainer(markup: string, text: string) {
+  const container = createNode()
+  const child = createLeaf(markup, text)
+  container.childNodes = [child]
+  container.html = markup
+  container.text = text
+  return container as unknown as HTMLElement
+}
+
+describe("markdownTerminalTransitionMode", () => {
+  test("uses crossfade only after a live stream with motion allowed", () => {
+    expect(
+      markdownTerminalTransitionMode({
+        hadStreamContent: true,
+        markdownLength: 120,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("crossfade")
+  })
+
+  test("stays instant for historical renders, reduced motion, and huge replies", () => {
+    expect(
+      markdownTerminalTransitionMode({
+        hadStreamContent: false,
+        markdownLength: 120,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("instant")
+    expect(
+      markdownTerminalTransitionMode({
+        hadStreamContent: true,
+        markdownLength: 120,
+        prefersReducedMotion: true,
+      }),
+    ).toBe("instant")
+    expect(
+      markdownTerminalTransitionMode({
+        hadStreamContent: true,
+        markdownLength: MARKDOWN_TERMINAL_CROSSFADE_MAX_CHARS + 1,
+        prefersReducedMotion: false,
+      }),
+    ).toBe("instant")
+  })
+})
+
+describe("applyMarkdownTerminalCrossfade", () => {
+  test("crossfades stream DOM into terminal HTML once, then collapses to the final tree", () => {
+    const container = createContainer("<p>stream partial</p>", "stream partial")
+    const frames: Array<() => void> = []
+    const timeouts: Array<{ callback: () => void; ms: number }> = []
+    const enhancedRoots: HTMLElement[] = []
+    let enhanceLive = 0
+
+    const cleanup = applyMarkdownTerminalCrossfade({
+      container,
+      html: "<p><strong>final</strong></p>",
+      durationMs: MARKDOWN_TERMINAL_CROSSFADE_MS,
+      enhance: (root) => {
+        enhancedRoots.push(root)
+        enhanceLive += 1
+        return () => {
+          enhanceLive -= 1
+        }
+      },
+      nextFrame: (callback) => {
+        frames.push(callback)
+        return frames.length
+      },
+      cancelFrame: () => {},
+      schedule: (callback, ms) => {
+        timeouts.push({ callback, ms })
+        return timeouts.length
+      },
+      cancel: () => {},
+      prefersReducedMotion: false,
+      markdownLength: 32,
+      hadStreamContent: true,
+    })
+
+    const stage = container.querySelector('[data-slot="markdown-terminal-crossfade"]')
+    expect(stage).toBeTruthy()
+    expect(container.querySelector('[data-slot="markdown-terminal-from"]')?.textContent).toBe("stream partial")
+    expect(container.querySelector('[data-slot="markdown-terminal-to"]')?.innerHTML).toBe(
+      "<p><strong>final</strong></p>",
+    )
+    expect(enhanceLive).toBe(1)
+    expect(enhancedRoots).toHaveLength(1)
+
+    expect(frames).toHaveLength(1)
+    frames[0]!()
+    expect(stage?.getAttribute("data-active")).toBe("true")
+    expect(timeouts).toHaveLength(1)
+    expect(timeouts[0]?.ms).toBe(MARKDOWN_TERMINAL_CROSSFADE_MS)
+
+    timeouts[0]!.callback()
+    expect(container.querySelector('[data-slot="markdown-terminal-crossfade"]')).toBeNull()
+    expect(container.innerHTML).toBe("<p><strong>final</strong></p>")
+    expect(enhanceLive).toBe(1)
+    expect(enhancedRoots).toHaveLength(1)
+
+    cleanup()
+    expect(enhanceLive).toBe(0)
+  })
+
+  test("replaces instantly when reduced motion is preferred", () => {
+    const container = createContainer("<p>stream partial</p>", "stream partial")
+    let enhanceLive = 0
+
+    applyMarkdownTerminalCrossfade({
+      container,
+      html: "<p>final</p>",
+      enhance: () => {
+        enhanceLive += 1
+        return () => {
+          enhanceLive -= 1
+        }
+      },
+      prefersReducedMotion: true,
+      markdownLength: 16,
+      hadStreamContent: true,
+    })
+
+    expect(container.innerHTML).toBe("<p>final</p>")
+    expect(enhanceLive).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Crossfade from the live streaming-markdown DOM into the one-shot high-fidelity terminal render when a text/reasoning stream completes.
- Keep mid-stream rendering on the existing O(delta) path; terminal `marked`/`shiki`/`katex` still runs once at the end.
- Skip the animation for historical messages, `prefers-reduced-motion`, and replies larger than 20k characters.

## Why
Issue #364 reports an abrupt cut when streaming output finishes and the final markdown appears. Streaming intermediate rendering is already implemented; this change only softens the end-of-stream swap.

## Test plan
- [x] `cd packages/ui && bun test test/markdown-terminal-transition.test.ts test/markdown-rendering.test.ts`
- [ ] Visual: stream a medium markdown reply and confirm a short fade into highlighted/final markdown
- [ ] Visual: historical completed messages still appear instantly without a fade flash
- [ ] Visual: reduced-motion setting replaces instantly

Closes #364