### PR TITLE
test: align tool processor fixture

### DIFF
--- a/packages/synergy/test/tool/exposure.test.ts
+++ b/packages/synergy/test/tool/exposure.test.ts
@@ -232,9 +232,17 @@ describe("tool exposure", () => {
 
         const session = await Session.create({})
         const outcome = Promise.withResolvers<any>()
+        const callbacks = new Map<string, Promise<unknown>>()
         const processor = {
           message: { id: "message_test" },
           partFromToolCall: () => undefined,
+          executeOnce: <T>(callID: string, execute: () => Promise<T>) => {
+            const existing = callbacks.get(callID)
+            if (existing) return existing as Promise<T>
+            const callback = Promise.resolve().then(execute)
+            callbacks.set(callID, callback)
+            return callback
+          },
           beginExecution: (callID: string) => ({
             callID,
             promise: outcome.promise,


### PR DESCRIPTION
## Summary

- add the missing `executeOnce` contract to the tool exposure test processor fixture
- mirror the runtime callback deduplication semantics
- allow the after-persist settlement test to exercise its intended behavior

## Root cause

Runtime tools now call `SessionProcessor.executeOnce()` before execution, but this hand-written test fixture was still cast through `any` without implementing the new method. The fixture therefore threw before reaching the settlement assertions.

## Validation

- `cd packages/synergy && bun test test/tool/exposure.test.ts` — 20 passed
- `cd packages/synergy && bun run test:changed` — 20 passed
- `bun run quality:quick` — passed
- push hooks — format, lint, typecheck, and dependency hygiene passed

## Known local-only failures

- Full `bun turbo test` was not green locally because the plugin-kit Solid build fixture fails on macOS; the referenced Ubuntu CI run passed that fixture.
- The full `packages/synergy` suite reached and passed the fixed test, but the unrelated provider proxy routing fixture fails locally on macOS and passed in the referenced Ubuntu CI run.
