### PR TITLE
fix(session): render steer messages without refresh

### DIFF
--- a/packages/synergy/src/session/input.ts
+++ b/packages/synergy/src/session/input.ts
@@ -691,13 +691,15 @@ export async function createUserMessage(input: InvokeInput, rootIDOverride?: str
   // remaining text part is the user's own input. Rendering/visibility of the
   // whole message is carried by info.visible/origin, so no metadata.synthetic
   // flag is needed.
+  // Persist the message envelope first so subscribers never receive orphaned parts.
+  await Session.updateMessage(info)
+
   for (const part of parts) {
     if (part.type === "text" && !part.origin) {
       ;(part as MessageV2.TextPart).origin = "user"
     }
     await Session.updatePart(part)
   }
-  await Session.updateMessage(info)
 
   return {
     info,

--- a/packages/synergy/test/session/input.test.ts
+++ b/packages/synergy/test/session/input.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { pathToFileURL } from "url"
 import { Asset } from "../../src/asset/asset"
+import { Bus } from "../../src/bus"
 import { FileTime } from "../../src/file/time"
 import { ScopeContext } from "../../src/scope/context"
 import { Identifier } from "../../src/id/id"
@@ -78,6 +79,50 @@ describe("session input identity anchors", () => {
 
         expect(created.info.agent).toBe("synergy")
         expect(created.info.model).toEqual(primaryModel)
+      },
+    })
+  })
+})
+
+describe("session input event ordering", () => {
+  test("publishes a steer message before its parts", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const root = await createUserMessage({
+          sessionID: session.id,
+          model: primaryModel,
+          parts: [{ type: "text", text: "initial request" }],
+        })
+        const messageID = Identifier.ascending("message")
+        const events: string[] = []
+        const unsubMessage = Bus.subscribe(MessageV2.Event.Updated, (event) => {
+          if (event.properties.info.id === messageID) events.push(event.type)
+        })
+        const unsubPart = Bus.subscribe(MessageV2.Event.PartUpdated, (event) => {
+          if (event.properties.part.messageID === messageID) events.push(event.type)
+        })
+
+        try {
+          await createUserMessage(
+            {
+              sessionID: session.id,
+              messageID,
+              model: primaryModel,
+              noReply: true,
+              parts: [{ type: "text", text: "steer this run" }],
+            },
+            root.info.id,
+          )
+
+          expect(events).toEqual(["message.updated", "message.part.updated"])
+        } finally {
+          unsubMessage()
+          unsubPart()
+          await Session.remove(session.id)
+        }
       },
     })
   })


### PR DESCRIPTION
## Summary

- publish the user message envelope before its parts so real-time subscribers never receive orphaned steer parts
- add a regression test covering the deterministic `message.updated` → `message.part.updated` event order
- preserve the existing frontend history-window and resource-freshness behavior rather than adding a forced refresh workaround

## Testing

- `bun test test/session/input.test.ts`
- `bun test test/session/inbox.test.ts`
- `bun run test:changed`
- `bun run typecheck`
- `bun run quality:quick`
- Prettier check and `git diff --check`