### PR TITLE
fix: publish cortex completion before parent wake

### DIFF
--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2098,6 +2098,14 @@ export type LearningConfig = {
    */
   encoderRetries?: number
   /**
+   * Wall-clock deadline for a single encoder LLM call in milliseconds (default: 60000)
+   */
+  encoderTimeoutMs?: number
+  /**
+   * Maximum characters collected from one encoder model stream before abort (default: 16000)
+   */
+  encoderMaxOutputChars?: number
+  /**
    * Max estimated tokens for tool output in turn digest (default: 800)
    */
   digestToolOutputBudget?: number

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -21163,8 +21163,7 @@
             "type": "string"
           }
         },
-        "required": ["id"],
-        "additionalProperties": false
+        "required": ["id"]
       },
       "ChannelInfo": {
         "type": "object",
@@ -23075,6 +23074,18 @@
             "description": "LLM retry count for intent/script/reward generation (default: 3)",
             "type": "integer",
             "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "encoderTimeoutMs": {
+            "description": "Wall-clock deadline for a single encoder LLM call in milliseconds (default: 60000)",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          },
+          "encoderMaxOutputChars": {
+            "description": "Maximum characters collected from one encoder model stream before abort (default: 16000)",
+            "type": "integer",
+            "minimum": 1,
             "maximum": 9007199254740991
           },
           "digestToolOutputBudget": {
@@ -25665,8 +25676,7 @@
               "color": {
                 "type": "string"
               }
-            },
-            "additionalProperties": false
+            }
           },
           "time": {
             "type": "object",
@@ -25681,8 +25691,7 @@
                 "type": "number"
               }
             },
-            "required": ["created", "updated"],
-            "additionalProperties": false
+            "required": ["created", "updated"]
           },
           "sandboxes": {
             "type": "array",
@@ -25691,8 +25700,7 @@
             }
           }
         },
