### PR TITLE
fix(session): release model stream memory

### DIFF
--- a/.synergy/skill/integrate-llm/SKILL.md
+++ b/.synergy/skill/integrate-llm/SKILL.md
@@ -55,6 +55,12 @@ Use a hidden reviewer through Cortex for decisions that must be independently au
 
 `config/setup.ts` uses `generateText()` for a live provider capability probe before normal agent/session orchestration is appropriate. Keep direct AI SDK usage limited to such bootstrap/provider plumbing or the implementation of the shared `LLM` layer. Product inference should not bypass provider transforms, configured roles, plugin hooks, telemetry, timeouts, or output policy.
 
+## Streaming Bounds
+
+Provider SSE protection is a per-event parser bound, not a total response, transport chunk, or process-memory limit. Keep code identifiers, error names, tests, and architecture documentation explicit about `SSE event parser bound` semantics. Test LF and CRLF event delimiters across chunk boundaries, including consecutive events exactly at the bound.
+
+Tool-call input has a separate serialized-input bound. Enforce it for incremental argument deltas, final-only provider tool calls, and immediately before executor dispatch so providers cannot bypass it by omitting delta events.
+
 ## Verify and Document
 
 1. Test the chosen lifecycle boundary as a behavior: no session for sessionless work; explicit child lineage and output for Cortex work.

--- a/.synergy/skill/integrate-llm/SKILL.md
+++ b/.synergy/skill/integrate-llm/SKILL.md
@@ -27,10 +27,11 @@ For every sessionless call:
 1. Define or reuse a hidden internal agent with the correct model role, prompt, temperature, and no unnecessary tools.
 2. Resolve it through `Agent.get()`, `Agent.getAvailableModel()`, and `Provider.getModel()` so role configuration and availability remain authoritative.
 3. Use `LLM.stream()` so provider transforms, variants, prompt-cache policy, plugin chat hooks, telemetry, and reasoning normalization still apply.
-4. Supply a bounded abort timeout, explicit retry count, and `tools: {}` unless tool execution is intentionally part of the contract.
-5. Bound input and output, treat tagged/untrusted content as data, and redact secrets before policy/classification calls.
-6. Parse and validate structured output with Zod or an equivalent explicit schema. Define whether timeout, unavailable model, malformed output, or provider error fails soft or propagates.
-7. Test model-role fallback, timeout/cancellation, parsing, redaction, and failure semantics without making a live provider call.
+4. Consume the result through `LLM.collectText()`, `LLM.takeTextStream()`, or `LLM.takeFullStream()`. Dispose owned streams in `finally`; do not access AI SDK stream/text getters directly because each getter retains a tee branch until explicitly cancelled.
+5. Supply a bounded abort timeout, explicit retry count, and `tools: {}` unless tool execution is intentionally part of the contract.
+6. Bound input and output, treat tagged/untrusted content as data, and redact secrets before policy/classification calls.
+7. Parse and validate structured output with Zod or an equivalent explicit schema. Define whether timeout, unavailable model, malformed output, or provider error fails soft or propagates.
+8. Test model-role fallback, timeout/cancellation, stream disposal, parsing, redaction, and failure semantics without making a live provider call.
 
 A sessionless call does not create session history, Cortex progress, completion notices, or Experience lineage. Do not imply those properties in UI or events.
 

--- a/bun.lock
+++ b/bun.lock
@@ -402,6 +402,7 @@
   "overrides": {
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
+    "eventsource-parser": "3.1.0",
   },
   "catalog": {
     "@babel/core": "7.28.4",
@@ -1869,7 +1870,7 @@
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
@@ -3540,8 +3541,6 @@
     "markitdown-ts/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "markitdown-ts/ai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "markitdown-ts/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 

--- a/docs/architecture/llm-loop.md
+++ b/docs/architecture/llm-loop.md
@@ -217,10 +217,15 @@ Separately, asynchronous pruning clears large outputs from older completed tool 
 - accumulated protected and prunable token thresholds are exceeded.
 
 Pruning is configurable and records a compaction timestamp on the tool state.
+It operates on the loop's existing immutable message snapshot, and its `Session.updatePart()` writes maintain the loop-scoped message cache incrementally. Running a prune job does not invalidate or reread the complete session history.
 
 ## Streaming and Persistence
 
 Text, reasoning, and tool parts are persisted throughout the step. Streaming text/reasoning writes are coalesced at a short write-behind interval; terminal and discrete updates flush immediately. Before a turn finalizes, pending writes are flushed so a missing terminal callback cannot silently lose accumulated text.
+
+Every `LLM.stream()` consumer takes one owned full stream, text stream, or text promise through the shared `LLM` ownership helpers. Those helpers immediately cancel the residual branch retained by the AI SDK's internal stream tee and settle that cancellation after the consumed branch finishes. Normal turn completion also removes the session-abort listener and closes the per-turn combined signal; settled streams cannot remain anchored until the whole session exits.
+
+Provider SSE input is bounded before it enters the AI SDK parser: one unterminated event may contain at most 16 MiB. Streamed tool-call input is bounded independently at 1 MiB and becomes a terminal tool and assistant error when exceeded.
 
 Client wire transport can replace full accumulated streaming parts with incremental delta frames and periodic full checkpoints. That optimization does not change the in-process message or event model; see [Frontend data sync](frontend-data-sync.md).
 

--- a/docs/architecture/llm-loop.md
+++ b/docs/architecture/llm-loop.md
@@ -225,7 +225,7 @@ Text, reasoning, and tool parts are persisted throughout the step. Streaming tex
 
 Every `LLM.stream()` consumer takes one owned full stream, text stream, or text promise through the shared `LLM` ownership helpers. Those helpers immediately cancel the residual branch retained by the AI SDK's internal stream tee and settle that cancellation after the consumed branch finishes. Normal turn completion also removes the session-abort listener and closes the per-turn combined signal; settled streams cannot remain anchored until the whole session exits.
 
-Provider SSE input is bounded before it enters the AI SDK parser: one unterminated event may contain at most 16 MiB. Streamed tool-call input is bounded independently at 1 MiB and becomes a terminal tool and assistant error when exceeded.
+Provider SSE input passes through a 16 MiB per-event **SSE event parser bound** before it enters the AI SDK parser. The bound terminates an event whose encoded bytes exceed that threshold, preventing unbounded parser state for one unterminated event; it is not a limit on the total response, transport chunk size, or process memory. Streamed tool-call input is bounded independently at 1 MiB for both incremental deltas and final-only provider calls, and an oversized call is rejected before tool execution with terminal tool and assistant errors.
 
 Client wire transport can replace full accumulated streaming parts with incremental delta frames and periodic full checkpoints. That optimization does not change the in-process message or event model; see [Frontend data sync](frontend-data-sync.md).
 

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
   ],
   "overrides": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "eventsource-parser": "3.1.0"
   },
   "patchedDependencies": {
     "ghostty-web@0.3.0": "patches/ghostty-web@0.3.0.patch",

--- a/packages/synergy/src/agent/agent.ts
+++ b/packages/synergy/src/agent/agent.ts
@@ -548,7 +548,7 @@ export namespace Agent {
       system: [],
       retries: 1,
     })
