### PR TITLE
fix: expose BlueprintLoop stop to execution agents

### DIFF
--- a/packages/synergy/src/agent/builtin-context.ts
+++ b/packages/synergy/src/agent/builtin-context.ts
@@ -118,6 +118,7 @@ function baseToolPermissions(profile: SubagentPermissionProfile): PermissionNext
     note_list: "allow",
     note_read: "allow",
     note_search: "allow",
+    blueprint_loop_stop: "allow",
     blueprint_loop_approve: "allow",
     blueprint_loop_reject: "allow",
     agenda_list: "allow",

--- a/packages/synergy/test/tool/exposure.test.ts
+++ b/packages/synergy/test/tool/exposure.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import z from "zod"
 import { Agent } from "../../src/agent/agent"
 import { createBuiltinMaxSubagents } from "../../src/agent/builtin-max-subagents"
+import { createBuiltinLegacySubagents } from "../../src/agent/builtin-legacy-subagents"
 import { BlueprintLoopStore } from "../../src/blueprint"
 import { MCP } from "../../src/mcp"
 import { PermissionNext } from "../../src/permission/next"
@@ -810,16 +811,29 @@ describe("tool exposure", () => {
           draft.blueprint = { loopID: loop.id, loopRole: "execution" }
         })
 
-        let availability = await ToolResolver.availability({
-          agent: allowAllAgent,
-          model,
-          sessionID: execution.id,
-          session: await Session.get(execution.id),
-          includeMCP: false,
-        })
-        expect(availability.visible.some((def) => def.id === "blueprint_loop_stop")).toBe(true)
-        expect(availability.visible.some((def) => def.id === "blueprint_loop_approve")).toBe(false)
-        expect(availability.visible.some((def) => def.id === "blueprint_loop_reject")).toBe(false)
+        const executionAgents = {
+          developer: createBuiltinLegacySubagents(builtinCtx).developer,
+          "implementation-engineer": createBuiltinMaxSubagents(builtinCtx)["implementation-engineer"],
+          "refactoring-engineer": createBuiltinMaxSubagents(builtinCtx)["refactoring-engineer"],
+        }
+        for (const [name, agent] of Object.entries(executionAgents)) {
+          if (!agent) throw new Error(`missing ${name}`)
+          const executionAvailability = await ToolResolver.availability({
+            agent,
+            model,
+            sessionID: execution.id,
+            session: await Session.get(execution.id),
+            includeMCP: false,
+          })
+          expect(
+            executionAvailability.visible.some((def) => def.id === "blueprint_loop_stop"),
+            `${name}:blueprint_loop_stop`,
+          ).toBe(true)
+          expect(executionAvailability.visible.some((def) => def.id === "blueprint_loop_approve")).toBe(false)
+          expect(executionAvailability.visible.some((def) => def.id === "blueprint_loop_reject")).toBe(false)
+        }
+
+        let availability: Awaited<ReturnType<typeof ToolResolver.availability>>
 
         const reviewer = await Session.create({
           parentID: execution.id,


### PR DESCRIPTION
## Summary

- allow built-in subagents to access `blueprint_loop_stop` when running as the active BlueprintLoop execution agent
- cover the production `developer`, `implementation-engineer`, and `refactoring-engineer` permission profiles instead of an allow-all test agent
- preserve the existing execution-session, loop-status, and loop-ownership availability checks

## Tests

- `bun test test/tool/exposure.test.ts test/agent/max-subagents.test.ts test/tool/blueprint-loop-tools.test.ts`
- `bun run typecheck` from `packages/synergy`
- `bun run format:check`
- `bun run quality:quick`