### PR TITLE
docs(config): complete synergy-config references

### DIFF
--- a/packages/synergy/src/skill/builtin/synergy-config/content.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/content.txt
@@ -35,7 +35,7 @@ Web Settings uses these same canonical domains. Common fields are editable in fo
 | Domain file | Owned keys |
 |---|---|
 | `00-general.jsonc` | `$schema`, `theme`, `keybinds`, `toast`, `logLevel`, `snapshot`, `username`, `layout`, `embedding`, `rerank` |
-| `10-models.jsonc` | `model`, `nano_model`, `mini_model`, `mid_model`, `thinking_model`, `long_context_model`, `creative_model`, `vision_model`, `role_variant` |
+| `10-models.jsonc` | `model`, `nano_model`, `mini_model`, `mid_model`, `thinking_model`, `long_context_model`, `creative_model`, `vision_model`, `role_variant`, `quick_switcher` |
 | `20-providers.jsonc` | `provider`, `providerCatalog`, `enabled_providers`, `disabled_providers` |
 | `30-library.jsonc` | `library` |
 | `40-mcp.jsonc` | `mcp`, `mcpDefaults` |

--- a/packages/synergy/src/skill/builtin/synergy-config/references/agents.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/references/agents.txt
@@ -240,6 +240,7 @@ Synergy ships with these agents. You can override any of them via config.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `model` | string | scope default | `provider/model` format |
+| `modelRole` | enum | — | Resolve the agent model through the `vision`, `nano`, `mini`, `mid`, `thinking`, `long`, or `creative` role. An explicit `model` wins. |
 | `description` | string | — | When to use this agent. Required for selection UI and routing. |
 | `mode` | enum | `"all"` | `"primary"`, `"subagent"`, or `"all"` |
 | `prompt` | string | — | System prompt. For markdown agents, this is the body. |
@@ -247,10 +248,37 @@ Synergy ships with these agents. You can override any of them via config.
 | `top_p` | number | — | Top-p sampling (0-1) |
 | `color` | string | — | Hex color (e.g., `"#FF5733"`). Must be `#` + 6 hex digits. |
 | `steps` | int | — | Max agentic iterations before forcing text-only response |
+| `maxSteps` | int | — | Deprecated. Use `steps`; legacy values are still converted when config is loaded. |
 | `hidden` | bool | `false` | Hide from autocomplete (subagent mode only) |
+| `visibleTo` | string[] | all callers | Agent names or delegation-group identities allowed to delegate to this subagent. Missing or empty means unrestricted visibility. |
+| `delegationGroups` | string[] | `[]` | Additional identities this agent receives when resolving which subagents it may delegate to. |
 | `disable` | bool | `false` | Disable the agent entirely |
 | `permission` | object | top-level | Permission overrides. Merges with and overrides top-level permission. |
+| `tools` | object | — | Deprecated. Use `permission`; legacy boolean tool entries are converted to permission rules. |
+| `controlProfile` | enum | inherited | Agent-level `guarded`, `autonomous`, or `full_access` profile. An explicit session or parent-session profile takes precedence. |
+| `defaultVariant` | string | role default | Default model variant for this agent. A per-request variant wins; otherwise this overrides `role_variant`. |
 | `options` | object | `{}` | Additional key-value options passed through to the agent |
+
+Example with role-based model selection, delegation visibility, and agent-level execution defaults:
+
+```jsonc
+{
+  "agent": {
+    "review-coordinator": {
+      "modelRole": "thinking",
+      "defaultVariant": "high",
+      "controlProfile": "autonomous",
+      "delegationGroups": ["reviewers"]
+    },
+    "security-reviewer": {
+      "mode": "subagent",
+      "visibleTo": ["review-coordinator", "reviewers"]
+    }
+  }
+}
+```
+
+Here `review-coordinator` can see agents whose `visibleTo` includes either its own name or `reviewers`.
 
 ## Options passthrough
 

--- a/packages/synergy/src/skill/builtin/synergy-config/references/models.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/references/models.txt
@@ -83,6 +83,22 @@ Models can have variants (e.g., different reasoning effort levels). Variants are
 }
 ```
 
+## Role variants
+
+Use `role_variant` in `10-models.jsonc` to select a default variant for each model role. Valid role keys are `vision`, `nano`, `mini`, `mid`, `thinking`, `long`, and `creative`; `default` applies to agents without a `modelRole`. Variant names are model-specific, so the model resolved for that role must expose the configured variant.
+
+```jsonc
+{
+  "role_variant": {
+    "default": "medium",
+    "thinking": "high",
+    "creative": "low"
+  }
+}
+```
+
+Variant precedence is: per-request selection → agent `defaultVariant` → `role_variant` for the agent's `modelRole` (or `default`). If the resolved model does not expose the selected variant, Synergy logs a warning and runs without that variant.
+
 ## How each model role affects your experience
 
 | Role | What changes when you set it |

--- a/packages/synergy/test/skill/skill.test.ts
+++ b/packages/synergy/test/skill/skill.test.ts
@@ -387,6 +387,37 @@ description: A skill in the .claude/skills directory.
     })
   })
 
+  test("synergy-config documents canonical agent and model settings", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const skill = await Skill.get("synergy-config")
+        if (!skill?.content) throw new Error("Expected the built-in synergy-config skill to have content")
+
+        const agents = skill.references?.["references/agents.txt"]
+        if (!agents) throw new Error("Expected synergy-config to include its agents reference")
+        for (const field of ["modelRole", "visibleTo", "delegationGroups", "controlProfile", "defaultVariant"]) {
+          expect(agents.split("\n").some((line) => line.startsWith(`| \`${field}\` |`))).toBe(true)
+        }
+        for (const field of ["tools", "maxSteps"]) {
+          const row = agents.split("\n").find((line) => line.startsWith(`| \`${field}\` |`))
+          expect(row).toContain("Deprecated")
+        }
+
+        const modelsDomain = skill.content.split("\n").find((line) => line.startsWith("| `10-models.jsonc` |"))
+        expect(modelsDomain).toContain("`quick_switcher`")
+
+        const models = skill.references?.["references/models.txt"]
+        if (!models) throw new Error("Expected synergy-config to include its models reference")
+        expect(models).toContain("## Role variants")
+        expect(models).toContain('"role_variant"')
+        expect(models).toContain('"thinking": "high"')
+      },
+    })
+  })
+
   test("reload discovers project-local skill created after initial config state", async () => {
     await using tmp = await tmpdir({ git: true })
 


### PR DESCRIPTION
## Summary

- add the missing canonical agent fields and legacy-field deprecation guidance to the built-in `synergy-config` agent reference
- document delegation visibility, agent control profiles, model-role selection, and variant precedence with examples
- list `quick_switcher` under the models domain and explain `role_variant`
- add regression coverage against the runtime-loaded built-in skill

## Root cause and impact

The built-in configuration skill had drifted behind the agent schema and models domain registry. As a result, Synergy could give incomplete self-configuration guidance for delegation, control profiles, model roles, model variants, and quick-switcher ownership. The updated reference now reflects the current runtime contracts.

## Validation

- `cd packages/synergy && bun test test/skill/skill.test.ts` — 20 passed
- `bun run quality:quick` — passed
- `cd packages/synergy && bun run test:changed` — 2052 passed, 1 unrelated existing failure in `test/provider/proxy.test.ts` (`configuredProxy.hits` expected 1, received 0)
- `cd packages/synergy && bun test test/provider/proxy.test.ts` — independently reproduced the same unrelated failure (8 passed, 1 failed)

Closes #576
