### PR TITLE
fix: honor dev hostname for Vite

### DIFF
--- a/.synergy/skill/develop-synergy/SKILL.md
+++ b/.synergy/skill/develop-synergy/SKILL.md
@@ -36,6 +36,12 @@ SYNERGY_HOME="$DEV_HOME" bun dev desktop --managed --server-port 4097 --app-port
 SYNERGY_HOME="$DEV_HOME" bun dev send "test request"
 ```
 
+Development modes bind to loopback by default. To expose an isolated Web stack deliberately, bind both the source server and Vite app with the shared hostname flag:
+
+```bash
+SYNERGY_HOME="$DEV_HOME" bun dev web --hostname 0.0.0.0 --server-port 4097 --app-port 3001
+```
+
 Use `server` for backend/CLI work, `web` for normal full-stack work, `desktop` for Electron-native behavior, and `desktop --managed` for the production-style managed-server path. Managed mode rebuilds the Web distribution before launch.
 
 ## Preserve Desktop Renderer Lifecycle

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -34,7 +34,7 @@ bun dev build desktop
 | `desktop --managed` | build plugin/app, then Electron with production-style managed server mode |
 | `send`              | one-off source CLI execution                                              |
 
-Use `--port` for standalone `server` and `app` modes. Use `--server-port`, `--app-port`, `--hostname`, and `--attach` for combined Web or Desktop flows. The orchestrator checks required ports and target health before starting dependent processes. In parallel modes it terminates sibling process trees when one exits so package-script wrappers cannot leave servers or Electron hosts running.
+Use `--port` for standalone `server` and `app` modes. Use `--server-port`, `--app-port`, `--hostname`, and `--attach` for combined Web or Desktop flows. `--hostname` binds both the source server and Vite app in Web and external Desktop modes. The orchestrator checks required ports and target health before starting dependent processes. In parallel modes it terminates sibling process trees when one exits so package-script wrappers cannot leave servers or Electron hosts running.
 
 Managed Desktop rebuilds the Web distribution before launch so packaged-server behavior is not tested against stale frontend assets. Normal daily Desktop work should use external mode for Vite reload speed.
 

--- a/packages/synergy/test/script/dev.test.ts
+++ b/packages/synergy/test/script/dev.test.ts
@@ -40,6 +40,17 @@ describe("dev orchestrator planner", () => {
     )
   })
 
+  test("binds both the server and app to the requested web hostname", () => {
+    const plan = createDevPlan(["web", "--hostname", "0.0.0.0"], options)
+
+    expect(plan.processes[0]?.command).toContain("0.0.0.0")
+    expect(plan.processes[1]?.command).toContain("0.0.0.0")
+    expect(plan.requiredPorts).toEqual([
+      { label: "server", port: 4096, host: "127.0.0.1" },
+      { label: "app", port: 3000, host: "127.0.0.1" },
+    ])
+  })
+
   test("plans desktop development in external mode by default", () => {
     const plan = createDevPlan(["desktop"], options)
 

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -8,7 +8,6 @@ import { randomBytes } from "node:crypto"
 const DEFAULT_SERVER_PORT = 4096
 const DEFAULT_APP_PORT = 3000
 const DEFAULT_HOSTNAME = "127.0.0.1"
-const DEFAULT_APP_HOST = "127.0.0.1"
 
 export interface DevProcessSpec {
   label:
@@ -71,8 +70,8 @@ function serverUrl(hostname: string, port: number) {
   return `http://${displayHost(hostname)}:${port}`
 }
 
