### PR TITLE
fix: restore question result theme hierarchy

### DIFF
--- a/packages/app/src/components/session/question-prompt.css
+++ b/packages/app/src/components/session/question-prompt.css
@@ -48,7 +48,7 @@
 
 .question-prompt-muted-icon {
   flex: none;
-  color: var(--text-muted);
+  color: var(--text-weak);
 }
 
 .question-prompt-collapsed-title {
@@ -67,7 +67,7 @@
   align-items: center;
   gap: 8px;
   overflow: hidden;
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 12px;
   font-weight: 500;
   text-overflow: ellipsis;
@@ -94,7 +94,7 @@
   height: 24px;
   display: grid;
   place-items: center;
-  color: var(--text-muted);
+  color: var(--text-weak);
   background: transparent;
   border: 0;
   border-radius: var(--radius-md);
@@ -111,7 +111,7 @@
 }
 
 .question-prompt-kicker {
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 12px;
   font-weight: 500;
 }
@@ -128,7 +128,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
 }
@@ -144,7 +144,7 @@
   height: 24px;
   min-width: auto;
   padding-inline: 8px;
-  color: var(--text-muted);
+  color: var(--text-weak);
   border-radius: var(--radius-md);
 }
 
@@ -161,7 +161,7 @@
   gap: 6px;
   min-height: 30px;
   padding: 0 11px;
-  color: var(--text-muted);
+  color: var(--text-weak);
   background: var(--question-control-bg);
   border: 0;
   border-radius: 999px;
@@ -251,7 +251,7 @@
   display: grid;
   place-items: center;
   margin-top: 1px;
-  color: var(--text-muted);
+  color: var(--text-weak);
   background: var(--question-control-bg);
   border-radius: var(--radius-full);
 }
@@ -278,7 +278,7 @@
 
 .question-prompt-option-description {
   display: block;
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 13px;
   font-weight: 500;
   line-height: 1.45;
@@ -312,7 +312,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 12px;
   font-weight: 600;
 }
@@ -372,11 +372,11 @@
 }
 
 .question-prompt-review-row.is-missing {
-  color: var(--text-muted);
+  color: var(--text-weak);
 }
 
 .question-prompt-review-label {
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 12px;
   font-weight: 600;
 }
@@ -392,7 +392,7 @@
 }
 
 .question-prompt-review-edit {
-  color: var(--text-muted);
+  color: var(--text-weak);
   font-size: 12px;
   font-weight: 600;
 }

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -525,6 +525,36 @@
     }
   }
 
