### PR TITLE
fix: isolate core test suite state in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,19 @@ jobs:
           SYNERGY_LINK_HOME: /tmp/synergy-link-ci-test
 
       - name: Run Synergy tests
-        run: bun test --timeout 30000
+        run: bun run test:ci
         working-directory: packages/synergy
         env:
           SYNERGY_LINK_HOME: /tmp/synergy-link-ci-test
+          SYNERGY_TEST_JUNIT_DIR: coverage/ci-tests
+
+      - name: Upload Synergy test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: synergy-test-reports
+          path: packages/synergy/coverage/ci-tests/*.xml
+          if-no-files-found: warn
 
   package-validation:
     name: Package Validation

--- a/.synergy/command/check.md
+++ b/.synergy/command/check.md
@@ -9,6 +9,9 @@ bun run quality:quick
 ```
 
 4. Run `bun run quality` when the change crosses shared abstractions, the user requests the full suite, or the work is ready for PR-level verification.
+
+For core-runtime harness changes or CI-equivalent verification, run `bun run test:ci` from `packages/synergy` after focused tests. This uses sequential fresh-process shards and may replace a redundant second single-process full-suite run when the CI boundary is the intended signal.
+
 5. Add specialized checks when relevant:
 
 ```bash

--- a/.synergy/skill/testing-guide/SKILL.md
+++ b/.synergy/skill/testing-guide/SKILL.md
@@ -27,7 +27,7 @@ For localized UI behavior, use a real Lingui `I18nProvider` with minimal English
 
 ## Use Real Isolation
 
-Use `tmpdir()` and `ScopeContext` instead of mocking Storage, Session, or the filesystem. Restore environment variables and singleton state in cleanup hooks. Honor abort signals and dispose processes, Browser pages, servers, and timers.
+Use `tmpdir()` and `ScopeContext` instead of mocking Storage, Session, or the filesystem. The preload-managed `SYNERGY_TEST_ROOT` contains temporary fixtures for process-level cleanup, so do not move fixtures back to unmanaged operating-system temp paths or delete them while Scope-owned asynchronous work may still reference them. Restore environment variables and singleton state in cleanup hooks. Honor abort signals and dispose processes, Browser pages, servers, and timers.
 
 Provider/model tests use the pinned `test/tool/fixtures/models-api.json` catalog. Update that fixture deliberately; never make deterministic tests depend on the live model catalog or real API keys.
 
@@ -41,6 +41,7 @@ Core runtime commands run from `packages/synergy`:
 bun test test/<domain>/<file>.test.ts
 bun run test:changed
 bun test
+bun run test:ci
 bun run test:coverage
 ```
 
@@ -64,6 +65,8 @@ bun run --cwd packages/app build
 Extraction must leave tracked PO catalogs unchanged, strict compilation must reject missing Simplified Chinese or invalid ICU messages, and the production build must keep non-English catalogs lazy while excluding development-only pseudo-localization. Exercise a Chinese cold start, rapid switching, catalog-load failure, `html.lang`, keyboard labels, and 375 px layout through an isolated Web/Desktop runtime.
 
 Run the narrow failing test during iteration, then the affected package/domain suite, then `quality:quick`. Run the full suite when the change crosses shared abstractions, persistence, generated contracts, package publication, or release boundaries, or when the user requests it.
+
+`bun run test:ci` is the CI-equivalent core suite. It runs four shards sequentially in fresh Bun processes to bound process-global state and fixture accumulation without introducing cross-shard port or environment races. Set `SYNERGY_TEST_JUNIT_DIR` to emit one JUnit report per shard.
 
 Use [Development reference](../../../docs/reference/development.md) and [Open-source quality](../../../docs/operations/open-source-quality.md) for current command ownership. Do not invent a root `bun test`; the root script intentionally rejects that ambiguous command.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ cd packages/synergy
 bun test test/<domain>/<file>.test.ts
 bun run test:changed
 bun test
+bun run test:ci
 bun run test:coverage
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ See the [development reference](docs/reference/development.md) for source modes,
    bun run quality
    ```
 
+   Core-runtime CI isolation can be reproduced from `packages/synergy` with `bun run test:ci`, which runs the complete suite as sequential fresh-process shards.
+
    CI runs the full matrix — see [docs/operations/open-source-quality.md](docs/operations/open-source-quality.md) for the complete model.
 
    Frontend copy, accessibility text, and locale-sensitive formatting must also keep the localization catalogs and source contract current:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Core runtime tests run from `packages/synergy`:
 ```bash
 cd packages/synergy
 bun test
+bun run test:ci # CI-equivalent sequential shards
 ```
 
 Frontend package suites run through their standard scripts and are included in `bun run quality`:

--- a/docs/operations/open-source-quality.md
+++ b/docs/operations/open-source-quality.md
@@ -4,21 +4,21 @@ Synergy runs a multi-layer quality system that covers formatting, linting, type-
 
 ## Quality Layers
 
-| Layer              | Local command                | CI job                | Tool                     | Pre-push |
-| ------------------ | ---------------------------- | --------------------- | ------------------------ | -------- |
-| Bun version check  | (pre-push only)              | —                     | `check-bun-version`      | ✅       |
-| Formatting         | `bun run format:check`       | `quality`             | Prettier                 | ✅       |
-| Lint               | `bun run lint`               | `quality`             | oxlint                   | ✅       |
-| Localization       | `bun run localization:check` | `quality`             | Lingui + source contract | —        |
-| Type checking      | `bun run typecheck`          | `typecheck`           | tsc via turbo            | ✅       |
-| Monorepo deps      | `bun run monorepo:check`     | `quality`             | sherif                   | ✅       |
-| Dead code          | `bun run deadcode`           | `quality`             | knip                     | —        |
-| CI workflow lint   | `bun run workflow:check`     | `workflow-validation` | actionlint + zizmor      | —        |
-| Secret scanning    | `bun run secrets:check`      | `secret-scan`         | gitleaks                 | —        |
-| Package validation | `bun run package:check`      | `package-validation`  | publint + attw           | —        |
-| Tests              | `bun turbo test`             | `test`                | bun test                 | —        |
-| Desktop checks     | `bun run desktop:test`       | `desktop`             | bun test + build         | —        |
-| Smoke test         | —                            | `smoke`               | Synergy health check     | —        |
+| Layer              | Local command                        | CI job                | Tool                          | Pre-push |
+| ------------------ | ------------------------------------ | --------------------- | ----------------------------- | -------- |
+| Bun version check  | (pre-push only)                      | —                     | `check-bun-version`           | ✅       |
+| Formatting         | `bun run format:check`               | `quality`             | Prettier                      | ✅       |
+| Lint               | `bun run lint`                       | `quality`             | oxlint                        | ✅       |
+| Localization       | `bun run localization:check`         | `quality`             | Lingui + source contract      | —        |
+| Type checking      | `bun run typecheck`                  | `typecheck`           | tsc via turbo                 | ✅       |
+| Monorepo deps      | `bun run monorepo:check`             | `quality`             | sherif                        | ✅       |
+| Dead code          | `bun run deadcode`                   | `quality`             | knip                          | —        |
+| CI workflow lint   | `bun run workflow:check`             | `workflow-validation` | actionlint + zizmor           | —        |
+| Secret scanning    | `bun run secrets:check`              | `secret-scan`         | gitleaks                      | —        |
+| Package validation | `bun run package:check`              | `package-validation`  | publint + attw                | —        |
+| Tests              | `bun turbo test` / `bun run test:ci` | `test`                | Turbo + sequential Bun shards | —        |
+| Desktop checks     | `bun run desktop:test`               | `desktop`             | bun test + build              | —        |
+| Smoke test         | —                                    | `smoke`               | Synergy health check          | —        |
 
 ### Pre-push hook (`.husky/pre-push`)
 
@@ -50,20 +50,20 @@ This runs the full suite locally. CI runs the same checks in parallel jobs.
 
 CI runs on push to `dev` / `main` and on pull requests targeting those branches. Jobs run in parallel:
 
-| Job                   | Purpose                                                               |
-| --------------------- | --------------------------------------------------------------------- |
-| `quality`             | Formatting, lint, localization, monorepo deps, dead code              |
-| `typecheck`           | TypeScript type checking                                              |
-| `test`                | Non-Synergy package tests plus one full Synergy test pass             |
-| `package-validation`  | publint + attw for publishable packages                               |
-| `workflow-validation` | actionlint + zizmor for CI workflow files                             |
-| `secret-scan`         | gitleaks for secrets and credentials                                  |
-| `desktop`             | Desktop typecheck, unit tests, build config validation, runtime smoke |
-| `smoke`               | Server health check smoke test                                        |
+| Job                   | Purpose                                                                |
+| --------------------- | ---------------------------------------------------------------------- |
+| `quality`             | Formatting, lint, localization, monorepo deps, dead code               |
+| `typecheck`           | TypeScript type checking                                               |
+| `test`                | Non-Synergy package tests plus sequential fresh-process Synergy shards |
+| `package-validation`  | publint + attw for publishable packages                                |
+| `workflow-validation` | actionlint + zizmor for CI workflow files                              |
+| `secret-scan`         | gitleaks for secrets and credentials                                   |
+| `desktop`             | Desktop typecheck, unit tests, build config validation, runtime smoke  |
+| `smoke`               | Server health check smoke test                                         |
 
 All jobs must pass for a PR to merge. The `package-validation` and `workflow-validation` jobs are not in the pre-push hook — they require network access or special tooling that is available in CI but may not be installed locally.
 
-The test job excludes `synergy` from the Turbo package pass, then runs the complete Synergy suite once from `packages/synergy`. Coverage is not collected in the required CI path.
+The test job excludes `synergy` from the Turbo package pass, then runs the complete Synergy suite as four sequential fresh-process shards from `packages/synergy`. Each attempted shard emits an uploaded JUnit report. Coverage is not collected in the required CI path.
 
 ## Tool Responsibilities
 
@@ -126,18 +126,18 @@ bun run secrets:check
 
 ## Failure Guidance
 
-| Failure        | Likely cause                                                                 | Fix                                                                     |
-| -------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Formatting     | Unformatted files                                                            | `./script/format.ts` and re-stage                                       |
-| Lint           | Code style violations                                                        | `bun run lint:fix` or fix manually                                      |
-| Localization   | Catalog drift, missing translation, invalid ICU, or unclassified source copy | Re-extract and translate catalogs, or fix/classify the source violation |
-| Typecheck      | Type errors                                                                  | Fix type errors in affected files                                       |
-| Monorepo check | Version mismatch across workspaces                                           | Sync catalog versions in root `package.json`                            |
-| Dead code      | Unused dependencies or exports                                               | Remove or export as needed                                              |
-| Workflow check | actionlint or zizmor violation                                               | Fix workflow file syntax or security issue                              |
-| Secret scan    | Credential leaked in code                                                    | Rotate credential, rewrite history, update allowlist                    |
-| Package check  | publint or attw failure                                                      | Fix package.json exports or module resolution                           |
-| Test failure   | Runtime/behavior regression                                                  | Run `bun test` locally, inspect failing tests                           |
+| Failure        | Likely cause                                                                 | Fix                                                                                                                |
+| -------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Formatting     | Unformatted files                                                            | `./script/format.ts` and re-stage                                                                                  |
+| Lint           | Code style violations                                                        | `bun run lint:fix` or fix manually                                                                                 |
+| Localization   | Catalog drift, missing translation, invalid ICU, or unclassified source copy | Re-extract and translate catalogs, or fix/classify the source violation                                            |
+| Typecheck      | Type errors                                                                  | Fix type errors in affected files                                                                                  |
+| Monorepo check | Version mismatch across workspaces                                           | Sync catalog versions in root `package.json`                                                                       |
+| Dead code      | Unused dependencies or exports                                               | Remove or export as needed                                                                                         |
+| Workflow check | actionlint or zizmor violation                                               | Fix workflow file syntax or security issue                                                                         |
+| Secret scan    | Credential leaked in code                                                    | Rotate credential, rewrite history, update allowlist                                                               |
+| Package check  | publint or attw failure                                                      | Fix package.json exports or module resolution                                                                      |
+| Test failure   | Runtime regression, leaked process state, or brittle isolation               | Run the focused test, then `bun run test:ci` from `packages/synergy`; inspect the uploaded per-shard JUnit reports |
 
 ## Common Contributor Scenarios
 
@@ -197,6 +197,8 @@ bun test <relevant test files>
 cd ../..
 bun run quality:quick
 ```
+
+For the complete core-runtime CI boundary, run `bun run test:ci` from `packages/synergy`. It executes four shards sequentially in fresh Bun processes; CI uploads one JUnit report per attempted shard.
 
 ### I changed frontend or UI package behavior
 

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -59,11 +59,14 @@ Core runtime tests run from `packages/synergy`:
 ```bash
 cd packages/synergy
 bun test
+bun run test:ci
 bun test test/tool/read.test.ts
 bun run test:changed
 bun run test:coverage
 bun test --watch
 ```
+
+`bun run test:ci` matches the CI core-suite boundary: four sequential shards run in separate Bun processes, limiting process-global state and temporary fixture accumulation while avoiding concurrent port and environment collisions. Set `SYNERGY_TEST_JUNIT_DIR` to a package-relative directory when per-shard JUnit reports are needed.
 
 Provider/model tests use the pinned `test/tool/fixtures/models-api.json` catalog loaded by `test/preload.ts`. Update the fixture deliberately when a test requires a new model; do not reintroduce live model-catalog fetching into deterministic tests.
 

--- a/packages/synergy/AGENTS.md
+++ b/packages/synergy/AGENTS.md
@@ -74,6 +74,7 @@ bun run typecheck
 bun test test/<domain>/<file>.test.ts
 bun run test:changed
 bun test
+bun run test:ci
 bun run test:coverage
 ```
 

--- a/packages/synergy/package.json
+++ b/packages/synergy/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "test": "bun test --timeout 30000",
+    "test:ci": "bun run script/test-ci.ts",
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --timeout 30000",
     "test:changed": "bun test --changed=origin/dev",
     "test:profile": "bun -e \"await import('node:fs/promises').then((fs) => fs.mkdir('coverage', { recursive: true }))\" && bun test --timeout 30000 --reporter=junit --reporter-outfile=coverage/test-profile-junit.xml",

--- a/packages/synergy/script/test-ci.ts
+++ b/packages/synergy/script/test-ci.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const DEFAULT_SHARD_COUNT = 4
+
+export function shardArgs(shard: number, shardCount = DEFAULT_SHARD_COUNT, reporterDirectory?: string): string[] {
+  if (!Number.isInteger(shardCount) || shardCount < 1) throw new Error("Shard count must be a positive integer.")
+  if (!Number.isInteger(shard) || shard < 1 || shard > shardCount) {
+    throw new Error(`Shard must be between 1 and ${shardCount}.`)
+  }
+
+  const args = ["test", "--timeout", "30000", "--no-orphans", `--shard=${shard}/${shardCount}`]
+  if (!reporterDirectory) return args
+  return [
+    ...args,
+    "--reporter=junit",
+    `--reporter-outfile=${path.join(reporterDirectory, `synergy-test-shard-${shard}-of-${shardCount}.xml`)}`,
+  ]
+}
+
+export async function runSequentialShards(
+  run: (args: string[]) => Promise<number>,
+  shardCount = DEFAULT_SHARD_COUNT,
+  reporterDirectory?: string,
+): Promise<number> {
+  for (let shard = 1; shard <= shardCount; shard++) {
+    const args = shardArgs(shard, shardCount, reporterDirectory)
+    console.log(`\n=== Synergy test shard ${shard}/${shardCount} ===`)
+    const exitCode = await run(args)
+    if (exitCode !== 0) return exitCode
+  }
+  return 0
+}
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+
+async function runBunTest(args: string[]): Promise<number> {
+  const child = Bun.spawn([process.execPath, ...args], {
+    cwd: packageRoot,
+    env: process.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  return child.exited
+}
+
+async function main() {
+  const reporterDirectory = process.env["SYNERGY_TEST_JUNIT_DIR"]
+  if (reporterDirectory) await fs.mkdir(path.resolve(packageRoot, reporterDirectory), { recursive: true })
+  return runSequentialShards(runBunTest, DEFAULT_SHARD_COUNT, reporterDirectory)
+}
+
+if (import.meta.main) process.exit(await main())

--- a/packages/synergy/test/browser/host-install.test.ts
+++ b/packages/synergy/test/browser/host-install.test.ts
@@ -40,8 +40,9 @@ async function fixture(options: { artifact?: Buffer; signatureValid?: boolean; e
     Buffer.from(options.signatureValid === false ? `${manifest}tampered` : manifest),
     pair.privateKey,
   ).toString("base64")
-  const publicDer = pair.publicKey.export({ format: "der", type: "spki" }) as Buffer
-  const publicKey = publicDer.subarray(publicDer.length - 32).toString("base64")
+  const publicJwk = pair.publicKey.export({ format: "jwk" })
+  if (!publicJwk.x) throw new Error("Ed25519 fixture public key is missing its raw coordinate.")
+  const publicKey = Buffer.from(publicJwk.x, "base64url").toString("base64")
   const responses = new Map<string, BodyInit>([
     [`https://release.test/${manifestName}`, manifest],
     [`https://release.test/${manifestName}.sig`, signature],

--- a/packages/synergy/test/fixture/fixture.ts
+++ b/packages/synergy/test/fixture/fixture.ts
@@ -68,7 +68,8 @@ export async function initializeGitFixture(dirpath: string, run: GitFixtureRunne
   )
 }
 export async function tmpdir<T>(options?: TmpDirOptions<T>) {
-  const dirpath = Filesystem.sanitizePath(path.join(os.tmpdir(), "synergy-test-" + Math.random().toString(36).slice(2)))
+  const root = process.env["SYNERGY_TEST_ROOT"] ?? os.tmpdir()
+  const dirpath = Filesystem.sanitizePath(path.join(root, "synergy-test-" + Math.random().toString(36).slice(2)))
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) await initializeGitFixture(dirpath)
   if (options?.config) {
@@ -87,12 +88,9 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   const result = {
     [Symbol.asyncDispose]: async () => {
       await options?.dispose?.(dirpath)
-      // Cleanup is intentionally disabled: tests often create sessions, scopes, and
-      // other persistent state that references the tmpdir path. Deleting the directory
-      // in asyncDispose breaks any remaining test assertions that read from it.
-      // Instead, preload.ts handles global cleanup via afterAll, and os.tmpdir() is
-      // typically purged on reboot. Individual tests manage their own cleanup.
-      // await fs.rm(dirpath, { recursive: true, force: true })
+      // Scope-owned asynchronous work may outlive this lexical fixture. The
+      // process cleanup root created by preload.ts reclaims all fixtures after
+      // those references have settled without deleting paths mid-test.
     },
     path: realpath,
     extra: extra as T,

--- a/packages/synergy/test/fixture/git.test.ts
+++ b/packages/synergy/test/fixture/git.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
+import os from "os"
 import path from "path"
 import { initializeGitFixture, tmpdir } from "./fixture"
 
 describe.serial("git fixture", () => {
+  test("creates fixtures inside the process cleanup root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-fixture-root-"))
+    const previous = process.env["SYNERGY_TEST_ROOT"]
+    process.env["SYNERGY_TEST_ROOT"] = root
+    let fixturePath: string | undefined
+
+    try {
+      const tmp = await tmpdir()
+      fixturePath = tmp.path
+      const realRoot = await fs.realpath(root)
+      expect(path.relative(realRoot, tmp.path).startsWith("..")).toBe(false)
+    } finally {
+      if (previous === undefined) delete process.env["SYNERGY_TEST_ROOT"]
+      else process.env["SYNERGY_TEST_ROOT"] = previous
+      if (fixturePath) await fs.rm(fixturePath, { recursive: true, force: true })
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("uses one init and one commit command", async () => {
     await using tmp = await tmpdir()
     const calls: string[][] = []

--- a/packages/synergy/test/preload.ts
+++ b/packages/synergy/test/preload.ts
@@ -7,6 +7,9 @@ import { afterAll } from "bun:test"
 
 const dir = path.join(os.tmpdir(), "synergy-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
+const fixtureRoot = path.join(dir, "fixtures")
+await fs.mkdir(fixtureRoot, { recursive: true })
+process.env["SYNERGY_TEST_ROOT"] = fixtureRoot
 afterAll(async () => {
   try {
     await fs.rm(dir, {

--- a/packages/synergy/test/script/test-ci.test.ts
+++ b/packages/synergy/test/script/test-ci.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
+import { runSequentialShards, shardArgs } from "../../script/test-ci"
+
+describe("Synergy CI test runner", () => {
+  test("builds isolated Bun test shard arguments", () => {
+    expect(shardArgs(2, 4)).toEqual(["test", "--timeout", "30000", "--no-orphans", "--shard=2/4"])
+  })
+
+  test("writes one JUnit report per shard when requested", () => {
+    expect(shardArgs(2, 4, "coverage/ci-tests")).toEqual([
+      "test",
+      "--timeout",
+      "30000",
+      "--no-orphans",
+      "--shard=2/4",
+      "--reporter=junit",
+      `--reporter-outfile=${path.join("coverage/ci-tests", "synergy-test-shard-2-of-4.xml")}`,
+    ])
+  })
+
+  test("runs every shard sequentially", async () => {
+    const calls: string[][] = []
+    const exitCode = await runSequentialShards(async (args) => {
+      calls.push(args)
+      return 0
+    }, 4)
+
+    expect(exitCode).toBe(0)
+    expect(calls.map((args) => args.at(-1))).toEqual(["--shard=1/4", "--shard=2/4", "--shard=3/4", "--shard=4/4"])
+  })
+
+  test("stops after the first failing shard", async () => {
+    const calls: string[][] = []
+    const exitCode = await runSequentialShards(async (args) => {
+      calls.push(args)
+      return calls.length === 2 ? 17 : 0
+    }, 4)
+
+    expect(exitCode).toBe(17)
+    expect(calls.map((args) => args.at(-1))).toEqual(["--shard=1/4", "--shard=2/4"])
+  })
+})

--- a/packages/synergy/test/snapshot/snapshot.test.ts
+++ b/packages/synergy/test/snapshot/snapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
@@ -58,29 +58,26 @@ function isSymlinkPrivilegeError(error: unknown) {
   const code = (error as { code?: unknown })?.code
   return code === "EPERM" || code === "EACCES" || code === "UNKNOWN"
 }
-
 async function withGitCommandLog<T>(fn: (commands: string[]) => Promise<T>) {
   const originalSpawn = Bun.spawn
   const commands: string[] = []
-  Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+  using _spawn = spyOn(Bun, "spawn").mockImplementation(((...args: Parameters<typeof Bun.spawn>) => {
     const command = args[0]
     if (Array.isArray(command) && command[0] === "git") commands.push(command.map(String).join(" "))
     return originalSpawn(...args)
-  }) as typeof Bun.spawn
-  try {
-    return await fn(commands)
-  } finally {
-    Bun.spawn = originalSpawn
-  }
+  }) as typeof Bun.spawn)
+  return await fn(commands)
 }
 
 describe.serial("snapshot", () => {
+  afterEach(() => mock.restore())
+
   test("retries a transient git spawn failure", async () => {
     await using tmp = await bootstrap()
     const scope = await tmp.scope()
     const originalSpawn = Bun.spawn
     let diffFilesAttempts = 0
-    Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+    using _spawn = spyOn(Bun, "spawn").mockImplementation(((...args: Parameters<typeof Bun.spawn>) => {
       const command = args[0]
       if (Array.isArray(command) && command[0] === "git" && command.includes("diff-files")) {
         diffFilesAttempts++
@@ -89,19 +86,15 @@ describe.serial("snapshot", () => {
         }
       }
       return originalSpawn(...args)
-    }) as typeof Bun.spawn
+    }) as typeof Bun.spawn)
 
-    try {
-      await ScopeContext.provide({
-        scope,
-        fn: async () => {
-          expect(await Snapshot.track(tmp.extra.sessionID)).toBeTruthy()
-        },
-      })
-      expect(diffFilesAttempts).toBe(2)
-    } finally {
-      Bun.spawn = originalSpawn
-    }
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        expect(await Snapshot.track(tmp.extra.sessionID)).toBeTruthy()
+      },
+    })
+    expect(diffFilesAttempts).toBe(2)
   })
 
   test("does not retry a permanent git spawn failure", async () => {
@@ -109,26 +102,22 @@ describe.serial("snapshot", () => {
     const scope = await tmp.scope()
     const originalSpawn = Bun.spawn
     let diffFilesAttempts = 0
-    Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+    using _spawn = spyOn(Bun, "spawn").mockImplementation(((...args: Parameters<typeof Bun.spawn>) => {
       const command = args[0]
       if (Array.isArray(command) && command[0] === "git" && command.includes("diff-files")) {
         diffFilesAttempts++
         throw Object.assign(new Error("permission denied"), { code: "EACCES" })
       }
       return originalSpawn(...args)
-    }) as typeof Bun.spawn
+    }) as typeof Bun.spawn)
 
-    try {
-      await ScopeContext.provide({
-        scope,
-        fn: async () => {
-          expect(await Snapshot.track(tmp.extra.sessionID)).toBeUndefined()
-        },
-      })
-      expect(diffFilesAttempts).toBe(1)
-    } finally {
-      Bun.spawn = originalSpawn
-    }
+    await ScopeContext.provide({
+      scope,
+      fn: async () => {
+        expect(await Snapshot.track(tmp.extra.sessionID)).toBeUndefined()
+      },
+    })
+    expect(diffFilesAttempts).toBe(1)
   })
 
   test("tracks deleted files correctly", async () => {


### PR DESCRIPTION
## Summary

- contain temporary test fixtures under a preload-managed per-process root and harden global `Bun.spawn` mock restoration
- derive Browser Host Ed25519 test keys through portable JWK data instead of DER byte offsets
- run the core suite as four sequential fresh-process shards, upload per-shard JUnit reports, and document the CI-equivalent command

## Why

The full core suite accumulated temporary fixtures and process-global state in one long-lived Bun process. That made unrelated tests fail nondeterministically in CI, while isolated tests and independent shards passed. Fresh sequential processes bound that state without introducing concurrent port or environment races.

## Verification

- `bun test test/script/test-ci.test.ts test/fixture/git.test.ts test/snapshot/snapshot.test.ts test/browser/host-install.test.ts` (56 pass, 0 fail)
- `bun run typecheck` from `packages/synergy`
- `bun test --timeout 30000 && bun run test:ci` from `packages/synergy`
- JUnit reporter smoke test for `coverage/ci-tests`
- `bun run format:check`
- `bun run workflow:check`
- `bun run quality:quick`

## Risk

The CI-equivalent command intentionally changes the core suite from one long-lived process to four sequential fresh-process shards. The ordinary `bun test` command remains available and also passed locally.