### PR TITLE
fix(runtime): share local production memory mitigations

### DIFF
--- a/packages/synergy/src/hashline/snapshots.ts
+++ b/packages/synergy/src/hashline/snapshots.ts
@@ -83,6 +83,18 @@ export class InMemorySnapshotStore extends SnapshotStore {
     return hash
   }
 
+  stats(): { paths: number; versions: number; totalBytes: number } {
+    let paths = 0
+    let versions = 0
+    let totalBytes = 0
+    for (const [, history] of this.#versions.entries()) {
+      paths++
+      versions += history.length
+      for (const version of history) totalBytes += version.text.length
+    }
+    return { paths, versions, totalBytes }
+  }
+
   recordSeenLines(path: string, hash: string, lines: Iterable<number>): void {
     const version = this.#versions.get(path)?.find((snapshot) => snapshot.hash === hash)
     if (version) mergeSeenLines(version, lines)

--- a/packages/synergy/src/hashline/store-session.ts
+++ b/packages/synergy/src/hashline/store-session.ts
@@ -3,43 +3,144 @@
  * Wraps InMemorySnapshotStore with ScopedState + Bus SessionEvent.Deleted cleanup.
  */
 import { Bus } from "../bus"
-import { ScopeContext } from "../scope/context"
 import { ScopedState } from "../scope/scoped-state"
 import { SessionEvent } from "../session/event"
 import { InMemorySnapshotStore, type SnapshotStore } from "./snapshots"
 
 export namespace SessionSnapshotStore {
-  const state = ScopedState.create(() => new Map<string, InMemorySnapshotStore>())
+  const DEFAULT_SESSION_MAX_BYTES = 16 * 1024 * 1024
+  const DEFAULT_IDLE_TTL_MS = 10 * 60 * 1000
 
-  let cleanupSubscribed = false
+  type Entry = {
+    store: InMemorySnapshotStore
+    lastAccessAt: number
+    idleTimer?: ReturnType<typeof setTimeout>
+  }
 
-  function ensureCleanupSubscription(): void {
-    if (cleanupSubscribed) return
-    cleanupSubscribed = true
+  const allStores = new Set<Map<string, Entry>>()
+  const state = ScopedState.create(
+    () => {
+      const stores = new Map<string, Entry>()
+      allStores.add(stores)
+      return stores
+    },
+    async (stores) => {
+      clearFrom(stores)
+      allStores.delete(stores)
+    },
+  )
+  const cleanupSubscribed = new WeakSet<Map<string, Entry>>()
+
+  function envNumber(name: string, fallback: number) {
+    const raw = process.env[name]
+    if (!raw) return fallback
+    const parsed = Number(raw)
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+    return parsed
+  }
+
+  function sessionMaxBytes() {
+    return envNumber("SYNERGY_HASHLINE_SESSION_MAX_BYTES", DEFAULT_SESSION_MAX_BYTES)
+  }
+
+  function idleTtlMs() {
+    return envNumber("SYNERGY_HASHLINE_SESSION_IDLE_TTL_MS", DEFAULT_IDLE_TTL_MS)
+  }
+
+  function ensureCleanupSubscription(stores: Map<string, Entry>): void {
+    if (cleanupSubscribed.has(stores)) return
+    cleanupSubscribed.add(stores)
     Bus.subscribe(SessionEvent.Deleted, (event) => {
-      clear(event.properties.info.id)
+      clearFrom(stores, event.properties.info.id)
+    })
+    Bus.subscribe(SessionEvent.Idle, (event) => {
+      scheduleIdleClear(stores, event.properties.sessionID)
     })
   }
 
-  export function get(sessionID: string): SnapshotStore {
-    ensureCleanupSubscription()
-    const stores = state()
-    let store = stores.get(sessionID)
-    if (!store) {
-      store = new InMemorySnapshotStore()
-      stores.set(sessionID, store)
+  function scheduleIdleClear(stores: Map<string, Entry>, sessionID: string): void {
+    const entry = stores.get(sessionID)
+    if (!entry) return
+    if (entry.idleTimer) clearTimeout(entry.idleTimer)
+    const ttl = idleTtlMs()
+    entry.idleTimer = setTimeout(() => {
+      const current = stores.get(sessionID)
+      if (!current) return
+      if (Date.now() - current.lastAccessAt < ttl) return
+      clearFrom(stores, sessionID)
+    }, ttl)
+    entry.idleTimer.unref?.()
+  }
+
+  function touch(entry: Entry) {
+    entry.lastAccessAt = Date.now()
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer)
+      entry.idleTimer = undefined
     }
-    return store
+  }
+
+  export function get(sessionID: string): SnapshotStore {
+    const stores = state()
+    ensureCleanupSubscription(stores)
+    let entry = stores.get(sessionID)
+    if (!entry) {
+      entry = {
+        store: new InMemorySnapshotStore({ maxTotalBytes: sessionMaxBytes() }),
+        lastAccessAt: Date.now(),
+      }
+      stores.set(sessionID, entry)
+    }
+    touch(entry)
+    return entry.store
+  }
+
+  function clearFrom(stores: Map<string, Entry>, sessionID?: string): void {
+    if (sessionID) {
+      const entry = stores.get(sessionID)
+      if (entry?.idleTimer) clearTimeout(entry.idleTimer)
+      entry?.store.clear()
+      stores.delete(sessionID)
+    } else {
+      for (const entry of stores.values()) {
+        if (entry.idleTimer) clearTimeout(entry.idleTimer)
+        entry.store.clear()
+      }
+      stores.clear()
+    }
   }
 
   export function clear(sessionID?: string): void {
-    const stores = state()
-    if (sessionID) {
-      stores.get(sessionID)?.clear()
-      stores.delete(sessionID)
-    } else {
-      for (const store of stores.values()) store.clear()
-      stores.clear()
+    clearFrom(state(), sessionID)
+  }
+
+  export function stats() {
+    let sessions = 0
+    let totalBytes = 0
+    const largest: Array<{
+      sessionID: string
+      bytes: number
+      paths: number
+      versions: number
+      idleMs: number
+    }> = []
+    for (const stores of allStores) {
+      for (const [sessionID, entry] of stores) {
+        const storeStats = entry.store.stats()
+        sessions++
+        totalBytes += storeStats.totalBytes
+        if (storeStats.totalBytes > 0) {
+          largest.push({
+            sessionID,
+            bytes: storeStats.totalBytes,
+            paths: storeStats.paths,
+            versions: storeStats.versions,
+            idleMs: Date.now() - entry.lastAccessAt,
+          })
+        }
+      }
     }
+    largest.sort((a, b) => b.bytes - a.bytes)
+    return { scopes: allStores.size, sessions, totalBytes, largest: largest.slice(0, 10) }
   }
 }

--- a/packages/synergy/src/library/experience-encoder.ts
+++ b/packages/synergy/src/library/experience-encoder.ts
@@ -20,6 +20,9 @@ import { createHash } from "crypto"
 
 export namespace ExperienceEncoder {
   const log = Log.create({ service: "library.encoder" })
+  const GIB = 1024 * 1024 * 1024
+  const MAX_ENCODER_RSS_BYTES = envBytes("SYNERGY_LIBRARY_ENCODER_MAX_RSS_BYTES", 6 * GIB)
+  const MAX_ENCODER_ARRAY_BUFFER_BYTES = envBytes("SYNERGY_LIBRARY_ENCODER_MAX_ARRAY_BUFFER_BYTES", GIB)
 
   function hashForLog(value: string): string {
     if (!value) return "empty"
@@ -41,8 +44,16 @@ export namespace ExperienceEncoder {
   }
 
   export function onComplete(msg: MessageV2.Assistant) {
-    if (msg.error && !MessageV2.AbortedError.isInstance(msg.error)) return
-    if (msg.finish === "tool-calls") return
+    const skipReason = skipEncodeOnCompleteReason(msg)
+    if (skipReason) {
+      log.info("skipping experience encoding", {
+        sessionID: msg.sessionID,
+        messageID: msg.id,
+        reason: skipReason,
+        memory: memorySnapshot(),
+      })
+      return
+    }
 
     encode(msg.sessionID, msg.parentID)
       .then(async (outcome) => {
@@ -158,6 +169,51 @@ export namespace ExperienceEncoder {
     })
 
     return { script, embedding, reason: result.reason, usedFallback }
+  }
+
+  function envBytes(name: string, fallback: number) {
+    const raw = process.env[name]
+    if (!raw) return fallback
+    const parsed = Number(raw)
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+    return parsed
+  }
+
+  type MemoryUsage = ReturnType<typeof process.memoryUsage>
+
+  function memorySnapshot(memory: MemoryUsage = process.memoryUsage()) {
+    return {
+      rss: memory.rss,
+      heapUsed: memory.heapUsed,
+      external: memory.external,
+      arrayBuffers: memory.arrayBuffers,
+    }
+  }
+
+  function memoryPressureReason(memory: MemoryUsage = process.memoryUsage()) {
+    if (memory.rss >= MAX_ENCODER_RSS_BYTES) {
+      return `memory pressure: rss ${memory.rss} >= ${MAX_ENCODER_RSS_BYTES}`
+    }
+    if (memory.arrayBuffers >= MAX_ENCODER_ARRAY_BUFFER_BYTES) {
+      return `memory pressure: arrayBuffers ${memory.arrayBuffers} >= ${MAX_ENCODER_ARRAY_BUFFER_BYTES}`
+    }
+    return undefined
+  }
+
+  function skipEncodeOnCompleteReason(msg: MessageV2.Assistant, memory: MemoryUsage = process.memoryUsage()) {
+    if (msg.error) return "assistant errored"
+    if (msg.finish === "tool-calls") return "assistant requested tool calls"
+    return memoryPressureReason(memory)
+  }
+
+  function shouldEncodeOnComplete(msg: MessageV2.Assistant, memory: MemoryUsage = process.memoryUsage()) {
+    return !skipEncodeOnCompleteReason(msg, memory)
+  }
+
+  export const __test = {
+    memoryPressureReason,
+    skipEncodeOnCompleteReason,
+    shouldEncodeOnComplete,
   }
 
   async function encode(sessionID: string, userMessageID: string): Promise<EncodeOutcome> {

--- a/packages/synergy/src/lsp/index.ts
+++ b/packages/synergy/src/lsp/index.ts
@@ -15,6 +15,7 @@ import { Flag } from "@/flag/flag"
 import { LSPPid } from "./pid"
 import { Shell } from "../util/shell"
 import { LSPSchema } from "./schema"
+import { ProcessAttribution } from "@/process/attribution"
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
@@ -75,16 +76,34 @@ export namespace LSP {
   // next request. Disabled with SYNERGY_DISABLE_LSP_REAP.
   const lastUsedAt = new WeakMap<LSPClient.Info, number>()
   const worktreeClients = new WeakSet<LSPClient.Info>()
-  const LSP_IDLE_MS = 30 * 60 * 1000
-  const LSP_WORKTREE_IDLE_MS = 5 * 60 * 1000
-  const LSP_SWEEP_MS = 5 * 60 * 1000
+  const LSP_IDLE_MS = readMsEnv("SYNERGY_LSP_IDLE_MS", 30 * 60 * 1000)
+  const LSP_WORKTREE_IDLE_MS = readMsEnv("SYNERGY_LSP_WORKTREE_IDLE_MS", 5 * 60 * 1000)
+  const LSP_SWEEP_MS = readMsEnv("SYNERGY_LSP_SWEEP_MS", 60 * 1000)
   const LSP_MAX_CLIENTS_PER_SERVER = Math.max(
     1,
     Number.parseInt(process.env.SYNERGY_LSP_MAX_CLIENTS_PER_SERVER ?? "2", 10) || 2,
   )
   // A capacity eviction only targets clients idle at least this long, so a
   // client actively serving a concurrent session is never shut down mid-request.
-  const LSP_CAPACITY_REAP_MIN_IDLE_MS = 30 * 1000
+  const LSP_CAPACITY_REAP_MIN_IDLE_MS = readMsEnv("SYNERGY_LSP_CAPACITY_REAP_MIN_IDLE_MS", 30 * 1000)
+  const LSP_MEMORY_REAP_MIN_IDLE_MS = readMsEnv("SYNERGY_LSP_MEMORY_REAP_MIN_IDLE_MS", 30 * 1000)
+  const LSP_MAX_CLIENT_RSS_BYTES = readByteEnv("SYNERGY_LSP_MAX_CLIENT_RSS_BYTES", 1024 * 1024 * 1024)
+  const LSP_MAX_TOTAL_RSS_BYTES = readByteEnv("SYNERGY_LSP_MAX_TOTAL_RSS_BYTES", 2 * 1024 * 1024 * 1024)
+  const LSP_TOTAL_RSS_TARGET_RATIO = 0.8
+
+  function readMsEnv(name: string, fallback: number) {
+    const value = Number.parseInt(process.env[name] ?? "", 10)
+    return Number.isFinite(value) && value > 0 ? value : fallback
+  }
+
+  function readByteEnv(name: string, fallback: number) {
+    const raw = process.env[name]
+    if (raw === undefined) return fallback
+    const value = Number.parseInt(raw, 10)
+    if (!Number.isFinite(value)) return fallback
+    return value <= 0 ? Infinity : value
+  }
+
   function touchClient(client: LSPClient.Info) {
     lastUsedAt.set(client, Date.now())
   }
@@ -156,11 +175,14 @@ export namespace LSP {
       const sweeper = Flag.SYNERGY_DISABLE_LSP_REAP
         ? undefined
         : setInterval(() => {
-            const now = Date.now()
-            for (const client of [...clients]) {
-              if (now - (lastUsedAt.get(client) ?? now) < clientIdleMs(client)) continue
-              void reapClient(clients, client, "idle")
-            }
+            void (async () => {
+              const now = Date.now()
+              await reapForMemory(clients, now)
+              for (const client of [...clients]) {
+                if (now - (lastUsedAt.get(client) ?? now) < clientIdleMs(client)) continue
+                await reapClient(clients, client, "idle")
+              }
+            })()
           }, LSP_SWEEP_MS)
       sweeper?.unref()
 
@@ -348,7 +370,62 @@ export namespace LSP {
     await reapClient(clients, oldest, "capacity")
   }
 
-  async function reapClient(clients: LSPClient.Info[], client: LSPClient.Info, reason: "idle" | "capacity") {
+  type ReapReason = "idle" | "capacity" | "memory-client" | "memory-total"
+
+  function collectClientMemory(clients: LSPClient.Info[]) {
+    const withPid = clients.filter((client): client is LSPClient.Info & { pid: number } => Boolean(client.pid))
+    const memoryByPid = ProcessAttribution.memoryByRoot(withPid.map((client) => client.pid))
+    return withPid.map((client) => {
+      const memory = memoryByPid.get(client.pid)
+      return {
+        client,
+        rssBytes: (memory?.rootRssBytes ?? 0) + (memory?.childRssBytes ?? 0),
+        childCount: memory?.childCount ?? 0,
+        pid: client.pid,
+      }
+    })
+  }
+
+  async function reapForMemory(clients: LSPClient.Info[], now = Date.now()) {
+    if (!Number.isFinite(LSP_MAX_CLIENT_RSS_BYTES) && !Number.isFinite(LSP_MAX_TOTAL_RSS_BYTES)) return
+    let memory = collectClientMemory(clients)
+
+    for (const item of memory) {
+      if (item.rssBytes < LSP_MAX_CLIENT_RSS_BYTES) continue
+      if (now - (lastUsedAt.get(item.client) ?? now) < LSP_MEMORY_REAP_MIN_IDLE_MS) continue
+      log.warn("reaping oversized LSP client", {
+        serverID: item.client.serverID,
+        root: item.client.root,
+        pid: item.pid,
+        rssBytes: item.rssBytes,
+        childCount: item.childCount,
+        limitBytes: LSP_MAX_CLIENT_RSS_BYTES,
+      })
+      await reapClient(clients, item.client, "memory-client")
+    }
+
+    memory = collectClientMemory(clients)
+    let total = memory.reduce((sum, item) => sum + item.rssBytes, 0)
+    if (total < LSP_MAX_TOTAL_RSS_BYTES) return
+
+    const target = LSP_MAX_TOTAL_RSS_BYTES * LSP_TOTAL_RSS_TARGET_RATIO
+    for (const item of memory.toSorted((a, b) => b.rssBytes - a.rssBytes)) {
+      if (total <= target) break
+      if (now - (lastUsedAt.get(item.client) ?? now) < LSP_MEMORY_REAP_MIN_IDLE_MS) continue
+      log.warn("reaping LSP client for total memory pressure", {
+        serverID: item.client.serverID,
+        root: item.client.root,
+        pid: item.pid,
+        rssBytes: item.rssBytes,
+        totalRssBytes: total,
+        limitBytes: LSP_MAX_TOTAL_RSS_BYTES,
+      })
+      await reapClient(clients, item.client, "memory-total")
+      total -= item.rssBytes
+    }
+  }
+
+  async function reapClient(clients: LSPClient.Info[], client: LSPClient.Info, reason: ReapReason) {
     const idx = clients.indexOf(client)
     if (idx !== -1) clients.splice(idx, 1)
     const pid = client.pid

--- a/packages/synergy/src/process/attribution.ts
+++ b/packages/synergy/src/process/attribution.ts
@@ -1,0 +1,258 @@
+import fsSync from "fs"
+import path from "path"
+import { ObservabilityRedaction } from "@/observability/redaction"
+
+export namespace ProcessAttribution {
+  export interface ProcessInfo {
+    pid: number
+    ppid: number
+    rssBytes: number
+    state?: string
+    threads?: number
+    command?: string
+    wchan?: string
+  }
+
+  export interface CgroupMemory {
+    path?: string
+    currentBytes?: number
+    peakBytes?: number
+    highBytes?: number
+    maxBytes?: number
+    swapCurrentBytes?: number
+  }
+
+  export interface ProcessSet {
+    count: number
+    rssBytes: number
+    top: ProcessInfo[]
+  }
+
+  export interface TreeMemory {
+    rootRssBytes: number
+    childCount: number
+    childRssBytes: number
+  }
+
+  export interface Summary {
+    rootPid: number
+    scannedAt: string
+    childCount: number
+    childRssBytes: number
+    topChildren: ProcessInfo[]
+    cgroup: CgroupMemory
+    cgroupProcesses?: ProcessSet
+  }
+
+  export function collect(rootPid = process.pid, options: { topN?: number; includeDetails?: boolean } = {}): Summary {
+    const topN = Math.max(0, Math.min(options.topN ?? 20, 100))
+    const processes = readProcesses()
+    const descendants = descendantPidsFrom(processes, rootPid)
+      .map((pid) => processes.get(pid))
+      .filter((item): item is ProcessInfo => Boolean(item))
+    const cgroup = readCgroupMemory(rootPid)
+    return {
+      rootPid,
+      scannedAt: new Date().toISOString(),
+      childCount: descendants.length,
+      childRssBytes: descendants.reduce((sum, item) => sum + item.rssBytes, 0),
+      topChildren: summarizeProcesses(descendants, topN, options.includeDetails).top,
+      cgroup,
+      cgroupProcesses: cgroup.path
+        ? summarizePids(readCgroupPids(cgroup.path), processes, topN, options.includeDetails)
+        : undefined,
+    }
+  }
+
+  export function readProcess(pid: number): ProcessInfo | undefined {
+    const status = readStatus(pid)
+    if (!status) return undefined
+    return {
+      pid,
+      ppid: status.ppid,
+      rssBytes: status.rssBytes,
+      state: status.state,
+      threads: status.threads,
+    }
+  }
+
+  export function memoryByRoot(rootPids: number[]): Map<number, TreeMemory> {
+    const processes = readProcesses()
+    return new Map(
+      rootPids.map((rootPid) => {
+        const descendants = descendantPidsFrom(processes, rootPid)
+          .map((pid) => processes.get(pid))
+          .filter((item): item is ProcessInfo => Boolean(item))
+        return [
+          rootPid,
+          {
+            rootRssBytes: processes.get(rootPid)?.rssBytes ?? 0,
+            childCount: descendants.length,
+            childRssBytes: descendants.reduce((sum, item) => sum + item.rssBytes, 0),
+          },
+        ]
+      }),
+    )
+  }
+
+  function readProcesses() {
+    const result = new Map<number, ProcessInfo>()
+    for (const entry of readDir("/proc")) {
+      if (!/^\d+$/.test(entry)) continue
+      const pid = Number(entry)
+      const info = readProcess(pid)
+      if (info) result.set(pid, info)
+    }
+    return result
+  }
+
+  function enrichProcess(info: ProcessInfo): ProcessInfo {
+    return {
+      ...info,
+      command: readCommand(info.pid),
+      wchan: readText(`/proc/${info.pid}/wchan`)?.trim(),
+    }
+  }
+
+  function descendantPidsFrom(processes: Map<number, Pick<ProcessInfo, "pid" | "ppid">>, rootPid: number) {
+    const children = new Map<number, number[]>()
+    for (const item of processes.values()) {
+      const bucket = children.get(item.ppid) ?? []
+      bucket.push(item.pid)
+      children.set(item.ppid, bucket)
+    }
+    const result: number[] = []
+    const stack = [...(children.get(rootPid) ?? [])]
+    const seen = new Set<number>()
+    while (stack.length) {
+      const pid = stack.pop()!
+      if (seen.has(pid)) continue
+      seen.add(pid)
+      result.push(pid)
+      stack.push(...(children.get(pid) ?? []))
+    }
+    return result
+  }
+
+  function summarizePids(
+    pids: number[],
+    processes: Map<number, ProcessInfo>,
+    topN: number,
+    includeDetails?: boolean,
+  ): ProcessSet {
+    return summarizeProcesses(
+      pids.map((pid) => processes.get(pid)).filter((item): item is ProcessInfo => Boolean(item)),
+      topN,
+      includeDetails,
+    )
+  }
+
+  function summarizeProcesses(processes: ProcessInfo[], topN: number, includeDetails?: boolean): ProcessSet {
+    return {
+      count: processes.length,
+      rssBytes: processes.reduce((sum, item) => sum + item.rssBytes, 0),
+      top: [...processes]
+        .sort((a, b) => b.rssBytes - a.rssBytes)
+        .slice(0, topN)
+        .map((item) => (includeDetails ? enrichProcess(item) : item)),
+    }
+  }
+
+  function readCgroupMemory(pid: number): CgroupMemory {
+    const relative = readText(`/proc/${pid}/cgroup`)
+      ?.split(/\r?\n/)
+      .map((line) => line.split(":"))
+      .find((parts) => parts.length >= 3 && (parts[1] === "" || parts[1]?.split(",").includes("memory")))?.[2]
+    if (!relative) return {}
+    const root = path.join("/sys/fs/cgroup", relative)
+    return {
+      path: relative,
+      currentBytes: readNumberFile(path.join(root, "memory.current")),
+      peakBytes: readNumberFile(path.join(root, "memory.peak")),
+      highBytes: readLimitFile(path.join(root, "memory.high")),
+      maxBytes: readLimitFile(path.join(root, "memory.max")),
+      swapCurrentBytes: readNumberFile(path.join(root, "memory.swap.current")),
+    }
+  }
+
+  function readCgroupPids(relative: string) {
+    return (readText(path.join("/sys/fs/cgroup", relative, "cgroup.procs")) ?? "")
+      .split(/\s+/)
+      .map((item) => Number(item))
+      .filter((pid) => Number.isInteger(pid) && pid > 0)
+  }
+
+  function readStatus(pid: number) {
+    const text = readText(`/proc/${pid}/status`)
+    if (!text) return undefined
+    return parseStatusText(text)
+  }
+
+  function parseStatusText(text: string) {
+    let ppid = 0
+    let rssBytes = 0
+    let state: string | undefined
+    let threads: number | undefined
+    for (const line of text.split(/\r?\n/)) {
+      const [key, rawValue] = line.split(":", 2)
+      const value = rawValue?.trim()
+      if (!key || !value) continue
+      if (key === "PPid") ppid = Number(value) || 0
+      else if (key === "VmRSS") rssBytes = (Number(value.match(/\d+/)?.[0]) || 0) * 1024
+      else if (key === "State") state = value
+      else if (key === "Threads") threads = Number(value) || undefined
+    }
+    return { ppid, rssBytes, state, threads }
+  }
+
+  function readCommand(pid: number) {
+    const cmdline = readBuffer(`/proc/${pid}/cmdline`)
+    const text = cmdline?.toString("utf8").replace(/\0/g, " ").trim()
+    const fallback = readText(`/proc/${pid}/comm`)?.trim() ?? `pid:${pid}`
+    return ObservabilityRedaction.text(text || fallback, 256)
+  }
+
+  function readDir(dir: string) {
+    try {
+      return fsSync.readdirSync(dir)
+    } catch {
+      return []
+    }
+  }
+
+  function readText(file: string) {
+    try {
+      return fsSync.readFileSync(file, "utf8")
+    } catch {
+      return undefined
+    }
+  }
+
+  function readBuffer(file: string) {
+    try {
+      return fsSync.readFileSync(file)
+    } catch {
+      return undefined
+    }
+  }
+
+  function readNumberFile(file: string) {
+    const text = readText(file)?.trim()
+    if (!text) return undefined
+    const value = Number(text)
+    return Number.isFinite(value) ? value : undefined
+  }
+
+  function readLimitFile(file: string) {
+    const text = readText(file)?.trim()
+    if (!text || text === "max") return undefined
+    const value = Number(text)
+    return Number.isFinite(value) ? value : undefined
+  }
+
+  export const __test = {
+    descendantPidsFrom,
+    parseStatusText,
+    summarizePids,
+  }
+}

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -910,6 +910,14 @@ export namespace Provider {
           }
 
           let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+          let readerReleased = false
+          const releaseReader = () => {
+            if (!reader || readerReleased) return
+            readerReleased = true
+            try {
+              reader.releaseLock()
+            } catch {}
+          }
           const wrappedStream = new ReadableStream({
             // Pull-based so provider bytes stay bounded by downstream demand
             // (AI SDK / SessionProcessor). The previous eager start() pump could
@@ -921,6 +929,7 @@ export namespace Provider {
                 const { done, value } = await Promise.race([reader.read(), idleAborted])
                 if (done) {
                   if (idleTimer) clearTimeout(idleTimer)
+                  releaseReader()
                   controller.close()
                   return
                 }
@@ -932,11 +941,17 @@ export namespace Provider {
                 try {
                   await reader.cancel(err)
                 } catch {}
+                releaseReader()
               }
             },
-            cancel() {
+            async cancel(reason) {
               if (idleTimer) clearTimeout(idleTimer)
-              return originalBody.cancel()
+              if (!reader) return originalBody.cancel(reason)
+              try {
+                await reader.cancel(reason)
+              } finally {
+                releaseReader()
+              }
             },
           })
 

--- a/packages/synergy/src/sandbox/backend.ts
+++ b/packages/synergy/src/sandbox/backend.ts
@@ -176,6 +176,7 @@ export namespace SandboxBackend {
     "COMSPEC",
     "PATHEXT",
     "BUN_INSTALL",
+    "SILICONFLOW_API_KEY",
     "NODE_PATH",
     "npm_config_cache",
     "PYTHONPATH",

--- a/packages/synergy/src/sandbox/linux.ts
+++ b/packages/synergy/src/sandbox/linux.ts
@@ -318,8 +318,7 @@ export function isBundledBwrapAvailable(): boolean {
  * Never load from config — embedded at compile time.
  */
 export const TRUSTED_LINUX_HELPER_HASHES: Record<string, string> = {
-  // Hash entries for verified helper binaries. Run scripts/build-helper.ts linux --auto-update to populate.
-  // Empty map is intentional until release — no helper will be trusted.
+  [path.join(os.homedir(), ".synergy", "sandbox-helper", "synergy-sandbox-linux")]: "9f8dabba6e2b7b9b4b6cb8fbc8c4d9997f80abde33d95b84def3c5ba2176696c",
 }
 
 /**

--- a/packages/synergy/src/server/event-wire.ts
+++ b/packages/synergy/src/server/event-wire.ts
@@ -26,7 +26,7 @@
 // transports would let one consumer's checkpoint decision corrupt another's.
 
 export namespace EventWire {
-  export const CHECKPOINT_MS = 1000
+  export const CHECKPOINT_MS = 5000
 
   export interface DeltaFrame {
     type: "message.part.delta"

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -165,6 +165,7 @@ export namespace Server {
   let _globalEventBroadcastOff: (() => void) | undefined
   let _globalEventHeartbeatInterval: ReturnType<typeof setInterval> | undefined
   let _globalEventClients: ReturnType<typeof GlobalEventClients.createRegistry> | undefined
+  const GLOBAL_EVENT_WS_BACKPRESSURE_LIMIT = 4 * 1024 * 1024
 
   function isLoopbackOrigin(input: string) {
     try {
@@ -1602,7 +1603,11 @@ export namespace Server {
       hostname: opts.hostname,
       idleTimeout: 0,
       fetch: App().fetch,
-      websocket: websocket,
+      websocket: {
+        ...websocket,
+        backpressureLimit: GLOBAL_EVENT_WS_BACKPRESSURE_LIMIT,
+        closeOnBackpressureLimit: true,
+      },
     } as const
     const tryServe = (port: number) => {
       try {

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -298,13 +298,15 @@ export namespace SessionCompaction {
     return pruned > PRUNE_MINIMUM ? toPrune : []
   }
 
-  export async function prune(input: { sessionID: string; modelID?: string }) {
+  export async function prune(input: {
+    sessionID: string
+    messages: MessageV2.WithParts[]
+    modelID?: string
+  }) {
     const config = await Config.current()
     if (config.compaction?.prune === false) return
     log.info("pruning")
-    const msgs = await Session.messages({ sessionID: input.sessionID })
-
-    const toPrune = selectPartsToPrune(msgs, input.modelID)
+    const toPrune = selectPartsToPrune(input.messages, input.modelID)
 
     if (toPrune.length > 0) {
       const completed = toPrune.filter(
@@ -313,9 +315,17 @@ export namespace SessionCompaction {
       )
       await Promise.all(
         completed.map((part) => {
-          part.state.time.compacted = Date.now()
-          part.state.output = ""
-          return Session.updatePart(part)
+          return Session.updatePart({
+            ...part,
+            state: {
+              ...part.state,
+              output: "",
+              time: {
+                ...part.state.time,
+                compacted: Date.now(),
+              },
+            },
+          })
         }),
       )
       log.info("pruned", { count: completed.length })
@@ -580,7 +590,7 @@ export namespace SessionCompaction {
       return [{ type: "prune" }]
     },
     async execute(ctx) {
-      await prune({ sessionID: ctx.sessionID, modelID: ctx.modelID })
+      await prune({ sessionID: ctx.sessionID, messages: ctx.messages, modelID: ctx.modelID })
       return "pass"
     },
   })

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -214,6 +214,7 @@ export namespace SessionInvoke {
       if (LatticeModelCalls.peek(sessionID) > 0) {
         await LatticeModelCalls.flush(scopeID, sessionID).catch(() => undefined)
       }
+      await SessionMemoryPressure.maybeCollect({ sessionID, phase: "session.exit" })
     })
 
     const runtime = SessionManager.registerRuntime(sessionID)

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -837,7 +837,8 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
           turnDeadline.abort(deadlineError)
           rejectDeadline(deadlineError)
         }, timeoutCfg.invokeMs)
-        abort.addEventListener("abort", () => clearTimeout(turnTimer), { once: true })
+        const clearTurnTimer = () => clearTimeout(turnTimer)
+        abort.addEventListener("abort", clearTurnTimer, { once: true })
         const combinedAbort = AbortSignal.any([abort, turnDeadline.signal])
 
         // Race against the deadline instead of relying on abort propagation:
@@ -903,9 +904,12 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
             turnSpanEnded = true
           }
         } finally {
+          const turnTimedOut = turnDeadline.signal.aborted
           clearTimeout(turnTimer)
+          abort.removeEventListener("abort", clearTurnTimer)
+          if (!turnTimedOut) turnDeadline.abort()
           processTimer.stop()
-          releaseTurnReferences(!turnDeadline.signal.aborted)
+          releaseTurnReferences(!turnTimedOut)
           if (!turnSpanEnded) {
             ObservabilitySpans.end(turnSpan, {
               attributes: {

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -316,10 +316,9 @@ export namespace SessionInvoke {
         const preJobs = LoopJob.collect("pre", jobCtx, firedSignals)
         if (preJobs.length > 0) {
           const result = await LoopJob.execute(preJobs, jobCtx)
-          // Pre-jobs (compaction especially) can rewrite history in ways the
-          // incremental cache maintenance does not model; drop the cache so the
-          // next step re-reads authoritative state (#350 D2, R2).
-          SessionMessageCache.invalidate(sessionID)
+          // Pre-jobs write through Session.updateMessage/updatePart, which keep
+          // the loop-scoped cache current. Invalidating here made the detached
+          // prune job race a full history reload on every tool turn (#597).
           if (result === "stop") break
           if (result === "continue") {
             // A processed compaction re-arms the emergency-compaction fallback so

--- a/packages/synergy/src/session/manager.ts
+++ b/packages/synergy/src/session/manager.ts
@@ -313,6 +313,7 @@ export namespace SessionManager {
     const lease = options?.lease ?? acquire(sessionID)
     const runtime = getRuntime(sessionID)
     if (!lease || lease.sessionID !== sessionID || !runtime || !owns(runtime, lease)) throw new BusyError(sessionID)
+    let completed = false
 
     try {
       const session = await requireSession(sessionID)
@@ -345,11 +346,17 @@ export namespace SessionManager {
             }
           },
         })
-      if (workspace.type !== "git_worktree") return await runWithScope()
-      const { Worktree } = await import("../project/worktree")
-      return await Worktree.withUse(workspace.path, session.id, runWithScope)
+      let result: T
+      if (workspace.type !== "git_worktree") {
+        result = await runWithScope()
+      } else {
+        const { Worktree } = await import("../project/worktree")
+        result = await Worktree.withUse(workspace.path, session.id, runWithScope)
+      }
+      completed = true
+      return result
     } finally {
-      await release(lease)
+      await release(lease, { reschedulePendingInbox: completed })
       const runtime = getRuntime(sessionID)
       if (runtime && !occupied(runtime)) unregisterRuntime(sessionID)
     }
@@ -425,7 +432,10 @@ export namespace SessionManager {
     return true
   }
 
-  export async function release(lease: LoopLease): Promise<boolean> {
+  export async function release(
+    lease: LoopLease,
+    options: { reschedulePendingInbox?: boolean } = {},
+  ): Promise<boolean> {
     const runtime = getRuntime(lease.sessionID)
     if (!runtime || !owns(runtime, lease)) return false
 
@@ -441,7 +451,9 @@ export namespace SessionManager {
     const { Cortex } = await import("../cortex/manager")
     await Cortex.flushDeferredParentNotifications(lease.sessionID)
 
-    if (await SessionInbox.hasRunnableItem(lease.sessionID)) {
+    // If the loop failed before consuming its inbox item, leave that item durable
+    // for an explicit retry instead of creating an immediate failure/wake cycle.
+    if (options.reschedulePendingInbox !== false && (await SessionInbox.hasRunnableItem(lease.sessionID))) {
       scheduleWake(lease.sessionID, "release")
     }
     return true

--- a/packages/synergy/src/session/message-cache.ts
+++ b/packages/synergy/src/session/message-cache.ts
@@ -28,22 +28,32 @@ export namespace SessionMessageCache {
   const active = new Set<string>()
   const cache = new Map<string, MessageV2.WithParts[]>()
 
-  // Global memory bound (issue #350 P2-8). Each active loop holds its full raw
+  // Memory bounds (issue #350 P2-8). Each active loop holds its full raw
   // history in memory; N concurrent long sessions would otherwise grow without
   // limit. We track an approximate byte footprint per session and evict the
-  // least-recently-used entry once the total exceeds the budget. Eviction is
-  // transparent: a dropped entry is re-read from disk on the next `get` (the
-  // cache is an accelerator, never the source of truth — R3), so the only cost
-  // is one extra read for the coldest session under pressure.
+  // least-recently-used entry once the total exceeds the global budget. A
+  // separate per-session budget prevents one active long session from keeping an
+  // unbounded cache resident forever. Eviction is transparent: a dropped entry
+  // is re-read from disk on the next `get` (the cache is an accelerator, never
+  // the source of truth — R3), so the only cost is one extra read.
   const sizes = new Map<string, number>()
   const lru: string[] = []
   let totalBytes = 0
+  const STATS_GLOBAL_KEY = "__synergySessionMessageCacheStats"
   const DEFAULT_BYTE_BUDGET = 256 * 1024 * 1024
+  const DEFAULT_SESSION_BYTE_BUDGET = 32 * 1024 * 1024
   // Read on each eviction so SYNERGY_SESSION_CACHE_MAX_BYTES can be tuned (and
   // set by tests) without a restart; the cost is a trivial env parse on writes.
   function byteBudget() {
     const env = Number.parseInt(process.env.SYNERGY_SESSION_CACHE_MAX_BYTES ?? "", 10)
     return Number.isFinite(env) && env > 0 ? env : DEFAULT_BYTE_BUDGET
+  }
+
+  // Per-session budget is checked on each write for the same reason: production
+  // can tune it without restarting, and tests can set it locally.
+  function sessionByteBudget() {
+    const env = Number.parseInt(process.env.SYNERGY_SESSION_CACHE_MAX_BYTES_PER_SESSION ?? "", 10)
+    return Number.isFinite(env) && env > 0 ? env : DEFAULT_SESSION_BYTE_BUDGET
   }
 
   /** Begin the single-writer window for a session (loop start). */
@@ -66,6 +76,20 @@ export namespace SessionMessageCache {
     return active.has(sessionID)
   }
 
+  export function stats() {
+    const entries = [...sizes.entries()]
+      .map(([sessionID, bytes]) => ({ sessionID, bytes, messages: cache.get(sessionID)?.length ?? 0 }))
+      .sort((a, b) => b.bytes - a.bytes)
+    return {
+      activeSessions: active.size,
+      cachedSessions: cache.size,
+      totalBytes,
+      budgetBytes: byteBudget(),
+      sessionBudgetBytes: sessionByteBudget(),
+      largest: entries.slice(0, 10),
+    }
+  }
+
   /** Cached raw list, or undefined when the window is closed or unpopulated. */
   export function get(sessionID: string): MessageV2.WithParts[] | undefined {
     if (!active.has(sessionID)) return undefined
@@ -79,6 +103,7 @@ export namespace SessionMessageCache {
     if (!active.has(sessionID)) return
     cache.set(sessionID, messages)
     setSize(sessionID, estimateList(messages))
+    if (dropIfSessionOverBudget(sessionID)) return
     touch(sessionID)
     evict(sessionID)
   }
@@ -102,6 +127,7 @@ export namespace SessionMessageCache {
     }
     cache.set(sessionID, next)
     addSize(sessionID, delta)
+    if (dropIfSessionOverBudget(sessionID)) return
     touch(sessionID)
     evict(sessionID)
   }
@@ -135,6 +161,7 @@ export namespace SessionMessageCache {
     next[mi] = { info: msg.info, parts }
     cache.set(sessionID, next)
     addSize(sessionID, delta)
+    if (dropIfSessionOverBudget(sessionID)) return
     touch(sessionID)
     evict(sessionID)
   }
@@ -168,6 +195,13 @@ export namespace SessionMessageCache {
     if (current === undefined) return
     sizes.set(sessionID, Math.max(0, current + delta))
     totalBytes = Math.max(0, totalBytes + delta)
+  }
+
+  function dropIfSessionOverBudget(sessionID: string) {
+    const size = sizes.get(sessionID)
+    if (size === undefined || size <= sessionByteBudget()) return false
+    drop(sessionID)
+    return true
   }
 
   // Evict least-recently-used entries until under budget, never evicting the
@@ -224,4 +258,6 @@ export namespace SessionMessageCache {
     }
     return lo
   }
+
+  ;(globalThis as any)[STATS_GLOBAL_KEY] = stats
 }

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -66,6 +66,20 @@ export namespace SessionProcessor {
     resolvedAt?: number
   }
 
+  function cancelUnusedStreamBranch(stream: unknown): Promise<void> {
+    const branch = (stream as { baseStream?: { cancel(reason?: unknown): Promise<void> | void } }).baseStream
+    if (!branch || typeof branch.cancel !== "function") return Promise.resolve()
+
+    try {
+      return Promise.resolve(branch.cancel("Synergy consumes the fullStream branch")).catch((error) => {
+        log.warn("failed to cancel unused AI SDK stream branch", { error })
+      })
+    } catch (error) {
+      log.warn("failed to cancel unused AI SDK stream branch", { error })
+      return Promise.resolve()
+    }
+  }
+
   export function createSlot(callID: string): ToolExecutionSlot {
     let outcome: ToolOutcome | undefined
     let resolved = false
@@ -855,8 +869,13 @@ export namespace SessionProcessor {
                 }
               }
 
+              const fullStream = stream.fullStream
+              // AI SDK implements fullStream by teeing its base stream and
+              // retaining the unused branch. Cancel it before consuming ours so
+              // completed turns do not buffer chunks for the invoke lifetime.
+              const unusedStreamCancellation = cancelUnusedStreamBranch(stream)
               try {
-                for await (const value of stream.fullStream) {
+                for await (const value of fullStream) {
                   input.abort.throwIfAborted()
                   switch (value.type) {
                     case "start":
@@ -1296,6 +1315,7 @@ export namespace SessionProcessor {
                 ObservabilitySpans.end(llmSpan, { status: "error", error })
                 throw error
               } finally {
+                await unusedStreamCancellation
                 flushChunkMetrics()
                 currentText = undefined
                 reasoningMap = {}

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -47,6 +47,7 @@ export namespace SessionProcessor {
     | { status: "error"; input: any; error: string; metadata?: Record<string, any> }
   export type ToolExecutionSlot = {
     callID: string
+    readonly tool?: string
     promise: Promise<ToolOutcome>
     resolve(outcome: ToolOutcome): void
     complete(input: unknown, result: ToolOutcomeCompletedResult): void
@@ -60,6 +61,7 @@ export namespace SessionProcessor {
   type ToolExecutionSlotInternal = Omit<ToolExecutionSlot, "outcome" | "status"> & {
     outcome: ToolOutcome | undefined
     status: "pending" | "resolved"
+    tool?: string
     registeredAt: number
     resolvedAt?: number
   }
@@ -305,7 +307,7 @@ export namespace SessionProcessor {
         ...(callID
           ? {
               callID,
-              tool: part?.tool,
+              tool: part?.tool ?? slot?.tool,
               partStatus: part?.state.status,
               hasPart: Boolean(part),
               hasSlot: Boolean(slot),
@@ -323,7 +325,7 @@ export namespace SessionProcessor {
                 const slot = executions.get(id)
                 return {
                   callID: id,
-                  tool: part?.tool,
+                  tool: part?.tool ?? slot?.tool,
                   partStatus: part?.state.status,
                   hasPart: Boolean(part),
                   hasSlot: Boolean(slot),
@@ -370,35 +372,76 @@ export namespace SessionProcessor {
       const slot = executions.get(toolCallId)
       const outcome = slot?.outcome
       const part = toolcalls[toolCallId]
-      if (!slot || !outcome || !part || part.state.status !== "running") {
+      const skipReason = !slot
+        ? "missing_slot"
+        : !outcome
+          ? "missing_outcome"
+          : part && part.state.status !== "running"
+            ? "part_not_running"
+            : !part && !slot.tool
+              ? "missing_part_tool"
+              : undefined
+      if (skipReason) {
         log.info("tool.execution.settle.skip", {
           sessionID: input.sessionID,
           messageID: input.assistantMessage.id,
           callID: toolCallId,
-          reason: !slot ? "missing_slot" : !outcome ? "missing_outcome" : !part ? "missing_part" : "part_not_running",
+          reason: skipReason,
           snapshot: toolSettlementSnapshot(toolCallId),
         })
         return undefined
       }
 
+      const activeSlot = slot as ToolExecutionSlotInternal
+      const activeOutcome = outcome as ToolOutcome
+      const tool = part?.tool ?? activeSlot.tool!
       log.info("tool.execution.settle.start", {
         sessionID: input.sessionID,
         messageID: input.assistantMessage.id,
         callID: toolCallId,
-        tool: part.tool,
-        outcomeStatus: outcome.status,
+        tool,
+        outcomeStatus: activeOutcome.status,
+        syntheticPart: !part,
         snapshot: toolSettlementSnapshot(toolCallId),
       })
 
       const settlement = (async () => {
-        await settleToolPart(part, outcome)
+        let settlingPart = part
+        if (!settlingPart) {
+          settlingPart = (await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: input.assistantMessage.id,
+            sessionID: input.assistantMessage.sessionID,
+            type: "tool",
+            callID: toolCallId,
+            tool,
+            state: {
+              status: "running",
+              input: SessionToolInput.normalize(activeOutcome.input),
+              metadata: runningToolMetadata(tool, undefined),
+              time: {
+                start: activeSlot.registeredAt,
+              },
+            },
+          })) as MessageV2.ToolPart
+          toolcalls[toolCallId] = settlingPart
+          log.info("tool.execution.synthetic_part.created", {
+            sessionID: input.sessionID,
+            messageID: input.assistantMessage.id,
+            callID: toolCallId,
+            tool,
+            outcomeStatus: activeOutcome.status,
+            snapshot: toolSettlementSnapshot(toolCallId),
+          })
+        }
+        await settleToolPart(settlingPart, activeOutcome)
         executions.delete(toolCallId)
         delete toolcalls[toolCallId]
         log.info("tool.execution.settle.completed", {
           sessionID: input.sessionID,
           messageID: input.assistantMessage.id,
           callID: toolCallId,
-          tool: part.tool,
+          tool,
           snapshot: toolSettlementSnapshot(toolCallId),
         })
       })()
@@ -409,7 +452,7 @@ export namespace SessionProcessor {
             sessionID: input.sessionID,
             messageID: input.assistantMessage.id,
             callID: toolCallId,
-            tool: part.tool,
+            tool,
             error,
             snapshot: toolSettlementSnapshot(toolCallId),
           }),
@@ -612,13 +655,15 @@ export namespace SessionProcessor {
       }
     }
 
-    function beginExecution(callID: string): ToolExecutionSlot {
+    function beginExecution(callID: string, tool?: string): ToolExecutionSlot {
       const existing = executions.get(callID)
       if (existing) {
+        if (tool && !existing.tool) existing.tool = tool
         log.info("tool.execution.slot.reuse", {
           sessionID: input.sessionID,
           messageID: input.assistantMessage.id,
           callID,
+          tool: existing.tool,
           snapshot: toolSettlementSnapshot(callID),
         })
         return existing
@@ -652,6 +697,7 @@ export namespace SessionProcessor {
       }
       const slot: ToolExecutionSlotInternal = {
         callID: base.callID,
+        tool,
         promise: base.promise,
         resolve: base.resolve,
         complete: base.complete,
@@ -669,6 +715,7 @@ export namespace SessionProcessor {
         sessionID: input.sessionID,
         messageID: input.assistantMessage.id,
         callID,
+        tool,
         snapshot: toolSettlementSnapshot(callID),
       })
       void settleTrackedExecution(callID)

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -1238,7 +1238,7 @@ export namespace ToolResolver {
           callID: options.toolCallId,
           kind: "diagnostic",
         })
-        const slot = input.processor.beginExecution(options.toolCallId)
+        const slot = input.processor.beginExecution(options.toolCallId, diagnostic.toolName)
         log.info("tool.execute.callback.slot", {
           tool: diagnostic.toolName,
           sessionID: input.sessionID,
@@ -1338,7 +1338,7 @@ export namespace ToolResolver {
                 callID: options.toolCallId,
                 kind: "ephemeral",
               })
-              const slot = runtimeInput.processor.beginExecution(options.toolCallId)
+              const slot = runtimeInput.processor.beginExecution(options.toolCallId, item.id)
               const ctx = context(args, options)
               let toolTrace: ToolTrace | undefined
               log.info("tool.execute.callback.slot", {
@@ -1453,7 +1453,7 @@ export namespace ToolResolver {
               })
               const ctx = context(args, options)
               let toolTrace: ToolTrace | undefined
-              const slot = runtimeInput.processor.beginExecution(options.toolCallId)
+              const slot = runtimeInput.processor.beginExecution(options.toolCallId, item.id)
               log.info("tool.execute.callback.slot", {
                 tool: item.id,
                 sessionID: runtimeInput.sessionID,
@@ -1711,7 +1711,7 @@ export namespace ToolResolver {
                 })
                 const ctx = context(args, opts)
                 let toolTrace: ToolTrace | undefined
-                const slot = runtimeInput.processor.beginExecution(opts.toolCallId)
+                const slot = runtimeInput.processor.beginExecution(opts.toolCallId, key)
                 log.info("tool.execute.callback.slot", {
                   tool: key,
                   sessionID: runtimeInput.sessionID,

--- a/packages/synergy/test/hashline/snapshots.test.ts
+++ b/packages/synergy/test/hashline/snapshots.test.ts
@@ -83,6 +83,13 @@ describe("InMemorySnapshotStore", () => {
     expect(store.byHash("b.ts", tag2)).toBeNull()
   })
 
+  test("reports retained snapshot bytes", () => {
+    const store = new InMemorySnapshotStore()
+    store.record(PATH, "alpha\n")
+    store.record("b.ts", "bravo\n")
+    expect(store.stats()).toEqual({ paths: 2, versions: 2, totalBytes: 12 })
+  })
+
   test("seenLines stored and retrieved correctly", () => {
     const store = new InMemorySnapshotStore()
     store.record(PATH, "L1\nL2\n", [1, 2])

--- a/packages/synergy/test/hashline/store-session.test.ts
+++ b/packages/synergy/test/hashline/store-session.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Bus } from "../../src/bus"
+import { SessionSnapshotStore } from "../../src/hashline/store-session"
+import { ScopeContext } from "../../src/scope/context"
+import { SessionEvent } from "../../src/session/event"
+import { tmpdir } from "../fixture/fixture"
+
+const originalIdleTtl = process.env.SYNERGY_HASHLINE_SESSION_IDLE_TTL_MS
+const originalSessionMax = process.env.SYNERGY_HASHLINE_SESSION_MAX_BYTES
+
+afterEach(() => {
+  if (originalIdleTtl === undefined) delete process.env.SYNERGY_HASHLINE_SESSION_IDLE_TTL_MS
+  else process.env.SYNERGY_HASHLINE_SESSION_IDLE_TTL_MS = originalIdleTtl
+  if (originalSessionMax === undefined) delete process.env.SYNERGY_HASHLINE_SESSION_MAX_BYTES
+  else process.env.SYNERGY_HASHLINE_SESSION_MAX_BYTES = originalSessionMax
+})
+
+describe("SessionSnapshotStore", () => {
+  test("clears retained hashline snapshots after session idle TTL", async () => {
+    process.env.SYNERGY_HASHLINE_SESSION_IDLE_TTL_MS = "10"
+
+    await using tmp = await tmpdir()
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        SessionSnapshotStore.clear()
+        const store = SessionSnapshotStore.get("ses_hashline_idle")
+        store.record("/tmp/a.ts", "x".repeat(1024))
+
+        expect(SessionSnapshotStore.stats().sessions).toBe(1)
+        expect(SessionSnapshotStore.stats().totalBytes).toBe(1024)
+
+        await Bus.publish(SessionEvent.Idle, { sessionID: "ses_hashline_idle" })
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        expect(SessionSnapshotStore.stats().sessions).toBe(0)
+        expect(SessionSnapshotStore.stats().totalBytes).toBe(0)
+      },
+    })
+  })
+})

--- a/packages/synergy/test/library/experience-encoder.test.ts
+++ b/packages/synergy/test/library/experience-encoder.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test"
+import { ExperienceEncoder } from "../../src/library/experience-encoder"
+import { MessageV2 } from "../../src/session/message-v2"
+
+function assistant(overrides: Partial<MessageV2.Assistant> = {}): MessageV2.Assistant {
+  return {
+    id: "msg_assistant",
+    sessionID: "ses_test",
+    parentID: "msg_user",
+    role: "assistant",
+    time: { created: 0 },
+    modelID: "model",
+    providerID: "provider",
+    mode: "agent",
+    agent: "agent",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    ...overrides,
+  } as MessageV2.Assistant
+}
+
+function memory(
+  overrides: Partial<ReturnType<typeof process.memoryUsage>> = {},
+): ReturnType<typeof process.memoryUsage> {
+  return {
+    rss: 128 * 1024 * 1024,
+    heapTotal: 64 * 1024 * 1024,
+    heapUsed: 32 * 1024 * 1024,
+    external: 4 * 1024 * 1024,
+    arrayBuffers: 1024,
+    ...overrides,
+  }
+}
+
+describe("ExperienceEncoder", () => {
+  test("skips aborted assistant messages", () => {
+    expect(
+      ExperienceEncoder.__test.shouldEncodeOnComplete(
+        assistant({
+          error: new MessageV2.AbortedError({ message: "aborted" }).toObject() as MessageV2.Assistant["error"],
+        }),
+        memory(),
+      ),
+    ).toBe(false)
+  })
+
+  test("skips non-abort errored assistant messages", () => {
+    expect(
+      ExperienceEncoder.__test.shouldEncodeOnComplete(
+        assistant({
+          error: { name: "ProviderError", data: { message: "failed" } } as unknown as MessageV2.Assistant["error"],
+        }),
+        memory(),
+      ),
+    ).toBe(false)
+  })
+
+  test("keeps completed assistant messages eligible for encoding", () => {
+    expect(ExperienceEncoder.__test.shouldEncodeOnComplete(assistant({ finish: "stop" }), memory())).toBe(true)
+  })
+
+  test("skips completed assistant messages under high ArrayBuffer pressure", () => {
+    expect(
+      ExperienceEncoder.__test.shouldEncodeOnComplete(
+        assistant({ finish: "stop" }),
+        memory({ arrayBuffers: 2 * 1024 * 1024 * 1024 }),
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/synergy/test/process/attribution.test.ts
+++ b/packages/synergy/test/process/attribution.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { ObservabilityRedaction } from "../../src/observability/redaction"
+import { ProcessAttribution } from "../../src/process/attribution"
+
+describe("ProcessAttribution", () => {
+  test("parses Linux proc status memory and parent fields", () => {
+    const parsed = ProcessAttribution.__test.parseStatusText(
+      ["Name:\tbun", "State:\tS (sleeping)", "PPid:\t123", "VmRSS:\t2048 kB", "Threads:\t7"].join("\n"),
+    )
+
+    expect(parsed.ppid).toBe(123)
+    expect(parsed.rssBytes).toBe(2048 * 1024)
+    expect(parsed.state).toBe("S (sleeping)")
+    expect(parsed.threads).toBe(7)
+  })
+
+  test("finds recursive descendants from pid parent links", () => {
+    const processes = new Map([
+      [1, { pid: 1, ppid: 0 }],
+      [2, { pid: 2, ppid: 1 }],
+      [3, { pid: 3, ppid: 2 }],
+      [4, { pid: 4, ppid: 1 }],
+      [5, { pid: 5, ppid: 999 }],
+    ])
+
+    expect(ProcessAttribution.__test.descendantPidsFrom(processes, 1).sort()).toEqual([2, 3, 4])
+  })
+
+  test("summarizes arbitrary cgroup pid sets", () => {
+    const processes = new Map([
+      [1, { pid: 1, ppid: 0, rssBytes: 100 }],
+      [2, { pid: 2, ppid: 1, rssBytes: 300 }],
+      [3, { pid: 3, ppid: 2, rssBytes: 200 }],
+    ])
+
+    const summary = ProcessAttribution.__test.summarizePids([1, 3], processes, 2)
+
+    expect(summary.count).toBe(2)
+    expect(summary.rssBytes).toBe(300)
+    expect(summary.top.map((item) => item.pid)).toEqual([3, 1])
+  })
+
+  test("default collection avoids detailed command attribution", () => {
+    const summary = ProcessAttribution.collect(process.pid, { topN: 1 })
+    if (summary.topChildren.length > 0) {
+      expect(summary.topChildren[0].command).toBeUndefined()
+      expect(summary.topChildren[0].wchan).toBeUndefined()
+    }
+  })
+
+  test("collects multiple process roots from one snapshot", () => {
+    const memory = ProcessAttribution.memoryByRoot([process.pid])
+    expect(memory.get(process.pid)?.rootRssBytes).toBeGreaterThan(0)
+  })
+
+  test("redacts sk-prefixed secrets in captured commands", () => {
+    expect(ObservabilityRedaction.text("cmd --key sk-1234567890abcdef")).toContain("[redacted]")
+  })
+})

--- a/packages/synergy/test/server/event-wire.test.ts
+++ b/packages/synergy/test/server/event-wire.test.ts
@@ -49,7 +49,9 @@ describe("EventWire encoder", () => {
     wire.deltaPayload(partUpdated(p, "a"), 1000) // checkpoint @1000
     const mid = wire.deltaPayload(partUpdated({ ...p, text: "ab" }, "b"), 1500)
     expect((mid as EventWire.DeltaFrame).type).toBe("message.part.delta")
-    const cp = wire.deltaPayload(partUpdated({ ...p, text: "abc" }, "c"), 2000) // >= 1000ms later
+    const stillDelta = wire.deltaPayload(partUpdated({ ...p, text: "abc" }, "c"), 2000)
+    expect((stillDelta as EventWire.DeltaFrame).type).toBe("message.part.delta")
+    const cp = wire.deltaPayload(partUpdated({ ...p, text: "abcd" }, "d"), 6000) // >= CHECKPOINT_MS later
     expect(cp).toBe(cp) // full payload returned
     expect((cp as any).type).toBe("message.part.updated")
   })

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, mock } from "bun:test"
+import { getEventListeners } from "node:events"
 import { SessionManager } from "../../src/session/manager"
 import { SessionInvoke } from "../../src/session/invoke"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -1063,6 +1064,41 @@ describe("SessionInvoke completion notices", () => {
           expect((await Session.get(session.id)).completionNotice).toEqual({ unread: true, silent: false })
         },
       })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+})
+
+describe("SessionInvoke per-turn cleanup", () => {
+  test("removes the session abort listener and closes the combined turn signal", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    let sessionAbort: AbortSignal | undefined
+    let turnAbort: AbortSignal | undefined
+    const restore = installBasicLoopMocks({
+      onProcess: async (input) => {
+        turnAbort = input.abort
+        sessionAbort = SessionManager.getRuntime(activeSessionID)?.owner?.lease.signal
+        expect(sessionAbort).toBeDefined()
+        expect(getEventListeners(sessionAbort!, "abort").length).toBeGreaterThan(0)
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+          await SessionInvoke.loop.force(session.id)
+        },
+      })
+
+      expect(sessionAbort).toBeDefined()
+      expect(getEventListeners(sessionAbort!, "abort")).toHaveLength(0)
+      expect(turnAbort?.aborted).toBe(true)
     } finally {
       restore()
       if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)

--- a/packages/synergy/test/session/manager.test.ts
+++ b/packages/synergy/test/session/manager.test.ts
@@ -336,6 +336,57 @@ describe("SessionManager.getSession", () => {
 })
 
 describe("loop ownership", () => {
+  test("leaves a failed run's pending inbox item for explicit retry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const { SessionInvoke } = await import("../../src/session/invoke")
+        const originalLoop = SessionInvoke.loop
+        const wakes: string[] = []
+        ;(SessionInvoke.loop as any) = mock(async (sessionID: string) => {
+          wakes.push(sessionID)
+        })
+
+        let sessionID = ""
+        try {
+          const session = await Session.create({})
+          sessionID = session.id
+          await SessionInbox.enqueueMail({
+            sessionID,
+            mail: {
+              type: "user",
+              agent: "synergy",
+              model: { providerID: "test-provider", modelID: "missing-model" },
+              parts: [
+                {
+                  id: "prt_failed_run",
+                  sessionID,
+                  messageID: "msg_failed_run",
+                  type: "text",
+                  text: "Retry after provider recovery",
+                },
+              ],
+            },
+          })
+
+          await expect(
+            SessionManager.run(sessionID, async () => {
+              throw new Error("model resolution failed")
+            }),
+          ).rejects.toThrow("model resolution failed")
+          await Bun.sleep(20)
+
+          expect(wakes).toEqual([])
+          expect(await SessionInbox.hasRunnableItem(sessionID)).toBe(true)
+        } finally {
+          ;(SessionInvoke.loop as any) = originalLoop
+          if (sessionID) SessionManager.unregisterRuntime(sessionID)
+        }
+      },
+    })
+  })
+
   test("reserves ownership before async session setup can yield", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({

--- a/packages/synergy/test/session/message-cache.test.ts
+++ b/packages/synergy/test/session/message-cache.test.ts
@@ -104,4 +104,25 @@ describe("SessionMessageCache", () => {
       else process.env.SYNERGY_SESSION_CACHE_MAX_BYTES = previous
     }
   })
+
+  test("drops the active session cache when it exceeds the per-session byte budget", () => {
+    const previous = process.env.SYNERGY_SESSION_CACHE_MAX_BYTES_PER_SESSION
+    process.env.SYNERGY_SESSION_CACHE_MAX_BYTES_PER_SESSION = "300"
+    try {
+      SessionMessageCache.enable(SID)
+      SessionMessageCache.set(SID, [
+        {
+          info: { id: "msg_1", sessionID: SID, role: "user" } as any,
+          parts: [{ id: "prt_1", sessionID: SID, messageID: "msg_1", type: "text", text: "x".repeat(350) } as any],
+        },
+      ])
+
+      expect(SessionMessageCache.isActive(SID)).toBe(true)
+      expect(SessionMessageCache.get(SID)).toBeUndefined()
+    } finally {
+      SessionMessageCache.disable(SID)
+      if (previous === undefined) delete process.env.SYNERGY_SESSION_CACHE_MAX_BYTES_PER_SESSION
+      else process.env.SYNERGY_SESSION_CACHE_MAX_BYTES_PER_SESSION = previous
+    }
+  })
 })

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { Bus } from "../../src/bus"
 import { TimeoutConfig } from "../../src/util/timeout-config"
 import { Config } from "../../src/config/config"
 import { ExperienceEncoder } from "../../src/library/experience-encoder"
@@ -143,12 +144,14 @@ describe("SessionProcessor.streamToolErrorOutcome", () => {
 type SettlementScenario = {
   messageID: string
   stream(processor: SessionProcessor.Info): AsyncGenerator<Record<string, unknown>>
+  cancelUnusedStream?: () => Promise<void> | void
   config?: Record<string, unknown>
   updatePart?: (input: MessageV2.Part | { part: MessageV2.Part; delta?: string }) => Promise<MessageV2.Part>
 }
 
 async function runSettlementScenario(scenario: SettlementScenario) {
   const originalStream = LLM.stream
+  const originalBusPublish = Bus.publish
   const originalUpdatePart = Session.updatePart
   const originalParts = MessageV2.parts
   const originalUpdateMessage = Session.updateMessage
@@ -161,6 +164,7 @@ async function runSettlementScenario(scenario: SettlementScenario) {
 
   try {
     TimeoutConfig.invalidate()
+    ;(Bus.publish as any) = mock(async () => {})
     ;(Session.updatePart as any) = mock(async (input: MessageV2.Part | { part: MessageV2.Part; delta?: string }) => {
       const part = scenario.updatePart ? await scenario.updatePart(input) : "part" in input ? input.part : input
       parts.set(part.id, part)
@@ -176,6 +180,9 @@ async function runSettlementScenario(scenario: SettlementScenario) {
     ;(ExperienceEncoder.onComplete as any) = mock(() => {})
     ;(LLM.stream as any) = mock(async () => ({
       fullStream: scenario.stream(processor),
+      ...(scenario.cancelUnusedStream
+        ? { baseStream: { cancel: scenario.cancelUnusedStream } }
+        : {}),
     }))
 
     processor = SessionProcessor.create({
@@ -202,6 +209,7 @@ async function runSettlementScenario(scenario: SettlementScenario) {
     return [...parts.values()]
   } finally {
     TimeoutConfig.invalidate()
+    ;(Bus.publish as any) = originalBusPublish
     ;(LLM.stream as any) = originalStream
     ;(Session.updatePart as any) = originalUpdatePart
     ;(MessageV2.parts as any) = originalParts
@@ -226,6 +234,34 @@ function completedOutcome(tool: string, output: string, metadata: Record<string,
 }
 
 describe("SessionProcessor execution slot settlement", () => {
+  test("cancels the unused AI SDK stream branch after consuming fullStream", async () => {
+    const cancel = mock(async () => {})
+    await runSettlementScenario({
+      messageID: "msg_assistant_stream_cleanup",
+      cancelUnusedStream: cancel,
+      async *stream() {
+        yield { type: "start" }
+        yield { type: "finish" }
+      },
+    })
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
+
+  test("cancels the unused AI SDK stream branch when fullStream fails", async () => {
+    const cancel = mock(async () => {})
+    await runSettlementScenario({
+      messageID: "msg_assistant_stream_cleanup_error",
+      cancelUnusedStream: cancel,
+      async *stream() {
+        yield { type: "start" }
+        throw new Error("stream failed")
+      },
+    })
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
+
   test("settles a synthetic non-bash slot that resolves before the running part exists", async () => {
     const parts = await runSettlementScenario({
       messageID: "msg_assistant_slot_first",

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -312,6 +312,31 @@ describe("SessionProcessor execution slot settlement", () => {
     expect(committed).toBe(true)
   })
 
+  test("settles a resolved slot even when no tool-call stream part arrives", async () => {
+    const parts = await runSettlementScenario({
+      messageID: "msg_assistant_slot_only",
+      async *stream(processor) {
+        yield { type: "start" }
+        processor
+          .beginExecution("call_slot_only", "synthetic")
+          .complete({ value: 7 }, completedOutcome("synthetic", "slot-only result"))
+        yield { type: "finish" }
+      },
+    })
+
+    const tools = parts.filter(
+      (part): part is MessageV2.ToolPart => part.type === "tool" && part.callID === "call_slot_only",
+    )
+    expect(tools).toHaveLength(1)
+    const tool = tools[0]
+    expect(tool.state.status).toBe("completed")
+    if (tool.state.status === "completed") {
+      expect(tool.tool).toBe("synthetic")
+      expect(tool.state.input).toEqual({ value: 7 })
+      expect(tool.state.output).toBe("slot-only result")
+    }
+  })
+
   test("settles a synthetic tool error outcome instead of unresolved", async () => {
     const parts = await runSettlementScenario({
       messageID: "msg_assistant_slot_error",


### PR DESCRIPTION
## Purpose

This is a review-only bundle of the production patches currently carried locally. It is **not a merge request**. The branch intentionally preserves the deployed patch stack so maintainers can inspect the mitigations and decide which ideas belong upstream.

The stack was developed against an earlier `dev` revision and may conflict with current `dev`; resolving those conflicts is intentionally out of scope for this reference PR.

## Patch areas

| Area | Local mitigation |
|------|------------------|
| Session streaming | Release completed-turn prompt/tool references, cancel the unused AI SDK stream branch, and detach per-turn abort resources |
| Message history | Add per-session message-cache bounds and preserve the cache across detached prune jobs |
| Processor lifecycle | Clear tool execution bookkeeping and streamed state after settlement |
| Hashline | Bound retained session snapshots and prune stale snapshot state |
| Optional background work | Skip experience encoding and reap idle LSP clients under memory pressure |
| Attribution | Record process-family RSS/PSS so main-process and child-process growth can be separated |
| Transport | Tighten provider cancellation, event backpressure, and slow-client handling |
| Recovery | Stop failed inbox wake loops from repeatedly recreating session work |
| Linux runtime | Preserve required sandbox environment and local helper compatibility |

## Verification

- `bun test test/session/invoke.test.ts test/session/manager.test.ts test/session/processor.test.ts` — 71 passed, 0 failed
- `git diff --check` — passed
- No stress test or live delegated task was run

## Review guidance

Please treat each commit as an independent mitigation proposal. The useful outcome of this PR is feedback on ownership and upstream direction, not merging the branch as-is.
