### PR TITLE
fix(app): prevent localized panel crashes

### DIFF
--- a/packages/app/script/test.ts
+++ b/packages/app/script/test.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 
 const root = path.resolve(import.meta.dir, "..")
 const isolated = "src/app-build-css-contract.test.ts"
+const browserOnly = "src/plugin/builtin-navigation.test.ts"
 
 async function collectTests(directory: string): Promise<string[]> {
   const entries = await readdir(path.join(root, directory), { withFileTypes: true })
@@ -17,8 +18,8 @@ async function collectTests(directory: string): Promise<string[]> {
   return tests
 }
 
-async function run(tests: string[]) {
-  const child = Bun.spawn([process.execPath, "test", ...tests], {
+async function run(tests: string[], options: { browser?: boolean } = {}) {
+  const child = Bun.spawn([process.execPath, "test", ...(options.browser ? ["--conditions=browser"] : []), ...tests], {
     cwd: root,
     stdin: "inherit",
     stdout: "inherit",
@@ -29,5 +30,6 @@ async function run(tests: string[]) {
 }
 
 const tests = (await collectTests("src")).toSorted()
-await run(tests.filter((test) => test !== isolated))
+await run(tests.filter((test) => test !== isolated && test !== browserOnly))
+await run([browserOnly], { browser: true })
 await run([isolated])

--- a/packages/app/src/components/library/experience-view.tsx
+++ b/packages/app/src/components/library/experience-view.tsx
@@ -637,8 +637,6 @@ export function ExperienceView(props: {
     </div>
   )
 }
-const { _ } = useLingui()
-const { fmt } = useLocale()
 function RewardDimensions(props: { rewards: RewardsInfo }) {
   const valueTone = (value: number) => {
     if (value > 0) return "text-text-on-success-base"
@@ -691,6 +689,7 @@ function ExperienceCard(props: {
   onDelete: (e: MouseEvent) => void
 }) {
   const { _ } = useLingui()
+  const { fmt } = useLocale()
   const reward = () => props.item.reward
   const rewards = () => props.item.rewards
   const qValue = () => props.item.qValue

--- a/packages/app/src/context/locale/formatter.test.ts
+++ b/packages/app/src/context/locale/formatter.test.ts
@@ -62,6 +62,13 @@ describe("createIntlFormatter", () => {
       const result = fmt.time(d)
       expect(result.length).toBeGreaterThan(0)
     })
+
+    test("accepts granular time fields without conflicting with the default style", () => {
+      const fmt = createIntlFormatter(() => zhCN)
+      const d = new Date(2026, 0, 15, 14, 30, 0)
+
+      expect(() => fmt.time(d, { hour: "2-digit", minute: "2-digit" })).not.toThrow()
+    })
   })
 
   describe("dateTime", () => {
@@ -70,6 +77,13 @@ describe("createIntlFormatter", () => {
       const d = new Date(2026, 0, 15, 14, 30, 0)
       const result = fmt.dateTime(d)
       expect(result).toContain("2026")
+    })
+
+    test("accepts granular date and time fields without conflicting with the default styles", () => {
+      const fmt = createIntlFormatter(() => zhCN)
+      const d = new Date(2026, 0, 15, 14, 30, 0)
+
+      expect(() => fmt.dateTime(d, { year: "numeric", hour: "2-digit" })).not.toThrow()
     })
   })
 

--- a/packages/app/src/context/locale/formatter.ts
+++ b/packages/app/src/context/locale/formatter.ts
@@ -9,6 +9,24 @@ function optionsKey(options: object | undefined): string {
     .join("|")
 }
 
+const dateTimeComponentKeys = [
+  "weekday",
+  "era",
+  "year",
+  "month",
+  "day",
+  "dayPeriod",
+  "hour",
+  "minute",
+  "second",
+  "fractionalSecondDigits",
+  "timeZoneName",
+] as const
+
+function hasDateTimeComponents(options: Intl.DateTimeFormatOptions | undefined): boolean {
+  return dateTimeComponentKeys.some((key) => options?.[key] !== undefined)
+}
+
 export interface IntlFormatter {
   number(value: number, options?: Intl.NumberFormatOptions): string
   percent(value: number, options?: Intl.NumberFormatOptions): string
@@ -105,12 +123,18 @@ export function createIntlFormatter(getLocale: () => ActiveLocale): IntlFormatte
 
     dateTime(value, options?) {
       ensureLocale()
-      return getDTF({ dateStyle: "medium", timeStyle: "short", ...options }).format(value)
+      const resolved: Intl.DateTimeFormatOptions | undefined = hasDateTimeComponents(options)
+        ? options
+        : { dateStyle: "medium", timeStyle: "short", ...options }
+      return getDTF(resolved).format(value)
     },
 
     time(value, options?) {
       ensureLocale()
-      return getDTF({ timeStyle: "short", ...options }).format(value)
+      const resolved: Intl.DateTimeFormatOptions | undefined = hasDateTimeComponents(options)
+        ? options
+        : { timeStyle: "short", ...options }
+      return getDTF(resolved).format(value)
     },
 
     relative(value, base?) {

--- a/packages/app/src/plugin/builtin-navigation.test.ts
+++ b/packages/app/src/plugin/builtin-navigation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, mock, test } from "bun:test"
+
+mock.module("@/locales/en/messages.po?lingui", () => ({ messages: {} }))
+import { getBuiltinNavigation } from "./registries/navigation-registry"
+
+describe("built-in navigation loaders", () => {
+  test("loads the localized Library module outside a component owner", async () => {
+    await import("./builtin-navigation")
+    const loader = getBuiltinNavigation("library")?.loader
+
+    expect(loader).toBeFunction()
+    const module = await loader!()
+    expect(module.default).toBeFunction()
+  })
+})


### PR DESCRIPTION
## Summary

- avoid combining `Intl.DateTimeFormat` style defaults with granular date/time fields supplied by callers
- move Library locale context hooks out of module evaluation and into `ExperienceCard`
- add regression coverage for granular formatter options and lazy Library module loading under Bun's browser conditions

## Root cause

The shared formatter unconditionally added `timeStyle`/`dateStyle` defaults, which Chromium/V8 rejects when callers also provide component fields such as `hour` and `minute`. Separately, the lazy Library module called `useLingui()` and `useLocale()` at module scope, before a Solid owner/provider existed.

## Verification

- `bun test src/context/locale/formatter.test.ts`
- `bun test --conditions=browser src/plugin/builtin-navigation.test.ts`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`

Fixes #691