### PR TITLE
fix(app): toast mute switch responds and applies immediately

### DIFF
--- a/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
@@ -148,4 +148,38 @@ describe("settings config patch", () => {
       }).experimental,
     ).toEqual({ coauthor_reminder: true })
   })
+
+  test("persists toast mute and duration preferences on the general domain", () => {
+    const state = defaultSettingsState("enter")
+    state.general.mutedToasts = ["info", "success"]
+    state.general.toastDurations.warning = "2500"
+
+    expect(
+      buildPatch({
+        cfg: {} as Config,
+        state,
+        originalMcps: {},
+      }).toast,
+    ).toEqual({
+      muted: ["info", "success"],
+      durationOverrides: { warning: 2000 },
+    })
+  })
+
+  test("clears toast config when mute and duration overrides return to defaults", () => {
+    const state = defaultSettingsState("enter")
+
+    expect(
+      buildPatch({
+        cfg: {
+          toast: {
+            muted: ["error"],
+            durationOverrides: { info: 1000 },
+          },
+        } as Config,
+        state,
+        originalMcps: {},
+      }).toast,
+    ).toBeUndefined()
+  })
 })

--- a/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.test.ts
@@ -166,8 +166,49 @@ describe("settings config patch", () => {
     })
   })
 
-  test("clears toast config when mute and duration overrides return to defaults", () => {
+  test("unmuting the last toast type sends muted:[] so domain merge can clear it", () => {
     const state = defaultSettingsState("enter")
+
+    expect(
+      buildPatch({
+        cfg: {
+          toast: {
+            muted: ["info"],
+          },
+        } as Config,
+        state,
+        originalMcps: {},
+      }).toast,
+    ).toEqual({
+      muted: [],
+    })
+  })
+
+  test("unmuting one type while duration overrides remain still clears that muted entry", () => {
+    const state = defaultSettingsState("enter")
+    state.general.toastDurations.warning = "2500"
+
+    expect(
+      buildPatch({
+        cfg: {
+          toast: {
+            muted: ["info"],
+            durationOverrides: { warning: 2000 },
+          },
+        } as Config,
+        state,
+        originalMcps: {},
+      }).toast,
+    ).toEqual({
+      muted: [],
+      durationOverrides: { warning: 2000 },
+    })
+  })
+
+  test("does not emit toast patch when mute and duration preferences are unchanged", () => {
+    const state = defaultSettingsState("enter")
+    state.general.mutedToasts = ["error"]
+    state.general.toastDurations.info = "1000"
 
     expect(
       buildPatch({

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@ericsanchezok/synergy-sdk/client"
-import { MODEL_ROLES, TOAST_TYPES, UI_DEFAULTS, resolvePermissionForUi, snapToastDuration } from "../types"
+import { UI_DEFAULTS, MODEL_ROLES, resolvePermissionForUi } from "../types"
+import { toastConfigFromPreferences } from "../toast-preferences"
 import type { SettingsState } from "../types"
 
 export type BuildPatchParams = {
@@ -37,7 +38,7 @@ function buildGeneralPatch(cfg: Config, state: SettingsState, patch: Record<stri
   const theme = general.theme.trim()
   if (theme !== (cfg.theme ?? UI_DEFAULTS.theme)) patch.theme = theme || undefined
 
-  const toast = buildToastPatch(general.mutedToasts, general.toastDurations)
+  const toast = toastConfigFromPreferences(general.mutedToasts, general.toastDurations) ?? {}
   if (JSON.stringify(toast) !== JSON.stringify(cfg.toast ?? {})) {
     patch.toast = Object.keys(toast).length ? toast : undefined
   }
@@ -376,31 +377,6 @@ function buildLibraryPatch(cfg: Config, state: SettingsState, patch: Record<stri
   nextLibrary.autonomy = library.autonomy !== "false"
 
   patch.library = nextLibrary
-}
-
-function buildToastPatch(
-  muted: string[],
-  durations: SettingsState["general"]["toastDurations"],
-): Record<string, unknown> {
-  const toast: Record<string, unknown> = {}
-  const normalizedMuted = muted.filter((value) => ["info", "success", "warning", "error"].includes(value))
-  if (normalizedMuted.length) toast.muted = normalizedMuted
-  const durationOverrides = parseToastDurations(durations)
-  if (Object.keys(durationOverrides).length) toast.durationOverrides = durationOverrides
-  return toast
-}
-
-function parseToastDurations(durations: SettingsState["general"]["toastDurations"]): Record<string, number> {
-  const result: Record<string, number> = {}
-  for (const type of TOAST_TYPES) {
-    const raw = durations[type]
-    if (!raw.trim()) continue
-    const parsed = Number(raw)
-    if (!Number.isNaN(parsed) && Number.isInteger(parsed) && parsed > 0 && parsed <= 30000) {
-      result[type] = snapToastDuration(parsed)
-    }
-  }
-  return result
 }
 
 function parseList(value: string): string[] {

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -1,6 +1,6 @@
 import type { Config } from "@ericsanchezok/synergy-sdk/client"
 import { UI_DEFAULTS, MODEL_ROLES, resolvePermissionForUi } from "../types"
-import { toastConfigFromPreferences } from "../toast-preferences"
+import { normalizeServerToast, toastPatchFromPreferences } from "../toast-preferences"
 import type { SettingsState } from "../types"
 
 export type BuildPatchParams = {
@@ -38,9 +38,11 @@ function buildGeneralPatch(cfg: Config, state: SettingsState, patch: Record<stri
   const theme = general.theme.trim()
   if (theme !== (cfg.theme ?? UI_DEFAULTS.theme)) patch.theme = theme || undefined
 
-  const toast = toastConfigFromPreferences(general.mutedToasts, general.toastDurations) ?? {}
-  if (JSON.stringify(toast) !== JSON.stringify(cfg.toast ?? {})) {
-    patch.toast = Object.keys(toast).length ? toast : undefined
+  const toast = toastPatchFromPreferences(general.mutedToasts, general.toastDurations)
+  const current = normalizeServerToast(cfg.toast) ?? { muted: [] }
+  // Always include muted so domain mergeDeep can replace/clear the array.
+  if (JSON.stringify(toast) !== JSON.stringify(current)) {
+    patch.toast = toast
   }
 }
 

--- a/packages/app/src/components/settings/hooks/useSettingsSave.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsSave.ts
@@ -1,7 +1,7 @@
 import { createEffect, createSignal, onCleanup } from "solid-js"
 import type { ConfigDomainSummary } from "@ericsanchezok/synergy-sdk/client"
 import { useGlobalSDK } from "@/context/global-sdk"
-import { showToast } from "@ericsanchezok/synergy-ui/toast"
+import { getToastConfig, showToast } from "@ericsanchezok/synergy-ui/toast"
 import type { ConfirmOptions } from "@/components/dialog/confirm-dialog"
 import { discardSettingsConfirm } from "@/components/dialog/confirm-copy"
 import { groupPatchByDomain, strategyForPatch } from "../domain-routing"
@@ -96,11 +96,13 @@ export function useSettingsSave(ctx: SaveContext) {
       bgResetTimer = setTimeout(() => {
         if (saveGen === gen) setBgStatus("idle")
       }, 2000)
-      showToast({
-        type: "success",
-        title: `Saved ${ctx.editingLabel()}`,
-        description: `Updated: ${Object.keys(patch).join(", ")}`,
-      })
+      if (!getToastConfig()?.muted?.includes("success")) {
+        showToast({
+          type: "success",
+          title: `Saved ${ctx.editingLabel()}`,
+          description: `Updated: ${Object.keys(patch).join(", ")}`,
+        })
+      }
     } catch (error: any) {
       if (saveGen !== gen) return
       setBgStatus("error")

--- a/packages/app/src/components/settings/panels/GeneralPanel.markup.test.ts
+++ b/packages/app/src/components/settings/panels/GeneralPanel.markup.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+describe("GeneralPanel toast mute markup", () => {
+  test("does not nest Kobalte Switch inside a native label", () => {
+    const source = readFileSync(join(import.meta.dir, "GeneralPanel.tsx"), "utf8")
+    expect(source).toContain('<div class="settings-muted-toggle">')
+    expect(source).not.toMatch(/<label class="settings-muted-toggle">/)
+    expect(source).toContain("setToastConfig")
+    expect(source).toContain("toastConfigFromPreferences")
+    expect(source).toContain("nextMutedToasts")
+  })
+})

--- a/packages/app/src/components/settings/panels/GeneralPanel.tsx
+++ b/packages/app/src/components/settings/panels/GeneralPanel.tsx
@@ -3,6 +3,7 @@ import { Button } from "@ericsanchezok/synergy-ui/button"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { getSemanticIcon, type SemanticIconTokenName } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { Switch } from "@ericsanchezok/synergy-ui/switch"
+import { setToastConfig } from "@ericsanchezok/synergy-ui/toast"
 import { useTheme, type ColorScheme } from "@ericsanchezok/synergy-ui/theme"
 import { useProductUpdate } from "@/context/product-update"
 import type { DesktopUpdateMode } from "@/context/platform"
@@ -24,6 +25,7 @@ import {
   type GeneralStore,
   type ToastType,
 } from "../types"
+import { nextMutedToasts, toastConfigFromPreferences } from "../toast-preferences"
 
 const colorSchemeOptions: Array<{
   value: ColorScheme
@@ -56,18 +58,19 @@ export function GeneralPanel(props: {
     theme.setThemeId(themeId)
   }
 
-  function toggleMutedToast(type: ToastType, enabled: boolean) {
-    const next = enabled
-      ? [...props.general.mutedToasts, type]
-      : props.general.mutedToasts.filter((item) => item !== type)
-    props.onGeneralChange("mutedToasts", Array.from(new Set(next)))
+  function toggleMutedToast(type: ToastType, mutedEnabled: boolean) {
+    const next = nextMutedToasts(props.general.mutedToasts, type, mutedEnabled)
+    props.onGeneralChange("mutedToasts", next)
+    setToastConfig(toastConfigFromPreferences(next, props.general.toastDurations))
   }
 
   function setToastDuration(type: ToastType, value: string) {
-    props.onGeneralChange("toastDurations", {
+    const next = {
       ...props.general.toastDurations,
       [type]: value,
-    })
+    }
+    props.onGeneralChange("toastDurations", next)
+    setToastConfig(toastConfigFromPreferences(props.general.mutedToasts, next))
   }
 
   return (
@@ -298,12 +301,12 @@ function ToastPreferenceRow(props: {
       </div>
 
       <div class="settings-toast-controls">
-        <label class="settings-muted-toggle">
-          <span>Mute</span>
+        <div class="settings-muted-toggle">
+          <span aria-hidden="true">Mute</span>
           <Switch checked={props.muted} hideLabel onChange={props.onMutedChange}>
             Mute {copy().label}
           </Switch>
-        </label>
+        </div>
 
         <div class="settings-duration-control">
           <div class="settings-duration-header">

--- a/packages/app/src/components/settings/toast-preferences.test.ts
+++ b/packages/app/src/components/settings/toast-preferences.test.ts
@@ -4,6 +4,7 @@ import {
   parseToastDurationOverrides,
   toastConfigFromPreferences,
   toastConfigFromServerToast,
+  toastPatchFromPreferences,
 } from "./toast-preferences"
 import { emptyToastDurationOverrides } from "./types"
 
@@ -24,6 +25,23 @@ describe("toast preference helpers", () => {
       durationOverrides: { warning: 2000 },
     })
     expect(toastConfigFromPreferences([], emptyToastDurationOverrides())).toBeUndefined()
+  })
+
+  test("domain patch always includes muted so unmute can clear mergeDeep state", () => {
+    expect(toastPatchFromPreferences([], emptyToastDurationOverrides())).toEqual({
+      muted: [],
+    })
+
+    const durations = emptyToastDurationOverrides()
+    durations.warning = "2500"
+    expect(toastPatchFromPreferences([], durations)).toEqual({
+      muted: [],
+      durationOverrides: { warning: 2000 },
+    })
+    expect(toastPatchFromPreferences(["info"], durations)).toEqual({
+      muted: ["info"],
+      durationOverrides: { warning: 2000 },
+    })
   })
 
   test("parses only valid positive toast duration overrides", () => {

--- a/packages/app/src/components/settings/toast-preferences.test.ts
+++ b/packages/app/src/components/settings/toast-preferences.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import {
+  nextMutedToasts,
+  parseToastDurationOverrides,
+  toastConfigFromPreferences,
+  toastConfigFromServerToast,
+} from "./toast-preferences"
+import { emptyToastDurationOverrides } from "./types"
+
+describe("toast preference helpers", () => {
+  test("adds and removes muted toast types without duplicates", () => {
+    expect(nextMutedToasts([], "info", true)).toEqual(["info"])
+    expect(nextMutedToasts(["info"], "info", true)).toEqual(["info"])
+    expect(nextMutedToasts(["info", "error"], "info", false)).toEqual(["error"])
+    expect(nextMutedToasts(["info", "not-a-type"], "success", true)).toEqual(["info", "success"])
+  })
+
+  test("builds runtime toast config from form state", () => {
+    const durations = emptyToastDurationOverrides()
+    durations.warning = "2500"
+
+    expect(toastConfigFromPreferences(["info", "bogus"], durations)).toEqual({
+      muted: ["info"],
+      durationOverrides: { warning: 2000 },
+    })
+    expect(toastConfigFromPreferences([], emptyToastDurationOverrides())).toBeUndefined()
+  })
+
+  test("parses only valid positive toast duration overrides", () => {
+    const durations = emptyToastDurationOverrides()
+    durations.info = "4000"
+    durations.success = "0"
+    durations.warning = "abc"
+    durations.error = "12000"
+
+    expect(parseToastDurationOverrides(durations)).toEqual({
+      info: 4000,
+      error: 8000,
+    })
+  })
+
+  test("normalizes server toast config for runtime application", () => {
+    expect(
+      toastConfigFromServerToast({
+        muted: ["success", "nope"],
+        durationOverrides: { error: 9000, info: -1 },
+      }),
+    ).toEqual({
+      muted: ["success"],
+      durationOverrides: { error: 8000 },
+    })
+    expect(toastConfigFromServerToast(undefined)).toBeUndefined()
+    expect(toastConfigFromServerToast({})).toBeUndefined()
+  })
+})

--- a/packages/app/src/components/settings/toast-preferences.ts
+++ b/packages/app/src/components/settings/toast-preferences.ts
@@ -1,0 +1,64 @@
+import type { ToastConfig, ToastType as RuntimeToastType } from "@ericsanchezok/synergy-ui/toast"
+import { TOAST_TYPES, snapToastDuration, type ToastDurationOverrides, type ToastType } from "./types"
+
+export function isToastType(value: string): value is ToastType {
+  return (TOAST_TYPES as readonly string[]).includes(value)
+}
+
+export function nextMutedToasts(muted: readonly string[], type: ToastType, mutedEnabled: boolean): string[] {
+  const next = mutedEnabled ? [...muted, type] : muted.filter((item) => item !== type)
+  return Array.from(new Set(next.filter(isToastType)))
+}
+
+export function parseToastDurationOverrides(durations: ToastDurationOverrides): Partial<Record<ToastType, number>> {
+  const result: Partial<Record<ToastType, number>> = {}
+  for (const type of TOAST_TYPES) {
+    const raw = durations[type]
+    if (!raw.trim()) continue
+    const parsed = Number(raw)
+    if (!Number.isNaN(parsed) && Number.isInteger(parsed) && parsed > 0 && parsed <= 30000) {
+      result[type] = snapToastDuration(parsed)
+    }
+  }
+  return result
+}
+
+export function toastConfigFromPreferences(
+  muted: readonly string[],
+  durations: ToastDurationOverrides,
+): ToastConfig | undefined {
+  const normalizedMuted = muted.filter(isToastType) as RuntimeToastType[]
+  const durationOverrides = parseToastDurationOverrides(durations)
+  if (!normalizedMuted.length && !Object.keys(durationOverrides).length) return undefined
+  return {
+    ...(normalizedMuted.length ? { muted: normalizedMuted } : {}),
+    ...(Object.keys(durationOverrides).length
+      ? { durationOverrides: durationOverrides as ToastConfig["durationOverrides"] }
+      : {}),
+  }
+}
+
+export function toastConfigFromServerToast(
+  toast:
+    | {
+        muted?: readonly string[]
+        durationOverrides?: Partial<Record<string, number>>
+      }
+    | undefined
+    | null,
+): ToastConfig | undefined {
+  if (!toast) return undefined
+  const muted = (toast.muted ?? []).filter(isToastType) as RuntimeToastType[]
+  const durationOverrides: Partial<Record<RuntimeToastType, number>> = {}
+  for (const type of TOAST_TYPES) {
+    const value = toast.durationOverrides?.[type]
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      durationOverrides[type] = snapToastDuration(value)
+    }
+  }
+  if (!muted.length && !Object.keys(durationOverrides).length) return undefined
+  return {
+    ...(muted.length ? { muted } : {}),
+    ...(Object.keys(durationOverrides).length ? { durationOverrides } : {}),
+  }
+}

--- a/packages/app/src/components/settings/toast-preferences.ts
+++ b/packages/app/src/components/settings/toast-preferences.ts
@@ -1,6 +1,11 @@
 import type { ToastConfig, ToastType as RuntimeToastType } from "@ericsanchezok/synergy-ui/toast"
 import { TOAST_TYPES, snapToastDuration, type ToastDurationOverrides, type ToastType } from "./types"
 
+export type ToastPatch = {
+  muted: RuntimeToastType[]
+  durationOverrides?: ToastConfig["durationOverrides"]
+}
+
 export function isToastType(value: string): value is ToastType {
   return (TOAST_TYPES as readonly string[]).includes(value)
 }
@@ -27,14 +32,48 @@ export function toastConfigFromPreferences(
   muted: readonly string[],
   durations: ToastDurationOverrides,
 ): ToastConfig | undefined {
+  const patch = toastPatchFromPreferences(muted, durations)
+  if (!patch.muted.length && !patch.durationOverrides) return undefined
+  return {
+    ...(patch.muted.length ? { muted: patch.muted } : {}),
+    ...(patch.durationOverrides ? { durationOverrides: patch.durationOverrides } : {}),
+  }
+}
+
+/** Domain-update payload that always carries `muted` so mergeDeep can clear it. */
+export function toastPatchFromPreferences(muted: readonly string[], durations: ToastDurationOverrides): ToastPatch {
   const normalizedMuted = muted.filter(isToastType) as RuntimeToastType[]
   const durationOverrides = parseToastDurationOverrides(durations)
-  if (!normalizedMuted.length && !Object.keys(durationOverrides).length) return undefined
   return {
-    ...(normalizedMuted.length ? { muted: normalizedMuted } : {}),
+    muted: normalizedMuted,
     ...(Object.keys(durationOverrides).length
       ? { durationOverrides: durationOverrides as ToastConfig["durationOverrides"] }
       : {}),
+  }
+}
+
+export function normalizeServerToast(
+  toast:
+    | {
+        muted?: readonly string[]
+        durationOverrides?: Partial<Record<string, number>>
+      }
+    | undefined
+    | null,
+): ToastPatch | undefined {
+  if (!toast) return undefined
+  const muted = (toast.muted ?? []).filter(isToastType) as RuntimeToastType[]
+  const durationOverrides: Partial<Record<RuntimeToastType, number>> = {}
+  for (const type of TOAST_TYPES) {
+    const value = toast.durationOverrides?.[type]
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      durationOverrides[type] = snapToastDuration(value)
+    }
+  }
+  if (!muted.length && !Object.keys(durationOverrides).length) return undefined
+  return {
+    muted,
+    ...(Object.keys(durationOverrides).length ? { durationOverrides } : {}),
   }
 }
 
@@ -47,18 +86,10 @@ export function toastConfigFromServerToast(
     | undefined
     | null,
 ): ToastConfig | undefined {
-  if (!toast) return undefined
-  const muted = (toast.muted ?? []).filter(isToastType) as RuntimeToastType[]
-  const durationOverrides: Partial<Record<RuntimeToastType, number>> = {}
-  for (const type of TOAST_TYPES) {
-    const value = toast.durationOverrides?.[type]
-    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
-      durationOverrides[type] = snapToastDuration(value)
-    }
-  }
-  if (!muted.length && !Object.keys(durationOverrides).length) return undefined
+  const normalized = normalizeServerToast(toast)
+  if (!normalized) return undefined
   return {
-    ...(muted.length ? { muted } : {}),
-    ...(Object.keys(durationOverrides).length ? { durationOverrides } : {}),
+    ...(normalized.muted.length ? { muted: normalized.muted } : {}),
+    ...(normalized.durationOverrides ? { durationOverrides: normalized.durationOverrides } : {}),
   }
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -11,6 +11,8 @@ import { showToast, Toast, toaster, setToastConfig } from "@ericsanchezok/synerg
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useNotification } from "@/context/notification"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
+import { toastConfigFromServerToast } from "@/components/settings/toast-preferences"
+import { HOME_SCOPE_KEY } from "@/utils/scope"
 
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { useTheme, type ColorScheme } from "@ericsanchezok/synergy-ui/theme"
@@ -50,20 +52,12 @@ export default function Layout(props: ParentProps) {
   const theme = useTheme()
   const [searchOpen, setSearchOpen] = createSignal(false)
   const { pickProjectDirectories } = useProjectDirectoryPicker()
-  // Wire toast config from serialized config, watching the current directory's config.
+  // Wire toast config from the active scope (project directory or home).
   createEffect(() => {
-    const dir = params.dir ? base64Decode(params.dir) : undefined
-    if (!dir) return
-    const [store] = globalSync.ensureScopeState(dir)
-    const cfg = (store.config as any)?.toast
-    setToastConfig(
-      cfg
-        ? {
-            muted: cfg.muted,
-            durationOverrides: cfg.durationOverrides,
-          }
-        : undefined,
-    )
+    const scopeKey = params.dir ? base64Decode(params.dir) : HOME_SCOPE_KEY
+    const [store] = globalSync.ensureScopeState(scopeKey)
+    if (store.status === "loading") return
+    setToastConfig(toastConfigFromServerToast(store.config.toast))
   })
 
   const colorSchemeOrder: ColorScheme[] = ["system", "light", "dark"]

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -129,6 +129,10 @@ export function setToastConfig(config: ToastConfig | undefined) {
   toastConfig = config
 }
 
+export function getToastConfig(): ToastConfig | undefined {
+  return toastConfig
+}
+
 export interface ToastOptions {
   type?: ToastType
   title?: string


### PR DESCRIPTION
## Summary
- Fix Settings > General > Notifications Mute switches by removing the nested native `<label>` around Kobalte Switch that cancelled toggles.
- Apply toast mute/duration preferences to the runtime immediately on change, and wire layout toast config for both project and home scopes.
- Skip background-save success toasts when `success` is muted, and add unit coverage for mute state, patch generation, and markup.

Closes #499

## Test plan
- [x] `bun test src/components/settings/toast-preferences.test.ts src/components/settings/hooks/useConfigPatch.test.ts src/components/settings/panels/GeneralPanel.markup.test.ts src/components/settings/types.test.ts` (from `packages/app`)
- [ ] Manually open Settings > General > Notifications and toggle Mute for each toast type; switch state should flip immediately
- [ ] Confirm muted toast types no longer appear, including after refresh
- [ ] Confirm mute still works on home route without a project directory