### PR TITLE
fix(permission): bound evaluation telemetry

### DIFF
--- a/.synergy/skill/develop-synergy/SKILL.md
+++ b/.synergy/skill/develop-synergy/SKILL.md
@@ -28,7 +28,7 @@ cp -R ~/.synergy/config "$DEV_HOME/.synergy/config"
 ## Choose the Smallest Mode
 
 ```bash
-SYNERGY_HOME="$DEV_HOME" bun dev server --server-port 4097
+SYNERGY_HOME="$DEV_HOME" bun dev server --port 4097
 SYNERGY_HOME="$DEV_HOME" bun dev app --attach http://127.0.0.1:4097 --port 3001
 SYNERGY_HOME="$DEV_HOME" bun dev web --server-port 4097 --app-port 3001
 SYNERGY_HOME="$DEV_HOME" bun dev desktop --server-port 4097 --app-port 3001

--- a/docs/operations/performance-observability.md
+++ b/docs/operations/performance-observability.md
@@ -17,6 +17,8 @@ Open the **Performance** workbench panel from the sidebar to inspect the default
 
 Every record is stored with low-cardinality attribution such as source, module, Scope/session/request/tool/provider/process IDs, correlation IDs, trace IDs, span IDs, and safe labels. Sensitive prompt, response, header, credential, environment, raw body, and file-content data is redacted or omitted before it reaches public read models or diagnostics packages.
 
+Permission evaluation logs contain only the permission name, requested pattern length, and merged ruleset count. Raw requested patterns and merged permission rules are intentionally omitted so repeated authorization checks remain bounded and do not expose command or path contents through observability.
+
 Server resource samples are kept separate from registered tool child process samples. Linux hosts report child RSS from `/proc/<pid>/status`; unsupported hosts still report registered child process counts. Stale registered child processes whose pid no longer exists are settled into finished process history before new resource samples are stored.
 
 ## Local storage

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -34,7 +34,7 @@ bun dev build desktop
 | `desktop --managed` | build plugin/app, then Electron with production-style managed server mode |
 | `send`              | one-off source CLI execution                                              |
 
-Use `--server-port`, `--app-port`, `--hostname`, and `--attach` to avoid conflicts. The orchestrator checks required ports and target health before starting dependent processes. In parallel modes it terminates sibling process trees when one exits so package-script wrappers cannot leave servers or Electron hosts running.
+Use `--port` for standalone `server` and `app` modes. Use `--server-port`, `--app-port`, `--hostname`, and `--attach` for combined Web or Desktop flows. The orchestrator checks required ports and target health before starting dependent processes. In parallel modes it terminates sibling process trees when one exits so package-script wrappers cannot leave servers or Electron hosts running.
 
 Managed Desktop rebuilds the Web distribution before launch so packaged-server behavior is not tested against stale frontend assets. Normal daily Desktop work should use external mode for Vite reload speed.
 

--- a/packages/synergy/src/permission/next.ts
+++ b/packages/synergy/src/permission/next.ts
@@ -241,7 +241,7 @@ export namespace PermissionNext {
 
   export function evaluate(permission: string, pattern: string, ...rulesets: Ruleset[]): Rule {
     const merged = merge(...rulesets)
-    log.info("evaluate", { permission, pattern, ruleset: merged })
+    log.info("evaluate", { permission, patternLength: pattern.length, rulesetCount: merged.length })
     const match = merged.findLast(
       (rule) => Wildcard.match(permission, rule.permission) && Wildcard.match(pattern, rule.pattern),
     )

--- a/packages/synergy/test/permission/telemetry.test.ts
+++ b/packages/synergy/test/permission/telemetry.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { ObservabilityStore } from "../../src/observability/store"
+import { PermissionNext } from "../../src/permission/next"
+
+test("permission evaluation emits bounded telemetry without rule contents", () => {
+  const permission = `telemetry-test-${crypto.randomUUID()}`
+  const sensitivePattern = `secret-pattern-${crypto.randomUUID()}`
+  const ruleset: PermissionNext.Ruleset = [
+    ...Array.from({ length: 256 }, (_, index) => ({
+      permission,
+      pattern: `${sensitivePattern}-${index}`,
+      action: "ask" as const,
+    })),
+    { permission, pattern: sensitivePattern, action: "allow" },
+  ]
+
+  expect(PermissionNext.evaluate(permission, sensitivePattern, ruleset).action).toBe("allow")
+
+  const event = ObservabilityStore.queryEvents({ type: "log.record" }).find((item) => {
+    const data = JSON.parse(item.data_json) as Record<string, unknown>
+    return data.permission === permission
+  })
+  expect(event).toBeDefined()
+
+  const data = JSON.parse(event!.data_json) as Record<string, unknown>
+  expect(data).toMatchObject({
+    service: "permission",
+    message: "evaluate",
+    permission,
+    patternLength: sensitivePattern.length,
+    rulesetCount: ruleset.length,
+  })
+  expect(data).not.toHaveProperty("pattern")
+  expect(data).not.toHaveProperty("ruleset")
+  expect(JSON.stringify(data)).not.toContain(sensitivePattern)
+  expect(JSON.stringify(data).length).toBeLessThan(256)
+})

--- a/packages/synergy/test/permission/telemetry.test.ts
+++ b/packages/synergy/test/permission/telemetry.test.ts
@@ -1,37 +1,76 @@
 import { expect, test } from "bun:test"
-import { ObservabilityStore } from "../../src/observability/store"
-import { PermissionNext } from "../../src/permission/next"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
 
-test("permission evaluation emits bounded telemetry without rule contents", () => {
-  const permission = `telemetry-test-${crypto.randomUUID()}`
-  const sensitivePattern = `secret-pattern-${crypto.randomUUID()}`
-  const ruleset: PermissionNext.Ruleset = [
-    ...Array.from({ length: 256 }, (_, index) => ({
-      permission,
-      pattern: `${sensitivePattern}-${index}`,
-      action: "ask" as const,
-    })),
-    { permission, pattern: sensitivePattern, action: "allow" },
-  ]
+test("permission evaluation emits bounded telemetry without rule contents", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-permission-telemetry-"))
+  const script = `
+    import { Log } from "./src/util/log.ts"
+    import { ObservabilityStore } from "./src/observability/store.ts"
+    import { PermissionNext } from "./src/permission/next.ts"
 
