### PR TITLE
fix: suppress consumed Cortex completion notices

### DIFF
--- a/docs/architecture/cortex.md
+++ b/docs/architecture/cortex.md
@@ -49,6 +49,8 @@ A background task returns its identity immediately and continues independently. 
 
 Completion is event-driven. The parent does not need to poll `task_output` in a loop. When a synchronous waiter exists, Cortex resolves that waiter directly. Otherwise, a visible task can notify the parent session when the parent is available; hidden reviewer tasks normally suppress parent-facing task events and notifications.
 
+When the parent explicitly reads a terminal task through `task_output`, the persisted tool result satisfies any deferred completion notification for that task. Reading live progress does not consume the future terminal notification.
+
 ## Progress
 
 Cortex observes the child session while it runs. Progress includes:

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -727,6 +727,17 @@ export namespace Cortex {
     })
   }
 
+  export function acknowledgeParentCompletion(input: { taskID: string; parentSessionID: string }): boolean {
+    const task = tasks.get(input.taskID)
+    if (!task || task.parentSessionID !== input.parentSessionID || !isTerminal(task.status)) return false
+
+    const pending = deferredParentNotifications.get(input.parentSessionID)
+    if (!pending?.delete(input.taskID)) return false
+    if (pending.size === 0) deferredParentNotifications.delete(input.parentSessionID)
+    log.info("acknowledged parent task completion", input)
+    return true
+  }
+
   export async function flushDeferredParentNotifications(parentSessionID: string): Promise<void> {
     const pending = deferredParentNotifications.get(parentSessionID)
     if (!pending || pending.size === 0) return

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -41,6 +41,7 @@ export namespace SessionProcessor {
           title: string
           metadata: Record<string, any>
           attachments?: MessageV2.AttachmentPart[]
+          afterPersist?: () => Promise<void> | void
         }
       }
     | { status: "error"; input: any; error: string; metadata?: Record<string, any> }
@@ -257,6 +258,7 @@ export namespace SessionProcessor {
             attachments: outcome.result.attachments,
           },
         })
