### PR TITLE
fix(file-search): hard-kill hung content search processes

### DIFF
--- a/packages/synergy/src/file/ripgrep.ts
+++ b/packages/synergy/src/file/ripgrep.ts
@@ -26,7 +26,7 @@ export namespace Ripgrep {
     ])
   }
 
-  async function terminate(proc: RipgrepProcess) {
+  export async function terminate(proc: RipgrepProcess) {
     proc.kill()
     if (await waitExited(proc, TERMINATE_GRACE_MS)) return
 

--- a/packages/synergy/src/workspace-file/search.ts
+++ b/packages/synergy/src/workspace-file/search.ts
@@ -125,10 +125,72 @@ async function searchContent(input: {
   const signal = input.signal
     ? AbortSignal.any([input.signal, AbortSignal.timeout(SEARCH_TIMEOUT_MS)])
     : AbortSignal.timeout(SEARCH_TIMEOUT_MS)
-  const kill = () => proc.kill()
-  signal.addEventListener("abort", kill, { once: true })
-  const text = await new Response(proc.stdout).text().finally(() => signal.removeEventListener("abort", kill))
-  await proc.exited.catch(() => {})
+
+  const reader = proc.stdout.getReader()
+  let stoppedEarly = false
+  let terminatePromise: Promise<void> | undefined
+  const requestTerminate = () => {
+    terminatePromise ??= Ripgrep.terminate(proc)
+    return terminatePromise
+  }
+  const onAbort = () => {
+    stoppedEarly = true
+    void reader.cancel().catch(() => {})
+    void requestTerminate()
+  }
+  signal.addEventListener("abort", onAbort, { once: true })
+  if (signal.aborted) onAbort()
+
+  const decoder = new TextDecoder()
+  let text = ""
+  let reachedEnd = false
+  try {
+    while (true) {
+      if (signal.aborted) {
+        stoppedEarly = true
+        break
+      }
+      const { done, value } = await reader.read()
+      if (done) {
+        reachedEnd = !stoppedEarly && !signal.aborted
+        break
+      }
+      if (signal.aborted) {
+        stoppedEarly = true
+        break
+      }
+      text += decoder.decode(value, { stream: true })
+    }
+    if (!signal.aborted) text += decoder.decode()
+  } finally {
+    if (!reachedEnd) {
+      stoppedEarly = true
+      void reader.cancel().catch(() => {})
+      await requestTerminate()
+    }
+    try {
+      reader.releaseLock()
+    } catch {
+      // Reader may already be released after cancel.
+    }
+    try {
+      if (reachedEnd) await proc.exited.catch(() => {})
+    } finally {
+      signal.removeEventListener("abort", onAbort)
+    }
+  }
+
+  if (stoppedEarly || signal.aborted) {
+    if (input.signal?.aborted) {
+      throw input.signal.reason ?? new DOMException("Search aborted", "AbortError")
+    }
+    return {
+      kind: "content",
+      query: input.query,
+      items: [],
+      truncated: false,
+    }
+  }
 
   const offset = parseCursor(input.cursor)
   const items: WorkspaceFile.ContentSearchItem[] = []

--- a/packages/synergy/test/file/ripgrep.test.ts
+++ b/packages/synergy/test/file/ripgrep.test.ts
@@ -9,6 +9,7 @@ function rgAvailable(): boolean {
   }
 }
 import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Ripgrep } from "../../src/file/ripgrep"
 import { tmpdir } from "../fixture/fixture"
@@ -117,5 +118,39 @@ describe("Ripgrep.files", () => {
 
     // Generator completed without throwing — abort path was exercised.
     expect(controller.signal.aborted).toBe(true)
+  })
+})
+
+describe("Ripgrep.terminate", () => {
+  test.skipIf(process.platform === "win32")("escalates to SIGKILL when the process ignores SIGTERM", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const script = path.join(dir, "ignore-term.sh")
+        await Bun.write(
+          script,
+          `#!/bin/sh
+trap '' TERM
+# Busy-loop in the shell itself so SIGKILL targets the same process that owns stdout.
+while true; do :; done
+`,
+        )
+        await fs.chmod(script, 0o755)
+      },
+    })
+
+    const script = path.join(tmp.path, "ignore-term.sh")
+    const proc = Bun.spawn([script], {
+      stdout: "pipe",
+      stderr: "ignore",
+    })
+
+    const started = Date.now()
+    await Ripgrep.terminate(proc)
+    const code = await proc.exited
+    const elapsed = Date.now() - started
+
+    expect(elapsed).toBeLessThan(5_000)
+    expect(code === null || code !== 0).toBe(true)
+    expect(proc.killed || code !== 0).toBe(true)
   })
 })

