### PR TITLE
fix(app): preserve new-session composer intent

### DIFF
--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -237,6 +237,10 @@ export function usePromptSubmit(input: PromptSubmitInput) {
     }
 
     const selectedVariant = local.model.variant.current()
+    const selectedModel = {
+      modelID: currentModel.id,
+      providerID: currentModel.provider.id,
+    }
     input.addToHistory(currentPrompt, mode)
     input.setStore("historyIndex", -1)
     input.setStore("savedPrompt", null)
@@ -284,7 +288,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
           lightLoop: armedLightLoop,
           blueprintSlot,
           agent: currentAgent.name,
-          model: { providerID: currentModel.provider.id, modelID: currentModel.id },
+          model: selectedModel,
           variant: selectedVariant,
           autoSubmit: false,
         }
@@ -375,6 +379,10 @@ export function usePromptSubmit(input: PromptSubmitInput) {
       if (session) {
         createdSessionForSubmit = true
         client = resolveSessionClient(sessionCreateScopeKey)
+        local.handoffNewSessionIntent(session.id)
+        if (selectedVariant) {
+          local.model.variant.setForSession(session.id, selectedVariant, selectedModel, sessionScopeKey)
+        }
         input.props.onNewSessionWorkspaceSelectionReset?.()
         publishNewSessionTransition(
           session.id,
@@ -527,15 +535,9 @@ export function usePromptSubmit(input: PromptSubmitInput) {
     }
     const activeSession = session!
 
-    const model = {
-      modelID: currentModel.id,
-      providerID: currentModel.provider.id,
-    }
+    const model = selectedModel
     const agent = currentAgent.name
     const variant = selectedVariant
-    if (createdSessionForSubmit && variant) {
-      local.model.variant.setForSession(activeSession.id, variant, model, sessionScopeKey)
-    }
     const clearInput = () => {
       prompt.resetDraft()
       input.setStore("mode", "normal")

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -124,6 +124,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               modelID: value.model.modelID,
             })
         },
+        handoffNewSessionIntent(sessionID: string) {
+          const next = ComposerIntent.handoffNewSessionDraft(store.draft, NEW_SESSION_INTENT_KEY, sessionID)
+          if (next === store.draft) return
+          const value = next[sessionID]
+          if (value !== undefined) setStore("draft", sessionID, value)
+        },
       }
     })()
 
@@ -436,6 +442,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               .catch(() => {})
           }
         },
+        handoffNewSessionIntent(sessionID: string) {
+          const next = ComposerIntent.handoffNewSessionDraft(draft.model, NEW_SESSION_INTENT_KEY, sessionID)
+          if (next === draft.model) return
+          const value = next[sessionID]
+          if (value !== undefined) setDraft("model", sessionID, value)
+        },
         inQuickSwitcher,
         isRecommended(model: ModelKey) {
           return recommendedSet().has(keyOf(model))
@@ -484,6 +496,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       slug: createMemo(() => base64Encode(sdk.scopeKey)),
       model,
       agent,
+      handoffNewSessionIntent(sessionID: string) {
+        batch(() => {
+          agent.handoffNewSessionIntent(sessionID)
+          model.handoffNewSessionIntent(sessionID)
+        })
+      },
     }
     return result
   },

--- a/packages/app/src/context/prompt/composer-intent.test.ts
+++ b/packages/app/src/context/prompt/composer-intent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  handoffNewSessionDraft,
   resolveVariantDisplay,
   resolveModel,
   resolveAgent,
@@ -18,6 +19,37 @@ const validOnly =
   (...keys: ModelKey[]) =>
   (m: ModelKey) =>
     keys.some((k) => k.providerID === m.providerID && k.modelID === m.modelID)
+
+describe("handoffNewSessionDraft", () => {
+  test("copies explicit new-session intent to the created session", () => {
+    const draft = { __new__: A, existing: B }
+
+    expect(handoffNewSessionDraft(draft, "__new__", "created")).toEqual({
+      __new__: A,
+      existing: B,
+      created: A,
+    })
+  })
+
+  test("does not inject an effective fallback when no explicit draft exists", () => {
+    const draft = { existing: B }
+
+    expect(handoffNewSessionDraft(draft, "__new__", "created")).toBe(draft)
+  })
+
+  test("keeps the explicit model selected across the route key transition", () => {
+    const draft = handoffNewSessionDraft({ __new__: A }, "__new__", "created")
+
+    expect(resolveModel([draft.created, undefined, B], validAll)).toBe(A)
+  })
+
+  test("supports agent drafts without changing the handoff semantics", () => {
+    expect(handoffNewSessionDraft({ __new__: "build" }, "__new__", "created")).toEqual({
+      __new__: "build",
+      created: "build",
+    })
+  })
+})
 
 describe("resolveModel", () => {
   test("returns the first valid candidate in priority order", () => {

--- a/packages/app/src/context/prompt/composer-intent.ts
+++ b/packages/app/src/context/prompt/composer-intent.ts
@@ -13,6 +13,15 @@
 // reactive store.
 
 export type ModelKey = { providerID: string; modelID: string }
+export function handoffNewSessionDraft<T>(
+  draft: Record<string, T>,
+  newSessionKey: string,
+  sessionID: string,
+): Record<string, T> {
+  const value = draft[newSessionKey]
+  if (value === undefined) return draft
+  return { ...draft, [sessionID]: value }
+}
 
 /** First candidate (in priority order) that passes validation. */
 export function resolveModel(


### PR DESCRIPTION
## Summary

- hand off explicit new-session model and agent drafts to the created session before navigation
- move model variant handoff to the same pre-navigation transition point
- add regression coverage for preserving explicit composer intent across the session key change

## Verification

- `bun test src/context/prompt/composer-intent.test.ts` (from `packages/app`)
- `bun run typecheck` (from `packages/app`)
- `bun run test` (from `packages/app`)
- `bun run quality:quick`

Fixes #674