+        await outcome.result.afterPersist?.()
       } else {
         await Session.updatePart({
           ...part,

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -1608,6 +1608,7 @@ export namespace ToolResolver {
                     ? { approval: approvalFromContext(ctx), ...(result.metadata ?? {}) }
                     : (result.metadata ?? {}),
                   attachments: result.attachments,
+                  afterPersist: item.afterPersist ? () => item.afterPersist!(args, toolCtx, result) : undefined,
                 })
                 log.info("tool.execute.callback.completed", {
                   tool: item.id,

--- a/packages/synergy/src/tool/task-output.ts
+++ b/packages/synergy/src/tool/task-output.ts
@@ -19,7 +19,7 @@ const parameters = z.object({
 
 interface TaskOutputMetadata {
   taskId?: string
-  status?: string
+  status?: CortexTypes.TaskStatus
   found: boolean
   description?: string
   timeout?: number
@@ -159,5 +159,12 @@ task_output(task_id: "ctx_abc123", block: true)
       },
       output,
     }
+  },
+  async afterPersist(params, ctx, result) {
+    if (!params.task_id || !result.metadata.found) return
+    const status = result.metadata.status
+    if (status !== "completed" && status !== "error" && status !== "cancelled" && status !== "interrupted") return
+    const { Cortex } = await import("../cortex")
+    Cortex.acknowledgeParentCompletion({ taskID: params.task_id, parentSessionID: ctx.sessionID })
   },
 })

--- a/packages/synergy/src/tool/tool.ts
+++ b/packages/synergy/src/tool/tool.ts
@@ -12,6 +12,13 @@ export namespace Tool {
     [key: string]: any
   }
 
+  export interface ExecutionResult<M extends Metadata = Metadata> {
+    title: string
+    metadata: M
+    output: string
+    attachments?: MessageV2.AttachmentPart[]
+  }
+
   export interface InitContext {
     agent?: Agent.Info
   }
@@ -48,15 +55,8 @@ export namespace Tool {
     init: (ctx?: InitContext) => Promise<{
       description: string
       parameters: Parameters
-      execute(
-        args: z.infer<Parameters>,
-        ctx: Context,
-      ): Promise<{
-        title: string
-        metadata: M
-        output: string
-        attachments?: MessageV2.AttachmentPart[]
-      }>
+      execute(args: z.infer<Parameters>, ctx: Context): Promise<ExecutionResult<M>>
+      afterPersist?(args: z.infer<Parameters>, ctx: Context, result: ExecutionResult<M>): Promise<void> | void
       formatValidationError?(error: z.ZodError): string
     }>
   }

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -9,6 +9,7 @@ import { SessionInvoke } from "../../src/session/invoke"
 import { SessionManager } from "../../src/session/manager"
 import { Identifier } from "../../src/id/id"
 import { CortexOutput } from "../../src/cortex/output"
+import { TaskOutputTool } from "../../src/tool/task-output"
 import { tmpdir } from "../fixture/fixture"
 
 async function launchAndCaptureCreatedTask(
@@ -1148,6 +1149,10 @@ describe.serial("Cortex", () => {
   })
 
   describe("parent completion notification", () => {
+    type TaskOutputInstance = Awaited<ReturnType<typeof TaskOutputTool.init>>
+    type TaskOutputParams = Parameters<TaskOutputInstance["execute"]>[0]
+    type TaskOutputContext = Parameters<TaskOutputInstance["execute"]>[1]
+
     async function waitUntilCompleted(taskID: string) {
       for (let i = 0; i < 50; i++) {
         const task = Cortex.get(taskID)
@@ -1155,6 +1160,23 @@ describe.serial("Cortex", () => {
         await Bun.sleep(10)
       }
       return Cortex.get(taskID)
+    }
+
+    function taskOutputContext(sessionID: string): TaskOutputContext {
+      return {
+        sessionID,
+        messageID: "msg_parent01234567890abc",
+        agent: "synergy",
+        abort: new AbortController().signal,
+        metadata: () => {},
+        ask: async () => {},
+      }
+    }
+
+    async function persistTaskOutput(tool: TaskOutputInstance, params: TaskOutputParams, ctx: TaskOutputContext) {
+      const result = await tool.execute(params, ctx)
+      await tool.afterPersist?.(params, ctx, result)
+      return result
     }
 
     test("notifies parent by default when no waiter consumes the result", async () => {
@@ -1401,6 +1423,172 @@ describe.serial("Cortex", () => {
             expect(deliveries).toHaveLength(1)
             expect(deliveries[0].target).toBe(parentSession.id)
             expect(deliveries[0].mail.metadata?.source).toBe("cortex")
+          } finally {
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionManager.isRunning as any) = originalIsRunning
+          }
+        },
+      })
+    })
+
+    test("does not notify parent after terminal task output is persisted", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const originalDeliver = SessionManager.deliver
+          const originalIsRunning = SessionManager.isRunning
+          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              return writeAssistantText(input.sessionID, "completed")
+            },
+          )
+          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+            deliveries.push(input)
+          })
+          try {
+            const parentSession = await Session.create({})
+            ;(SessionManager.isRunning as any) = mock((sessionID: string) => sessionID === parentSession.id)
+            const taskOutput = await TaskOutputTool.init()
+            const ctx = taskOutputContext(parentSession.id)
+            for (const mode of ["summary", "progress", "tail", "full"] as const) {
+              const task = await Cortex.launch({
+                description: `Consume ${mode} task result`,
+                prompt: "Do something",
+                agent: "developer",
+                parentSessionID: parentSession.id,
+                parentMessageID: "msg_test01234567890abc",
+                model: { providerID: "test-provider", modelID: "test-model" },
+                output: { mode: "final_response" },
+              })
+
+              const completed = await waitUntilCompleted(task.id)
+              expect(completed?.status).toBe("completed")
+              const result = await persistTaskOutput(taskOutput, { task_id: task.id, mode }, ctx)
+              expect(result.metadata.status).toBe("completed")
+            }
+
+            expect(deliveries).toHaveLength(0)
+
+            await Cortex.flushDeferredParentNotifications(parentSession.id)
+
+            expect(deliveries).toHaveLength(0)
+          } finally {
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionManager.isRunning as any) = originalIsRunning
+          }
+        },
+      })
+    })
+
+    test("still notifies after task output observes only a running task", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const originalDeliver = SessionManager.deliver
+          const originalIsRunning = SessionManager.isRunning
+          const childMayFinish = Promise.withResolvers<void>()
+          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              await childMayFinish.promise
+              return writeAssistantText(input.sessionID, "completed")
+            },
+          )
+          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+            deliveries.push(input)
+          })
+          try {
+            const parentSession = await Session.create({})
+            ;(SessionManager.isRunning as any) = mock((sessionID: string) => sessionID === parentSession.id)
+            const task = await Cortex.launch({
+              description: "Observe running task",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: "msg_test01234567890abc",
+              model: { providerID: "test-provider", modelID: "test-model" },
+            })
+            const taskOutput = await TaskOutputTool.init()
+            const result = await persistTaskOutput(
+              taskOutput,
+              { task_id: task.id, mode: "progress" },
+              taskOutputContext(parentSession.id),
+            )
+
+            expect(result.metadata.status).toBe("running")
+            childMayFinish.resolve()
+            expect((await waitUntilCompleted(task.id))?.status).toBe("completed")
+
+            await Cortex.flushDeferredParentNotifications(parentSession.id)
+
+            expect(deliveries).toHaveLength(1)
+          } finally {
+            childMayFinish.resolve()
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+            ;(SessionManager.deliver as any) = originalDeliver
+            ;(SessionManager.isRunning as any) = originalIsRunning
+          }
+        },
+      })
+    })
+
+    test("only suppresses the completion notification for the task that was observed", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          const originalDeliver = SessionManager.deliver
+          const originalIsRunning = SessionManager.isRunning
+          const deliveries: Parameters<typeof SessionManager.deliver>[0][] = []
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              return writeAssistantText(input.sessionID, "completed")
+            },
+          )
+          ;(SessionManager.deliver as any) = mock(async (input: Parameters<typeof SessionManager.deliver>[0]) => {
+            deliveries.push(input)
+          })
+          try {
+            const parentSession = await Session.create({})
+            ;(SessionManager.isRunning as any) = mock((sessionID: string) => sessionID === parentSession.id)
+            const first = await Cortex.launch({
+              description: "Observed task",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: "msg_test01234567890abc",
+              model: { providerID: "test-provider", modelID: "test-model" },
+            })
+            const second = await Cortex.launch({
+              description: "Unobserved task",
+              prompt: "Do something else",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID: "msg_test01234567890abc",
+              model: { providerID: "test-provider", modelID: "test-model" },
+            })
+            expect((await waitUntilCompleted(first.id))?.status).toBe("completed")
+            expect((await waitUntilCompleted(second.id))?.status).toBe("completed")
+
+            const taskOutput = await TaskOutputTool.init()
+            await persistTaskOutput(
+              taskOutput,
+              { task_id: first.id, mode: "full" },
+              taskOutputContext(parentSession.id),
+            )
+            await Cortex.flushDeferredParentNotifications(parentSession.id)
+
+            expect(deliveries).toHaveLength(1)
+            expect(JSON.stringify(deliveries[0])).toContain(second.id)
+            expect(JSON.stringify(deliveries[0])).not.toContain(first.id)
           } finally {
             ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
             ;(SessionManager.deliver as any) = originalDeliver

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -279,6 +279,39 @@ describe("SessionProcessor execution slot settlement", () => {
     if (tool?.state.status === "completed") expect(tool.state.output).toBe("no tool-result needed")
   })
 
+  test("runs a completed tool post-persist effect after the tool part is durable", async () => {
+    let persisted = false
+    let committed = false
+    await runSettlementScenario({
+      messageID: "msg_assistant_post_persist",
+      updatePart: async (input) => {
+        const part = "part" in input ? input.part : input
+        if (part.type === "tool" && part.state.status === "completed") {
+          expect(committed).toBe(false)
+          persisted = true
+        }
+        return part
+      },
+      async *stream(processor) {
+        yield { type: "start" }
+        const slot = processor.beginExecution("call_post_persist")
+        yield { type: "tool-call", toolCallId: "call_post_persist", toolName: "synthetic", input: {} }
+        slot.complete(
+          {},
+          {
+            ...completedOutcome("synthetic", "persisted result"),
+            afterPersist: async () => {
+              expect(persisted).toBe(true)
+              committed = true
+            },
+          },
+        )
+      },
+    })
+
+    expect(committed).toBe(true)
+  })
+
   test("settles a synthetic tool error outcome instead of unresolved", async () => {
     const parts = await runSettlementScenario({
       messageID: "msg_assistant_slot_error",

--- a/packages/synergy/test/tool/exposure.test.ts
+++ b/packages/synergy/test/tool/exposure.test.ts
@@ -210,6 +210,70 @@ describe("tool exposure", () => {
     })
   })
 
+  test("runtime tools defer afterPersist effects to processor settlement", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const id = `post_persist_test_${Math.random().toString(36).slice(2)}`
+        let committed = false
+        await ToolRegistry.register(
+          Tool.define(id, {
+            description: "A test tool with a post-persist effect.",
+            parameters: z.object({ value: z.string() }),
+            async execute({ value }) {
+              return { title: id, output: value, metadata: {} }
+            },
+            afterPersist() {
+              committed = true
+            },
+          }),
+        )
+
+        const session = await Session.create({})
+        const outcome = Promise.withResolvers<any>()
+        const processor = {
+          message: { id: "message_test" },
+          partFromToolCall: () => undefined,
+          beginExecution: (callID: string) => ({
+            callID,
+            promise: outcome.promise,
+            resolve: outcome.resolve,
+            complete(input: unknown, result: unknown) {
+              outcome.resolve({ status: "completed", input, result })
+            },
+            fail(input: unknown, error: string, metadata?: Record<string, unknown>) {
+              outcome.resolve({ status: "error", input, error, metadata })
+            },
+            get outcome() {
+              return undefined
+            },
+            get status() {
+              return "pending" as const
+            },
+          }),
+        } as any
+        const resolved = await ToolResolver.resolveWithAvailability({
+          agent: allowAllAgent,
+          model,
+          sessionID: session.id,
+          processor,
+          session: await Session.get(session.id),
+          includeMCP: false,
+        })
+
+        await (resolved.tools[id] as any).execute({ value: "persist me" }, { toolCallId: "call_post_persist" })
+        const completed = await outcome.promise
+
+        expect(committed).toBe(false)
+        expect(completed.result.output).toBe("persist me")
+        expect(completed.result.afterPersist).toBeFunction()
+        await completed.result.afterPersist()
+        expect(committed).toBe(true)
+      },
+    })
+  })
+
   test("internal tools are hidden from search and visible only when force-enabled", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({


### PR DESCRIPTION
## Summary

- acknowledge terminal `task_output` consumption only after the completed tool part is durable
- remove only the matching deferred Cortex completion notice, preserving notifications for running and unobserved tasks
- document the consumption contract and add processor, resolver, and Cortex regression coverage

## Regression

The deferred parent-notification queue did not record that a terminal background-task result had already been consumed through `task_output`. When the parent later became available, flushing that queue delivered the same completion again and woke the parent a second time.

## Tests

- `bun test test/cortex/manager.test.ts test/session/processor.test.ts`
- `bun test test/tool/exposure.test.ts`
- `bun run typecheck`
- `bun run quality:quick`
- `bun run test:changed` — 2,139 passed; two environment/isolation failures both passed on isolated rerun
- `env -u NO_PROXY -u no_proxy bun test` — 4,341 passed, 1 skipped; two setup failures in the browser controller contract because Playwright Chromium is not installed locally