-  expect(PermissionNext.evaluate(permission, sensitivePattern, ruleset).action).toBe("allow")
+    await Log.init({ print: false, dev: true, level: "INFO" })
 
-  const event = ObservabilityStore.queryEvents({ type: "log.record" }).find((item) => {
-    const data = JSON.parse(item.data_json) as Record<string, unknown>
-    return data.permission === permission
-  })
-  expect(event).toBeDefined()
+    const permission = \`telemetry-test-\${crypto.randomUUID()}\`
+    const sensitivePattern = \`secret-pattern-\${crypto.randomUUID()}\`
+    const ruleset: PermissionNext.Ruleset = [
+      ...Array.from({ length: 256 }, (_, index) => ({
+        permission,
+        pattern: \`\${sensitivePattern}-\${index}\`,
+        action: "ask" as const,
+      })),
+      { permission, pattern: sensitivePattern, action: "allow" },
+    ]
 
-  const data = JSON.parse(event!.data_json) as Record<string, unknown>
-  expect(data).toMatchObject({
-    service: "permission",
-    message: "evaluate",
-    permission,
-    patternLength: sensitivePattern.length,
-    rulesetCount: ruleset.length,
-  })
-  expect(data).not.toHaveProperty("pattern")
-  expect(data).not.toHaveProperty("ruleset")
-  expect(JSON.stringify(data)).not.toContain(sensitivePattern)
-  expect(JSON.stringify(data).length).toBeLessThan(256)
+    const action = PermissionNext.evaluate(permission, sensitivePattern, ruleset).action
+    const event = ObservabilityStore.queryEvents({ type: "log.record" }).find((item) => {
+      const data = JSON.parse(item.data_json)
+      return data.permission === permission
+    })
+    const data = event ? JSON.parse(event.data_json) : undefined
+    ObservabilityStore.close()
+    process.stdout.write(JSON.stringify({ action, data, permission, sensitivePattern }))
+  `
+  const env = { ...process.env }
+  delete env.SYNERGY_HOME
+  env.SYNERGY_TEST_HOME = home
+  env.SYNERGY_DISABLE_MODELS_FETCH = "true"
+
+  try {
+    const proc = Bun.spawn([process.execPath, "--conditions=browser", "-e", script], {
+      cwd: path.resolve(import.meta.dir, "../.."),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    if (exitCode !== 0) throw new Error(stderr)
+
+    const result = JSON.parse(stdout) as {
+      action: string
+      data?: Record<string, unknown>
+      permission: string
+      sensitivePattern: string
+    }
+
+    expect(result.action).toBe("allow")
+    expect(result.data).toMatchObject({
+      service: "permission",
+      message: "evaluate",
+      permission: result.permission,
+      patternLength: result.sensitivePattern.length,
+      rulesetCount: 257,
+    })
+    expect(result.data).not.toHaveProperty("pattern")
+    expect(result.data).not.toHaveProperty("ruleset")
+    expect(JSON.stringify(result.data)).not.toContain(result.sensitivePattern)
+    expect(JSON.stringify(result.data).length).toBeLessThan(256)
+  } finally {
+    await fs.rm(home, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary

- replace raw permission evaluation patterns and merged rulesets with bounded metadata
- add a behavioral regression test covering log payload size, content omission, and unchanged matching
- document the bounded observability contract and correct the isolated standalone server port example

## Root cause

`PermissionNext.evaluate()` runs for every permission check and logged both the requested pattern and the complete merged ruleset. The logging layer serialized that payload to the development log and mirrored it into the observability store. Long tool-heavy sessions therefore multiplied allocation and I/O work until GC and the event loop could become saturated, leaving the listener alive while HTTP and WebSocket handshakes stopped responding.

The fix preserves useful diagnostics as `permission`, `patternLength`, and `rulesetCount`; it does not change permission merge order or matching semantics.

## Validation

- `bun test test/permission/telemetry.test.ts test/permission/next.test.ts` — 67 passed
- `bun run quality:quick` — passed
- `bun run format:check` and `bun run skill:check` after the documentation correction — passed
- isolated source runtime — health returned HTTP 200 and the global delta WebSocket returned HTTP 101

`bun run test:changed` ran 2,265 tests: 2,264 passed and the existing `proxy option routes wrapped fetch through configured proxy` test failed. The failure reproduces when that provider test runs alone, and this branch has no provider or proxy changes relative to `origin/dev`.

Fixes #577