+  [data-slot="question-item"] {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-block: 4px;
+  }
+
+  [data-slot="question-header"] {
+    color: var(--text-weaker);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+  }
+
+  [data-slot="question-text"] {
+    color: var(--text-base);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-large);
+  }
+
+  [data-slot="question-answer"] {
+    padding-top: 2px;
+    color: var(--text-weak);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+  }
+
   &[data-scrollable] {
     height: auto;
     max-height: 240px;

--- a/packages/ui/test/css-token-integrity.test.ts
+++ b/packages/ui/test/css-token-integrity.test.ts
@@ -22,6 +22,7 @@ const PHASE2_UI_FILES: FileSet[] = [
 
 const APP_FILES = [
   "../app/src/components/prompt-input/quick-actions.css",
+  "../app/src/components/session/question-prompt.css",
   "../app/src/components/header-bar.css",
   "../app/src/components/context-bar.css",
   "../app/src/components/dialog/dialog-settings.css",
@@ -120,6 +121,7 @@ const KNOWN_LOCAL_TOKENS = new Set([
   "workbench-panel-bg-hover",
   "workbench-card-bg",
   "workbench-card-bg-hover",
+  "workbench-row-bg",
   "workbench-card-secondary-bg",
   "workbench-control-bg",
   "workbench-control-bg-hover",

--- a/packages/ui/test/question-result-style.test.ts
+++ b/packages/ui/test/question-result-style.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { chromium, type Browser, type Page } from "playwright"
+
+let browser: Browser | undefined
+let page: Page
+let messagePartCss: string
+
+beforeAll(async () => {
+  messagePartCss = await Bun.file(new URL("../src/components/message-part.css", import.meta.url)).text()
+  browser = await chromium.launch({ headless: true })
+  page = await browser.newPage({ viewport: { width: 800, height: 600 } })
+})
+
+afterAll(async () => {
+  await browser?.close()
+})
+
+describe("question tool result styles", () => {
+  test("keeps question hierarchy explicit in light and dark themes", async () => {
+    await page.setContent(`
+      <style>
+        ${messagePartCss}
+      </style>
+      <div
+        id="light"
+        style="
+          width: 480px;
+          --font-size-small: 14px;
+          --font-size-base: 16px;
+          --font-weight-regular: 400;
+          --font-weight-medium: 500;
+          --line-height-large: 1.5;
+          --text-base: #111827;
+          --text-weak: #374151;
+          --text-weaker: #6b7280;
+          --surface-inset-base: #f4f4f5;
+          --border-weaker-base: #d1d5db;
+        "
+      >
+        <div data-component="tool-output">
+          <div data-slot="question-item">
+            <div data-slot="question-header">Scope</div>
+            <div data-slot="question-text">Which environment should receive the deployment?</div>
+            <div data-slot="question-answer">→ Staging</div>
+          </div>
+        </div>
+      </div>
+      <div
+        id="dark"
+        style="
+          width: 480px;
+          --font-size-small: 14px;
+          --font-size-base: 16px;
+          --font-weight-regular: 400;
+          --font-weight-medium: 500;
+          --line-height-large: 1.5;
+          --text-base: #f4f4f5;
+          --text-weak: #d4d4d8;
+          --text-weaker: #a1a1aa;
+          --surface-inset-base: #222326;
+          --border-weaker-base: #3f3f46;
+        "
+      >
+        <div data-component="tool-output">
+          <div data-slot="question-item">
+            <div data-slot="question-header">Scope</div>
+            <div data-slot="question-text">Which environment should receive the deployment?</div>
+            <div data-slot="question-answer">→ Staging</div>
+          </div>
+        </div>
+      </div>
+    `)
+
+    for (const contract of [
+      {
+        id: "light",
+        header: "rgb(107, 114, 128)",
+        prompt: "rgb(17, 24, 39)",
+        answer: "rgb(55, 65, 81)",
+      },
+      {
+        id: "dark",
+        header: "rgb(161, 161, 170)",
+        prompt: "rgb(244, 244, 245)",
+        answer: "rgb(212, 212, 216)",
+      },
+    ]) {
+      const styles = await page.locator(`#${contract.id} [data-slot="question-item"]`).evaluate((item) => {
+        const read = (slot: string) => {
+          const element = item.querySelector<HTMLElement>(`[data-slot="${slot}"]`)
+          if (!element) throw new Error(`Missing ${slot}`)
+          const style = getComputedStyle(element)
+          return {
+            color: style.color,
+            fontSize: style.fontSize,
+            fontWeight: style.fontWeight,
+            lineHeight: style.lineHeight,
+          }
+        }
+        const itemStyle = getComputedStyle(item)
+        return {
+          item: {
+            display: itemStyle.display,
+            flexDirection: itemStyle.flexDirection,
+            gap: itemStyle.gap,
+            paddingTop: itemStyle.paddingTop,
+          },
+          header: read("question-header"),
+          prompt: read("question-text"),
+          answer: read("question-answer"),
+        }
+      })
+
+      expect(styles.item).toEqual({
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+        paddingTop: "4px",
+      })
+      expect(styles.header).toEqual({
+        color: contract.header,
+        fontSize: "14px",
+        fontWeight: "500",
+        lineHeight: "21px",
+      })
+      expect(styles.prompt).toEqual({
+        color: contract.prompt,
+        fontSize: "16px",
+        fontWeight: "400",
+        lineHeight: "24px",
+      })
+      expect(styles.answer).toEqual({
+        color: contract.answer,
+        fontSize: "14px",
+        fontWeight: "500",
+        lineHeight: "21px",
+      })
+    }
+  })
+})

--- a/packages/ui/test/visual-token-contract.test.ts
+++ b/packages/ui/test/visual-token-contract.test.ts
@@ -34,6 +34,25 @@ function extractVarRefs(css: string): string[] {
   return refs
 }
 
+function extractRuleBlock(css: string, selector: string): string {
+  const selectorStart = css.indexOf(selector)
+  if (selectorStart === -1) return ""
+
+  const blockStart = css.indexOf("{", selectorStart)
+  if (blockStart === -1) return ""
+
+  let depth = 0
+  for (let index = blockStart; index < css.length; index++) {
+    const char = css[index]
+    if (char === "{") depth++
+    if (char !== "}") continue
+    depth--
+    if (depth === 0) return css.slice(selectorStart, index + 1)
+  }
+
+  return ""
+}
+
 function extractCustomPropValue(css: string, token: string): string | undefined {
   const re = new RegExp(`^\\s*--${token}\\s*:\\s*([^;]+);`, "gm")
   const matches = [...css.matchAll(re)]
@@ -435,6 +454,27 @@ describe("Visual Token Contract", () => {
       expect(outputBlock, "message-part.css 应定义 tool-output 样式块").not.toBe("")
       expect(outputBlock).toContain("var(--workbench-control-bg")
       expect(outputBlock).toContain("var(--workbench-border")
+    })
+
+    test("question tool results preserve header, prompt, and answer hierarchy", async () => {
+      const css = await readFileSafe("src/components/message-part.css")
+      const item = extractRuleBlock(css, '[data-slot="question-item"]')
+      const header = extractRuleBlock(css, '[data-slot="question-header"]')
+      const prompt = extractRuleBlock(css, '[data-slot="question-text"]')
+      const answer = extractRuleBlock(css, '[data-slot="question-answer"]')
+
+      expect(item).toContain("display: flex")
+      expect(item).toContain("flex-direction: column")
+      expect(item).toContain("gap: 4px")
+      expect(header).toContain("color: var(--text-weaker)")
+      expect(header).toContain("font-size: var(--font-size-small)")
+      expect(header).toContain("font-weight: var(--font-weight-medium)")
+      expect(prompt).toContain("color: var(--text-base)")
+      expect(prompt).toContain("font-size: var(--font-size-base)")
+      expect(prompt).toContain("line-height: var(--line-height-large)")
+      expect(answer).toContain("color: var(--text-weak)")
+      expect(answer).toContain("font-size: var(--font-size-small)")
+      expect(answer).toContain("font-weight: var(--font-weight-medium)")
     })
   })
 


### PR DESCRIPTION
## Summary

- add explicit canonical theme hierarchy for completed question tool results
- replace undefined `--text-muted` references in the interactive question prompt with `--text-weak`
- add token integrity, CSS contract, and light/dark computed-style regression coverage

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run --cwd packages/ui test`
- `bun run --cwd packages/app test`
- `bun run monorepo:check`
- `bun run package:check`

Closes #614