### PR TITLE
fix: recover missing tool cards after reconnect (#509)

### DIFF
--- a/docs/architecture/frontend-data-sync.md
+++ b/docs/architecture/frontend-data-sync.md
@@ -130,9 +130,11 @@ For `ok`, the frontend applies replayed events through the same event reducer an
 
 Resources outside the normalized store, including BlueprintLoop feature state, observe `reconnectVersion` and refetch after connection recovery.
 
+Active session message/part snapshots also observe reconnect recovery. Because tool-part updates are published as unsequenced streaming events, reconnect replay alone cannot restore a missed tool card. After a reconnect, `sync.session.sync()` force-reloads the viewed session's durable message/part snapshot in addition to volatile collections.
+
 ### Current recovery limitation
 
-Reconnect replay starts from the watermark retained before the disconnect and is the reliable missed-event recovery path.
+Reconnect replay starts from the watermark retained before the disconnect and is the reliable missed-event recovery path for sequenced state events.
 
 The live gap detector currently adopts the newly received sequence before it starts `replayOrResync()`. A replay triggered only by that gap therefore starts at the new watermark rather than the pre-gap value. Maintainers must not describe live gap detection as proven backfill until the reducer retains the prior watermark for that request.
 

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -25,6 +25,7 @@ import { resolveWorkspaceTransition } from "./workspace-transition"
 import { planCompactionReplace } from "./session-compaction"
 import { observeWatermark, type Watermark } from "./sync-watermark"
 import { planBucketEviction } from "./message-eviction"
+import { describeToolPartApply } from "./session-sync-plan"
 import type { SessionWorkspace } from "@ericsanchezok/synergy-sdk/client"
 import {
   createPlanBlueprintOfferFromPart,
@@ -1056,9 +1057,31 @@ function createGlobalSync() {
         const part = event.properties.part
         const parts = store.part[part.messageID]
         if (!parts) {
+          if (part.type === "tool") {
+            console.debug("[sync] tool.part.apply", {
+              action: describeToolPartApply({ hasBucket: false, found: false }),
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              partID: part.id,
+              callID: (part as any).callID,
+              tool: (part as any).tool,
+              status: (part as any).state?.status,
+            })
+          }
           setStore("part", part.messageID, [part])
         } else {
           const result = Binary.search(parts, part.id, (p) => p.id)
+          if (part.type === "tool") {
+            console.debug("[sync] tool.part.apply", {
+              action: describeToolPartApply({ hasBucket: true, found: result.found }),
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              partID: part.id,
+              callID: (part as any).callID,
+              tool: (part as any).tool,
+              status: (part as any).state?.status,
+            })
+          }
           if (result.found) {
             // reconcile so a streaming text/tool part only touches changed
             // leaves instead of re-rendering the whole part on every delta.

--- a/packages/app/src/context/session-sync-plan.test.ts
+++ b/packages/app/src/context/session-sync-plan.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import { describeToolPartApply, planSessionSyncReload } from "./session-sync-plan"
+
+describe("planSessionSyncReload (#509)", () => {
+  test("short-circuits when session and messages are current", () => {
+    expect(
+      planSessionSyncReload({
+        hasSessionRecord: true,
+        hasMessages: true,
+        reconnectVersion: 2,
+        lastSyncedReconnectVersion: 2,
+        canUnrollback: false,
+      }),
+    ).toEqual({
+      versionStale: false,
+      needsDerivedHistoryRefresh: false,
+      forceSession: false,
+      forceMessages: false,
+      ready: true,
+    })
+  })
+
+  test("forces message snapshot reload when reconnectVersion advances", () => {
+    expect(
+      planSessionSyncReload({
+        hasSessionRecord: true,
+        hasMessages: true,
+        reconnectVersion: 3,
+        lastSyncedReconnectVersion: 2,
+        canUnrollback: false,
+      }),
+    ).toEqual({
+      versionStale: true,
+      needsDerivedHistoryRefresh: false,
+      forceSession: true,
+      forceMessages: true,
+      ready: false,
+    })
+  })
+
+  test("forces both loads on first sync after reconnect tracking starts", () => {
+    expect(
+      planSessionSyncReload({
+        hasSessionRecord: true,
+        hasMessages: true,
+        reconnectVersion: 0,
+        lastSyncedReconnectVersion: undefined,
+        canUnrollback: false,
+      }),
+    ).toMatchObject({
+      versionStale: true,
+      forceSession: true,
+      forceMessages: true,
+      ready: false,
+    })
+  })
+
+  test("loads missing messages without treating them as a reconnect", () => {
+    expect(
+      planSessionSyncReload({
+        hasSessionRecord: true,
+        hasMessages: false,
+        reconnectVersion: 1,
+        lastSyncedReconnectVersion: 1,
+        canUnrollback: false,
+      }),
+    ).toEqual({
+      versionStale: false,
+      needsDerivedHistoryRefresh: false,
+      forceSession: false,
+      forceMessages: true,
+      ready: false,
+    })
+  })
+
+  test("refreshes when unrollback history requires a derived reload", () => {
+    expect(
+      planSessionSyncReload({
+        hasSessionRecord: true,
+        hasMessages: true,
+        reconnectVersion: 4,
+        lastSyncedReconnectVersion: 4,
+        canUnrollback: true,
+      }),
+    ).toMatchObject({
+      needsDerivedHistoryRefresh: true,
+      forceSession: true,
+      forceMessages: true,
+      ready: false,
+    })
+  })
+})
+
+describe("describeToolPartApply", () => {
+  test("labels create/insert/reconcile actions for diagnostics", () => {
+    expect(describeToolPartApply({ hasBucket: false, found: false })).toBe("create-bucket")
+    expect(describeToolPartApply({ hasBucket: true, found: false })).toBe("insert")
+    expect(describeToolPartApply({ hasBucket: true, found: true })).toBe("reconcile")
+  })
+})

--- a/packages/app/src/context/session-sync-plan.ts
+++ b/packages/app/src/context/session-sync-plan.ts
@@ -1,0 +1,42 @@
+export type SessionSyncPlanInput = {
+  hasSessionRecord: boolean
+  hasMessages: boolean
+  reconnectVersion: number
+  lastSyncedReconnectVersion: number | undefined
+  canUnrollback: boolean
+}
+
+export type SessionSyncPlan = {
+  versionStale: boolean
+  needsDerivedHistoryRefresh: boolean
+  forceSession: boolean
+  forceMessages: boolean
+  ready: boolean
+}
+
+/**
+ * Decide whether session metadata and/or durable message/part snapshots must be
+ * re-fetched. Tool parts publish as unsequenced streaming events, so reconnect
+ * recovery cannot rely on event replay alone (issue #509).
+ */
+export function planSessionSyncReload(input: SessionSyncPlanInput): SessionSyncPlan {
+  const versionStale = input.lastSyncedReconnectVersion !== input.reconnectVersion
+  const needsDerivedHistoryRefresh = input.canUnrollback
+  const forceSession = !input.hasSessionRecord || versionStale || needsDerivedHistoryRefresh
+  const forceMessages = !input.hasMessages || versionStale || needsDerivedHistoryRefresh
+  const ready = input.hasSessionRecord && input.hasMessages && !versionStale && !needsDerivedHistoryRefresh
+  return {
+    versionStale,
+    needsDerivedHistoryRefresh,
+    forceSession,
+    forceMessages,
+    ready,
+  }
+}
+
+export type ToolPartApplyAction = "create-bucket" | "insert" | "reconcile"
+
+export function describeToolPartApply(input: { hasBucket: boolean; found: boolean }): ToolPartApplyAction {
+  if (!input.hasBucket) return "create-bucket"
+  return input.found ? "reconcile" : "insert"
+}

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -9,6 +9,7 @@ import type { Message, Part, PermissionRequest, Session } from "@ericsanchezok/s
 import { refreshPlanBlueprintOfferFromLoadedParts, updatePlanBlueprintOfferState } from "./global-sync"
 import { createSessionMessageLoader, type SessionMessageLoadState } from "./session-message-loader"
 import { requestErrorMessage } from "@/utils/error"
+import { planSessionSyncReload } from "./session-sync-plan"
 
 type RefreshOptions = { force?: boolean }
 type SessionSyncOptions = { refreshVolatile?: boolean }
@@ -33,13 +34,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       loading: {} as Record<string, boolean>,
       messageLoad: {} as Record<string, SessionMessageLoadState>,
     })
-    // Track the reconnectVersion at the time of each session's last explicit
-    // load, so we can force a re-fetch after a backend restart — whose
-    // in-memory state the server cannot replay via events. Follows the same
-    // pattern as blueprint loop refetch (issue #331). Without this, a session
-    // that was already in the store before the restart short-circuits
-    // sync.session.sync() and never refreshes persisted metadata such as
-    // workflow kind (plan/lightloop/lattice), causing mode chips to disappear.
+    // Track the reconnectVersion at the time of each session's last successful
+    // message/part snapshot load. After reconnect, force both session metadata
+    // and durable message/part reloads: tool parts publish as unsequenced
+    // streaming events, so event replay alone cannot restore a missed tool card
+    // (issue #509). Session metadata still follows the same restart pattern as
+    // blueprint loop refetch (issue #331).
     const sessionReconnectVersions = new Map<string, number>()
 
     const getSession = (sessionID: string) => {
@@ -107,8 +107,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       await retry(() => sdk.client.session.get({ sessionID })).then((session) => {
         if (!session.data) return
         upsertSession(session.data)
-        sessionReconnectVersions.set(sessionID, globalSync.reconnectVersion())
       })
+    }
+
+    const markSessionSynced = (sessionID: string) => {
+      sessionReconnectVersions.set(sessionID, globalSync.reconnectVersion())
     }
 
     type SessionMessagesResponse = Awaited<ReturnType<(typeof sdk.client.session)["messages"]>>
@@ -158,11 +161,15 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const loadMessages = (sessionID: string, limit: number, options?: { force?: boolean }) =>
-      messageLoader.load(sessionID, {
-        force: options?.force,
-        hasSnapshot: store.message[sessionID] !== undefined,
-        input: { limit },
-      })
+      messageLoader
+        .load(sessionID, {
+          force: options?.force,
+          hasSnapshot: store.message[sessionID] !== undefined,
+          input: { limit },
+        })
+        .then(() => {
+          markSessionSynced(sessionID)
+        })
 
     const loadInbox = (sessionID: string, options?: RefreshOptions) => {
       if (!options?.force && store.inbox[sessionID] !== undefined) return
@@ -321,37 +328,37 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
                 setStore("permission", sessionID, reconcile(entries, { key: "id" }))
               })
               .catch(() => {})
-
-          // Force a session reload after a backend restart, whose in-memory
-          // state the server cannot replay via events (same pattern as issue
-          // #331 for blueprint loops). Without this, sync() short-circuits
-          // because hasSession is true from the stale pre-restart store copy,
-          // and persisted fields such as workflow kind (plan/lightloop/lattice)
-          // never refresh — causing mode chips to disappear.
+          // Force session/message reloads after reconnect or backend restart.
+          // Session metadata alone is not enough: tool parts publish as
+          // unsequenced streaming events, so reconnect recovery must re-fetch
+          // durable message/part snapshots too (issue #509 / #331).
           const currentReconnectVersion = globalSync.reconnectVersion()
-          const versionStale = sessionReconnectVersions.get(sessionID) !== currentReconnectVersion
-
           const session = getSession(sessionID)
-          const hasSession = session !== undefined && !versionStale
-          const needsDerivedHistoryRefresh = session?.history?.rollback?.canUnrollback === true
           hydrateMessages(sessionID)
-
-          const hasMessages = store.message[sessionID] !== undefined
-          const ready = hasSession && hasMessages && !needsDerivedHistoryRefresh
-          const pending = ready ? undefined : inflight.get(sessionID)
+          const plan = planSessionSyncReload({
+            hasSessionRecord: session !== undefined,
+            hasMessages: store.message[sessionID] !== undefined,
+            reconnectVersion: currentReconnectVersion,
+            lastSyncedReconnectVersion: sessionReconnectVersions.get(sessionID),
+            canUnrollback: session?.history?.rollback?.canUnrollback === true,
+          })
+          const pending = plan.ready ? undefined : inflight.get(sessionID)
           const baseReq =
             pending ??
-            (ready
+            (plan.ready
               ? Promise.resolve()
               : (() => {
                   const limit = meta.limit[sessionID] ?? chunk
-                  const sessionReq =
-                    hasSession && !needsDerivedHistoryRefresh
-                      ? Promise.resolve()
-                      : loadSession(sessionID, { force: needsDerivedHistoryRefresh || versionStale })
-                  const messagesReq = hasMessages ? Promise.resolve() : loadMessages(sessionID, limit)
+                  const sessionReq = plan.forceSession ? loadSession(sessionID, { force: true }) : Promise.resolve()
+                  const messagesReq = plan.forceMessages
+                    ? loadMessages(sessionID, limit, { force: true })
+                    : Promise.resolve()
                   const promise = Promise.all([sessionReq, messagesReq])
-                    .then(() => {})
+                    .then(() => {
+                      // Session-only reloads (no message fetch) still advance the
+                      // reconnect watermark so later sync() calls can short-circuit.
+                      if (!plan.forceMessages) markSessionSynced(sessionID)
+                    })
                     .finally(() => {
                       inflight.delete(sessionID)
                     })

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -648,11 +648,7 @@ export namespace Server {
               })
               const payload = event?.payload
               const part = payload?.properties?.part
-              if (
-                result.dropped > 0 &&
-                payload?.type === "message.part.updated" &&
-                part?.type === "tool"
-              ) {
+              if (result.dropped > 0 && payload?.type === "message.part.updated" && part?.type === "tool") {
                 log.warn("global event ws tool part send failed", {
                   sessionID: part.sessionID,
                   messageID: part.messageID,

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -655,7 +655,21 @@ export namespace Server {
               for (const [client, mode] of globalEventClients) {
                 try {
                   client.send(mode === "delta" ? deltaEncoding() : fullEncoding())
-                } catch {
+                } catch (error) {
+                  const payload = event?.payload
+                  const part = payload?.properties?.part
+                  if (payload?.type === "message.part.updated" && part?.type === "tool") {
+                    log.warn("global event ws tool part send failed", {
+                      sessionID: part.sessionID,
+                      messageID: part.messageID,
+                      partID: part.id,
+                      callID: part.callID,
+                      tool: part.tool,
+                      status: part.state?.status,
+                      mode,
+                      error,
+                    })
+                  }
                   globalEventClients.delete(client)
                 }
               }

--- a/packages/synergy/src/session/index.ts
+++ b/packages/synergy/src/session/index.ts
@@ -1004,6 +1004,21 @@ export namespace Session {
       // do not need to advance the cache — the terminal write for each part does.
       SessionMessageCache.upsertPart(part.sessionID, part)
     }
+    if (part.type === "tool") {
+      // Tool parts are published as unsequenced streaming events. Keep a
+      // durable breadcrumb so missing frontend cards can be correlated with
+      // backend settlement (issue #509).
+      const tool = part as MessageV2.ToolPart
+      log.info("tool.part.publish", {
+        sessionID: tool.sessionID,
+        messageID: tool.messageID,
+        partID: tool.id,
+        callID: tool.callID,
+        tool: tool.tool,
+        status: tool.state.status,
+        durable: delta === undefined,
+      })
+    }
     Bus.publish(MessageV2.Event.PartUpdated, {
       part,
       delta,


### PR DESCRIPTION
## Summary
- Force-reload durable session message/part snapshots when `reconnectVersion` advances, so missed unsequenced tool-part events can self-heal after reconnect.
- Add tool-part publish/apply diagnostics on the backend and frontend to correlate missing cards with settlement/delivery.
- Document the reconnect message/part recovery path in frontend data sync architecture.

## Why
Tool parts are published as streaming `message.part.updated` events (no seq/journal). Reconnect previously refreshed session metadata and volatile state, but skipped message/part snapshots when they were already loaded, leaving randomly missing tool cards until a manual refresh.

## Test plan
- [x] `bun test src/context/session-sync-plan.test.ts` (packages/app)
- [x] `bun test src/context/session-message-loader.test.ts` (packages/app)
- [x] `bun test src/context/sync-watermark.test.ts` (packages/app)
- [ ] Manual: break WebSocket during tool execution, reconnect, confirm completed tool card appears without hard refresh
- [ ] Manual: inspect logs for `tool.part.publish` / `[sync] tool.part.apply` during a normal tool call

Closes #509