-    const text = (await result.text.catch(() => "")) ?? ""
+    const text = (await LLM.collectText(result).catch(() => "")) ?? ""
     const match = text.match(/\{[\s\S]*\}/)
     if (!match) throw new Error("agent generator did not return JSON")
     return z

--- a/packages/synergy/src/library/experience-encoder.ts
+++ b/packages/synergy/src/library/experience-encoder.ts
@@ -514,15 +514,14 @@ export namespace ExperienceEncoder {
         retries: ctx.learning.encoderRetries,
       })
 
-      const textStream =
-        stream.textStream ??
-        (async function* () {
-          yield await stream.text
-        })()
-
-      return await withTimeout(collectBoundedText({ textStream, maxChars, abort }), timeoutMs, {
-        message: `encoder ${agentName} timed out after ${timeoutMs}ms`,
-      })
+      const textStream = LLM.takeTextStream(stream)
+      try {
+        return await withTimeout(collectBoundedText({ textStream: textStream.stream, maxChars, abort }), timeoutMs, {
+          message: `encoder ${agentName} timed out after ${timeoutMs}ms`,
+        })
+      } finally {
+        await textStream.dispose()
+      }
     } catch (error) {
       if (error instanceof EncoderStreamError) throw error
       if (abort.signal.aborted || timeout.aborted) {

--- a/packages/synergy/src/permission/smart-allow.ts
+++ b/packages/synergy/src/permission/smart-allow.ts
@@ -247,7 +247,7 @@ export namespace SmartAllow {
       retries: 0,
     })
 
-    const text = (await stream.text.catch(() => "")) ?? ""
+    const text = (await LLM.collectText(stream).catch(() => "")) ?? ""
     return parseClassification(text)
   }
 

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -892,7 +892,7 @@ export namespace Provider {
 
         const responseBody =
           response.body && ProviderStream.isSSE(response.headers)
-            ? ProviderStream.limitSSEEventBytes(response.body)
+            ? ProviderStream.enforceSSEEventParserBound(response.body)
             : response.body
 
         // For streaming responses, wrap the body to reset idle timer on each chunk

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -44,6 +44,7 @@ import { ProviderCatalog } from "./catalog"
 import { ProviderProfile } from "./profile"
 import { ProviderAuthRecovery } from "./auth-recovery"
 import { authHook as pluginAuthHook } from "@/plugin/auth-provider"
+import { ProviderStream } from "./stream"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -889,17 +890,29 @@ export namespace Provider {
           })
         }
 
+        const responseBody =
+          response.body && ProviderStream.isSSE(response.headers)
+            ? ProviderStream.limitSSEEventBytes(response.body)
+            : response.body
+
         // For streaming responses, wrap the body to reset idle timer on each chunk
