### PR TITLE
fix: prevent bottom workbench overlap in sessions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "@types/luxon": "catalog:",
         "@types/node": "catalog:",
         "@typescript/native-preview": "catalog:",
+        "playwright": "1.61.0",
         "typescript": "catalog:",
         "vite": "catalog:",
         "vite-plugin-icons-spritesheet": "3.0.1",
@@ -1927,7 +1928,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -3211,8 +3212,6 @@
 
     "pdfjs-dist/@napi-rs/canvas": ["@napi-rs/canvas@0.1.80", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.80", "@napi-rs/canvas-darwin-arm64": "0.1.80", "@napi-rs/canvas-darwin-x64": "0.1.80", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80", "@napi-rs/canvas-linux-arm64-gnu": "0.1.80", "@napi-rs/canvas-linux-arm64-musl": "0.1.80", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-musl": "0.1.80", "@napi-rs/canvas-win32-x64-msvc": "0.1.80" } }, "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww=="],
 
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
     "plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
@@ -3261,6 +3260,8 @@
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
@@ -3290,6 +3291,8 @@
     "unzipper/fs-extra": ["fs-extra@11.3.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g=="],
 
     "verror/core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,6 +26,7 @@
     "@types/luxon": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
+    "playwright": "1.61.0",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-icons-spritesheet": "3.0.1",

--- a/packages/app/src/app-build-css-contract.test.ts
+++ b/packages/app/src/app-build-css-contract.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { chromium, webkit } from "playwright"
 
 const appDir = fileURLToPath(new URL("..", import.meta.url))
 
@@ -170,6 +171,63 @@ async function readBuiltAssets(outDir: string) {
   return readdir(path.join(outDir, "assets"))
 }
 
+async function expectSessionWorkbenchPaneTracksBottomSurface(css: string) {
+  const browserType = process.env.SYNERGY_APP_LAYOUT_BROWSER === "webkit" ? webkit : chromium
+  const browser = await browserType.launch({ headless: true })
+  try {
+    const page = await browser.newPage({ viewport: { width: 1200, height: 800 } })
+    await page.setContent(`
+      <style>
+        html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+        ${css}
+      </style>
+      <main class="relative size-full overflow-hidden flex flex-col contain-[layout_style_paint]">
+        <div class="synergy-workbench-canvas relative size-full overflow-hidden flex flex-col">
+          <div class="flex-1 min-h-0 flex flex-col md:flex-row relative">
+            <div data-pane class="session-workbench-pane relative flex flex-col flex-1">
+              <div data-prompt class="absolute inset-x-0 bottom-0 h-20"></div>
+            </div>
+          </div>
+          <div
+            data-bottom
+            class="workbench-surface workbench-surface--bottom workbench-surface--resizing"
+          ></div>
+        </div>
+      </main>
+    `)
+
+    const bottom = page.locator("[data-bottom]")
+    for (const bottomHeight of [0, 280, 480]) {
+      await bottom.evaluate((element, height) => {
+        element.style.height = `${height}px`
+      }, bottomHeight)
+
+      const layout = await page.evaluate(() => {
+        const pane = document.querySelector<HTMLElement>("[data-pane]")
+        const prompt = document.querySelector<HTMLElement>("[data-prompt]")
+        const bottomSurface = document.querySelector<HTMLElement>("[data-bottom]")
+        if (!pane || !prompt || !bottomSurface) throw new Error("Missing session layout fixture")
+
+        const paneRect = pane.getBoundingClientRect()
+        const promptRect = prompt.getBoundingClientRect()
+        const bottomRect = bottomSurface.getBoundingClientRect()
+        return {
+          paneHeight: paneRect.height,
+          paneBottom: paneRect.bottom,
+          promptBottom: promptRect.bottom,
+          bottomTop: bottomRect.top,
+        }
+      })
+
+      expect(Math.abs(layout.paneHeight - (800 - bottomHeight))).toBeLessThanOrEqual(1)
+      expect(Math.abs(layout.paneBottom - layout.bottomTop)).toBeLessThanOrEqual(1)
+      expect(Math.abs(layout.promptBottom - layout.bottomTop)).toBeLessThanOrEqual(1)
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
 async function runAppBuild(outDir: string) {
   const proc = Bun.spawn({
     cmd: [process.execPath, "run", "build", "--outDir", outDir, "--emptyOutDir"],
@@ -218,6 +276,7 @@ describe("app production build contract", () => {
       ])
       const markdownChunk = assets.find((asset) => asset.startsWith("vendor-markdown-") && asset.endsWith(".js"))
       expect(markdownChunk).toBeDefined()
+      await expectSessionWorkbenchPaneTracksBottomSurface(css)
       expect((await stat(path.join(outDir, "assets", markdownChunk!))).size).toBeLessThan(200_000)
     } finally {
       await rm(outDir, { recursive: true, force: true })

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -172,6 +172,11 @@ a:active,
   background-color: var(--workbench-canvas-bg);
 }
 
+.session-workbench-pane {
+  height: 100%;
+  min-height: 0;
+}
+
 .synergy-workbench-canvas :where(.workbench-panel-surface) {
   background-color: var(--workbench-panel-bg);
   border-color: var(--workbench-border);

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -975,7 +975,7 @@ function SessionPageContent() {
       <div class="synergy-workbench-canvas relative bg-background-stronger size-full overflow-hidden flex flex-col">
         <div class="flex-1 min-h-0 flex flex-col md:flex-row relative">
           <div
-            class="session-workbench-pane synergy-workbench-canvas @container relative min-w-0 flex flex-col min-h-0 h-full min-h-dvh bg-background-stronger pt-3 pb-0 md:py-3"
+            class="session-workbench-pane synergy-workbench-canvas @container relative min-w-0 flex flex-col bg-background-stronger pt-3 pb-0 md:py-3"
             classList={{
               "flex-1": !(isDesktop() && showTabs()),
             }}


### PR DESCRIPTION
## Summary

- remove the viewport-sized minimum height that prevented the session pane from shrinking when BottomSpace opened
- define the session pane height contract explicitly with `height: 100%` and `min-height: 0`
- add a production-CSS Playwright geometry regression covering closed, default-height, and large bottom workbench surfaces

Fixes #645.

## Verification

- `bun test src/app-build-css-contract.test.ts` (Chromium)
- `SYNERGY_APP_LAYOUT_BROWSER=webkit bun test src/app-build-css-contract.test.ts`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`