--- a/packages/synergy/test/workspace-file/service.test.ts
+++ b/packages/synergy/test/workspace-file/service.test.ts
@@ -10,6 +10,7 @@ import { WorkspaceFileSearch } from "../../src/workspace-file/search"
 import { WorkspaceFileService } from "../../src/workspace-file/service"
 import { WorkspaceFileStatus } from "../../src/workspace-file/status"
 import { LSP } from "../../src/lsp"
+import { Ripgrep } from "../../src/file/ripgrep"
 import { tmpdir } from "../fixture/fixture"
 
 function isSymlinkPrivilegeError(error: unknown) {
@@ -372,6 +373,55 @@ describe("WorkspaceFileSearch", () => {
       },
     )
   })
+
+  test.skipIf(process.platform === "win32")(
+    "content search aborts and returns when the search process ignores SIGTERM",
+    async () => {
+      await using hang = await tmpdir({
+        init: async (dir) => {
+          const script = path.join(dir, "hang-rg.sh")
+          await Bun.write(
+            script,
+            `#!/bin/sh
+trap '' TERM
+# Busy-loop in the shell itself so SIGKILL targets the same process that owns stdout.
+# Response/stream consumers would hang forever if the process is not hard-killed.
+while true; do :; done
+`,
+          )
+          await fs.chmod(script, 0o755)
+        },
+      })
+
+      const hangScript = path.join(hang.path, "hang-rg.sh")
+      const originalFilepath = Ripgrep.filepath
+      ;(Ripgrep as any).filepath = async () => hangScript
+
+      try {
+        await withWorkspace(
+          async (dir) => {
+            await Bun.write(path.join(dir, "src.txt"), "needle\n")
+          },
+          async () => {
+            const controller = new AbortController()
+            const search = WorkspaceFileSearch.search({
+              kind: "content",
+              query: "needle",
+              limit: 10,
+              signal: controller.signal,
+            })
+
+            setTimeout(() => controller.abort(), 50)
+            const started = Date.now()
+            await expect(search).rejects.toMatchObject({ name: "AbortError" })
+            expect(Date.now() - started).toBeLessThan(5_000)
+          },
+        )
+      } finally {
+        ;(Ripgrep as any).filepath = originalFilepath
+      }
+    },
+  )
 
   test("reports symbol search unavailable when no LSP client is active", async () => {
     await withWorkspace(


### PR DESCRIPTION
## Summary
- Fixes #503: `file_search` content search could hang forever after abort/timeout when the spawned process ignored SIGTERM and kept stdout open.
- Export `Ripgrep.terminate` (SIGTERM → grace → SIGKILL / Windows `taskkill`) and use it from content search.
- Stream-read stdout with cancelable reader so abort returns instead of awaiting `Response.text()` forever.
- Add behavioral tests for hard-kill escalation and content-search abort with a SIGTERM-ignoring process.

## Test plan
- [x] `cd packages/synergy && bun test test/file/ripgrep.test.ts test/workspace-file/service.test.ts test/tool/file-search.test.ts`
- [x] Prettier check on changed files
- [x] CI on PR