### PR TITLE
fix: bound experience encoder LLM streams (#560)

### DIFF
--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -833,6 +833,18 @@ export const Learning = z
       .min(0)
       .optional()
       .describe("LLM retry count for intent/script/reward generation (default: 3)"),
+    encoderTimeoutMs: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Wall-clock deadline for a single encoder LLM call in milliseconds (default: 60000)"),
+    encoderMaxOutputChars: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Maximum characters collected from one encoder model stream before abort (default: 16000)"),
     digestToolOutputBudget: z
       .number()
       .int()
@@ -914,6 +926,8 @@ export const LEARNING_DEFAULTS = {
   snapThreshold: 0.5,
   legacyRewardConfidence: 0.3,
   encoderRetries: 3,
+  encoderTimeoutMs: 60_000,
+  encoderMaxOutputChars: 16_000,
   digestToolOutputBudget: 800,
   encoderToolFieldBudget: 500,
   encoderToolOutputBudget: 300,

--- a/packages/synergy/src/library/encoder-constants.ts
+++ b/packages/synergy/src/library/encoder-constants.ts
@@ -18,3 +18,9 @@ export const SCRIPT_MIN_CHARS = 20
 
 /** Minimum numbered steps required in a valid trajectory script. */
 export const SCRIPT_MIN_STEPS = 2
+
+/** Wall-clock deadline for a single encoder LLM call (intent/script/reward). */
+export const ENCODER_LLM_TIMEOUT_MS = 60_000
+
+/** Maximum characters collected from one encoder model stream before aborting. */
+export const ENCODER_MAX_OUTPUT_CHARS = 16_000

--- a/packages/synergy/src/library/experience-encoder.ts
+++ b/packages/synergy/src/library/experience-encoder.ts
@@ -6,7 +6,7 @@ import { ExperienceRecall } from "./experience-recall"
 import { Intent } from "./intent"
 import { Script } from "./script"
 import { Agent } from "../agent/agent"
-import { INTENT_MAX_CHARS } from "./encoder-constants"
+import { ENCODER_LLM_TIMEOUT_MS, ENCODER_MAX_OUTPUT_CHARS, INTENT_MAX_CHARS } from "./encoder-constants"
 import { Provider } from "../provider/provider"
 import { LLM } from "../session/llm"
 import { Turn } from "../session/turn"
@@ -15,6 +15,7 @@ import { Scope } from "../scope"
 import { Log } from "../util/log"
 import { Config } from "../config/config"
 import { Plugin } from "../plugin"
+import { withTimeout } from "../util/timeout"
 import { createHash } from "crypto"
 
 export namespace ExperienceEncoder {
@@ -453,6 +454,37 @@ export namespace ExperienceEncoder {
     learning: Required<Config.Learning>
   }
 
+  export class EncoderStreamError extends Error {
+    readonly code: "timeout" | "oversized" | "aborted" | "stream"
+
+    constructor(code: EncoderStreamError["code"], message: string) {
+      super(message)
+      this.name = "EncoderStreamError"
+      this.code = code
+    }
+  }
+
+  export async function collectBoundedText(input: {
+    textStream: AsyncIterable<string>
+    maxChars: number
+    abort?: AbortController
+  }): Promise<string> {
+    let text = ""
+    for await (const chunk of input.textStream) {
+      if (!chunk) continue
+      text += chunk
+      if (text.length > input.maxChars) {
+        input.abort?.abort()
+        throw new EncoderStreamError("oversized", `encoder stream exceeded ${input.maxChars} characters`)
+      }
+    }
+    return text
+  }
+
+  export async function callAgentForTest(agentName: string, ctx: AgentContext, content: string): Promise<string> {
+    return callAgent(agentName, ctx, content)
+  }
+
   async function callAgent(agentName: string, ctx: AgentContext, content: string): Promise<string> {
     const agent = await Agent.get(agentName)
     if (!agent || !ctx.userMsg) return ""
@@ -461,19 +493,48 @@ export namespace ExperienceEncoder {
     const model = agentModel ? await Provider.getModel(agentModel.providerID, agentModel.modelID) : ctx.model
     if (!model) return ""
 
-    const stream = await LLM.stream({
-      agent,
-      user: ctx.userMsg,
-      tools: {},
-      model,
-      small: true,
-      messages: [{ role: "user" as const, content }],
-      abort: new AbortController().signal,
-      sessionID: ctx.sessionID,
-      system: [],
-      retries: ctx.learning.encoderRetries,
-    })
-    return (await stream.text.catch(() => "")) ?? ""
+    const timeoutMs = ctx.learning.encoderTimeoutMs ?? ENCODER_LLM_TIMEOUT_MS
+    const maxChars = ctx.learning.encoderMaxOutputChars ?? ENCODER_MAX_OUTPUT_CHARS
+    const abort = new AbortController()
+    const timeout = AbortSignal.timeout(timeoutMs)
+    const onTimeout = () => abort.abort()
+    timeout.addEventListener("abort", onTimeout, { once: true })
+
+    try {
+      const stream = await LLM.stream({
+        agent,
+        user: ctx.userMsg,
+        tools: {},
+        model,
+        small: true,
+        messages: [{ role: "user" as const, content }],
+        abort: abort.signal,
+        sessionID: ctx.sessionID,
+        system: [],
+        retries: ctx.learning.encoderRetries,
+      })
+
+      const textStream =
+        stream.textStream ??
+        (async function* () {
+          yield await stream.text
+        })()
+
+      return await withTimeout(collectBoundedText({ textStream, maxChars, abort }), timeoutMs, {
+        message: `encoder ${agentName} timed out after ${timeoutMs}ms`,
+      })
+    } catch (error) {
+      if (error instanceof EncoderStreamError) throw error
+      if (abort.signal.aborted || timeout.aborted) {
+        throw new EncoderStreamError("timeout", `encoder ${agentName} timed out after ${timeoutMs}ms`)
+      }
+      if (error instanceof Error && /timed out/i.test(error.message)) {
+        throw new EncoderStreamError("timeout", error.message)
+      }
+      throw error
+    } finally {
+      timeout.removeEventListener("abort", onTimeout)
+    }
   }
 
   async function generateIntent(ctx: AgentContext, history: string | undefined, userInput: string): Promise<string> {

--- a/packages/synergy/test/library/experience-encoder-bounds.test.ts
+++ b/packages/synergy/test/library/experience-encoder-bounds.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { Agent } from "../../src/agent/agent"
+import { Config } from "../../src/config/config"
+import { ExperienceEncoder } from "../../src/library/experience-encoder"
+import { Provider } from "../../src/provider/provider"
+import { LLM } from "../../src/session/llm"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+const originalAgentGet = Agent.get
+const originalAgentModel = Agent.getAvailableModel
+const originalProviderGetModel = Provider.getModel
+const originalStream = LLM.stream
+
+afterEach(() => {
+  ;(Agent.get as any) = originalAgentGet
+  ;(Agent.getAvailableModel as any) = originalAgentModel
+  ;(Provider.getModel as any) = originalProviderGetModel
+  ;(LLM.stream as any) = originalStream
+})
+
+function installAgentMocks() {
+  ;(Agent.get as any) = mock(async () => ({ name: "script", prompt: "script" }))
+  ;(Agent.getAvailableModel as any) = mock(async () => ({ providerID: "test", modelID: "test-model" }))
+  ;(Provider.getModel as any) = mock(async () => ({
+    id: "test-model",
+    providerID: "test",
+    modelID: "test-model",
+  }))
+}
+
+function agentContext(overrides: Partial<Config.Learning> = {}) {
+  return {
+    sessionID: "ses_test",
+    userMsg: {
+      id: "msg_user",
+      sessionID: "ses_test",
+      role: "user",
+      time: { created: Date.now() },
+      model: { providerID: "test", modelID: "test-model" },
+    } as MessageV2.User,
+    model: {
+      id: "test-model",
+      providerID: "test",
+      modelID: "test-model",
+    } as unknown as Provider.Model,
+    learning: {
+      ...Config.LEARNING_DEFAULTS,
+      rewardWeights: { ...Config.REWARD_WEIGHT_DEFAULTS },
+      ...overrides,
+    } as Required<Config.Learning>,
+  }
+}
+
+describe("ExperienceEncoder stream bounds", () => {
+  test("collectBoundedText aborts oversized streams", async () => {
+    const abort = new AbortController()
+    const stream = (async function* () {
+      yield "1. step one\n"
+      yield "x".repeat(100)
+      yield "still more"
+    })()
+
+    await expect(
+      ExperienceEncoder.collectBoundedText({
+        textStream: stream,
+        maxChars: 50,
+        abort,
+      }),
+    ).rejects.toMatchObject({
+      name: "EncoderStreamError",
+      code: "oversized",
+    })
+    expect(abort.signal.aborted).toBe(true)
+  })
+
+  test("collectBoundedText returns complete bounded text", async () => {
+    const stream = (async function* () {
+      yield "1. Inspect the failing path\n"
+      yield "2. Bound the encoder stream\n"
+      yield "3. Record encoding_failed on timeout\n"
+    })()
+
+    await expect(
+      ExperienceEncoder.collectBoundedText({
+        textStream: stream,
+        maxChars: 1_000,
+      }),
+    ).resolves.toBe("1. Inspect the failing path\n2. Bound the encoder stream\n3. Record encoding_failed on timeout\n")
+  })
+
+  test("callAgent fails closed on oversized script streams", async () => {
+    installAgentMocks()
+    let aborted = false
+    ;(LLM.stream as any) = mock(async (input: { abort: AbortSignal }) => {
+      input.abort.addEventListener("abort", () => {
+        aborted = true
+      })
+      return {
+        textStream: (async function* () {
+          yield "1. start\n"
+          yield "x".repeat(200)
+          if (input.abort.aborted) return
+          yield "should not be collected"
+        })(),
+        text: Promise.resolve("unused"),
+      }
+    })
+
+    await expect(
+      ExperienceEncoder.callAgentForTest("script", agentContext({ encoderMaxOutputChars: 50 }), "raw conversation"),
+    ).rejects.toMatchObject({
+      name: "EncoderStreamError",
+      code: "oversized",
+    })
+    expect(aborted).toBe(true)
+  })
+
+  test("callAgent fails closed when the stream never finishes", async () => {
+    installAgentMocks()
+    ;(LLM.stream as any) = mock(async () => {
+      return {
+        textStream: (async function* () {
+          yield "1. partial\n"
+          await new Promise(() => {})
+        })(),
+        text: new Promise<string>(() => {}),
+      }
+    })
+
+    await expect(
+      ExperienceEncoder.callAgentForTest("script", agentContext({ encoderTimeoutMs: 40 }), "raw conversation"),
+    ).rejects.toMatchObject({
+      name: "EncoderStreamError",
+      code: "timeout",
+    })
+  })
+
+  test("learning defaults expose encoder timeout and output bounds", () => {
+    expect(Config.LEARNING_DEFAULTS.encoderTimeoutMs).toBe(60_000)
+    expect(Config.LEARNING_DEFAULTS.encoderMaxOutputChars).toBe(16_000)
+  })
+})


### PR DESCRIPTION
## Summary
- Bound Library Experience encoder LLM calls with a wall-clock deadline (`encoderTimeoutMs`, default 60s) and hard collected-output cap (`encoderMaxOutputChars`, default 16k).
- Collect encoder text incrementally and abort oversized/stalled streams as fail-closed `EncoderStreamError`s instead of unbounded `stream.text` accumulation.
- Keep existing encode failure path (`insertFailed` / `encoding_failed`) so a bad script stream cannot hang the main process or health checks.

## Context
Fixes #560. The failure boundary was after the script provider returned HTTP 200 and before `script generated`, where `callAgent()` awaited unbounded `stream.text` with a never-aborted signal.

## Test plan
- [x] `cd packages/synergy && bun test test/library/experience-encoder-bounds.test.ts`
- [x] `cd packages/synergy && bun test test/library/script.test.ts test/library/intent.test.ts`
- [ ] Manual: complete a top-level session with experience encoding enabled and confirm script generation either completes or fails closed without CPU/memory runaway