### PR TITLE
fix: settle interrupted sessions during recovery

### DIFF
--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -1846,18 +1846,12 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
 
       if (!pendingReply) continue
 
-      // Auto-repair: if a session has pendingReply but the latest assistant
-      // message is incomplete (time.completed == null) and no runtime is
-      // active, repair it so working.ts stops reporting "recovering".
-      const latestAssistant = messages.find((m) => m.info.role === "assistant")?.info as MessageV2.Assistant | undefined
-      if (latestAssistant && latestAssistant.time.completed == null && !SessionManager.isRunning(sessionID)) {
-        log.info("pending reply found with incomplete assistant; auto-repairing", { sessionID })
-        // Startup reconciliation persists state only; connected clients recover
-        // from the subsequent status snapshot rather than a lifecycle event.
-        await repairIncompleteAssistant(sessionID).catch((err) => {
-          log.error("auto-repair failed", { sessionID, error: err })
-        })
-        continue
+      if (!SessionManager.isRunning(sessionID)) {
+        const repaired = await repairAfterAbort(sessionID)
+        if (repaired) {
+          log.info("repaired incomplete assistant during startup recovery", { sessionID })
+          continue
+        }
       }
 
       log.info("pending reply found; automatic assistant resume is disabled", { sessionID })

--- a/packages/synergy/test/session/working.test.ts
+++ b/packages/synergy/test/session/working.test.ts
@@ -415,6 +415,109 @@ describe("SessionWorking", () => {
       })
     })
 
+    test("resumePending repairs the latest interrupted turn and publishes idle status", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          const completedUserID = Identifier.ascending("message")
+          const completedUser = await Session.updateMessage({
+            id: completedUserID,
+            sessionID: session.id,
+            role: "user",
+            agent: "test",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+            isRoot: true,
+            rootID: completedUserID,
+          })
+          const completedAssistantID = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: completedAssistantID,
+            sessionID: session.id,
+            role: "assistant",
+            parentID: completedUser.id,
+            time: { created: Date.now(), completed: Date.now() },
+            modelID: "test-model",
+            providerID: "test-provider",
+            path: { cwd: projectRoot, root: projectRoot },
+            mode: "test",
+            agent: "test",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            finish: "stop",
+          })
+          const interruptedUserID = Identifier.ascending("message")
+          const interruptedUser = await Session.updateMessage({
+            id: interruptedUserID,
+            sessionID: session.id,
+            role: "user",
+            agent: "test",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+            isRoot: true,
+            rootID: interruptedUserID,
+          })
+          const interruptedAssistantID = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: interruptedAssistantID,
+            sessionID: session.id,
+            role: "assistant",
+            parentID: interruptedUser.id,
+            time: { created: Date.now() },
+            modelID: "test-model",
+            providerID: "test-provider",
+            path: { cwd: projectRoot, root: projectRoot },
+            mode: "test",
+            agent: "test",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          })
+          await Session.update(session.id, (draft) => {
+            draft.pendingReply = true
+          })
+
+          const statuses: Array<{ type: string }> = []
+          let idleEvents = 0
+          const unsubscribeStatus = Bus.subscribe(SessionEvent.Status, (event) => {
+            if (event.properties.sessionID === session.id) statuses.push(event.properties.status)
+          })
+          const unsubscribeIdle = Bus.subscribe(SessionEvent.Idle, (event) => {
+            if (event.properties.sessionID === session.id) idleEvents++
+          })
+
+          try {
+            await SessionInvoke.resumePending({ scopeID: ScopeContext.current.scope.id })
+          } finally {
+            unsubscribeStatus()
+            unsubscribeIdle()
+          }
+
+          expect(statuses).toEqual([{ type: "idle" }])
+          expect(idleEvents).toBe(0)
+          expect((await Session.get(session.id)).pendingReply).toBeUndefined()
+          expect(await SessionWorking.resolve(session.id)).toBeUndefined()
+
+          const messages = await Session.messages({ sessionID: session.id })
+          const completedAssistant = messages.find((message) => message.info.id === completedAssistantID)?.info as
+            | import("../../src/session/message-v2").MessageV2.Assistant
+            | undefined
+          const interruptedAssistant = messages.find((message) => message.info.id === interruptedAssistantID)?.info as
+            | import("../../src/session/message-v2").MessageV2.Assistant
+            | undefined
+          assertExists(completedAssistant)
+          assertExists(interruptedAssistant)
+          expect(completedAssistant.time.completed).toBeNumber()
+          expect(completedAssistant.finish).toBe("stop")
+          expect(completedAssistant.error).toBeUndefined()
+          expect(interruptedAssistant.time.completed).toBeNumber()
+          expect(interruptedAssistant.finish).toBe("error")
+          expect(interruptedAssistant.error?.name).toBe("MessageAbortedError")
+        },
+      })
+    })
+
     test("resumePending reconciles interrupted Cortex delegation state after restart", async () => {
       await using tmp = await tmpdir({ git: true })
       await ScopeContext.provide({


### PR DESCRIPTION
## Summary

- route startup pending-reply reconciliation through the shared abort-repair path
- repair the latest interrupted assistant, clear stale pending-reply state, and publish status-only idle after state converges
- add multi-turn regression coverage while preserving lifecycle idle ownership

## Testing

- `bun test test/session/working.test.ts --test-name-pattern 'resumePending repairs the latest interrupted turn'`
- `bun test test/session/working.test.ts`
- `bun run quality:quick`