### PR TITLE
fix(app): restore file workbench styles

### DIFF
--- a/packages/app/src/app-build-css-contract.test.ts
+++ b/packages/app/src/app-build-css-contract.test.ts
@@ -67,18 +67,6 @@ const rootRuleContracts: CssRuleContract[] = [
     declarations: ["flex-shrink:0", "width:16px", "height:16px"],
   },
   {
-    selector: ".file-workbench",
-    declarations: ["display:flex", "height:100%", "min-width:0", "flex-direction:column", "overflow:hidden"],
-  },
-  {
-    selector: ".file-workbench-main",
-    declarations: ["position:relative", "display:flex", "min-height:0", "min-width:0", "flex:1", "overflow:hidden"],
-  },
-  {
-    selector: ".file-explorer",
-    declarations: ["position:relative", "display:flex", "min-width:220px", "flex-shrink:0", "flex-direction:column"],
-  },
-  {
     selector: "[data-component=popover-content]",
     declarations: [
       "z-index:50",
@@ -121,6 +109,38 @@ const rootRuleContracts: CssRuleContract[] = [
     ],
   },
 ]
+
+const fileWorkbenchRuleContracts: CssRuleContract[] = [
+  {
+    selector: ".file-workbench",
+    declarations: ["display:flex", "height:100%", "min-width:0", "flex-direction:column", "overflow:hidden"],
+  },
+  {
+    selector: ".file-workbench-main",
+    declarations: [
+      "position:relative",
+      "display:flex",
+      "min-height:0",
+      "min-width:0",
+      "flex:1",
+      "overflow:hidden",
+      "container-type:inline-size",
+    ],
+  },
+  {
+    selector: ".file-explorer",
+    declarations: ["position:relative", "display:flex", "min-width:220px", "flex-shrink:0", "flex-direction:column"],
+  },
+]
+
+type ViteManifestChunk = {
+  src?: string
+  file: string
+  css?: string[]
+  imports?: string[]
+  isEntry?: boolean
+  isDynamicEntry?: boolean
+}
 
 type CssRuleMatch = {
   body: string
@@ -258,6 +278,31 @@ async function readBuiltCss(outDir: string) {
 
   const chunks = await Promise.all(cssFiles.map((file) => readFile(path.join(assetsDir, file), "utf8")))
   return chunks.join("\n")
+}
+
+async function readBuiltManifest(outDir: string): Promise<Record<string, ViteManifestChunk>> {
+  return JSON.parse(await readFile(path.join(outDir, ".vite", "manifest.json"), "utf8"))
+}
+
+function collectManifestCss(manifest: Record<string, ViteManifestChunk>, roots: string[]) {
+  const visited = new Set<string>()
+  const css = new Set<string>()
+
+  const visit = (key: string) => {
+    if (visited.has(key)) return
+    visited.add(key)
+    const chunk = manifest[key]
+    if (!chunk) return
+    for (const file of chunk.css ?? []) css.add(file)
+    for (const imported of chunk.imports ?? []) visit(imported)
+  }
+
+  for (const root of roots) visit(root)
+  return [...css]
+}
+
+async function readCssAssets(outDir: string, files: string[]) {
+  return (await Promise.all(files.map((file) => readFile(path.join(outDir, file), "utf8")))).join("\n")
 }
 
 async function readBuiltIndex(outDir: string) {
@@ -474,9 +519,48 @@ async function expectStatusbarSubsessionContentFillsBody(css: string) {
   }
 }
 
+async function expectFileWorkbenchExplorerResizeMatchesMode(css: string) {
+  const browserType = process.env.SYNERGY_APP_LAYOUT_BROWSER === "webkit" ? webkit : chromium
+  const browser = await browserType.launch({ headless: true })
+  try {
+    const page = await browser.newPage({ viewport: { width: 1000, height: 600 } })
+    await page.setContent(`
+      <style>*, ::before, ::after { box-sizing: border-box; } ${css}</style>
+      <div class="file-workbench" style="height: 480px;">
+        <div class="file-workbench-main">
+          <main class="file-viewer"></main>
+          <aside class="file-explorer" style="width: 296px;">
+            <div data-component="resize-handle" data-direction="horizontal" data-edge="start"></div>
+          </aside>
+        </div>
+      </div>
+    `)
+
+    const measure = async (width: number) => {
+      await page.locator(".file-workbench").evaluate((element, value) => {
+        ;(element as HTMLElement).style.width = `${value}px`
+      }, width)
+      return page.evaluate(() => {
+        const explorer = document.querySelector<HTMLElement>(".file-explorer")
+        const handle = explorer?.querySelector<HTMLElement>('[data-component="resize-handle"]')
+        if (!explorer || !handle) throw new Error("Missing file explorer layout fixture")
+        return {
+          explorerPosition: getComputedStyle(explorer).position,
+          handleDisplay: getComputedStyle(handle).display,
+        }
+      })
+    }
+
+    expect(await measure(640)).toEqual({ explorerPosition: "absolute", handleDisplay: "none" })
+    expect(await measure(800)).toEqual({ explorerPosition: "relative", handleDisplay: "block" })
+  } finally {
+    await browser.close()
+  }
+}
+
 async function runAppBuild(outDir: string) {
   const proc = Bun.spawn({
-    cmd: [process.execPath, "run", "build", "--outDir", outDir, "--emptyOutDir"],
+    cmd: [process.execPath, "run", "build", "--outDir", outDir, "--emptyOutDir", "--manifest"],
     cwd: appDir,
     stdout: "pipe",
     stderr: "pipe",
@@ -497,15 +581,36 @@ describe("app production build contract", () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "synergy-app-dist-"))
     try {
       await runAppBuild(outDir)
-      const [css, index, assets, javascript] = await Promise.all([
+      const [css, index, assets, javascript, manifest] = await Promise.all([
         readBuiltCss(outDir),
         readBuiltIndex(outDir),
         readBuiltAssets(outDir),
         readBuiltJavaScript(outDir),
+        readBuiltManifest(outDir),
       ])
 
       for (const contract of rootRuleContracts) {
         expectRootRule(css, contract)
+      }
+
+      const initialManifestEntries = Object.entries(manifest)
+        .filter(([, chunk]) => chunk.isEntry)
+        .map(([key]) => key)
+      const fileWorkbenchManifestEntry = Object.entries(manifest).find(
+        ([, chunk]) => chunk.src === "src/components/file-workbench/content.tsx",
+      )
+      expect(initialManifestEntries.length, "Production manifest must include an initial entry").toBeGreaterThan(0)
+      expect(fileWorkbenchManifestEntry, "Production manifest must include the lazy File workbench entry").toBeDefined()
+      expect(fileWorkbenchManifestEntry![1].isDynamicEntry).toBe(true)
+
+      const initialCss = await readCssAssets(outDir, collectManifestCss(manifest, initialManifestEntries))
+      const fileWorkbenchCss = await readCssAssets(
+        outDir,
+        collectManifestCss(manifest, [fileWorkbenchManifestEntry![0]]),
+      )
+      for (const contract of fileWorkbenchRuleContracts) {
+        expect(collectRootRuleBodies(initialCss, contract.selector)).toHaveLength(0)
+        expectRootRule(fileWorkbenchCss, contract)
       }
 
       const expandedCompactionBodies = collectRootRuleBodies(
@@ -566,6 +671,7 @@ describe("app production build contract", () => {
       await expectSessionInboxBadgePreservesIconCenter(css)
       await expectPromptDockKeepsReadableWidth(css)
       await expectStatusbarSubsessionContentFillsBody(css)
+      await expectFileWorkbenchExplorerResizeMatchesMode(css)
       expect((await stat(path.join(outDir, "assets", markdownChunk!))).size).toBeLessThan(200_000)
     } finally {
       await rm(outDir, { recursive: true, force: true })

--- a/packages/app/src/app-build-css-contract.test.ts
+++ b/packages/app/src/app-build-css-contract.test.ts
@@ -67,6 +67,18 @@ const rootRuleContracts: CssRuleContract[] = [
     declarations: ["flex-shrink:0", "width:16px", "height:16px"],
   },
   {
+    selector: ".file-workbench",
+    declarations: ["display:flex", "height:100%", "min-width:0", "flex-direction:column", "overflow:hidden"],
+  },
+  {
+    selector: ".file-workbench-main",
+    declarations: ["position:relative", "display:flex", "min-height:0", "min-width:0", "flex:1", "overflow:hidden"],
+  },
+  {
+    selector: ".file-explorer",
+    declarations: ["position:relative", "display:flex", "min-width:220px", "flex-shrink:0", "flex-direction:column"],
+  },
+  {
     selector: "[data-component=popover-content]",
     declarations: [
       "z-index:50",

--- a/packages/app/src/components/file-workbench/content.tsx
+++ b/packages/app/src/components/file-workbench/content.tsx
@@ -12,6 +12,7 @@ import type { WorkbenchPanelContentProps } from "@/plugin/registries/workbench-p
 import { FileExplorer } from "./explorer"
 import { classifyFilePreview, resolveWorkspaceRelativePath } from "./model"
 import { FileSourceView } from "./source-view"
+import "./styles.css"
 import { fileWorkbench as F } from "@/locales/messages"
 import { useLocale } from "@/context/locale"
 

--- a/packages/app/src/components/file-workbench/styles.css
+++ b/packages/app/src/components/file-workbench/styles.css
@@ -526,6 +526,10 @@
     max-width: 86%;
     box-shadow: -12px 0 24px color-mix(in srgb, var(--background-stronger) 32%, transparent);
   }
+
+  .file-explorer [data-component="resize-handle"] {
+    display: none;
+  }
 }
 
 @media (pointer: coarse) {


### PR DESCRIPTION
## Summary

- restore the lazy File workbench stylesheet import so its toolbar, Explorer, and content pane use the intended layout
- add a production CSS bundle contract covering the File workbench, main pane, and Explorer layout rules

## Tests

- `bun test src/app-build-css-contract.test.ts` (from `packages/app`)
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`
- `TMPDIR=/private/tmp bun turbo test --env-mode=loose --force`