### PR TITLE
fix(session): add compaction recovery hint

### DIFF
--- a/docs/architecture/llm-loop.md
+++ b/docs/architecture/llm-loop.md
@@ -202,7 +202,7 @@ If the summarization call itself exceeds context, Synergy writes a deterministic
 
 The active task anchor is resolved directly from root `R`: user-authored text first, then the root summary title. There is no backward heuristic scan or carried anchor metadata.
 
-Automatic compaction writes a hidden non-root system continuation belonging to `R`, includes the anchor, and returns `continue`. The next iteration rereads filtered history and resumes the same task.
+Automatic compaction writes a hidden non-root system continuation belonging to `R`, includes the anchor, and returns `continue`. The continuation also carries a deterministic recovery hint: use the summary as the primary handoff, avoid repeating completed work, and only when exact earlier message context is missing, expand the deferred Session tools if needed and use `session_read` around the compaction summary message. The next iteration rereads filtered history and resumes the same task.
 
 ### Filtering and pruning
 

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -363,6 +363,20 @@ export namespace SessionCompaction {
     return anchor ? formatAnchor(anchor.text) : undefined
   }
 
+  export function buildRecoveryHint(input: { sessionID: string; summaryMessageID: string }): string {
+    return [
+      "<recovery-hint>",
+      "This task is continuing after context compaction.",
+      "Use the latest compaction summary as the primary handoff, resume from its first unfinished next step, and do not repeat work recorded as completed.",
+      "Earlier message text and tool-call summaries remain durably stored in this session.",
+      "Do not read the earlier history unless the continuation summary is insufficient.",
+      'If exact earlier message context is required and `session_read` is not visible, first expand the "session" tool group.',
+      `Then use \`session_read\` with target session "${input.sessionID}", around message "${input.summaryMessageID}", and limit 50.`,
+      "Do not guess when the missing context can be recovered from the stored session.",
+      "</recovery-hint>",
+    ].join("\n")
+  }
+
   export async function process(input: {
     parentID: string
     messages: MessageV2.WithParts[]
@@ -531,6 +545,16 @@ export namespace SessionCompaction {
         synthetic: true,
         origin: "system",
         text: "Continue if you have next steps",
+        time: { start: now, end: now },
+      })
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: continueMsg.id,
+        sessionID: input.sessionID,
+        type: "text",
+        synthetic: true,
+        origin: "system",
+        text: buildRecoveryHint({ sessionID: input.sessionID, summaryMessageID: msg.id }),
         time: { start: now, end: now },
       })
       if (anchor) {

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -597,6 +597,23 @@ describe("session.compaction.buildAnchor", () => {
   })
 })
 
+describe("session.compaction.buildRecoveryHint", () => {
+  test("points the continuation at durable history around the compaction boundary", () => {
+    const hint = SessionCompaction.buildRecoveryHint({
+      sessionID: "ses_test",
+      summaryMessageID: "msg_summary",
+    })
+
+    expect(hint).toContain("<recovery-hint>")
+    expect(hint).toContain("Do not read the earlier history unless the continuation summary is insufficient")
+    expect(hint).toContain('expand the "session" tool group')
+    expect(hint).toContain('target session "ses_test"')
+    expect(hint).toContain('around message "msg_summary"')
+    expect(hint).toContain("limit 50")
+    expect(hint).toContain("</recovery-hint>")
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Token.encodingForModelID
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- inject a deterministic hidden `<recovery-hint>` after automatic compaction
- direct the continuing agent to use the latest summary first and avoid repeating completed work
- provide the current session and compaction-summary boundary for bounded, on-demand `session_read` recovery
- document the continuation contract and cover the recovery hint with a regression test

## Why

The existing hidden continuation preserved the root request but did not tell the continuing agent that earlier message text and tool-call summaries remained available. When the compaction summary omitted exact prior context, the agent could guess or stall instead of recovering it from durable session history.

The hint avoids eagerly reloading old history, expands the deferred Session tool group only when needed, and reads around the exact compaction boundary with a limit of 50 messages.

## Validation

- `cd packages/synergy && bun test test/session/compaction.test.ts test/session/invoke-compaction.test.ts` — 73 passed
- `bun run typecheck`
- `bun run quality:quick`