-function appUrl(port: number) {
-  return `http://${DEFAULT_APP_HOST}:${port}`
+function appUrl(hostname: string, port: number) {
+  return `http://${displayHost(hostname)}:${port}`
 }
 
 function directories(repoRoot: string) {
@@ -160,7 +159,7 @@ Options:
   --port <port>           Port for bun dev server/app
   --server-port <port>    Server port for web/desktop (default: 4096)
   --app-port <port>       Vite app port for web/desktop (default: 3000)
-  --hostname <host>       Server bind hostname (default: 127.0.0.1)
+  --hostname <host>       Server and Vite bind hostname (default: 127.0.0.1)
   --attach <url>          Reuse an existing server instead of starting one
   --open                  Open the browser for bun dev app
   --no-open               Do not open the browser for bun dev web
@@ -205,18 +204,24 @@ function serverProcess(input: {
   }
 }
 
-function appProcess(input: { repoRoot: string; bunPath: string; appPort: number; attachUrl: string }): DevProcessSpec {
+function appProcess(input: {
+  repoRoot: string
+  bunPath: string
+  appPort: number
+  attachUrl: string
+  hostname: string
+}): DevProcessSpec {
   const dirs = directories(input.repoRoot)
   const server = normalizeUrl(input.attachUrl)
   return {
     label: "app",
-    command: [input.bunPath, "run", "dev", "--host", DEFAULT_APP_HOST, "--port", String(input.appPort), "--strictPort"],
+    command: [input.bunPath, "run", "dev", "--host", input.hostname, "--port", String(input.appPort), "--strictPort"],
     cwd: dirs.app,
     env: {
       VITE_SYNERGY_SERVER_URL: server,
       VITE_SYNERGY_CALLBACK_URL: `${server}/holos/callback`,
     },
-    waitUrl: appUrl(input.appPort),
+    waitUrl: appUrl(input.hostname, input.appPort),
   }
 }
 
@@ -225,6 +230,7 @@ function desktopProcess(input: {
   bunPath: string
   mode: "external" | "managed"
   appPort?: number
+  appHostname?: string
   browserServerUrl?: string
   browserHostSecret?: string
 }): DevProcessSpec {
@@ -236,7 +242,8 @@ function desktopProcess(input: {
     SYNERGY_BROWSER_HOST_REGISTRATION_SECRET: input.browserHostSecret,
     SYNERGY_BROWSER_BROKER_SERVER_URL: input.browserServerUrl,
   }
-  if (input.mode === "external") env.SYNERGY_DESKTOP_APP_URL = appUrl(input.appPort ?? DEFAULT_APP_PORT)
+  if (input.mode === "external")
+    env.SYNERGY_DESKTOP_APP_URL = appUrl(input.appHostname ?? DEFAULT_HOSTNAME, input.appPort ?? DEFAULT_APP_PORT)
   return {
     label: "desktop",
     command: [input.bunPath, "run", "dev"],
@@ -323,6 +330,7 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
 
   if (command === "app") {
     const appPort = numberFlag(parsed.flags, "port", DEFAULT_APP_PORT)
+    const hostname = stringFlag(parsed.flags, "hostname", DEFAULT_HOSTNAME)
     const attachUrl = normalizeUrl(stringFlag(parsed.flags, "attach", serverUrl(DEFAULT_HOSTNAME, DEFAULT_SERVER_PORT)))
     return {
       kind: "run",
@@ -330,9 +338,9 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
       command,
       help,
       exitCode: 0,
-      processes: [appProcess({ repoRoot, bunPath, appPort, attachUrl })],
-      openUrl: boolFlag(parsed.flags, "open") ? appUrl(appPort) : undefined,
-      requiredPorts: [{ label: "app", port: appPort, host: DEFAULT_APP_HOST }],
+      processes: [appProcess({ repoRoot, bunPath, appPort, attachUrl, hostname })],
+      openUrl: boolFlag(parsed.flags, "open") ? appUrl(hostname, appPort) : undefined,
+      requiredPorts: [{ label: "app", port: appPort, host: displayHost(hostname) }],
       requiredServers: [attachUrl],
     }
   }
@@ -357,7 +365,7 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
               browserHostSecret,
             }),
           ]),
-      appProcess({ repoRoot, bunPath, appPort, attachUrl }),
+      appProcess({ repoRoot, bunPath, appPort, attachUrl, hostname }),
       ...(attach ? [] : [browserHostProcess({ repoRoot, bunPath, serverUrl: attachUrl, secret: browserHostSecret })]),
     ]
     return {
@@ -367,10 +375,10 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
       help,
       exitCode: 0,
       processes,
-      openUrl: boolFlag(parsed.flags, "open", true) ? appUrl(appPort) : undefined,
+      openUrl: boolFlag(parsed.flags, "open", true) ? appUrl(hostname, appPort) : undefined,
       requiredPorts: [
         ...(attach ? [] : [{ label: "server", port: serverPort, host: displayHost(hostname) }]),
-        { label: "app", port: appPort, host: DEFAULT_APP_HOST },
+        { label: "app", port: appPort, host: displayHost(hostname) },
       ],
       requiredServers: attach ? [attachUrl] : [],
     }
@@ -417,12 +425,13 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
               browserHostSecret,
             }),
           ]),
-      appProcess({ repoRoot, bunPath, appPort, attachUrl }),
+      appProcess({ repoRoot, bunPath, appPort, attachUrl, hostname }),
       desktopProcess({
         repoRoot,
         bunPath,
         mode: "external",
         appPort,
+        appHostname: hostname,
         browserServerUrl: attach ? undefined : attachUrl,
         browserHostSecret: attach ? undefined : browserHostSecret,
       }),
@@ -436,7 +445,7 @@ export function createDevPlan(args: string[], options: PlanOptions = {}): DevPla
       processes,
       requiredPorts: [
         ...(attach ? [] : [{ label: "server", port: serverPort, host: displayHost(hostname) }]),
-        { label: "app", port: appPort, host: DEFAULT_APP_HOST },
+        { label: "app", port: appPort, host: displayHost(hostname) },
       ],
       requiredServers: attach ? [attachUrl] : [],
     }


### PR DESCRIPTION
## Summary

- apply `--hostname` to both the Synergy source server and Vite app
- keep Web and external Desktop app URLs and port preflight aligned with the requested hostname
- add a planner regression test and update the development reference and workflow

## Root cause

The development orchestrator passed `--hostname` only to the Synergy server while hardcoding Vite to loopback, so combined Web mode could not expose the frontend as requested.

## Validation

- `cd packages/synergy && bun test test/script/dev.test.ts` (9 passed)
- `bun run quality:quick`
- isolated `bun dev web --hostname 0.0.0.0` runtime check confirmed both server and Vite listeners were externally bound and healthy