-        "required": ["id"],
-        "additionalProperties": false
+        "required": ["id"]
       },
       "FileDiff": {
         "type": "object",

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -602,17 +602,12 @@ export namespace Cortex {
       }
 
       const waiters = taskWaiters.get(taskID)
-      if (!waiters?.size && terminalTask.notifyParentOnComplete !== false) {
-        // Register a deferred notification before exposing the terminal state.
-        // release() can then never observe "completed" without also seeing the
-        // pending wake. For an idle parent, enqueue the notification before
-        // publishing the terminal state, then process it asynchronously so the
-        // parent cannot re-enter while the in-memory task still looks active.
-        if (SessionManager.isRunning(terminalTask.parentSessionID)) {
-          deferParentNotification(terminalTask)
-        } else {
-          await notifyParentSession(terminalTask)
-        }
+      const shouldNotifyParent = !waiters?.size && terminalTask.notifyParentOnComplete !== false
+      if (shouldNotifyParent) {
+        // Register the pending delivery before publishing terminal state so a
+        // concurrent parent release cannot miss it. The inbox notification is
+        // flushed only after task readers can observe the terminal result.
+        deferParentNotification(terminalTask)
       } else {
         if (waiters?.size) {
           log.info("task result has waiters, skipping mail", { taskID, waiterCount: waiters.size })
@@ -631,6 +626,9 @@ export namespace Cortex {
 
       if (terminalTask.visibility !== "hidden") {
         Bus.publish(Event.TaskCompleted, { task: terminalTask })
+      }
+      if (shouldNotifyParent && !SessionManager.isRunning(terminalTask.parentSessionID)) {
+        await flushDeferredParentNotifications(terminalTask.parentSessionID)
       }
       const pluginSnapshot = pluginTaskSnapshotFromTask(terminalTask)
       if (pluginSnapshot) {

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -605,8 +605,9 @@ export namespace Cortex {
       if (!waiters?.size && terminalTask.notifyParentOnComplete !== false) {
         // Register a deferred notification before exposing the terminal state.
         // release() can then never observe "completed" without also seeing the
-        // pending wake. For an idle parent, finish delivery before publishing the
-        // terminal state so callers observe one coherent completion boundary.
+        // pending wake. For an idle parent, enqueue the notification before
+        // publishing the terminal state, then process it asynchronously so the
+        // parent cannot re-enter while the in-memory task still looks active.
         if (SessionManager.isRunning(terminalTask.parentSessionID)) {
           deferParentNotification(terminalTask)
         } else {
@@ -773,6 +774,7 @@ export namespace Cortex {
     try {
       await SessionManager.deliver({
         target: task.parentSessionID,
+        waitForProcessing: false,
         mail: {
           type: "user",
           metadata: { source: "cortex", sourceSessionID: task.sessionID },

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -4,6 +4,7 @@ import { CortexTypes } from "../../src/cortex/types"
 import { Bus } from "../../src/bus"
 import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
+import { SessionInbox } from "../../src/session/inbox"
 import { SessionInvoke } from "../../src/session/invoke"
 import { SessionManager } from "../../src/session/manager"
 import { Identifier } from "../../src/id/id"
@@ -1195,6 +1196,85 @@ describe.serial("Cortex", () => {
           } finally {
             ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
             ;(SessionInvoke.loop as any) = originalLoop
+            if (parentSessionID) SessionManager.unregisterRuntime(parentSessionID)
+          }
+        },
+      })
+    })
+
+    test("publishes the terminal task before a concurrently starting parent observes its completion notice", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const childMayFinish = Promise.withResolvers<void>()
+          const observedOutput = Promise.withResolvers<string>()
+          let parentSessionID = ""
+          let taskID = ""
+
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              await childMayFinish.promise
+              return writeAssistantText(input.sessionID, "final prose")
+            },
+          )
+          const unsubscribe = Bus.subscribe(SessionInbox.Event.Updated, async (event) => {
+            if (event.properties.sessionID !== parentSessionID || !taskID) return
+            if (!event.properties.items.some((item) => item.message?.metadata?.source === "cortex")) return
+            expect(SessionManager.acquire(parentSessionID)).toBeDefined()
+            observedOutput.resolve(await Cortex.output(taskID, "full"))
+          })
+
+          try {
+            const parentSession = await Session.create({})
+            parentSessionID = parentSession.id
+            const rootID = Identifier.ascending("message")
+            await Session.updateMessage({
+              id: rootID,
+              role: "user",
+              sessionID: parentSession.id,
+              time: { created: Date.now() },
+              agent: "synergy",
+              model: { providerID: "test-provider", modelID: "test-model" },
+              isRoot: true,
+              rootID,
+            } as any)
+            await Session.updatePart({
+              id: Identifier.ascending("part"),
+              messageID: rootID,
+              sessionID: parentSession.id,
+              type: "text",
+              text: "parent root",
+            })
+
+            const task = await Cortex.launch({
+              description: "Notify concurrently starting parent with terminal output",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: rootID,
+              model: { providerID: "test-provider", modelID: "test-model" },
+              output: { mode: "final_response" },
+            })
+            taskID = task.id
+            childMayFinish.resolve()
+
+            const output = await Promise.race([
+              observedOutput.promise,
+              Bun.sleep(1_000).then(() => {
+                throw new Error("Cortex completion notice was not observed")
+              }),
+            ])
+            await waitUntilTerminal(taskID)
+
+            expect(output).toContain("Status: completed")
+            expect(output).toContain("--- Result ---")
+            expect(output).toContain("final prose")
+          } finally {
+            childMayFinish.resolve()
+            unsubscribe()
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
             if (parentSessionID) SessionManager.unregisterRuntime(parentSessionID)
           }
         },

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -1119,6 +1119,88 @@ describe.serial("Cortex", () => {
       })
     })
 
+    test("publishes the terminal task before an idle parent processes its completion notice", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const originalLoop = SessionInvoke.loop
+          let parentSessionID = ""
+          let taskID = ""
+          let resolveObservedOutput!: (output: string) => void
+          const observedOutput = new Promise<string>((resolve) => {
+            resolveObservedOutput = resolve
+          })
+
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              return writeAssistantText(input.sessionID, "final prose")
+            },
+          )
+          ;(SessionInvoke.loop as any) = mock(async (sessionID: string) => {
+            if (sessionID === parentSessionID && taskID) {
+              resolveObservedOutput(await Cortex.output(taskID, "full"))
+            }
+          })
+
+          try {
+            const parentSession = await Session.create({})
+            parentSessionID = parentSession.id
+            const rootID = Identifier.ascending("message")
+            await Session.updateMessage({
+              id: rootID,
+              role: "user",
+              sessionID: parentSession.id,
+              time: { created: Date.now() },
+              agent: "synergy",
+              model: { providerID: "test-provider", modelID: "test-model" },
+              isRoot: true,
+              rootID,
+            } as any)
+            await Session.updatePart({
+              id: Identifier.ascending("part"),
+              messageID: rootID,
+              sessionID: parentSession.id,
+              type: "text",
+              text: "parent root",
+            })
+
+            const { createdTask, launchPromise } = await launchAndCaptureCreatedTask(
+              () =>
+                Cortex.launch({
+                  description: "Notify idle parent with terminal output",
+                  prompt: "Do something",
+                  agent: "developer",
+                  parentSessionID: parentSession.id,
+                  parentMessageID: rootID,
+                  model: { providerID: "test-provider", modelID: "test-model" },
+                  output: { mode: "final_response" },
+                }),
+              (task) => task.parentSessionID === parentSession.id,
+            )
+            taskID = createdTask.id
+            await launchPromise
+
+            const output = await Promise.race([
+              observedOutput,
+              Bun.sleep(1_000).then(() => {
+                throw new Error("Parent session was not woken for the Cortex completion notice")
+              }),
+            ])
+
+            expect(output).toContain("Status: completed")
+            expect(output).toContain("--- Result ---")
+            expect(output).toContain("final prose")
+          } finally {
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+            ;(SessionInvoke.loop as any) = originalLoop
+            if (parentSessionID) SessionManager.unregisterRuntime(parentSessionID)
+          }
+        },
+      })
+    })
+
     test("defers parent notification until the mid-turn parent releases", async () => {
       await using tmp = await tmpdir({ git: true })
       await ScopeContext.provide({


### PR DESCRIPTION
## Summary
- enqueue Cortex completion notices without synchronously processing the parent turn
- publish the terminal in-memory task before the parent can read task output
- add a regression test covering the idle-parent completion wake ordering
- sync generated LearningConfig timeout and output-limit contracts

## Verification
- `bun test test/cortex` (113 passed)
- `bun test test/session/manager.test.ts` (14 passed)
- `bun run quality:quick` (passed)
- `bun run test:changed` selected 2,041 tests: 2,026 passed, 1 skipped, and 14 failed under broad Windows parallel resource contention; the affected Cortex and Session Manager suites passed independently