### PR TITLE
fix: stabilize snapshot Git spawning under contention

### DIFF
--- a/packages/synergy/src/session/snapshot.ts
+++ b/packages/synergy/src/session/snapshot.ts
@@ -17,6 +17,9 @@ export namespace Snapshot {
   const SNAPSHOT_HARD_TIMEOUT_MS = SNAPSHOT_TIMEOUT_MS + 5_000
   const SNAPSHOT_MAX_FILE_BYTES = 2 * 1024 * 1024
   const CANDIDATE_STATE_CONCURRENCY = 32
+  const GIT_SPAWN_MAX_ATTEMPTS = 3
+  const GIT_SPAWN_RETRY_BASE_MS = 25
+  const TRANSIENT_GIT_SPAWN_CODES = new Set(["EAGAIN", "EMFILE", "ENFILE", "ENOMEM"])
   const EXCLUDED_DIRS = new Set([
     ".git",
     ".synergy",
@@ -116,6 +119,40 @@ export namespace Snapshot {
     })
   }
 
+  function gitSpawnError(error: unknown) {
+    const code = (error as { code?: unknown })?.code
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      code: typeof code === "string" ? code : undefined,
+      message,
+    }
+  }
+
+  function isTransientGitSpawnError(error: unknown) {
+    const code = gitSpawnError(error).code
+    return code !== undefined && TRANSIENT_GIT_SPAWN_CODES.has(code)
+  }
+
+  async function waitForGitSpawnRetry(attempt: number, signal?: AbortSignal) {
+    if (signal?.aborted) return false
+    const delayMs = GIT_SPAWN_RETRY_BASE_MS * 2 ** (attempt - 1)
+    return new Promise<boolean>((resolve) => {
+      let settled = false
+      let timer: ReturnType<typeof setTimeout>
+      const finish = (value: boolean) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        signal?.removeEventListener("abort", onAbort)
+        resolve(value)
+      }
+      const onAbort = () => finish(false)
+      timer = setTimeout(() => finish(true), delayMs)
+      signal?.addEventListener("abort", onAbort, { once: true })
+      if (signal?.aborted) onAbort()
+    })
+  }
+
   async function gitSpawn(
     args: string[],
     cwd: string,
@@ -124,44 +161,59 @@ export namespace Snapshot {
     stdin?: string,
   ): Promise<{ exitCode: number; text: string; stderr: string }> {
     if (signal?.aborted) return abortedGitResult()
-    const childSignal = spawnSignal(SNAPSHOT_TIMEOUT_MS, signal)
-    let proc: Bun.Subprocess<"ignore" | "pipe", "pipe", "pipe"> | undefined
-    try {
-      proc = Bun.spawn(args, {
-        cwd,
-        stdin: stdin === undefined ? "ignore" : "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
-        env: env ? { ...process.env, ...env } : process.env,
-        signal: childSignal.signal,
-      })
-      if (stdin !== undefined) {
-        if (!proc.stdin) throw new Error("git subprocess stdin pipe unavailable")
-        proc.stdin.write(stdin)
-        proc.stdin.end()
-      }
-      const stdout = new Response(proc.stdout).text()
-      const stderr = new Response(proc.stderr).text().catch(() => "")
-      const [text, stderrText, exitCode] = await withTimeout(
-        withAbort(Promise.all([stdout, stderr, proc.exited]), childSignal.signal),
-        SNAPSHOT_HARD_TIMEOUT_MS,
-        { message: `git subprocess did not settle within ${SNAPSHOT_HARD_TIMEOUT_MS}ms` },
-      )
-      return { exitCode, text, stderr: stderrText }
-    } catch (err) {
-      if (signal?.aborted) {
+    for (let attempt = 1; ; attempt++) {
+      const childSignal = spawnSignal(SNAPSHOT_TIMEOUT_MS, signal)
+      let proc: Bun.Subprocess<"ignore" | "pipe", "pipe", "pipe"> | undefined
+      try {
+        proc = Bun.spawn(args, {
+          cwd,
+          stdin: stdin === undefined ? "ignore" : "pipe",
+          stdout: "pipe",
+          stderr: "pipe",
+          env: env ? { ...process.env, ...env } : process.env,
+          signal: childSignal.signal,
+        })
+        if (stdin !== undefined) {
+          if (!proc.stdin) throw new Error("git subprocess stdin pipe unavailable")
+          proc.stdin.write(stdin)
+          proc.stdin.end()
+        }
+        const stdout = new Response(proc.stdout).text()
+        const stderr = new Response(proc.stderr).text().catch(() => "")
+        const [text, stderrText, exitCode] = await withTimeout(
+          withAbort(Promise.all([stdout, stderr, proc.exited]), childSignal.signal),
+          SNAPSHOT_HARD_TIMEOUT_MS,
+          { message: `git subprocess did not settle within ${SNAPSHOT_HARD_TIMEOUT_MS}ms` },
+        )
+        return { exitCode, text, stderr: stderrText }
+      } catch (error) {
+        if (signal?.aborted) {
+          try {
+            proc?.kill()
+          } catch {}
+          return abortedGitResult()
+        }
         try {
           proc?.kill()
         } catch {}
-        return abortedGitResult()
+        const details = gitSpawnError(error)
+        const retrying = proc === undefined && isTransientGitSpawnError(error) && attempt < GIT_SPAWN_MAX_ATTEMPTS
+        log.warn("git spawn failed", {
+          args,
+          cwd,
+          attempt,
+          maxAttempts: GIT_SPAWN_MAX_ATTEMPTS,
+          retrying,
+          code: details.code,
+          error: details.message,
+        })
+        if (!retrying || !(await waitForGitSpawnRetry(attempt, signal))) {
+          const stderr = details.code ? `${details.code}: ${details.message}` : details.message
+          return { exitCode: -1, text: "", stderr }
+        }
+      } finally {
+        childSignal.cleanup()
       }
-      log.warn("git spawn failed", { args, cwd, error: String(err) })
-      try {
-        proc?.kill()
-      } catch {}
-      return { exitCode: -1, text: "", stderr: "" }
-    } finally {
-      childSignal.cleanup()
     }
   }
 

--- a/packages/synergy/test/fixture/fixture.ts
+++ b/packages/synergy/test/fixture/fixture.ts
@@ -20,6 +20,9 @@ type GitCommandResult = {
 
 export type GitFixtureRunner = (args: string[], cwd: string) => Promise<GitCommandResult>
 
+const GIT_FIXTURE_INIT_MAX_ATTEMPTS = 3
+const GIT_FIXTURE_INIT_RETRY_MS = 25
+
 async function runGitCommand(args: string[], cwd: string): Promise<GitCommandResult> {
   try {
     const child = Bun.spawn(["git", ...args], {
@@ -36,11 +39,18 @@ async function runGitCommand(args: string[], cwd: string): Promise<GitCommandRes
 }
 
 async function runGitFixtureStage(stage: string, args: string[], cwd: string, run: GitFixtureRunner) {
-  const result = await run(args, cwd)
-  if (result.exitCode === 0) return
-  throw new Error(
-    `Git fixture ${stage} failed with exit code ${result.exitCode}: ${result.stderr.trim() || "no stderr"}`,
-  )
+  const maxAttempts = args[0] === "init" ? GIT_FIXTURE_INIT_MAX_ATTEMPTS : 1
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await run(args, cwd)
+    if (result.exitCode === 0) return
+    if (result.exitCode === 141 && attempt < maxAttempts) {
+      await Bun.sleep(GIT_FIXTURE_INIT_RETRY_MS * attempt)
+      continue
+    }
+    throw new Error(
+      `Git fixture ${stage} failed with exit code ${result.exitCode}: ${result.stderr.trim() || "no stderr"}`,
+    )
+  }
 }
 
 export async function initializeGitFixture(dirpath: string, run: GitFixtureRunner = runGitCommand) {

--- a/packages/synergy/test/fixture/git.test.ts
+++ b/packages/synergy/test/fixture/git.test.ts
@@ -23,11 +23,68 @@ describe.serial("git fixture", () => {
     expect(await Bun.file(path.join(tmp.path, ".git", "config")).text()).toContain("email = test@synergy.dev")
   })
 
-  test("reports the failed initialization stage with exit details", async () => {
+  test("retries a transient SIGPIPE exit", async () => {
     await using tmp = await tmpdir()
+    let initAttempts = 0
+    let commitAttempts = 0
+
+    await initializeGitFixture(tmp.path, async (args) => {
+      if (args[0] === "init") {
+        initAttempts++
+        if (initAttempts === 1) return { exitCode: 141, stderr: "" }
+        await fs.mkdir(path.join(tmp.path, ".git"))
+        await Bun.write(path.join(tmp.path, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n")
+      } else {
+        commitAttempts++
+      }
+      return { exitCode: 0, stderr: "" }
+    })
+
+    expect(initAttempts).toBe(2)
+    expect(commitAttempts).toBe(1)
+  })
+
+  test("reports a SIGPIPE failure after exhausting init retries", async () => {
+    await using tmp = await tmpdir()
+    let initAttempts = 0
 
     await expect(
-      initializeGitFixture(tmp.path, async () => ({ exitCode: 17, stderr: "fixture init exploded\n" })),
+      initializeGitFixture(tmp.path, async () => {
+        initAttempts++
+        return { exitCode: 141, stderr: "" }
+      }),
+    ).rejects.toThrow("Git fixture init failed with exit code 141: no stderr")
+    expect(initAttempts).toBe(3)
+  })
+
+  test("reports a permanent initialization failure without retrying", async () => {
+    await using tmp = await tmpdir()
+    let attempts = 0
+
+    await expect(
+      initializeGitFixture(tmp.path, async () => {
+        attempts++
+        return { exitCode: 17, stderr: "fixture init exploded\n" }
+      }),
     ).rejects.toThrow("Git fixture init failed with exit code 17: fixture init exploded")
+    expect(attempts).toBe(1)
+  })
+
+  test("does not retry a root commit SIGPIPE failure", async () => {
+    await using tmp = await tmpdir()
+    let commitAttempts = 0
+
+    await expect(
+      initializeGitFixture(tmp.path, async (args) => {
+        if (args[0] === "init") {
+          await fs.mkdir(path.join(tmp.path, ".git"))
+          await Bun.write(path.join(tmp.path, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n")
+          return { exitCode: 0, stderr: "" }
+        }
+        commitAttempts++
+        return { exitCode: 141, stderr: "" }
+      }),
+    ).rejects.toThrow("Git fixture root commit failed with exit code 141: no stderr")
+    expect(commitAttempts).toBe(1)
   })
 })

--- a/packages/synergy/test/library/experience-reencode.test.ts
+++ b/packages/synergy/test/library/experience-reencode.test.ts
@@ -710,24 +710,42 @@ describe("ExperienceReencode worker primitives", () => {
   test("runs a continuous worker pool without exceeding concurrency", async () => {
     let active = 0
     let peak = 0
+    let slowCompleted = false
+    const started: string[] = []
     const completed: string[] = []
+    const releaseSlow = Promise.withResolvers<void>()
+    const fastTwoStarted = Promise.withResolvers<void>()
 
-    await ExperienceReencode.runPool({
+    const pending = ExperienceReencode.runPool({
       items: ["slow", "fast-1", "fast-2", "fast-3"],
       concurrency: 2,
       signal: new AbortController().signal,
       async process(item) {
         active++
         peak = Math.max(peak, active)
-        await Bun.sleep(item === "slow" ? 35 : 5)
-        completed.push(item)
-        active--
+        started.push(item)
+        try {
+          if (item === "slow") await releaseSlow.promise
+          if (item === "fast-2") fastTwoStarted.resolve()
+          completed.push(item)
+          if (item === "slow") slowCompleted = true
+        } finally {
+          active--
+        }
       },
     })
 
-    expect(peak).toBe(2)
+    await fastTwoStarted.promise
+    const startedBeforeSlowRelease = [...started]
+    const slowCompletedBeforeRelease = slowCompleted
+    const peakBeforeRelease = peak
+    releaseSlow.resolve()
+    await pending
+
+    expect(startedBeforeSlowRelease).toContain("fast-2")
+    expect(slowCompletedBeforeRelease).toBe(false)
+    expect(peakBeforeRelease).toBe(2)
     expect(completed).toHaveLength(4)
-    expect(completed.indexOf("fast-2")).toBeLessThan(completed.indexOf("slow"))
   })
 
   test("stops claiming new work after cancellation", async () => {

--- a/packages/synergy/test/snapshot/snapshot.test.ts
+++ b/packages/synergy/test/snapshot/snapshot.test.ts
@@ -75,6 +75,62 @@ async function withGitCommandLog<T>(fn: (commands: string[]) => Promise<T>) {
 }
 
 describe.serial("snapshot", () => {
+  test("retries a transient git spawn failure", async () => {
+    await using tmp = await bootstrap()
+    const scope = await tmp.scope()
+    const originalSpawn = Bun.spawn
+    let diffFilesAttempts = 0
+    Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+      const command = args[0]
+      if (Array.isArray(command) && command[0] === "git" && command.includes("diff-files")) {
+        diffFilesAttempts++
+        if (diffFilesAttempts === 1) {
+          throw Object.assign(new Error("too many open files"), { code: "EMFILE" })
+        }
+      }
+      return originalSpawn(...args)
+    }) as typeof Bun.spawn
+
+    try {
+      await ScopeContext.provide({
+        scope,
+        fn: async () => {
+          expect(await Snapshot.track(tmp.extra.sessionID)).toBeTruthy()
+        },
+      })
+      expect(diffFilesAttempts).toBe(2)
+    } finally {
+      Bun.spawn = originalSpawn
+    }
+  })
+
+  test("does not retry a permanent git spawn failure", async () => {
+    await using tmp = await bootstrap()
+    const scope = await tmp.scope()
+    const originalSpawn = Bun.spawn
+    let diffFilesAttempts = 0
+    Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+      const command = args[0]
+      if (Array.isArray(command) && command[0] === "git" && command.includes("diff-files")) {
+        diffFilesAttempts++
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" })
+      }
+      return originalSpawn(...args)
+    }) as typeof Bun.spawn
+
+    try {
+      await ScopeContext.provide({
+        scope,
+        fn: async () => {
+          expect(await Snapshot.track(tmp.extra.sessionID)).toBeUndefined()
+        },
+      })
+      expect(diffFilesAttempts).toBe(1)
+    } finally {
+      Bun.spawn = originalSpawn
+    }
+  })
+
   test("tracks deleted files correctly", async () => {
     await using tmp = await bootstrap()
     await ScopeContext.provide({


### PR DESCRIPTION
## Summary

- retry transient pre-spawn Git resource failures in snapshot operations while preserving cancellation, permanent-error, timeout, and non-zero-exit behavior
- replace the reencode worker-pool test's real-timer completion-order assumption with deterministic concurrency gates
- add regression coverage for transient `EMFILE` recovery and permanent-error non-retry behavior

## Root cause

Two independent flakes appeared in the `Test` job:

- the reencode worker-pool test inferred scheduling behavior from `Bun.sleep()` completion order, which is not stable when the CI event loop is contended
- snapshot Git helpers converted a transient `Bun.spawn()` resource error into a generic failed result, causing `Snapshot.track()` to return `undefined` without preserving the original diagnostic

The snapshot retry is intentionally limited to `EAGAIN`, `EMFILE`, `ENFILE`, and `ENOMEM` thrown before a subprocess is created. Git non-zero exits, permanent spawn errors, post-spawn failures, timeouts, and cancellations are not retried.

## Verification

- `bun test test/snapshot/snapshot.test.ts --timeout 30000`: 43 passed
- `bun test test/library/experience-reencode.test.ts --timeout 30000`: 15 passed
- repeated the reencode worker-pool regression 20 times
- repeated the snapshot transient-spawn regression 10 times
- `bun run typecheck` in `packages/synergy`
- `bun run format:check`
- `bun run quality:quick`
- `bun test` in `packages/synergy`: 4,570 passed; one unrelated config-import test exceeded its 5-second suite timeout
- the timed-out config-import test passed in isolation under the same default 5-second limit
- `bun test test/config/import.test.ts --timeout 30000`: 19 passed