-        if (idleController && response.body) {
-          const originalBody = response.body
+        if (idleController && responseBody) {
+          const originalBody = responseBody
           const idleSignal = idleController.signal
           // Aborting the fetch signal does not reliably reject a pending body
           // read on a half-open connection, so the idle timeout must also win
           // a race against the read itself.
+          let rejectIdle!: (reason: unknown) => void
           const idleAborted = new Promise<never>((_, reject) => {
-            idleSignal.addEventListener("abort", () => reject(idleSignal.reason), { once: true })
+            rejectIdle = reject
           })
+          const onIdleAbort = () => rejectIdle(idleSignal.reason)
+          idleSignal.addEventListener("abort", onIdleAbort, { once: true })
           idleAborted.catch(() => {})
+          const cleanupStream = () => {
+            if (idleTimer) clearTimeout(idleTimer)
+            idleSignal.removeEventListener("abort", onIdleAbort)
+          }
           const resetIdle = () => {
             if (idleTimer) clearTimeout(idleTimer)
             idleTimer = setTimeout(() => {
@@ -920,27 +933,35 @@ export namespace Provider {
               try {
                 const { done, value } = await Promise.race([reader.read(), idleAborted])
                 if (done) {
-                  if (idleTimer) clearTimeout(idleTimer)
+                  cleanupStream()
                   controller.close()
                   return
                 }
                 resetIdle()
                 controller.enqueue(value)
               } catch (err) {
-                if (idleTimer) clearTimeout(idleTimer)
+                cleanupStream()
                 controller.error(err)
                 try {
                   await reader.cancel(err)
                 } catch {}
               }
             },
-            cancel() {
-              if (idleTimer) clearTimeout(idleTimer)
-              return originalBody.cancel()
+            cancel(reason) {
+              cleanupStream()
+              return reader ? reader.cancel(reason) : originalBody.cancel(reason)
             },
           })
 
           return new Response(wrappedStream, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          })
+        }
+
+        if (responseBody !== response.body) {
+          return new Response(responseBody, {
             status: response.status,
             statusText: response.statusText,
             headers: response.headers,

--- a/packages/synergy/src/provider/stream.ts
+++ b/packages/synergy/src/provider/stream.ts
@@ -1,0 +1,50 @@
+export namespace ProviderStream {
+  export const SSE_EVENT_MAX_BYTES = 16 * 1024 * 1024
+
+  export class SSEEventTooLargeError extends Error {
+    constructor(maxBytes: number) {
+      super(`SSE event exceeded ${maxBytes} bytes`)
+      this.name = "ProviderSSEEventTooLargeError"
+    }
+  }
+
+  export function isSSE(headers: Headers): boolean {
+    return headers.get("content-type")?.toLowerCase().includes("text/event-stream") === true
+  }
+
+  export function limitSSEEventBytes(
+    stream: ReadableStream<Uint8Array>,
+    maxBytes = SSE_EVENT_MAX_BYTES,
+  ): ReadableStream<Uint8Array> {
+    let eventBytes = 0
+    let atLineStart = true
+    let previousWasCarriageReturn = false
+
+    return stream.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          for (const byte of chunk) {
+            eventBytes++
+            if (byte === 13) {
+              if (atLineStart) eventBytes = 0
+              atLineStart = true
+              previousWasCarriageReturn = true
+            } else if (byte === 10) {
+              if (previousWasCarriageReturn) {
+                previousWasCarriageReturn = false
+              } else {
+                if (atLineStart) eventBytes = 0
+                atLineStart = true
+              }
+            } else {
+              atLineStart = false
+              previousWasCarriageReturn = false
+            }
+            if (eventBytes > maxBytes) throw new SSEEventTooLargeError(maxBytes)
+          }
+          controller.enqueue(chunk)
+        },
+      }),
+    )
+  }
+}

--- a/packages/synergy/src/provider/stream.ts
+++ b/packages/synergy/src/provider/stream.ts
@@ -1,10 +1,10 @@
 export namespace ProviderStream {
-  export const SSE_EVENT_MAX_BYTES = 16 * 1024 * 1024
+  export const SSE_EVENT_PARSER_BOUND_BYTES = 16 * 1024 * 1024
 
-  export class SSEEventTooLargeError extends Error {
-    constructor(maxBytes: number) {
-      super(`SSE event exceeded ${maxBytes} bytes`)
-      this.name = "ProviderSSEEventTooLargeError"
+  export class SSEEventParserBoundError extends Error {
+    constructor(parserBoundBytes: number) {
+      super(`SSE event parser bound of ${parserBoundBytes} bytes exceeded`)
+      this.name = "ProviderSSEEventParserBoundError"
     }
   }
 
@@ -12,13 +12,14 @@ export namespace ProviderStream {
     return headers.get("content-type")?.toLowerCase().includes("text/event-stream") === true
   }
 
-  export function limitSSEEventBytes(
+  export function enforceSSEEventParserBound(
     stream: ReadableStream<Uint8Array>,
-    maxBytes = SSE_EVENT_MAX_BYTES,
+    parserBoundBytes = SSE_EVENT_PARSER_BOUND_BYTES,
   ): ReadableStream<Uint8Array> {
     let eventBytes = 0
     let atLineStart = true
     let previousWasCarriageReturn = false
+    let previousCarriageReturnEndedEvent = false
 
     return stream.pipeThrough(
       new TransformStream<Uint8Array, Uint8Array>({
@@ -26,12 +27,15 @@ export namespace ProviderStream {
           for (const byte of chunk) {
             eventBytes++
             if (byte === 13) {
-              if (atLineStart) eventBytes = 0
+              previousCarriageReturnEndedEvent = atLineStart
+              if (previousCarriageReturnEndedEvent) eventBytes = 0
               atLineStart = true
               previousWasCarriageReturn = true
             } else if (byte === 10) {
               if (previousWasCarriageReturn) {
+                if (previousCarriageReturnEndedEvent) eventBytes = 0
                 previousWasCarriageReturn = false
+                previousCarriageReturnEndedEvent = false
               } else {
                 if (atLineStart) eventBytes = 0
                 atLineStart = true
@@ -39,8 +43,9 @@ export namespace ProviderStream {
             } else {
               atLineStart = false
               previousWasCarriageReturn = false
+              previousCarriageReturnEndedEvent = false
             }
-            if (eventBytes > maxBytes) throw new SSEEventTooLargeError(maxBytes)
+            if (eventBytes > parserBoundBytes) throw new SSEEventParserBoundError(parserBoundBytes)
           }
           controller.enqueue(chunk)
         },

--- a/packages/synergy/src/session/bounds.ts
+++ b/packages/synergy/src/session/bounds.ts
@@ -1,4 +1,5 @@
 export namespace SessionBounds {
+  export const TOOL_INPUT_MAX_BYTES = 1_048_576
   export const TOOL_OUTPUT_MAX_CHARS = 32_000
   export const DIFF_PREVIEW_MAX_CHARS = 8_000
 

--- a/packages/synergy/src/session/bounds.ts
+++ b/packages/synergy/src/session/bounds.ts
@@ -7,6 +7,14 @@ export namespace SessionBounds {
     return Buffer.byteLength(value, "utf8")
   }
 
+  export function toolInputByteLength(input: unknown): number {
+    return byteLength(JSON.stringify(input) ?? "")
+  }
+
+  export function toolInputExceededMessage(): string {
+    return `Tool input exceeded ${TOOL_INPUT_MAX_BYTES} bytes`
+  }
+
   export function middlePreview(value: string, maxChars: number): { text: string; truncated: boolean } {
     if (value.length <= maxChars) return { text: value, truncated: false }
     const omitted = value.length - maxChars

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -298,25 +298,29 @@ export namespace SessionCompaction {
     return pruned > PRUNE_MINIMUM ? toPrune : []
   }
 
-  export async function prune(input: { sessionID: string; modelID?: string }) {
+  export async function prune(input: { sessionID: string; messages: MessageV2.WithParts[]; modelID?: string }) {
     const config = await Config.current()
     if (config.compaction?.prune === false) return
     log.info("pruning")
-    const msgs = await Session.messages({ sessionID: input.sessionID })
-
-    const toPrune = selectPartsToPrune(msgs, input.modelID)
+    const toPrune = selectPartsToPrune(input.messages, input.modelID)
 
     if (toPrune.length > 0) {
       const completed = toPrune.filter(
         (part): part is MessageV2.ToolPart & { state: { status: "completed"; time: { compacted?: number } } } =>
           part.state.status === "completed",
       )
+      const compacted = Date.now()
       await Promise.all(
-        completed.map((part) => {
-          part.state.time.compacted = Date.now()
-          part.state.output = ""
-          return Session.updatePart(part)
-        }),
+        completed.map((part) =>
+          Session.updatePart({
+            ...part,
+            state: {
+              ...part.state,
+              output: "",
+              time: { ...part.state.time, compacted },
+            },
+          }),
+        ),
       )
       log.info("pruned", { count: completed.length })
     }
@@ -604,7 +608,7 @@ export namespace SessionCompaction {
       return [{ type: "prune" }]
     },
     async execute(ctx) {
-      await prune({ sessionID: ctx.sessionID, modelID: ctx.modelID })
+      await prune({ sessionID: ctx.sessionID, messages: ctx.messages, modelID: ctx.modelID })
       return "pass"
     },
   })

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -315,10 +315,6 @@ export namespace SessionInvoke {
         const preJobs = LoopJob.collect("pre", jobCtx, firedSignals)
         if (preJobs.length > 0) {
           const result = await LoopJob.execute(preJobs, jobCtx)
-          // Pre-jobs (compaction especially) can rewrite history in ways the
-          // incremental cache maintenance does not model; drop the cache so the
-          // next step re-reads authoritative state (#350 D2, R2).
-          SessionMessageCache.invalidate(sessionID)
           if (result === "stop") break
           if (result === "continue") {
             // A processed compaction re-arms the emergency-compaction fallback so
@@ -837,7 +833,8 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
           turnDeadline.abort(deadlineError)
           rejectDeadline(deadlineError)
         }, timeoutCfg.invokeMs)
-        abort.addEventListener("abort", () => clearTimeout(turnTimer), { once: true })
+        const onSessionAbort = () => clearTimeout(turnTimer)
+        abort.addEventListener("abort", onSessionAbort, { once: true })
         const combinedAbort = AbortSignal.any([abort, turnDeadline.signal])
 
         // Race against the deadline instead of relying on abort propagation:
@@ -903,9 +900,12 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
             turnSpanEnded = true
           }
         } finally {
+          const turnTimedOut = turnDeadline.signal.aborted
           clearTimeout(turnTimer)
+          abort.removeEventListener("abort", onSessionAbort)
+          turnDeadline.abort()
           processTimer.stop()
-          releaseTurnReferences(!turnDeadline.signal.aborted)
+          releaseTurnReferences(!turnTimedOut)
           if (!turnSpanEnded) {
             ObservabilitySpans.end(turnSpan, {
               attributes: {

--- a/packages/synergy/src/session/llm.ts
+++ b/packages/synergy/src/session/llm.ts
@@ -29,6 +29,62 @@ export namespace LLM {
 
   export const OUTPUT_TOKEN_MAX = ModelLimit.OUTPUT_TOKEN_MAX
 
+  function cancelResidualStream<TOOLS extends ToolSet, PARTIAL_OUTPUT>(
+    result: StreamTextResult<TOOLS, PARTIAL_OUTPUT>,
+  ) {
+    const residual = (result as StreamTextResult<TOOLS, PARTIAL_OUTPUT> & { baseStream?: ReadableStream<unknown> })
+      .baseStream
+    let cancellation: Promise<void> | undefined
+    try {
+      // AI SDK implements fullStream with tee() and retains the second branch as baseStream.
+      // Cancel it immediately, but wait only after the consumed branch settles because tee
+      // cancellation itself waits for the sibling branch to close.
+      cancellation = residual?.cancel().catch((error) => {
+        log.warn("failed to cancel residual stream branch", { error })
+      })
+    } catch (error) {
+      log.warn("failed to cancel residual stream branch", { error })
+    }
+    return cancellation
+  }
+
+  function ownStream<TOOLS extends ToolSet, PARTIAL_OUTPUT, STREAM>(
+    result: StreamTextResult<TOOLS, PARTIAL_OUTPUT>,
+    stream: STREAM,
+  ) {
+    const cancellation = cancelResidualStream(result)
+    return {
+      stream,
+      async dispose() {
+        await cancellation
+      },
+    }
+  }
+
+  export function takeFullStream<TOOLS extends ToolSet, PARTIAL_OUTPUT>(
+    result: StreamTextResult<TOOLS, PARTIAL_OUTPUT>,
+  ) {
+    return ownStream(result, result.fullStream)
+  }
+
+  export function takeTextStream<TOOLS extends ToolSet, PARTIAL_OUTPUT>(
+    result: StreamTextResult<TOOLS, PARTIAL_OUTPUT>,
+  ) {
+    return ownStream(result, result.textStream)
+  }
+
+  export async function collectText<TOOLS extends ToolSet, PARTIAL_OUTPUT>(
+    result: StreamTextResult<TOOLS, PARTIAL_OUTPUT>,
+  ) {
+    const text = result.text
+    const cancellation = cancelResidualStream(result)
+    try {
+      return await text
+    } finally {
+      await cancellation
+    }
+  }
+
   /**
    * Tool call repair logic, extracted for testability.
    *

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -929,7 +929,7 @@ export namespace SessionProcessor {
                       if (prevRaw === undefined) break
                       const receivedBytes = (generatingBytes[value.id] ?? 0) + SessionBounds.byteLength(value.delta)
                       if (receivedBytes > SessionBounds.TOOL_INPUT_MAX_BYTES) {
-                        const error = `Tool input exceeded ${SessionBounds.TOOL_INPUT_MAX_BYTES} bytes`
+                        const error = SessionBounds.toolInputExceededMessage()
                         const part = await Session.updatePart({
                           ...match,
                           state: {
@@ -998,6 +998,32 @@ export namespace SessionProcessor {
                       if (shouldIgnoreSettledStreamEvent(value.toolCallId, "tool-call", value.toolName)) break
                       const match = toolcalls[value.toolCallId]
                       const toolInput = SessionToolInput.normalize(value.input)
+                      if (SessionBounds.toolInputByteLength(toolInput) > SessionBounds.TOOL_INPUT_MAX_BYTES) {
+                        const error = SessionBounds.toolInputExceededMessage()
+                        const part = await Session.updatePart({
+                          ...(match ?? {
+                            id: Identifier.ascending("part"),
+                            messageID: input.assistantMessage.id,
+                            sessionID: input.assistantMessage.sessionID,
+                            type: "tool" as const,
+                            callID: value.toolCallId,
+                          }),
+                          tool: value.toolName,
+                          state: {
+                            status: "error",
+                            input: {},
+                            error,
+                            metadata: runningToolMetadata(value.toolName, value.providerMetadata),
+                            time: { start: Date.now(), end: Date.now() },
+                          },
+                          metadata: value.providerMetadata,
+                        })
+                        toolcalls[value.toolCallId] = part as MessageV2.ToolPart
+                        settledToolCalls.add(value.toolCallId)
+                        delete generatingAccum[value.toolCallId]
+                        delete generatingBytes[value.toolCallId]
+                        throw new Error(error)
+                      }
                       const part = await Session.updatePart({
                         ...(match ?? {
                           id: Identifier.ascending("part"),

--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -26,6 +26,7 @@ import { ObservabilityToolFailures } from "@/observability/tool-failures"
 import { ObservabilitySpans } from "@/observability/spans"
 import { ObservabilityContext } from "@/observability/context"
 import { SessionMemoryPressure } from "./memory-pressure"
+import { SessionBounds } from "./bounds"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -177,6 +178,7 @@ export namespace SessionProcessor {
     const settlementPromises = new Map<string, Promise<void>>()
     const settledToolCalls = new Set<string>()
     const generatingAccum: Record<string, string> = {}
+    const generatingBytes: Record<string, number> = {}
     let snapshot: string | undefined
     let blocked = false
     let attempt = 0
@@ -344,6 +346,7 @@ export namespace SessionProcessor {
     function shouldIgnoreSettledStreamEvent(callID: string, event: "tool-input-start" | "tool-call", tool: string) {
       if (!settledToolCalls.has(callID)) return false
       delete generatingAccum[callID]
+      delete generatingBytes[callID]
       log.warn("ignoring tool stream event after settlement", {
         sessionID: input.sessionID,
         messageID: input.assistantMessage.id,
@@ -539,6 +542,8 @@ export namespace SessionProcessor {
     function forgetToolCall(callID: string) {
       executions.delete(callID)
       delete toolcalls[callID]
+      delete generatingAccum[callID]
+      delete generatingBytes[callID]
     }
 
     async function waitForOutcomesAndSettle(parts: MessageV2.Part[]) {
@@ -700,6 +705,7 @@ export namespace SessionProcessor {
       settlementPromises.clear()
       settledToolCalls.clear()
       for (const callID of Object.keys(generatingAccum)) delete generatingAccum[callID]
+      for (const callID of Object.keys(generatingBytes)) delete generatingBytes[callID]
       snapshot = undefined
       log.info("processor disposed", {
         sessionID: input.sessionID,
@@ -808,8 +814,9 @@ export namespace SessionProcessor {
                 }
               }
 
+              const ownedStream = LLM.takeFullStream(stream)
               try {
-                for await (const value of stream.fullStream) {
+                for await (const value of ownedStream.stream) {
                   input.abort.throwIfAborted()
                   switch (value.type) {
                     case "start":
@@ -911,6 +918,7 @@ export namespace SessionProcessor {
                       })
                       toolcalls[value.id] = part as MessageV2.ToolPart
                       generatingAccum[value.id] = ""
+                      generatingBytes[value.id] = 0
                       break
                     }
 
@@ -919,6 +927,26 @@ export namespace SessionProcessor {
                       if (!match) break
                       const prevRaw = generatingAccum[value.id]
                       if (prevRaw === undefined) break
+                      const receivedBytes = (generatingBytes[value.id] ?? 0) + SessionBounds.byteLength(value.delta)
+                      if (receivedBytes > SessionBounds.TOOL_INPUT_MAX_BYTES) {
+                        const error = `Tool input exceeded ${SessionBounds.TOOL_INPUT_MAX_BYTES} bytes`
+                        const part = await Session.updatePart({
+                          ...match,
+                          state: {
+                            status: "error",
+                            input: {},
+                            error,
+                            metadata: streamingToolMetadata(match),
+                            time: { start: Date.now(), end: Date.now() },
+                          },
+                        })
+                        toolcalls[value.id] = part as MessageV2.ToolPart
+                        settledToolCalls.add(value.id)
+                        delete generatingAccum[value.id]
+                        delete generatingBytes[value.id]
+                        throw new Error(error)
+                      }
+                      generatingBytes[value.id] = receivedBytes
                       const raw = prevRaw + value.delta
                       generatingAccum[value.id] = raw
                       // Throttle generating updates: emit when enough new content has accumulated
@@ -991,6 +1019,7 @@ export namespace SessionProcessor {
                       })
                       toolcalls[value.toolCallId] = part as MessageV2.ToolPart
                       delete generatingAccum[value.toolCallId]
+                      delete generatingBytes[value.toolCallId]
                       log.info("tool.stream.tool_call.part_running", {
                         sessionID: input.sessionID,
                         messageID: input.assistantMessage.id,
@@ -1249,6 +1278,7 @@ export namespace SessionProcessor {
                 ObservabilitySpans.end(llmSpan, { status: "error", error })
                 throw error
               } finally {
+                await ownedStream.dispose()
                 flushChunkMetrics()
                 currentText = undefined
                 reasoningMap = {}

--- a/packages/synergy/src/session/summary.ts
+++ b/packages/synergy/src/session/summary.ts
@@ -216,7 +216,7 @@ export namespace SessionSummary {
         system: [],
         retries: 3,
       })
-      const result = await stream.text.catch((err) => {
+      const result = await LLM.collectText(stream).catch((err) => {
         log.error("failed to generate summary title", { error: err })
         return undefined
       })
@@ -256,7 +256,7 @@ export namespace SessionSummary {
         system: [],
         retries: 3,
       })
-      return stream.text.catch((err) => {
+      return LLM.collectText(stream).catch((err) => {
         log.error("failed to generate summary body", { error: err })
         return undefined
       })

--- a/packages/synergy/src/session/title.ts
+++ b/packages/synergy/src/session/title.ts
@@ -86,7 +86,7 @@ export async function ensureTitle(input: {
       ...MessageV2.toModelMessage(contextMessages),
     ],
   })
-  const text = await result.text.catch((err) => log.error("failed to generate title", { error: err }))
+  const text = await LLM.collectText(result).catch((err) => log.error("failed to generate title", { error: err }))
   if (text) {
     const { Session } = await import(".")
     return Session.update(input.session.id, (draft) => {

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -26,6 +26,8 @@ import { SessionManager } from "./manager"
 import type { Info } from "./types"
 import { MessageV2 } from "./message-v2"
 import type { SessionProcessor } from "./processor"
+import { SessionBounds } from "./bounds"
+import { SessionToolInput } from "./tool-input"
 import { ScopeContext } from "@/scope/context"
 import { EnforcementGate, type Capability } from "@/enforcement/gate"
 import { SandboxBackend } from "@/sandbox/backend"
@@ -1942,7 +1944,15 @@ export namespace ToolResolver {
     return {
       ...runtimeTool,
       execute(args, options) {
-        return input.processor.executeOnce(options.toolCallId, () => execute.call(runtimeTool, args, options))
+        return input.processor.executeOnce(options.toolCallId, () => {
+          const toolInput = SessionToolInput.normalize(args)
+          if (SessionBounds.toolInputByteLength(toolInput) > SessionBounds.TOOL_INPUT_MAX_BYTES) {
+            const error = SessionBounds.toolInputExceededMessage()
+            input.processor.beginExecution(options.toolCallId).fail({}, error)
+            throw new Error(error)
+          }
+          return execute.call(runtimeTool, args, options)
+        })
       },
     } as AITool
   }

--- a/packages/synergy/test/provider/sse-buffer.test.ts
+++ b/packages/synergy/test/provider/sse-buffer.test.ts
@@ -23,15 +23,23 @@ async function read(stream: ReadableStream<Uint8Array>) {
   }
 }
 
-describe("ProviderStream.limitSSEEventBytes", () => {
+describe("ProviderStream.enforceSSEEventParserBound", () => {
   test("passes bounded events and recognizes delimiters split across chunks", async () => {
     const input = ["data: first\r", "\n\r", "\ndata: second\n", "\n"]
-    const output = await read(ProviderStream.limitSSEEventBytes(source(...input), 32))
+    const output = await read(ProviderStream.enforceSSEEventParserBound(source(...input), 32))
     expect(output).toBe(input.join(""))
   })
 
+  test("accepts consecutive CRLF events at the exact parser bound", async () => {
+    const maxBytes = 32
+    const event = `data: ${"x".repeat(maxBytes - "data: ".length - 2)}\r\n\r\n`
+    const input = event.repeat(2)
+
+    await expect(read(ProviderStream.enforceSSEEventParserBound(source(input), maxBytes))).resolves.toBe(input)
+  })
+
   test("terminates an unterminated event at the byte limit", async () => {
-    const stream = ProviderStream.limitSSEEventBytes(source("data: ", "x".repeat(33)), 32)
-    await expect(read(stream)).rejects.toThrow("SSE event exceeded 32 bytes")
+    const stream = ProviderStream.enforceSSEEventParserBound(source("data: ", "x".repeat(33)), 32)
+    await expect(read(stream)).rejects.toThrow("SSE event parser bound of 32 bytes exceeded")
   })
 })

--- a/packages/synergy/test/provider/sse-buffer.test.ts
+++ b/packages/synergy/test/provider/sse-buffer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderStream } from "../../src/provider/stream"
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function source(...chunks: string[]) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function read(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader()
+  let output = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) return output
+    output += decoder.decode(value, { stream: true })
+  }
+}
+
+describe("ProviderStream.limitSSEEventBytes", () => {
+  test("passes bounded events and recognizes delimiters split across chunks", async () => {
+    const input = ["data: first\r", "\n\r", "\ndata: second\n", "\n"]
+    const output = await read(ProviderStream.limitSSEEventBytes(source(...input), 32))
+    expect(output).toBe(input.join(""))
+  })
+
+  test("terminates an unterminated event at the byte limit", async () => {
+    const stream = ProviderStream.limitSSEEventBytes(source("data: ", "x".repeat(33)), 32)
+    await expect(read(stream)).rejects.toThrow("SSE event exceeded 32 bytes")
+  })
+})

--- a/packages/synergy/test/session/compaction.test.ts
+++ b/packages/synergy/test/session/compaction.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { Token } from "../../src/util/token"
 import { Log } from "../../src/util/log"
 import { Session } from "../../src/session"
 import { SessionCompaction } from "../../src/session/compaction"
 import { MessageV2 } from "../../src/session/message-v2"
+import { Config } from "../../src/config/config"
 import type { Provider } from "../../src/provider/provider"
 import { ModelLimit } from "@ericsanchezok/synergy-util/model-limit"
 
@@ -887,5 +888,48 @@ describe("session.compaction.selectPartsToPrune", () => {
 
     expect(withoutModel).toHaveLength(0)
     expect(withModel).toHaveLength(0)
+  })
+
+  test("prunes from the loop snapshot without rereading or mutating it", async () => {
+    const oldPart = toolPart({ id: "old-tool", output: "x".repeat(300_000) })
+    const msgs: MessageV2.WithParts[] = [
+      userMsg("u0"),
+      assistantMsg("a0", [oldPart]),
+      userMsg("u1"),
+      assistantMsg("a1", []),
+      userMsg("u2"),
+      assistantMsg("a2", []),
+    ]
+    const originalMessages = Session.messages
+    const originalUpdatePart = Session.updatePart
+    const originalConfigCurrent = Config.current
+    let persisted: MessageV2.Part | undefined
+    ;(Config.current as any) = mock(async () => ({ compaction: {} }))
+    ;(Session.messages as any) = mock(async () => {
+      throw new Error("prune reread full history")
+    })
+    ;(Session.updatePart as any) = mock(async (part: MessageV2.Part) => {
+      persisted = part
+      return part
+    })
+
+    try {
+      await SessionCompaction.prune({ sessionID: "test-session", messages: msgs })
+    } finally {
+      ;(Config.current as any) = originalConfigCurrent
+      ;(Session.messages as any) = originalMessages
+      ;(Session.updatePart as any) = originalUpdatePart
+    }
+
+    expect(oldPart.state.status).toBe("completed")
+    if (oldPart.state.status === "completed") {
+      expect(oldPart.state.output.length).toBe(300_000)
+      expect(oldPart.state.time.compacted).toBeUndefined()
+    }
+    expect(persisted?.type).toBe("tool")
+    if (persisted?.type === "tool" && persisted.state.status === "completed") {
+      expect(persisted.state.output).toBe("")
+      expect(persisted.state.time.compacted).toBeNumber()
+    }
   })
 })

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -19,6 +19,7 @@ import { Identifier } from "../../src/id/id"
 import { Cortex } from "../../src/cortex/manager"
 import { Embedding } from "../../src/vector/embedding"
 import { Worktree } from "../../src/project/worktree"
+import { SessionMessageCache } from "../../src/session/message-cache"
 
 const sessionID = "ses_test"
 
@@ -1064,6 +1065,129 @@ describe("SessionInvoke completion notices", () => {
         },
       })
     } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+})
+
+describe("SessionInvoke turn lifecycle", () => {
+  test("keeps the loop message cache populated across pre-jobs", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    let cacheVisibleToProcessor = false
+    const restore = installBasicLoopMocks({
+      onProcess() {
+        cacheVisibleToProcessor = SessionMessageCache.get(activeSessionID) !== undefined
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+          await SessionInvoke.loop.force(session.id)
+        },
+      })
+
+      expect(cacheVisibleToProcessor).toBe(true)
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
+  test("removes the per-turn listener from the session abort signal", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalAcquire = SessionManager.acquire
+    const added: EventListenerOrEventListenerObject[] = []
+    const removed: EventListenerOrEventListenerObject[] = []
+    let activeSessionID = ""
+    const restore = installBasicLoopMocks()
+
+    ;(SessionManager.acquire as any) = mock((id: string) => {
+      const lease = originalAcquire(id)
+      if (!lease) return lease
+      const signal = lease.signal
+      const addEventListener = signal.addEventListener.bind(signal)
+      const removeEventListener = signal.removeEventListener.bind(signal)
+      Object.defineProperties(signal, {
+        addEventListener: {
+          configurable: true,
+          value(
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: AddEventListenerOptions | boolean,
+          ) {
+            if (type === "abort") added.push(listener)
+            return addEventListener(type, listener, options)
+          },
+        },
+        removeEventListener: {
+          configurable: true,
+          value(type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean) {
+            if (type === "abort") removed.push(listener)
+            return removeEventListener(type, listener, options)
+          },
+        },
+      })
+      return lease
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+          await SessionInvoke.loop.force(session.id)
+        },
+      })
+
+      expect(added.length).toBeGreaterThan(0)
+      expect(added.every((listener) => removed.includes(listener))).toBe(true)
+    } finally {
+      ;(SessionManager.acquire as any) = originalAcquire
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
+  test("closes the combined turn signal after normal processor completion", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalParts = MessageV2.parts
+    let activeSessionID = ""
+    let processReturned = false
+    let turnSignal: AbortSignal | undefined
+    let observedAfterTurn: boolean | undefined
+    const restore = installBasicLoopMocks({
+      onProcess(input) {
+        turnSignal = input.abort
+        processReturned = true
+      },
+    })
+
+    ;(MessageV2.parts as any) = mock(async (input: Parameters<typeof MessageV2.parts>[0]) => {
+      const parts = await originalParts(input)
+      if (processReturned && observedAfterTurn === undefined) observedAfterTurn = turnSignal?.aborted
+      return parts
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+          await SessionInvoke.loop.force(session.id)
+        },
+      })
+
+      expect(observedAfterTurn).toBe(true)
+    } finally {
+      ;(MessageV2.parts as any) = originalParts
       restore()
       if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
     }

--- a/packages/synergy/test/session/llm-stream-lifecycle.test.ts
+++ b/packages/synergy/test/session/llm-stream-lifecycle.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { LLM } from "../../src/session/llm"
+
+function residual(onCancel: () => void) {
+  return {
+    async cancel() {
+      onCancel()
+    },
+  }
+}
+
+describe("LLM stream ownership", () => {
+  test("collectText cancels the branch retained by the AI SDK text promise", async () => {
+    let cancellations = 0
+    const result: any = {
+      get text() {
+        this.baseStream = residual(() => cancellations++)
+        return Promise.resolve("complete text")
+      },
+    }
+
+    expect(await LLM.collectText(result)).toBe("complete text")
+    expect(cancellations).toBe(1)
+  })
+
+  test("takeTextStream cancels the branch retained by the AI SDK text stream", async () => {
+    let cancellations = 0
+    const result: any = {
+      get textStream() {
+        this.baseStream = residual(() => cancellations++)
+        return (async function* () {
+          yield "a"
+          yield "b"
+        })()
+      },
+    }
+
+    const owned = LLM.takeTextStream(result)
+    let text = ""
+    try {
+      for await (const chunk of owned.stream) text += chunk
+    } finally {
+      await owned.dispose()
+    }
+
+    expect(text).toBe("ab")
+    expect(cancellations).toBe(1)
+  })
+
+  test("releases one residual branch for every completed turn", async () => {
+    let cancellations = 0
+    for (let turn = 0; turn < 100; turn++) {
+      const result: any = {
+        get fullStream() {
+          this.baseStream = residual(() => cancellations++)
+          return (async function* () {
+            yield { type: "finish" }
+          })()
+        },
+      }
+      const owned = LLM.takeFullStream(result)
+      try {
+        for await (const part of owned.stream) void part
+      } finally {
+        await owned.dispose()
+      }
+    }
+
+    expect(cancellations).toBe(100)
+  })
+})

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -7,6 +7,8 @@ import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionProcessor } from "../../src/session/processor"
+import { SessionBounds } from "../../src/session/bounds"
+import { Bus } from "../../src/bus"
 import { ObservabilityStore } from "../../src/observability/store"
 import { ObservabilityToolFailures } from "../../src/observability/tool-failures"
 import { cleanupObservabilityHomes, resetObservabilityHome } from "../observability/fixture"
@@ -145,6 +147,8 @@ type SettlementScenario = {
   stream(processor: SessionProcessor.Info): AsyncGenerator<Record<string, unknown>>
   config?: Record<string, unknown>
   updatePart?: (input: MessageV2.Part | { part: MessageV2.Part; delta?: string }) => Promise<MessageV2.Part>
+  abort?: AbortSignal
+  residualStream?: { cancel(reason?: unknown): Promise<void> }
 }
 
 async function runSettlementScenario(scenario: SettlementScenario) {
@@ -156,6 +160,7 @@ async function runSettlementScenario(scenario: SettlementScenario) {
   const originalConfigCurrent = Config.current
   const originalPluginTrigger = Plugin.trigger
   const originalExperienceComplete = ExperienceEncoder.onComplete
+  const originalBusPublish = Bus.publish
   const parts = new Map<string, MessageV2.Part>()
   let processor!: SessionProcessor.Info
 
@@ -174,8 +179,10 @@ async function runSettlementScenario(scenario: SettlementScenario) {
     )
     ;(Plugin.trigger as any) = mock(async (_name: string, _context: unknown, value: unknown) => value)
     ;(ExperienceEncoder.onComplete as any) = mock(() => {})
+    ;(Bus.publish as any) = mock(async () => {})
     ;(LLM.stream as any) = mock(async () => ({
       fullStream: scenario.stream(processor),
+      baseStream: scenario.residualStream,
     }))
 
     processor = SessionProcessor.create({
@@ -195,7 +202,7 @@ async function runSettlementScenario(scenario: SettlementScenario) {
       },
       sessionID: "ses_test",
       model: { id: "test-model", modelID: "test-model", providerID: "test-provider" } as any,
-      abort: new AbortController().signal,
+      abort: scenario.abort ?? new AbortController().signal,
     })
 
     await processor.process({} as any)
@@ -210,8 +217,56 @@ async function runSettlementScenario(scenario: SettlementScenario) {
     ;(Config.current as any) = originalConfigCurrent
     ;(Plugin.trigger as any) = originalPluginTrigger
     ;(ExperienceEncoder.onComplete as any) = originalExperienceComplete
+    ;(Bus.publish as any) = originalBusPublish
   }
 }
+
+describe("SessionProcessor stream lifecycle", () => {
+  for (const testCase of ["completion", "failure", "abort"] as const) {
+    test(`cancels the residual AI SDK stream branch after ${testCase}`, async () => {
+      let cancelCount = 0
+      const controller = new AbortController()
+      await runSettlementScenario({
+        messageID: `msg_stream_${testCase}`,
+        abort: controller.signal,
+        residualStream: {
+          async cancel() {
+            cancelCount++
+          },
+        },
+        async *stream() {
+          if (testCase === "failure") throw new Error("stream failed")
+          if (testCase === "abort") controller.abort()
+          yield { type: "finish" }
+        },
+      })
+
+      expect(cancelCount).toBe(1)
+    })
+  }
+})
+
+describe("SessionProcessor tool input bounds", () => {
+  test("terminates a tool part when streamed input exceeds the byte limit", async () => {
+    const parts = await runSettlementScenario({
+      messageID: "msg_tool_input_limit",
+      async *stream() {
+        yield { type: "tool-input-start", id: "call_large", toolName: "edit" }
+        yield {
+          type: "tool-input-delta",
+          id: "call_large",
+          delta: "x".repeat(SessionBounds.TOOL_INPUT_MAX_BYTES + 1),
+        }
+      },
+    })
+
+    const part = firstTool(parts, "call_large")
+    expect(part?.state.status).toBe("error")
+    if (part?.state.status === "error") {
+      expect(part.state.error).toContain("exceeded")
+    }
+  })
+})
 
 function firstTool(parts: MessageV2.Part[], callID?: string) {
   return parts.find((part): part is MessageV2.ToolPart => part.type === "tool" && (!callID || part.callID === callID))

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -266,6 +266,26 @@ describe("SessionProcessor tool input bounds", () => {
       expect(part.state.error).toContain("exceeded")
     }
   })
+
+  test("terminates a final-only tool call when input exceeds the byte limit", async () => {
+    const parts = await runSettlementScenario({
+      messageID: "msg_final_tool_input_limit",
+      async *stream() {
+        yield {
+          type: "tool-call",
+          toolCallId: "call_final_large",
+          toolName: "edit",
+          input: { value: "x".repeat(SessionBounds.TOOL_INPUT_MAX_BYTES + 1) },
+        }
+      },
+    })
+
+    const part = firstTool(parts, "call_final_large")
+    expect(part?.state.status).toBe("error")
+    if (part?.state.status === "error") {
+      expect(part.state.error).toContain("exceeded")
+    }
+  })
 })
 
 function firstTool(parts: MessageV2.Part[], callID?: string) {

--- a/packages/synergy/test/session/tool-call-execution.test.ts
+++ b/packages/synergy/test/session/tool-call-execution.test.ts
@@ -5,6 +5,7 @@ import { ScopeContext } from "../../src/scope/context"
 import { SessionProcessor } from "../../src/session/processor"
 import { ToolResolver } from "../../src/session/tool-resolver"
 import { tmpdir } from "../fixture/fixture"
+import { SessionBounds } from "../../src/session/bounds"
 
 for (const scenario of [
   { name: "successful", terminalEvent: "tool-result", error: false },
@@ -76,6 +77,73 @@ for (const scenario of [
     })
   })
 }
+
+test("rejects oversized tool input before the handler executes", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const sessionID = "ses_tool_input_bound"
+      const processor = SessionProcessor.create({
+        assistantMessage: {
+          id: "msg_tool_input_bound",
+          sessionID,
+          role: "assistant",
+          parentID: "msg_user",
+          modelID: "test-model",
+          providerID: "test-provider",
+          mode: "build",
+          agent: "synergy",
+          path: { cwd: ScopeContext.current.directory, root: ScopeContext.current.directory },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 0 },
+        },
+        sessionID,
+        model,
+        abort: new AbortController().signal,
+      })
+      let executionCount = 0
+
+      try {
+        const resolved = await ToolResolver.resolveWithAvailability({
+          agent: allowAllAgent,
+          model,
+          sessionID,
+          processor,
+          ephemeralTools: [
+            {
+              id: "bounded_execution",
+              description: "Rejects oversized input before execution",
+              inputSchema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              async execute() {
+                executionCount++
+                return { title: "Unexpected", output: "unexpected" }
+              },
+            },
+          ],
+          userTools: { bounded_execution: true },
+          includeMCP: false,
+        })
+
+        await expect(
+          (resolved.tools.bounded_execution as any).execute(
+            { value: "x".repeat(SessionBounds.TOOL_INPUT_MAX_BYTES + 1) },
+            { toolCallId: "call_oversized" },
+          ),
+        ).rejects.toThrow(`Tool input exceeded ${SessionBounds.TOOL_INPUT_MAX_BYTES} bytes`)
+        expect(executionCount).toBe(0)
+      } finally {
+        processor.dispose("test")
+      }
+    },
+  })
+})
 
 const allowAllAgent = {
   name: "synergy",


### PR DESCRIPTION
## Summary

- cancel the residual AI SDK tee branch for every shared full/text stream consumer and release per-turn abort wiring
- keep the loop message cache incremental while pruning from the existing message snapshot
- bound provider SSE events at 16 MiB and streamed tool input at 1 MiB, and update `eventsource-parser` to 3.1.0

## Verification

- `bun test test/session/llm-stream-lifecycle.test.ts test/session/processor.test.ts test/session/invoke.test.ts test/session/compaction.test.ts test/session/summary.test.ts test/provider/sse-buffer.test.ts` — 132 pass, 0 fail
- `cd packages/synergy && bun run typecheck`
- `bun run quality:quick`
- full `cd packages/synergy && bun test` — 4,363 pass, 1 skip, with the known baseline proxy test failure described below

## Known baseline failure

`test/provider/proxy.test.ts` expects one configured-proxy hit but observes zero on this host. The same failure reproduces from an unchanged `dev` checkout, so it is unrelated to this patch.

Fixes #597
