### PR TITLE
fix: package sandbox assets in product releases

### DIFF
--- a/.github/workflows/build-helpers.yml
+++ b/.github/workflows/build-helpers.yml
@@ -3,6 +3,13 @@ name: Build Sandbox Helpers
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - ".github/workflows/build-helpers.yml"
+      - "packages/synergy/src/sandbox/helper-linux/**"
+      - "packages/synergy/src/sandbox/helper/**"
+      - "packages/synergy/scripts/build-helper.ts"
   push:
     branches: [dev, main]
     paths:

--- a/.github/workflows/build-helpers.yml
+++ b/.github/workflows/build-helpers.yml
@@ -1,20 +1,35 @@
-name: Build Sandbox Helpers & Update Hashes
+name: Build Sandbox Helpers
 
 on:
+  workflow_call:
+  workflow_dispatch:
   push:
     branches: [dev, main]
     paths:
+      - ".github/workflows/build-helpers.yml"
       - "packages/synergy/src/sandbox/helper-linux/**"
       - "packages/synergy/src/sandbox/helper/**"
       - "packages/synergy/scripts/build-helper.ts"
-  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build-and-update-hashes:
-    runs-on: ubuntu-latest
+  linux:
+    name: Linux ${{ matrix.arch }} sandbox assets
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            os: ubuntu-latest
+            gnu_target: x86_64-unknown-linux-gnu
+            musl_target: x86_64-unknown-linux-musl
+          - arch: arm64
+            os: ubuntu-24.04-arm
+            gnu_target: aarch64-unknown-linux-gnu
+            musl_target: aarch64-unknown-linux-musl
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -22,69 +37,70 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          targets: ${{ matrix.gnu_target }},${{ matrix.musl_target }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build Linux helper (x64) & update hashes
-        run: bun run packages/synergy/scripts/build-helper.ts linux --auto-update
-
-      - name: Build Linux helper (arm64) & append hash
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-            bun run packages/synergy/scripts/build-helper.ts linux --auto-update --append --target aarch64-unknown-linux-gnu
-
-      - name: Setup Windows cross-compile
-        run: |
-          rustup target add x86_64-pc-windows-msvc
-          cargo install --locked cargo-xwin
-
-      - name: Cache Windows SDK
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: ~/.cache/cargo-xwin
-          key: cargo-xwin-${{ runner.os }}-${{ hashFiles('packages/synergy/src/sandbox/helper/Cargo.lock') }}
+          bun-version: "1.3.14"
 
-      - name: Build Windows helper & update hashes
-        run: |
-          cargo xwin build --release --target x86_64-pc-windows-msvc \
-            --manifest-path packages/synergy/src/sandbox/helper/Cargo.toml
-          bun run packages/synergy/scripts/build-helper.ts windows --auto-update --target x86_64-pc-windows-msvc --skip-build
+      - name: Install musl toolchain
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      - name: Upload Linux x64 binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: synergy-sandbox-linux-x64
-          path: packages/synergy/src/sandbox/helper-linux/target/release/synergy-sandbox-linux
-
-      - name: Upload Linux arm64 binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: synergy-sandbox-linux-arm64
-          path: packages/synergy/src/sandbox/helper-linux/target/aarch64-unknown-linux-gnu/release/synergy-sandbox-linux
-
-      - name: Upload Windows x64 binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: synergy-sandbox-windows-x64
-          path: packages/synergy/src/sandbox/helper/target/x86_64-pc-windows-msvc/release/synergy-sandbox-windows.exe
-
-      - name: Commit and push updated hashes
+      - name: Build and stage Linux helpers
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          GIT_AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/synergy/src/sandbox/linux.ts packages/synergy/src/sandbox/windows.ts
-          git diff --cached --quiet || git commit -m "chore: auto-update sandbox helper hashes [skip ci]"
-          GIT_CONFIG_COUNT=1 \
-            GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
-            GIT_CONFIG_VALUE_0="$GIT_AUTH_HEADER" \
-            git push
+          bun run packages/synergy/scripts/build-helper.ts linux --target "${{ matrix.gnu_target }}"
+          bun run packages/synergy/scripts/build-helper.ts linux --target "${{ matrix.musl_target }}"
+          mkdir -p \
+            "packages/synergy/sandbox-assets/linux-${{ matrix.arch }}" \
+            "packages/synergy/sandbox-assets/linux-${{ matrix.arch }}-musl"
+          cp \
+            "packages/synergy/src/sandbox/helper-linux/target/${{ matrix.gnu_target }}/release/synergy-sandbox-linux" \
+            "packages/synergy/sandbox-assets/linux-${{ matrix.arch }}/synergy-sandbox-linux"
+          cp \
+            "packages/synergy/src/sandbox/helper-linux/target/${{ matrix.musl_target }}/release/synergy-sandbox-linux" \
+            "packages/synergy/sandbox-assets/linux-${{ matrix.arch }}-musl/synergy-sandbox-linux"
+          chmod 755 packages/synergy/sandbox-assets/linux-*/synergy-sandbox-linux
+
+      - name: Upload Linux sandbox assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sandbox-assets-linux-${{ matrix.arch }}
+          path: packages/synergy/sandbox-assets
+          if-no-files-found: error
+
+  windows:
+    name: Windows x64 sandbox assets
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Build and stage Windows helper
+        shell: bash
+        run: |
+          bun run packages/synergy/scripts/build-helper.ts windows --target x86_64-pc-windows-msvc
+          mkdir -p packages/synergy/sandbox-assets/windows-x64
+          cp \
+            packages/synergy/src/sandbox/helper/target/x86_64-pc-windows-msvc/release/synergy-sandbox-windows.exe \
+            packages/synergy/sandbox-assets/windows-x64/synergy-sandbox-windows.exe
+
+      - name: Upload Windows sandbox assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sandbox-assets-windows-x64
+          path: packages/synergy/sandbox-assets
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,16 @@ on:
         default: latest
 
 jobs:
+  stable_sandbox_assets:
+    name: Build Stable Sandbox Assets
+    if: ${{ inputs.target == 'product' }}
+    uses: ./.github/workflows/build-helpers.yml
+    permissions:
+      contents: read
+
   stable_candidate:
     name: Publish Stable Candidate
+    needs: [stable_sandbox_assets]
     if: ${{ inputs.target == 'product' }}
     runs-on: ubuntu-latest
     permissions:
@@ -52,6 +60,27 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
+
+      - name: Download sandbox assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: packages/synergy/sandbox-assets
+          pattern: sandbox-assets-*
+          merge-multiple: true
+
+      - name: Validate product release environment
+        run: bun run ./script/release/validate-product-environment.ts
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BROWSER_HOST_MANIFEST_SIGNING_KEY: ${{ secrets.BROWSER_HOST_MANIFEST_SIGNING_KEY }}
+          BROWSER_HOST_MANIFEST_PUBLIC_KEY: ${{ secrets.BROWSER_HOST_MANIFEST_PUBLIC_KEY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
 
       - name: Configure Git
         run: |
@@ -75,6 +104,9 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNERGY_BROWSER_HOST_PUBLIC_KEY: ${{ secrets.BROWSER_HOST_MANIFEST_PUBLIC_KEY }}
+          SYNERGY_REQUIRE_BROWSER_HOST_PUBLIC_KEY: "1"
+          SYNERGY_REQUIRE_SANDBOX_ASSETS: "1"
+          SYNERGY_BUILD_TARGETS: linux-arm64,linux-x64,linux-x64-baseline,linux-arm64-musl,linux-x64-musl,linux-x64-baseline-musl,darwin-arm64,darwin-x64,darwin-x64-baseline,win32-x64,win32-x64-baseline
 
       - name: Upload release state
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -84,8 +116,8 @@ jobs:
 
   stable_desktop_package:
     name: Build Desktop Artifacts (${{ matrix.platform }})
-    needs: [stable_candidate]
-    if: ${{ inputs.target == 'product' && needs.stable_candidate.result == 'success' }}
+    needs: [stable_candidate, stable_sandbox_assets]
+    if: ${{ inputs.target == 'product' && needs.stable_candidate.result == 'success' && needs.stable_sandbox_assets.result == 'success' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -100,8 +132,8 @@ jobs:
             host_builder_args: --mac zip --x64 --arm64
           - os: windows-latest
             platform: win32
-            runtime_targets: win32-x64,win32-arm64
-            builder_args: --win nsis zip --x64 --arm64
+            runtime_targets: win32-x64
+            builder_args: --win nsis zip --x64
             host_builder_args: --win zip --x64 --arm64
           - os: ubuntu-latest
             platform: linux
@@ -127,6 +159,13 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Download sandbox assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: packages/synergy/sandbox-assets
+          pattern: sandbox-assets-*
+          merge-multiple: true
+
       - name: Prepare release version
         run: bun run ./script/release/desktop-prepare-version.ts
         env:
@@ -140,6 +179,8 @@ jobs:
           SYNERGY_BUILD_TARGETS: ${{ matrix.runtime_targets }}
           SYNERGY_REUSE_PUBLISHED_RUNTIME: ${{ matrix.platform == 'win32' && '1' || '' }}
           SYNERGY_BROWSER_HOST_PUBLIC_KEY: ${{ secrets.BROWSER_HOST_MANIFEST_PUBLIC_KEY }}
+          SYNERGY_REQUIRE_BROWSER_HOST_PUBLIC_KEY: "1"
+          SYNERGY_REQUIRE_SANDBOX_ASSETS: "1"
 
       - name: Build desktop main process
         run: bun run --cwd packages/desktop desktop:build

--- a/.synergy/skill/change-execution-boundaries/SKILL.md
+++ b/.synergy/skill/change-execution-boundaries/SKILL.md
@@ -28,6 +28,7 @@ description: Add, modify, or review Synergy capability classification, control p
 3. Test both positive and adversarial forms, including argument aliases, shell wrappers, external/protected paths, main checkout versus worktree, saved deny precedence, autonomous ask-to-deny behavior, and sandbox-unavailable fallback.
 4. Run focused suites under `test/control-profile`, `test/enforcement`, `test/permission`, `test/sandbox`, and `test/workspace` as applicable, then typecheck and `bun run quality:quick`.
 5. Use `develop-synergy` for platform or end-to-end shell verification. Never experiment against the runtime carrying the current task.
+6. For packaged Linux or Windows sandboxes, build helpers per supported OS, architecture, and ABI before compiling the runtime. Embed the matching helper digest, fail a Stable build when an asset is missing, preserve the helper through every installer/package layout, and validate the installed artifact rather than only the source build.
 
 Update the architecture document when the pipeline, profile semantics, capability contract, workspace boundary, or sandbox guarantee changes. Update `git-guide`, `add-tool`, or `change-plugin-runtime` when their executable workflow depends on the new classification.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Download a platform installer from [GitHub Releases](https://github.com/SII-Holo
 
 The recommended installers include the Desktop app and expose its packaged runtime as the `synergy` CLI. Portable artifacts are also published but do not configure a system CLI.
 
+Released packages do not require Rust. Rust is used only to build the Linux and Windows sandbox helpers. The Linux `.deb` installs Bubblewrap as a package dependency; Linux portable and CLI archive users must install `bubblewrap` with their system package manager. Windows Desktop and CLI releases currently support x64.
+
 ### CLI and Web
 
 Install the current release:
@@ -59,6 +61,8 @@ curl -fsSL https://raw.githubusercontent.com/SII-Holos/synergy/main/install | ba
 ```
 
 The CLI installer places the runtime, Web UI, and schema assets under `~/.synergy/`. It does not install the Electron Desktop app.
+
+Desktop Browser presentation includes Electron's Chromium. Headless Browser tools used directly by the CLI/server require an installed Chrome or Chromium; set `CHROMIUM_PATH` when it is not in a standard system or Playwright cache location.
 
 Configure a model provider, start the background runtime, and open the Web client:
 

--- a/docs/architecture/browser-runtime.md
+++ b/docs/architecture/browser-runtime.md
@@ -17,6 +17,8 @@ The server derives the canonical owner key and includes it in every session-stat
 
 Chromium and Playwright start lazily when Browser is first used. The process-wide runtime holds one `BrowserSession` per owner. Each Browser session holds zero or one page plus annotations and observers.
 
+Desktop-native and downloaded remote Browser Hosts run on Electron's packaged Chromium. Direct headless Browser tools in the standalone runtime discover Chrome or Chromium from `CHROMIUM_PATH`, Synergy and Playwright caches, or standard system installation paths. They return an installation hint instead of silently downloading an unverified browser when no executable is available.
+
 Creating or retrieving a Browser session does not create its page. `navigate` is the only ordinary control command that resolves or creates a missing page; commands such as click, read, resize, history, or evaluation require the page to exist.
 
 An active tool-created headless page migrates to the selected Host presentation when the Browser workspace opens. The client issues one `resume` after its passive session read; empty and suspended sessions remain passive. Host readiness is calculated for the current owner and page rather than inferred from global broker availability.

--- a/docs/architecture/execution-boundaries.md
+++ b/docs/architecture/execution-boundaries.md
@@ -93,6 +93,8 @@ Network policy is represented separately as full or restricted access. Restricte
 
 Synergy compiles the policy into platform-specific wrappers: Seatbelt on macOS, a Linux sandbox helper, and Windows/WSL-specific restricted execution paths. The configured fallback (`deny`, `warn`, or `allow`) determines what happens when the requested sandbox cannot be enforced on the current platform.
 
+Stable Linux and Windows runtimes package an architecture- and ABI-matched helper. The runtime embeds that helper's SHA-256 during compilation and verifies it before execution; a Stable build fails when the required helper asset is absent. Linux uses either a verified optional bundled Bubblewrap binary or the system `bubblewrap` package. The Debian installer declares Bubblewrap as a dependency, while portable and CLI archive installations report it as an external prerequisite.
+
 An explicit policy authorization can mark a shell operation as sandbox-bypassed. Otherwise, Bash receives the resolved sandbox wrapper when its profile mode is not `none`.
 
 ## OOM Victim Preference

--- a/docs/operations/desktop-release.md
+++ b/docs/operations/desktop-release.md
@@ -36,16 +36,19 @@ Recommended Desktop installer artifacts:
 - `Synergy-darwin-x64-${version}.pkg`
 - `Synergy-darwin-arm64-${version}.pkg`
 - `Synergy-win32-x64-${version}.exe`
-- `Synergy-win32-arm64-${version}.exe`
 - `Synergy-linux-x86_64-${version}.deb`
 - `Synergy-linux-arm64-${version}.deb`
 - `Synergy-${version}-checksums.txt`
+
+Windows ARM64 Browser Host artifacts remain published, but the full Windows ARM64 Desktop/runtime is not a Stable target until all native runtime dependencies are available for that architecture.
 
 Portable and updater artifacts are still published but are not the full Desktop + CLI install entry:
 
 - macOS `.zip` is required by updater metadata.
 - macOS `.dmg` is an app-bundle artifact and does not install the CLI link.
 - Linux `.AppImage` and `.tar.gz` are portable/debug artifacts and do not install global commands.
+
+The Linux `.deb` depends on the system `bubblewrap` package. Linux portable artifacts require users to install Bubblewrap separately.
 
 The product release also publishes the minimal remote Browser Host for every supported OS/architecture:
 
@@ -95,17 +98,18 @@ Browser Host artifact trust:
 - `BROWSER_HOST_MANIFEST_SIGNING_KEY` — base64 PKCS#8 Ed25519 private key used only by the release matrix
 - `BROWSER_HOST_MANIFEST_PUBLIC_KEY` — base64 raw Ed25519 public key embedded in product runtime binaries
 
-PR/package validation must work without signing secrets. Release workflows sign and notarize only when the relevant secrets are present.
+PR/package validation works without signing secrets. A product Release validates every required signing secret before publishing a candidate and verifies that the Browser Host private/public key pair matches.
 
 ## GitHub Actions Flow
 
 Product release keeps the existing candidate/finalize model:
 
-1. `stable_candidate` runs `script/release/stable-start.ts`, publishes npm candidates, builds core runtime assets, creates the draft GitHub Release, and uploads release state.
-2. `stable_desktop_package` runs a three-way desktop matrix for macOS, Windows, and Linux. Each platform job builds both `x64` and `arm64` Desktop artifacts and minimal Browser Host zip artifacts.
-3. Each desktop matrix job rewrites package versions to the candidate version, builds matching Synergy runtimes with the Browser Host public key embedded, packages Desktop, signs each Browser Host manifest with the independent Ed25519 signing key, and uploads the full platform bundle.
-4. `stable_desktop_publish` downloads all desktop artifacts, generates `Synergy-${version}-checksums.txt`, and uploads the desktop assets to the draft GitHub Release.
-5. `stable_finalize` verifies npm candidates, runtime assets, recommended Desktop installer artifacts, portable artifacts, checksum, and updater metadata by reading the draft GitHub Release assets, then promotes npm tags and publishes the GitHub Release.
+1. `stable_sandbox_assets` builds Linux x64/arm64 helpers for glibc and musl plus the Windows x64 helper, then uploads target-keyed assets. It never commits generated hashes.
+2. `stable_candidate` validates signing material, downloads the helper assets, runs `script/release/stable-start.ts`, publishes npm candidates, builds core runtime assets, creates the draft GitHub Release, and uploads release state. Missing helpers or Browser Host trust material fail before publication.
+3. `stable_desktop_package` runs a three-way desktop matrix for macOS, Windows, and Linux. macOS and Linux build x64/arm64 Desktop artifacts; Windows builds x64 Desktop artifacts. Every platform still builds x64/arm64 minimal Browser Host zips.
+4. Each desktop matrix job rewrites package versions to the candidate version, builds matching Synergy runtimes with the Browser Host public key and helper hash embedded, packages Desktop, signs each Browser Host manifest with the independent Ed25519 signing key, and uploads the full platform bundle.
+5. `stable_desktop_publish` downloads all desktop artifacts, generates `Synergy-${version}-checksums.txt`, and uploads the desktop assets to the draft GitHub Release.
+6. `stable_finalize` verifies npm candidates, runtime assets, recommended Desktop installer artifacts, portable artifacts, checksum, and updater metadata by reading the draft GitHub Release assets, then promotes npm tags and publishes the GitHub Release.
 
 ## Failure Recovery
 
@@ -124,6 +128,8 @@ Product release keeps the existing candidate/finalize model:
 - `bun run --cwd packages/desktop browser-host:dist`
 - `cd packages/desktop && SYNERGY_DESKTOP_ALLOW_MISSING_RUNTIME=1 bunx electron-builder --dir --publish=never --config electron-builder.json` for config-only CI validation
 - Install `.pkg`, `.exe`, and `.deb` in platform runners or VMs and check `synergy --version` plus `synergy doctor`
+- Confirm every Linux/Windows runtime archive contains `sandbox/synergy-sandbox-*` and `synergy doctor` reports a verified helper
+- Confirm Linux `.deb` installs Bubblewrap and portable Linux checks report a clear prerequisite when it is absent
 - Confirm the packaged macOS Dock badge, Windows taskbar overlay, and Linux launcher/tray indicators appear for unread completion notices and clear after acknowledgement
 - Confirm Windows does not expose internal runtime helper binaries through PATH
 - Confirm Linux provides both `/usr/bin/synergy-desktop` for the desktop shell and `/usr/bin/synergy` for the runtime CLI

--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -10,7 +10,7 @@ The root manifest pins Bun `1.3.14`. Install that version, then run:
 bun dev prepare
 ```
 
-Preparation installs dependencies, generates OpenAPI/SDK artifacts, builds the plugin SDK and Web app, and prepares the platform sandbox helper where supported. Linux and Windows helper compilation requires Rust; Linux sandboxing also uses Bubblewrap.
+Preparation installs dependencies, generates OpenAPI/SDK artifacts, builds the plugin SDK and Web app, and prepares the platform sandbox helper where supported. Linux and Windows helper compilation requires Rust; Linux sandboxing also uses Bubblewrap. `build-helper.ts --local` installs the local helper without editing tracked trust hashes. Stable builds compile each release helper first and embed its SHA-256 into the matching runtime binary.
 
 ## Development Modes
 

--- a/install
+++ b/install
@@ -74,6 +74,19 @@ has_bundled_assets() {
     [ -f "$ROOT_DIR/schema/config.schema.json" ]
 }
 
+has_required_sandbox_asset() {
+    local platform="${SYNERGY_INSTALL_PLATFORM:-$(uname -s)}"
+    case "$platform" in
+        Linux*) [ -f "$ROOT_DIR/sandbox/synergy-sandbox-linux" ] ;;
+        MINGW*|MSYS*|CYGWIN*|Windows*) [ -f "$ROOT_DIR/sandbox/synergy-sandbox-windows.exe" ] ;;
+        *) return 0 ;;
+    esac
+}
+
+has_complete_bundle() {
+    has_bundled_assets && has_required_sandbox_asset
+}
+
 install_bundle_contents() {
     local bundle_root="$1"
 
@@ -90,6 +103,11 @@ install_bundle_contents() {
 
     if [ -d "$bundle_root/schema" ]; then
         cp -R "$bundle_root/schema/." "$ROOT_DIR/schema/"
+    fi
+
+    rm -rf "$ROOT_DIR/sandbox"
+    if [ -d "$bundle_root/sandbox" ]; then
+        cp -R "$bundle_root/sandbox" "$ROOT_DIR/sandbox"
     fi
 
     rm -f "$ROOT_DIR/vec0.so" "$ROOT_DIR/vec0.dylib" "$ROOT_DIR/vec0.dll"
@@ -111,7 +129,14 @@ install_bundle_contents() {
     if [ -f "$INSTALL_DIR/ast-grep.exe" ]; then
         chmod 755 "$INSTALL_DIR/ast-grep.exe"
     fi
+    if [ -f "$ROOT_DIR/sandbox/synergy-sandbox-linux" ]; then
+        chmod 755 "$ROOT_DIR/sandbox/synergy-sandbox-linux"
+    fi
 }
+
+if [ "${SYNERGY_INSTALL_LIBRARY_MODE:-}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 # If --binary is provided, skip all download/detection logic
 if [ -n "$binary_path" ]; then
@@ -258,7 +283,7 @@ check_version() {
 
         if [[ "$installed_version" != "$specific_version" ]]; then
             print_message info "${MUTED}Installed version: ${NC}$installed_version."
-        else
+        elif has_complete_bundle; then
             print_message info "${MUTED}Version ${NC}$specific_version${MUTED} already installed"
             exit 0
         fi
@@ -392,6 +417,10 @@ if [ -n "$binary_path" ]; then
 else
     check_version
     download_and_install
+fi
+
+if [[ "$(uname -s)" == Linux* ]] && ! command -v bwrap >/dev/null 2>&1; then
+    print_message warning "${ORANGE}Linux sandbox prerequisite missing: install bubblewrap with your system package manager.${NC}"
 fi
 
 

--- a/packages/desktop/electron-builder.json
+++ b/packages/desktop/electron-builder.json
@@ -153,7 +153,19 @@
   },
   "deb": {
     "afterInstall": "build/linux/deb-after-install.sh",
-    "afterRemove": "build/linux/deb-after-remove.sh"
+    "afterRemove": "build/linux/deb-after-remove.sh",
+    "depends": [
+      "libgtk-3-0",
+      "libnotify4",
+      "libnss3",
+      "libxss1",
+      "libxtst6",
+      "xdg-utils",
+      "libatspi2.0-0",
+      "libuuid1",
+      "libsecret-1-0",
+      "bubblewrap"
+    ]
   },
   "electronFuses": {
     "runAsNode": false,

--- a/packages/desktop/src/release-assets.ts
+++ b/packages/desktop/src/release-assets.ts
@@ -4,6 +4,17 @@ export const DESKTOP_RELEASE_ARCHES = ["x64", "arm64"] as const
 export type DesktopReleasePlatform = (typeof DESKTOP_RELEASE_PLATFORMS)[number]
 export type DesktopReleaseArch = (typeof DESKTOP_RELEASE_ARCHES)[number]
 
+const DESKTOP_RELEASE_TARGETS: ReadonlyArray<{
+  platform: DesktopReleasePlatform
+  arch: DesktopReleaseArch
+}> = [
+  { platform: "darwin", arch: "x64" },
+  { platform: "darwin", arch: "arm64" },
+  { platform: "win32", arch: "x64" },
+  { platform: "linux", arch: "x64" },
+  { platform: "linux", arch: "arm64" },
+]
+
 export function desktopPrimaryArtifactName(
   version: string,
   platform: DesktopReleasePlatform,
@@ -15,20 +26,15 @@ export function desktopPrimaryArtifactName(
 }
 
 export function desktopPortableArtifactNames(version: string): string[] {
-  return DESKTOP_RELEASE_PLATFORMS.flatMap((platform) =>
-    DESKTOP_RELEASE_ARCHES.flatMap((arch) => {
-      const artifactArch = platform === "linux" && arch === "x64" ? "x86_64" : arch
-      const extensions =
-        platform === "darwin" ? ["dmg", "zip"] : platform === "win32" ? ["zip"] : ["AppImage", "tar.gz"]
-      return extensions.map((extension) => `Synergy-${platform}-${artifactArch}-${version}.${extension}`)
-    }),
-  )
+  return DESKTOP_RELEASE_TARGETS.flatMap(({ platform, arch }) => {
+    const artifactArch = platform === "linux" && arch === "x64" ? "x86_64" : arch
+    const extensions = platform === "darwin" ? ["dmg", "zip"] : platform === "win32" ? ["zip"] : ["AppImage", "tar.gz"]
+    return extensions.map((extension) => `Synergy-${platform}-${artifactArch}-${version}.${extension}`)
+  })
 }
 
 export function expectedDesktopPrimaryArtifacts(version: string): string[] {
-  return DESKTOP_RELEASE_PLATFORMS.flatMap((platform) =>
-    DESKTOP_RELEASE_ARCHES.map((arch) => desktopPrimaryArtifactName(version, platform, arch)),
-  )
+  return DESKTOP_RELEASE_TARGETS.map(({ platform, arch }) => desktopPrimaryArtifactName(version, platform, arch))
 }
 
 export function desktopChecksumsName(version: string): string {

--- a/packages/desktop/test/packaging.test.ts
+++ b/packages/desktop/test/packaging.test.ts
@@ -22,6 +22,7 @@ interface ElectronBuilderConfig {
   deb?: {
     afterInstall?: string
     afterRemove?: string
+    depends?: string[]
   }
   extraResources?: Array<{
     from?: string
@@ -79,6 +80,7 @@ describe("desktop packaging", () => {
     expect(config.nsis?.include).toBe("build/installer.nsh")
     expect(config.deb?.afterInstall).toBe("build/linux/deb-after-install.sh")
     expect(config.deb?.afterRemove).toBe("build/linux/deb-after-remove.sh")
+    expect(config.deb?.depends).toContain("bubblewrap")
   })
 
   test("Windows installer publishes only the launcher directory, not runtime internals", async () => {

--- a/packages/desktop/test/release-assets.test.ts
+++ b/packages/desktop/test/release-assets.test.ts
@@ -20,8 +20,10 @@ describe("desktop release asset names", () => {
   })
 
   test("lists all expected primary installer artifacts", () => {
-    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toHaveLength(6)
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toHaveLength(5)
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-darwin-x64-1.2.3.pkg")
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-win32-x64-1.2.3.exe")
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).not.toContain("Synergy-win32-arm64-1.2.3.exe")
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.deb")
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.deb")
   })
@@ -31,6 +33,7 @@ describe("desktop release asset names", () => {
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-darwin-arm64-1.2.3.zip")
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.AppImage")
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.tar.gz")
+    expect(desktopPortableArtifactNames("1.2.3")).not.toContain("Synergy-win32-arm64-1.2.3.zip")
   })
 
   test("names checksum and updater metadata predictably", () => {

--- a/packages/synergy/script/build.ts
+++ b/packages/synergy/script/build.ts
@@ -14,10 +14,21 @@ process.chdir(dir)
 
 import pkg from "../package.json"
 import { Script } from "@ericsanchezok/synergy-script"
+import {
+  assertPackagedSandboxAsset,
+  copySandboxAsset,
+  resolveSandboxAsset,
+  type SandboxRuntimeTarget,
+} from "./sandbox-assets"
 
 const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
+const requireSandboxAssets = process.env.SYNERGY_REQUIRE_SANDBOX_ASSETS === "1"
+const browserHostPublicKey = process.env.SYNERGY_BROWSER_HOST_PUBLIC_KEY ?? ""
+if (process.env.SYNERGY_REQUIRE_BROWSER_HOST_PUBLIC_KEY === "1" && !browserHostPublicKey) {
+  throw new Error("SYNERGY_BROWSER_HOST_PUBLIC_KEY is required for a product release build")
+}
 const requestedTargets = new Set(
   (process.env.SYNERGY_BUILD_TARGETS ?? "")
     .split(",")
@@ -134,9 +145,12 @@ for (const item of targets) {
   console.log(`building ${name}`)
   if (shouldReusePublishedRuntime(item)) {
     await extractPublishedRuntimePackage(name, Script.version)
+    if (requireSandboxAssets) assertPackagedSandboxAsset(item, path.join("dist", name))
     binaries[name] = Script.version
     continue
   }
+
+  const sandboxAsset = resolveSandboxAsset(item, { required: requireSandboxAssets })
 
   await $`mkdir -p dist/${name}/bin`
 
@@ -162,7 +176,8 @@ for (const item of targets) {
         SYNERGY_VERSION: `'${Script.version}'`,
         SYNERGY_CHANNEL: `'${Script.channel}'`,
         SYNERGY_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
-        SYNERGY_BROWSER_HOST_PUBLIC_KEY: `'${process.env.SYNERGY_BROWSER_HOST_PUBLIC_KEY ?? ""}'`,
+        SYNERGY_BROWSER_HOST_PUBLIC_KEY: JSON.stringify(browserHostPublicKey),
+        SYNERGY_SANDBOX_HELPER_SHA256: JSON.stringify(sandboxAsset?.sha256 ?? ""),
       },
     }),
   )
@@ -181,40 +196,14 @@ for (const item of targets) {
   )
   binaries[name] = Script.version
 
-  // Copy sandbox helper into dist for tarball embedding
-  await copySandboxHelper(item, name)
+  if (sandboxAsset) {
+    copySandboxAsset(sandboxAsset, path.join("dist", name))
+  } else if (item.os !== "darwin") {
+    console.warn(`Sandbox asset is unavailable for ${targetKey(item)} — packaged runtime will not include a helper.`)
+  }
 }
 
-async function copySandboxHelper(item: { os: string; arch: string }, name: string): Promise<void> {
-  // macOS uses sandbox-exec built into the OS — no helper needed
-  if (item.os === "darwin") return
-
-  let helperSrc: string
-  let helperDest: string
-
-  if (item.os === "linux") {
-    const helperDir = path.resolve(dir, "src", "sandbox", "helper-linux", "target", "release")
-    helperSrc = path.join(helperDir, "synergy-sandbox-linux")
-    helperDest = path.join("dist", name, "sandbox", "synergy-sandbox-linux")
-  } else if (item.os === "win32") {
-    const helperDir = path.resolve(dir, "src", "sandbox", "helper", "target", "release")
-    helperSrc = path.join(helperDir, "synergy-sandbox-windows.exe")
-    helperDest = path.join("dist", name, "sandbox", "synergy-sandbox-windows.exe")
-  } else {
-    return
-  }
-
-  if (!fs.existsSync(helperSrc)) {
-    console.warn(`Sandbox helper not found at ${helperSrc} — skipping embed. Build the Rust helper first.`)
-    return
-  }
-
-  console.log(`Copying sandbox helper: ${helperSrc} → ${helperDest}`)
-  fs.mkdirSync(path.dirname(helperDest), { recursive: true })
-  fs.copyFileSync(helperSrc, helperDest)
-}
-
-function targetKey(item: { os: string; arch: string; abi?: string; avx2?: false }): string {
+function targetKey(item: SandboxRuntimeTarget): string {
   return [item.os, item.arch, item.avx2 === false ? "baseline" : undefined, item.abi].filter(Boolean).join("-")
 }
 

--- a/packages/synergy/script/postinstall.mjs
+++ b/packages/synergy/script/postinstall.mjs
@@ -60,7 +60,22 @@ function symlinkBinary(sourcePath, binaryName) {
   }
 }
 
-async function installSandboxHelper() {
+function filesEqual(left, right) {
+  try {
+    const leftStat = fs.statSync(left)
+    const rightStat = fs.statSync(right)
+    return (
+      leftStat.isFile() &&
+      rightStat.isFile() &&
+      leftStat.size === rightStat.size &&
+      fs.readFileSync(left).equals(fs.readFileSync(right))
+    )
+  } catch {
+    return false
+  }
+}
+
+async function installSandboxHelper(binaryPath) {
   const platform = os.platform()
   const homedir = os.homedir()
 
@@ -84,14 +99,23 @@ async function installSandboxHelper() {
   const destDir = path.join(homedir, ".synergy", "sandbox-helper")
   const destPath = path.join(destDir, helperBinaryName)
 
-  // Idempotent: skip if already installed
-  if (fs.existsSync(destPath)) return
-
-  // Search for the helper in node_modules/@ericsanchezok/
+  // Prefer the helper embedded in the selected platform package, then support
+  // legacy standalone helper packages if one is present.
   const scopeDir = path.join(__dirname, "..", "node_modules", "@ericsanchezok")
   let found = false
 
-  if (fs.existsSync(scopeDir)) {
+  const packagedHelper = path.resolve(path.dirname(binaryPath), "..", "sandbox", helperBinaryName)
+  if (fs.existsSync(packagedHelper)) {
+    if (!filesEqual(packagedHelper, destPath)) {
+      fs.mkdirSync(destDir, { recursive: true })
+      fs.copyFileSync(packagedHelper, destPath)
+      if (platform === "linux") fs.chmodSync(destPath, 0o755)
+      console.log(`Sandbox helper installed: ${destPath}`)
+    }
+    found = true
+  }
+
+  if (!found && fs.existsSync(scopeDir)) {
     try {
       const entries = fs.readdirSync(scopeDir)
       for (const entry of entries) {
@@ -123,13 +147,14 @@ async function main() {
       // On Windows, the .exe is already included in the package and bin field points to it
       // No postinstall setup needed
       console.log("Windows detected: binary setup not needed (using packaged .exe)")
-      await installSandboxHelper()
+      const { binaryPath } = findBinary()
+      await installSandboxHelper(binaryPath)
       return
     }
 
     const { binaryPath, binaryName } = findBinary()
     symlinkBinary(binaryPath, binaryName)
-    await installSandboxHelper()
+    await installSandboxHelper(binaryPath)
   } catch (error) {
     console.error("Failed to setup synergy binary:", error.message)
     process.exit(1)

--- a/packages/synergy/script/sandbox-assets.ts
+++ b/packages/synergy/script/sandbox-assets.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+
+export interface SandboxRuntimeTarget {
+  os: string
+  arch: "arm64" | "x64"
+  abi?: "musl"
+  avx2?: false
+}
+
+export interface SandboxAsset {
+  sourcePath: string
+  relativePath: string
+  sha256: string
+}
+
+export interface ResolveSandboxAssetOptions {
+  assetsRoot?: string
+  required?: boolean
+}
+
+const ELF_MACHINE = { x64: 62, arm64: 183 } as const
+const PE_MACHINE = { x64: 0x8664, arm64: 0xaa64 } as const
+
+export function sandboxAssetKey(target: SandboxRuntimeTarget): string {
+  const platform = target.os === "win32" ? "windows" : target.os
+  return [platform, target.arch, target.abi].filter(Boolean).join("-")
+}
+
+export function sandboxAssetBinaryName(target: SandboxRuntimeTarget): string | undefined {
+  if (target.os === "linux") return "synergy-sandbox-linux"
+  if (target.os === "win32") return "synergy-sandbox-windows.exe"
+  return undefined
+}
+
+function assertSandboxAssetFormat(target: SandboxRuntimeTarget, contents: Buffer): void {
+  if (target.os === "linux") {
+    const validElf =
+      contents.length >= 20 &&
+      contents.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) &&
+      contents[4] === 2 &&
+      contents[5] === 1 &&
+      contents.readUInt16LE(18) === ELF_MACHINE[target.arch]
+    if (!validElf) throw new Error(`Sandbox asset ${sandboxAssetKey(target)} is not a matching 64-bit ELF binary`)
+    return
+  }
+
+  if (target.os === "win32") {
+    const peOffset = contents.length >= 64 ? contents.readUInt32LE(0x3c) : -1
+    const validPe =
+      peOffset >= 0 &&
+      peOffset + 6 <= contents.length &&
+      contents.subarray(0, 2).equals(Buffer.from("MZ")) &&
+      contents.subarray(peOffset, peOffset + 4).equals(Buffer.from("PE\0\0")) &&
+      contents.readUInt16LE(peOffset + 4) === PE_MACHINE[target.arch]
+    if (!validPe) throw new Error(`Sandbox asset ${sandboxAssetKey(target)} is not a matching PE binary`)
+  }
+}
+
+export function resolveSandboxAsset(
+  target: SandboxRuntimeTarget,
+  options: ResolveSandboxAssetOptions = {},
+): SandboxAsset | undefined {
+  const binaryName = sandboxAssetBinaryName(target)
+  if (!binaryName) return
+
+  const assetsRoot =
+    options.assetsRoot ??
+    process.env.SYNERGY_SANDBOX_ASSETS_DIR ??
+    path.resolve(import.meta.dir, "..", "sandbox-assets")
+  const key = sandboxAssetKey(target)
+  const sourcePath = path.join(assetsRoot, key, binaryName)
+  if (!fs.existsSync(sourcePath)) {
+    if (options.required) {
+      throw new Error(`Sandbox asset ${key}/${binaryName} is required but was not found in ${assetsRoot}`)
+    }
+    return
+  }
+
+  const stat = fs.statSync(sourcePath)
+  if (!stat.isFile() || stat.size < 1_024) {
+    throw new Error(`Sandbox asset ${key}/${binaryName} is not a valid helper binary`)
+  }
+
+  const contents = fs.readFileSync(sourcePath)
+  assertSandboxAssetFormat(target, contents)
+
+  return {
+    sourcePath,
+    relativePath: path.join("sandbox", binaryName),
+    sha256: createHash("sha256").update(contents).digest("hex"),
+  }
+}
+
+export function copySandboxAsset(asset: SandboxAsset, targetDirectory: string): void {
+  const destination = path.join(targetDirectory, asset.relativePath)
+  fs.mkdirSync(path.dirname(destination), { recursive: true })
+  fs.copyFileSync(asset.sourcePath, destination)
+  if (!destination.endsWith(".exe")) fs.chmodSync(destination, 0o755)
+}
+
+export function assertPackagedSandboxAsset(target: SandboxRuntimeTarget, targetDirectory: string): void {
+  const binaryName = sandboxAssetBinaryName(target)
+  if (!binaryName) return
+  const packaged = path.join(targetDirectory, "sandbox", binaryName)
+  if (!fs.existsSync(packaged) || !fs.statSync(packaged).isFile()) {
+    throw new Error(`Packaged runtime ${sandboxAssetKey(target)} is missing sandbox/${binaryName}`)
+  }
+}

--- a/packages/synergy/scripts/build-helper.ts
+++ b/packages/synergy/scripts/build-helper.ts
@@ -1,154 +1,65 @@
 #!/usr/bin/env bun
-import * as fs from "fs"
-import * as path from "path"
-import { createHash } from "crypto"
+import { createHash } from "node:crypto"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { $ } from "bun"
 
 const args = process.argv.slice(2)
-
-const platform = args.find((a) => a === "linux" || a === "windows") ?? "linux"
+const platform = args.find((arg) => arg === "linux" || arg === "windows") ?? "linux"
 const helperDir = platform === "linux" ? "helper-linux" : "helper"
-const targetModule = platform === "linux" ? "linux.ts" : "windows.ts"
-const constName = platform === "linux" ? "TRUSTED_LINUX_HELPER_HASHES" : "TRUSTED_WINDOWS_HELPER_HASHES"
 const binaryName = platform === "linux" ? "synergy-sandbox-linux" : "synergy-sandbox-windows.exe"
-
-const targetArgIdx = args.indexOf("--target")
-const targetTriple = targetArgIdx >= 0 ? args[targetArgIdx + 1] : null
+const targetIndex = args.indexOf("--target")
+const targetTriple = targetIndex >= 0 ? args[targetIndex + 1] : undefined
+const helperPathIndex = args.indexOf("--helper-path")
+const helperPath = helperPathIndex >= 0 ? args[helperPathIndex + 1] : undefined
 const dryRun = args.includes("--dry-run")
 const skipBuild = args.includes("--skip-build")
 const localMode = args.includes("--local")
 
-// --helper-path allows overriding the binary path when used with --local
-const helperPathIdx = args.indexOf("--helper-path")
-const localHelperPath = helperPathIdx >= 0 ? args[helperPathIdx + 1] : null
-
-const helperDirAbs = path.resolve(import.meta.dir, "..", "src", "sandbox", helperDir)
-const releaseSubdir = targetTriple ? path.join("target", targetTriple, "release") : path.join("target", "release")
-const binaryPath = path.join(helperDirAbs, releaseSubdir, binaryName)
-
-if (dryRun) {
-  console.log(`[dry-run] Would build ${platform} helper in ${helperDirAbs}`)
-  if (targetTriple) {
-    console.log(`[dry-run] Would use target triple: ${targetTriple}`)
-  }
-} else if (skipBuild) {
-  console.log(`Skipping build for ${platform} (--skip-build)`)
-} else {
-  // Build
-  console.log(`Building ${platform} helper in ${helperDirAbs}...`)
-  if (targetTriple) {
-    await $`cargo build --release --target ${targetTriple}`.cwd(helperDirAbs)
-  } else {
-    await $`cargo build --release`.cwd(helperDirAbs)
-  }
+if (args.includes("--auto-update") || args.includes("--append")) {
+  throw new Error("Helper hashes are embedded by script/build.ts; source hash maps are no longer updated")
 }
+if (targetIndex >= 0 && !targetTriple) throw new Error("--target requires a Rust target triple")
+if (helperPathIndex >= 0 && !helperPath) throw new Error("--helper-path requires a file path")
 
-// Compute hash (use placeholder for dry-run)
-let hash: string
+const helperDirectory = path.resolve(import.meta.dir, "..", "src", "sandbox", helperDir)
+const releaseDirectory = targetTriple ? path.join("target", targetTriple, "release") : path.join("target", "release")
+const builtBinary = path.join(helperDirectory, releaseDirectory, binaryName)
+const binaryPath = helperPath ? path.resolve(process.cwd(), helperPath) : builtBinary
+
 if (dryRun) {
-  hash = "0000000000000000000000000000000000000000000000000000000000000000"
+  console.log(`[dry-run] Would build ${platform} helper in ${helperDirectory}`)
+  if (targetTriple) console.log(`[dry-run] Would use target triple: ${targetTriple}`)
   console.log(`[dry-run] Would read binary at: ${binaryPath}`)
-} else {
-  const binary = fs.readFileSync(binaryPath)
-  hash = createHash("sha256").update(binary).digest("hex")
+} else if (!skipBuild) {
+  console.log(`Building ${platform} helper in ${helperDirectory}...`)
+  if (targetTriple) {
+    await $`cargo build --release --target ${targetTriple}`.cwd(helperDirectory)
+  } else {
+    await $`cargo build --release`.cwd(helperDirectory)
+  }
 }
+
+const hash = dryRun
+  ? "0000000000000000000000000000000000000000000000000000000000000000"
+  : createHash("sha256").update(fs.readFileSync(binaryPath)).digest("hex")
 
 console.log(`platform: ${platform}`)
 if (targetTriple) console.log(`target: ${targetTriple}`)
 console.log(`binary: ${binaryName}`)
 console.log(`SHA-256: ${hash}`)
-console.log()
-console.log(`Add to packages/synergy/src/sandbox/${targetModule}:`)
-// Generated hash map keys use forward-slash since CI runs on Linux.
-// verifyHelperHash() iterates Object.values() (ignores keys). If key-based
-// lookup is ever added, normalize the lookup key with normalizeSlashes() first.
-console.log(`export const ${constName}: Record<string, string> = {`)
-console.log(`  [path.join(os.homedir(), ".synergy", "sandbox-helper", "${binaryName}")]: "${hash}",`)
-console.log(`}`)
+console.log("Runtime release builds embed this hash while packaging the matching helper asset.")
 
-const autoUpdate = args.includes("--auto-update")
-const append = args.includes("--append")
-if (autoUpdate) {
-  const sourceFile = path.resolve(import.meta.dir, "..", "src", "sandbox", targetModule)
-  let content = fs.readFileSync(sourceFile, "utf-8")
-
-  let archSuffix = ""
-  if (targetTriple) {
-    if (targetTriple.includes("aarch64")) archSuffix = "-arm64"
-    else if (targetTriple.includes("x86_64")) archSuffix = "-x64"
-  }
-  const binaryKey = binaryName + archSuffix
-  const newEntry = `  [path.join(os.homedir(), ".synergy", "sandbox-helper", "${binaryKey}")]: "${hash}",`
-
-  if (append) {
-    // Append mode: insert the new entry before the closing `}` of the existing map,
-    // preserving all existing entries.
-    const pattern = new RegExp(`(export const ${constName}: Record<string, string> = \\{[^}]*)`, "s")
-    if (pattern.test(content)) {
-      content = content.replace(pattern, `$1\n${newEntry}`)
-    } else {
-      // Map not in expected format — fall back to full replacement
-      const fallbackPattern = new RegExp(`export const ${constName}: Record<string, string> = \\{[^}]*\\}`, "s")
-      content = content.replace(
-        fallbackPattern,
-        `export const ${constName}: Record<string, string> = {\n${newEntry}\n}`,
-      )
-    }
-  } else {
-    // Replace mode: replace the entire map.
-    if (dryRun) {
-      const replacement = `export const ${constName}: Record<string, string> = {\n${newEntry}\n}`
-      console.log(`[dry-run] Would update ${sourceFile} with:`)
-      console.log(replacement)
-    } else {
-      const pattern = new RegExp(`export const ${constName}: Record<string, string> = \\{[^}]*\\}`, "s")
-      content = content.replace(pattern, `export const ${constName}: Record<string, string> = {\n${newEntry}\n}`)
-    }
-  }
-
-  if (dryRun) {
-    console.log(`[dry-run] Would update ${sourceFile}`)
-  } else {
-    fs.writeFileSync(sourceFile, content)
-    console.log(`Updated ${sourceFile}`)
-  }
-}
-
-// --local: one-step setup for source-deploy users.
-// Reads an already-built helper binary, computes its hash, and auto-updates
-// the trusted hash map in the source file.
-// Usage: bun run scripts/build-helper.ts linux --local --helper-path target/release/synergy-sandbox-linux
 if (localMode) {
-  const sourceFile = path.resolve(import.meta.dir, "..", "src", "sandbox", targetModule)
-
-  const readPath = localHelperPath ?? binaryPath
-  if (!fs.existsSync(readPath)) {
-    console.error(`Helper binary not found: ${readPath}`)
-    console.error("Build it first: cargo build --release")
-    console.error(`Or pass --helper-path to point to an existing binary.`)
-    process.exit(1)
+  const destinationDirectory = path.join(os.homedir(), ".synergy", "sandbox-helper")
+  const destination = path.join(destinationDirectory, binaryName)
+  if (dryRun) {
+    console.log(`[dry-run] Would install helper at: ${destination}`)
+  } else {
+    fs.mkdirSync(destinationDirectory, { recursive: true })
+    fs.copyFileSync(binaryPath, destination)
+    if (platform === "linux") fs.chmodSync(destination, 0o755)
+    console.log(`Installed ${binaryName} at ${destination}`)
   }
-
-  const binary = fs.readFileSync(readPath)
-  const localHash = createHash("sha256").update(binary).digest("hex")
-
-  let content = fs.readFileSync(sourceFile, "utf-8")
-  const newEntry = `  [path.join(os.homedir(), ".synergy", "sandbox-helper", "${binaryName}")]: "${localHash}",`
-  const pattern = new RegExp(`export const ${constName}: Record<string, string> = \\{[^}]*\\}`, "s")
-  content = content.replace(pattern, `export const ${constName}: Record<string, string> = {\n${newEntry}\n}`)
-  fs.writeFileSync(sourceFile, content)
-
-  console.log(`Registered ${binaryName} hash in ${targetModule}`)
-  console.log(`SHA-256: ${localHash}`)
-  console.log()
-  console.log("Next steps:")
-  if (platform === "linux") {
-    console.log(`  cp ${readPath} ~/.synergy/sandbox-helper/${binaryName}`)
-    console.log("  sudo apt install bubblewrap   # or: bash scripts/download-bwrap.sh")
-  } else if (platform === "windows") {
-    console.log(`  copy ${readPath} %USERPROFILE%\\.synergy\\sandbox-helper\\${binaryName}`)
-  }
-  console.log("  # Then restart Synergy")
-
-  process.exit(0)
 }

--- a/packages/synergy/src/browser/install.ts
+++ b/packages/synergy/src/browser/install.ts
@@ -67,17 +67,40 @@ async function findChromiumInDir(dir: string): Promise<string | null> {
   return null
 }
 
-async function findPlaywrightChromium(cacheDir: string, platform: string): Promise<string | null> {
+async function findPlaywrightChromium(
+  cacheDir: string,
+  platform: NodeJS.Platform,
+  arch: string,
+): Promise<string | null> {
   try {
     const entries = await fs.readdir(cacheDir, { withFileTypes: true })
     for (const entry of entries) {
       if (!entry.isDirectory() || !entry.name.startsWith("chromium-")) continue
 
-      if (platform === "darwin") {
-        const candidate = path.join(cacheDir, entry.name, "chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium")
-        if (await fileExists(candidate)) return candidate
-      } else {
-        const candidate = path.join(cacheDir, entry.name, "chrome-linux", "chrome")
+      const candidates =
+        platform === "darwin"
+          ? [
+              path.join(
+                cacheDir,
+                entry.name,
+                arch === "arm64" ? "chrome-mac-arm64" : "chrome-mac-x64",
+                "Google Chrome for Testing.app",
+                "Contents",
+                "MacOS",
+                "Google Chrome for Testing",
+              ),
+              path.join(cacheDir, entry.name, "chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium"),
+            ]
+          : platform === "win32"
+            ? [
+                path.join(cacheDir, entry.name, "chrome-win64", "chrome.exe"),
+                path.join(cacheDir, entry.name, "chrome-win", "chrome.exe"),
+              ]
+            : [
+                path.join(cacheDir, entry.name, arch === "arm64" ? "chrome-linux" : "chrome-linux64", "chrome"),
+                path.join(cacheDir, entry.name, "chrome-linux", "chrome"),
+              ]
+      for (const candidate of candidates) {
         if (await fileExists(candidate)) return candidate
       }
     }
@@ -226,14 +249,23 @@ export namespace BrowserInstall {
   }
 
   /** Discover Chromium in priority order. Returns null if not found. */
-  export async function discoverChromium(): Promise<string | null> {
-    const platform = os.platform()
-    const home = os.homedir()
+  export async function discoverChromium(
+    options: {
+      platform?: NodeJS.Platform
+      arch?: string
+      home?: string
+      env?: Record<string, string | undefined>
+    } = {},
+  ): Promise<string | null> {
+    const platform = options.platform ?? os.platform()
+    const arch = options.arch ?? os.arch()
+    const home = options.home ?? os.homedir()
+    const env = options.env ?? Bun.env
 
     // 1. $CHROMIUM_PATH env
-    if (Bun.env.CHROMIUM_PATH) {
-      if (await fileExists(Bun.env.CHROMIUM_PATH)) {
-        return Bun.env.CHROMIUM_PATH
+    if (env.CHROMIUM_PATH) {
+      if (await fileExists(env.CHROMIUM_PATH)) {
+        return env.CHROMIUM_PATH
       }
     }
 
@@ -245,9 +277,11 @@ export namespace BrowserInstall {
     const playwrightDir =
       platform === "darwin"
         ? path.join(home, "Library", "Caches", "ms-playwright")
-        : path.join(home, ".cache", "ms-playwright")
+        : platform === "win32"
+          ? path.join(env.LOCALAPPDATA ?? path.join(home, "AppData", "Local"), "ms-playwright")
+          : path.join(home, ".cache", "ms-playwright")
 
-    const playwrightResult = await findPlaywrightChromium(playwrightDir, platform)
+    const playwrightResult = await findPlaywrightChromium(playwrightDir, platform, arch)
     if (playwrightResult) return playwrightResult
 
     try {
@@ -265,7 +299,26 @@ export namespace BrowserInstall {
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
             "/Applications/Chromium.app/Contents/MacOS/Chromium",
           ]
-        : ["/usr/bin/chromium", "/usr/bin/chromium-browser", "/usr/bin/google-chrome"]
+        : platform === "win32"
+          ? [
+              path.join(env.PROGRAMFILES ?? "C:\\Program Files", "Google", "Chrome", "Application", "chrome.exe"),
+              path.join(
+                env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)",
+                "Google",
+                "Chrome",
+                "Application",
+                "chrome.exe",
+              ),
+              path.join(
+                env.LOCALAPPDATA ?? path.join(home, "AppData", "Local"),
+                "Google",
+                "Chrome",
+                "Application",
+                "chrome.exe",
+              ),
+              path.join(env.PROGRAMFILES ?? "C:\\Program Files", "Microsoft", "Edge", "Application", "msedge.exe"),
+            ]
+          : ["/usr/bin/chromium", "/usr/bin/chromium-browser", "/usr/bin/google-chrome"]
     for (const sysPath of systemPaths) {
       if (await fileExists(sysPath)) return sysPath
     }

--- a/packages/synergy/src/global/installation.ts
+++ b/packages/synergy/src/global/installation.ts
@@ -10,6 +10,7 @@ import { Flag } from "../flag/flag"
 declare global {
   const SYNERGY_VERSION: string
   const SYNERGY_CHANNEL: string
+  const SYNERGY_SANDBOX_HELPER_SHA256: string
 }
 
 export namespace Installation {

--- a/packages/synergy/src/sandbox/helper-linux/bwrap/README.md
+++ b/packages/synergy/src/sandbox/helper-linux/bwrap/README.md
@@ -1,33 +1,11 @@
-# Bundled bwrap binary
+# Optional bundled bwrap binary
 
-This directory holds a statically-linked `bwrap` binary for the target
-Linux architecture. In CI/release builds, the binary is placed here
-during packaging and the Rust helper discovers it automatically via
-`bwrap_binary()`.
+Linux Stable packages use the system `bubblewrap` package by default. The Debian installer declares it as a dependency; portable and CLI archive users install it with their distribution package manager.
 
-## Obtaining a static bwrap binary
+The sandbox helper also supports an optional verified binary at:
 
-### Option A: Build from source
-
-```
-git clone https://github.com/containers/bubblewrap
-cd bubblewrap
-./autogen.sh
-./configure LDFLAGS="-static"
-make
-cp bwrap ../../packages/synergy/src/sandbox/helper-linux/bwrap/
+```text
+~/.synergy/sandbox-helper/bwrap/bwrap
 ```
 
-### Option B: Download prebuilt
-
-Check the latest release at https://github.com/containers/bubblewrap/releases
-
-## CI integration
-
-In CI, the bwrap binary is downloaded/built as part of the release pipeline
-and placed in this directory. The Rust helper's `bwrap_binary()` function
-checks this path before falling back to the system `bwrap`.
-
-## Security
-
-Always verify the binary's SHA-256 hash before including it in a release.
+Use `packages/synergy/scripts/download-bwrap.sh` for source-development experiments. A bundled binary must be architecture-matched and SHA-256 verified before it is distributed. The product Release does not claim that this directory is populated automatically.

--- a/packages/synergy/src/sandbox/linux.ts
+++ b/packages/synergy/src/sandbox/linux.ts
@@ -153,7 +153,7 @@ function tryInstallCargoHelper(): boolean {
 
   for (const srcPath of cargoPaths) {
     try {
-      if (fs.existsSync(srcPath) && (!fs.existsSync(destPath) || isTarballHelperUpToDate(srcPath, destPath))) {
+      if (fs.existsSync(srcPath) && (!fs.existsSync(destPath) || !isTarballHelperUpToDate(srcPath, destPath))) {
         fs.mkdirSync(destDir, { recursive: true })
         fs.copyFileSync(srcPath, destPath)
         fs.chmodSync(destPath, 0o755)
@@ -318,8 +318,11 @@ export function isBundledBwrapAvailable(): boolean {
  * Never load from config — embedded at compile time.
  */
 export const TRUSTED_LINUX_HELPER_HASHES: Record<string, string> = {
-  // Hash entries for verified helper binaries. Run scripts/build-helper.ts linux --auto-update to populate.
-  // Empty map is intentional until release — no helper will be trusted.
+  ...(typeof SYNERGY_SANDBOX_HELPER_SHA256 === "string" && SYNERGY_SANDBOX_HELPER_SHA256
+    ? {
+        [path.join(os.homedir(), ".synergy", "sandbox-helper", "synergy-sandbox-linux")]: SYNERGY_SANDBOX_HELPER_SHA256,
+      }
+    : {}),
 }
 
 /**

--- a/packages/synergy/src/sandbox/readiness.ts
+++ b/packages/synergy/src/sandbox/readiness.ts
@@ -193,7 +193,7 @@ export async function getSandboxReadiness(sandboxCfg?: SandboxReadinessConfig): 
         label: "bwrap (bubblewrap)",
         status: bwrapAvailable ? "pass" : "fail",
         detail: bwrapAvailable
-          ? "bwrap found on PATH"
+          ? "A verified bundled bwrap or system bwrap is available"
           : "bubblewrap is not installed. Run: sudo apt install bubblewrap (Debian/Ubuntu) or sudo dnf install bubblewrap (Fedora)",
         recovery: bwrapAvailable
           ? undefined
@@ -277,21 +277,11 @@ export async function getSandboxReadiness(sandboxCfg?: SandboxReadinessConfig): 
       if (!bundledBwrapInfo) {
         checks.push({
           id: "linux_bundled_bwrap",
-          label: "Bundled bwrap",
-          status: "fail",
-          detail:
-            "Bundled bwrap not found in ~/.synergy/sandbox-helper/bwrap/. Run: bun run packages/synergy/scripts/download-bwrap.sh",
-          recovery: {
-            action: "install_bundled_bwrap",
-            label: "Download and build bundled bwrap",
-            command: "bun run packages/synergy/scripts/download-bwrap.sh",
-          },
-        })
-        checks.push({
-          id: "linux_bundled_bwrap_hash",
-          label: "Bundled bwrap hash verification",
-          status: "fail",
-          detail: "Cannot verify hash — bundled bwrap binary not found.",
+          label: "Optional bundled bwrap",
+          status: bwrapAvailable ? "pass" : "warn",
+          detail: bwrapAvailable
+            ? "Bundled bwrap is not installed; using the system bubblewrap package."
+            : "Bundled bwrap is not installed. Install the system bubblewrap package before using the Linux sandbox.",
         })
       } else if (!bundledBwrapInfo.verified) {
         checks.push({

--- a/packages/synergy/src/sandbox/utils.ts
+++ b/packages/synergy/src/sandbox/utils.ts
@@ -8,7 +8,8 @@ export function isTarballHelperUpToDate(src: string, dst: string): boolean {
   try {
     const srcStat = fs.statSync(src)
     const dstStat = fs.statSync(dst)
-    return srcStat.mtimeMs <= dstStat.mtimeMs
+    if (!srcStat.isFile() || !dstStat.isFile() || srcStat.size !== dstStat.size) return false
+    return fs.readFileSync(src).equals(fs.readFileSync(dst))
   } catch {
     return false
   }

--- a/packages/synergy/src/sandbox/windows.ts
+++ b/packages/synergy/src/sandbox/windows.ts
@@ -110,8 +110,12 @@ function installTarballHelper(): boolean {
  * Never load from config — embedded at compile time.
  */
 export const TRUSTED_WINDOWS_HELPER_HASHES: Record<string, string> = {
-  [path.join(os.homedir(), ".synergy", "sandbox-helper", "synergy-sandbox-windows.exe")]:
-    "dda59069707637c0099e1adfa0eb6e9002347180b2acf9e57038dc71f3a70b48",
+  ...(typeof SYNERGY_SANDBOX_HELPER_SHA256 === "string" && SYNERGY_SANDBOX_HELPER_SHA256
+    ? {
+        [path.join(os.homedir(), ".synergy", "sandbox-helper", "synergy-sandbox-windows.exe")]:
+          SYNERGY_SANDBOX_HELPER_SHA256,
+      }
+    : {}),
 }
 
 /**

--- a/packages/synergy/test/browser/host-install.test.ts
+++ b/packages/synergy/test/browser/host-install.test.ts
@@ -123,6 +123,25 @@ describe("Browser Host artifact installation", () => {
   })
 })
 
+describe("Chromium discovery", () => {
+  test("finds current Playwright Chromium layouts in the Windows local cache", async () => {
+    const localAppData = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-playwright-windows-"))
+    tempDirs.push(localAppData)
+    const executable = path.join(localAppData, "ms-playwright", "chromium-1234", "chrome-win64", "chrome.exe")
+    await fs.mkdir(path.dirname(executable), { recursive: true })
+    await fs.writeFile(executable, "browser")
+
+    await expect(
+      BrowserInstall.discoverChromium({
+        platform: "win32",
+        arch: "x64",
+        home: localAppData,
+        env: { LOCALAPPDATA: localAppData },
+      }),
+    ).resolves.toBe(executable)
+  })
+})
+
 async function zip(name: string, content: string): Promise<Buffer> {
   const writer = new BlobWriter("application/zip")
   const zipWriter = new ZipWriter(writer)

--- a/packages/synergy/test/sandbox/build-helper.test.ts
+++ b/packages/synergy/test/sandbox/build-helper.test.ts
@@ -1,43 +1,33 @@
-import { test, expect, describe } from "bun:test"
+import { describe, expect, test } from "bun:test"
+import path from "node:path"
 import { $ } from "bun"
-import * as path from "path"
 
 const BUILD_HELPER = path.resolve(import.meta.dir, "..", "..", "scripts", "build-helper.ts")
 
 describe("build-helper.ts", () => {
-  // Test 1: Linux dry-run generates valid TypeScript hash map
-  test("linux --dry-run generates valid TypeScript hash map", async () => {
+  test("reports the Linux helper hash without proposing a source rewrite", async () => {
     const result = await $`bun run ${BUILD_HELPER} linux --dry-run`.nothrow().quiet()
     const stdout = result.stdout.toString()
 
     expect(result.exitCode).toBe(0)
-
-    // Verify the output contains the correct computed property syntax
-    expect(stdout).toContain("[path.join(os.homedir()")
-    expect(stdout).toContain('"synergy-sandbox-linux"')
-    expect(stdout).toContain("Record<string, string>")
-
-    // Must NOT contain the broken form (bare homedir without brackets)
-    expect(stdout).not.toMatch(/^\s+path\.join\(homedir,/m)
-
-    // Must use computed property brackets [ ]
-    expect(stdout).toMatch(/^\s+\[path\.join\(os\.homedir\(\)/m)
+    expect(stdout).toContain("synergy-sandbox-linux")
+    expect(stdout).toContain("SHA-256:")
+    expect(stdout).toContain("release builds embed this hash")
+    expect(stdout).not.toContain("TRUSTED_LINUX_HELPER_HASHES")
+    expect(stdout).not.toContain("Would update")
   })
 
-  // Test 2: Windows dry-run generates valid TypeScript hash map
-  test("windows --dry-run generates valid TypeScript hash map", async () => {
+  test("reports the Windows helper hash without proposing a source rewrite", async () => {
     const result = await $`bun run ${BUILD_HELPER} windows --dry-run`.nothrow().quiet()
     const stdout = result.stdout.toString()
 
     expect(result.exitCode).toBe(0)
-    expect(stdout).toContain("[path.join(os.homedir()")
-    expect(stdout).toContain('"synergy-sandbox-windows.exe"')
-    expect(stdout).not.toMatch(/^\s+path\.join\(homedir,/m)
-    expect(stdout).toMatch(/^\s+\[path\.join\(os\.homedir\(\)/m)
+    expect(stdout).toContain("synergy-sandbox-windows.exe")
+    expect(stdout).toContain("SHA-256:")
+    expect(stdout).not.toContain("TRUSTED_WINDOWS_HELPER_HASHES")
   })
 
-  // Test 3: --target flag changes binary path
-  test("--target x86_64-pc-windows-msvc uses target-specific release path", async () => {
+  test("uses the target-specific Cargo release path", async () => {
     const result = await $`bun run ${BUILD_HELPER} windows --dry-run --target x86_64-pc-windows-msvc`.nothrow().quiet()
     const stdout = result.stdout.toString().replace(/\\/g, "/")
 
@@ -47,38 +37,19 @@ describe("build-helper.ts", () => {
     expect(stdout).not.toContain("target/release/synergy-sandbox-windows.exe")
   })
 
-  // Test 4: --auto-update --dry-run shows what would be written
-  test("--auto-update --dry-run shows replacement without writing", async () => {
+  test("local dry-run installs the helper without changing tracked hash maps", async () => {
+    const result = await $`bun run ${BUILD_HELPER} linux --local --dry-run`.nothrow().quiet()
+    const stdout = result.stdout.toString()
+
+    expect(result.exitCode).toBe(0)
+    expect(stdout).toContain("Would install helper at:")
+    expect(stdout).not.toContain("Would update")
+  })
+
+  test("rejects the retired source hash update flags", async () => {
     const result = await $`bun run ${BUILD_HELPER} linux --auto-update --dry-run`.nothrow().quiet()
-    const stdout = result.stdout.toString()
 
-    expect(result.exitCode).toBe(0)
-    expect(stdout).toContain("[dry-run] Would update")
-    expect(stdout).toContain("[path.join(os.homedir()")
-    expect(stdout).toContain("TRUSTED_LINUX_HELPER_HASHES")
-  })
-
-  // Test 5: --target aarch64-unknown-linux-gnu
-  test("--target aarch64-unknown-linux-gnu uses target-specific path", async () => {
-    const result = await $`bun run ${BUILD_HELPER} linux --dry-run --target aarch64-unknown-linux-gnu`.nothrow().quiet()
-    const stdout = result.stdout.toString().replace(/\\/g, "/")
-
-    expect(result.exitCode).toBe(0)
-    expect(stdout).toContain("target: aarch64-unknown-linux-gnu")
-    expect(stdout).toContain("target/aarch64-unknown-linux-gnu/release")
-    expect(stdout).not.toContain("target/release/synergy-sandbox-linux")
-  })
-})
-
-describe("hash-helper replacement (build-helper --skip-build --dry-run)", () => {
-  test("console output generates valid TypeScript hash map using computed property syntax", async () => {
-    const result = await $`bun run ${BUILD_HELPER} linux --skip-build --dry-run`.nothrow().quiet()
-    const stdout = result.stdout.toString()
-
-    // Verify the output uses computed property syntax with os.homedir()
-    expect(stdout).toContain('[path.join(os.homedir(), ".synergy", "sandbox-helper"')
-
-    // Must NOT contain the broken form (bare homedir, no brackets)
-    expect(stdout).not.toMatch(/\spath\.join\(homedir,/)
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr.toString()).toContain("hashes are embedded")
   })
 })

--- a/packages/synergy/test/sandbox/helper-install.test.ts
+++ b/packages/synergy/test/sandbox/helper-install.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { isTarballHelperUpToDate } from "../../src/sandbox/utils"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  )
+})
+
+async function helperPair(source: Buffer, destination: Buffer) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-helper-install-"))
+  temporaryDirectories.push(root)
+  const sourcePath = path.join(root, "source-helper")
+  const destinationPath = path.join(root, "installed-helper")
+  await Promise.all([fs.writeFile(sourcePath, source), fs.writeFile(destinationPath, destination)])
+  return { sourcePath, destinationPath }
+}
+
+describe("sandbox helper installation", () => {
+  test("treats identical helper contents as current regardless of timestamps", async () => {
+    const helper = await helperPair(Buffer.alloc(2_048, 1), Buffer.alloc(2_048, 1))
+    const old = new Date("2020-01-01T00:00:00Z")
+    const recent = new Date("2030-01-01T00:00:00Z")
+    await fs.utimes(helper.sourcePath, old, old)
+    await fs.utimes(helper.destinationPath, recent, recent)
+
+    expect(isTarballHelperUpToDate(helper.sourcePath, helper.destinationPath)).toBe(true)
+  })
+
+  test("replaces a different installed helper even when its timestamp is newer", async () => {
+    const helper = await helperPair(Buffer.alloc(2_048, 1), Buffer.alloc(2_048, 2))
+    const old = new Date("2020-01-01T00:00:00Z")
+    const recent = new Date("2030-01-01T00:00:00Z")
+    await fs.utimes(helper.sourcePath, old, old)
+    await fs.utimes(helper.destinationPath, recent, recent)
+
+    expect(isTarballHelperUpToDate(helper.sourcePath, helper.destinationPath)).toBe(false)
+  })
+})

--- a/packages/synergy/test/sandbox/release-assets.test.ts
+++ b/packages/synergy/test/sandbox/release-assets.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createHash } from "node:crypto"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import {
+  copySandboxAsset,
+  resolveSandboxAsset,
+  sandboxAssetKey,
+  type SandboxRuntimeTarget,
+} from "../../script/sandbox-assets"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  )
+})
+
+async function fixture(target: SandboxRuntimeTarget, binaryName: string, binaryArch = target.arch) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-sandbox-release-"))
+  temporaryDirectories.push(root)
+  const source = path.join(root, sandboxAssetKey(target), binaryName)
+  const contents = Buffer.alloc(2_048, 7)
+  if (target.os === "linux") {
+    Buffer.from([0x7f, 0x45, 0x4c, 0x46]).copy(contents)
+    contents[4] = 2
+    contents[5] = 1
+    contents.writeUInt16LE(binaryArch === "x64" ? 62 : 183, 18)
+  } else if (target.os === "win32") {
+    Buffer.from("MZ").copy(contents)
+    contents.writeUInt32LE(0x80, 0x3c)
+    Buffer.from("PE\0\0").copy(contents, 0x80)
+    contents.writeUInt16LE(binaryArch === "x64" ? 0x8664 : 0xaa64, 0x84)
+  }
+  await fs.mkdir(path.dirname(source), { recursive: true })
+  await fs.writeFile(source, contents, { mode: 0o755 })
+  return { root, source, contents }
+}
+
+describe("sandbox release assets", () => {
+  test("maps baseline variants to the same architecture-specific helper", () => {
+    expect(sandboxAssetKey({ os: "linux", arch: "x64", avx2: false })).toBe("linux-x64")
+    expect(sandboxAssetKey({ os: "linux", arch: "x64", abi: "musl", avx2: false })).toBe("linux-x64-musl")
+    expect(sandboxAssetKey({ os: "win32", arch: "x64" })).toBe("windows-x64")
+  })
+
+  test("resolves and hashes the exact Linux helper for a runtime target", async () => {
+    const target = { os: "linux", arch: "x64", abi: "musl" } satisfies SandboxRuntimeTarget
+    const input = await fixture(target, "synergy-sandbox-linux")
+    const asset = resolveSandboxAsset(target, { assetsRoot: input.root, required: true })
+
+    expect(asset?.sourcePath).toBe(input.source)
+    expect(asset?.relativePath).toBe(path.join("sandbox", "synergy-sandbox-linux"))
+    expect(asset?.sha256).toBe(createHash("sha256").update(input.contents).digest("hex"))
+  })
+
+  test("copies the Windows helper into the packaged runtime layout", async () => {
+    const target = { os: "win32", arch: "x64" } satisfies SandboxRuntimeTarget
+    const input = await fixture(target, "synergy-sandbox-windows.exe")
+    const output = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-sandbox-output-"))
+    temporaryDirectories.push(output)
+    const asset = resolveSandboxAsset(target, { assetsRoot: input.root, required: true })
+    if (!asset) throw new Error("Expected a Windows sandbox asset")
+
+    copySandboxAsset(asset, output)
+
+    expect(await Bun.file(path.join(output, "sandbox", "synergy-sandbox-windows.exe")).arrayBuffer()).toEqual(
+      input.contents.buffer,
+    )
+  })
+
+  test("fails a required non-macOS build when its helper is missing", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-sandbox-missing-"))
+    temporaryDirectories.push(root)
+
+    expect(() => resolveSandboxAsset({ os: "linux", arch: "arm64" }, { assetsRoot: root, required: true })).toThrow(
+      /linux-arm64.*required/i,
+    )
+  })
+
+  test("rejects a helper built for the wrong architecture", async () => {
+    const input = await fixture({ os: "linux", arch: "arm64" }, "synergy-sandbox-linux", "x64")
+
+    expect(() =>
+      resolveSandboxAsset({ os: "linux", arch: "arm64" }, { assetsRoot: input.root, required: true }),
+    ).toThrow(/linux-arm64.*matching 64-bit ELF/i)
+  })
+
+  test("does not require a helper for macOS", () => {
+    expect(resolveSandboxAsset({ os: "darwin", arch: "arm64" }, { required: true })).toBeUndefined()
+  })
+})

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -727,7 +727,6 @@ async function runPrepare(repoRoot: string, bunPath: string): Promise<number> {
   }
   const target = platform === "linux" ? "linux" : "windows"
   const sandbox = await runSerial([
-    { label: "sandbox", command: ["cargo", "build", "--release"], cwd: helperDir },
     {
       label: "sandbox",
       command: [bunPath, "run", "packages/synergy/scripts/build-helper.ts", target, "--local"],

--- a/script/install.test.ts
+++ b/script/install.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  )
+})
+
+describe("CLI bundle installer", () => {
+  test("preserves the packaged sandbox helper beside the installed runtime", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-install-test-"))
+    temporaryDirectories.push(root)
+    const home = path.join(root, "home")
+    const bundle = path.join(root, "bundle")
+    await Promise.all([
+      fs.mkdir(path.join(bundle, "bin"), { recursive: true }),
+      fs.mkdir(path.join(bundle, "app"), { recursive: true }),
+      fs.mkdir(path.join(bundle, "schema"), { recursive: true }),
+      fs.mkdir(path.join(bundle, "sandbox"), { recursive: true }),
+    ])
+    await Promise.all([
+      fs.writeFile(path.join(bundle, "bin", "synergy"), "runtime"),
+      fs.writeFile(path.join(bundle, "app", "index.html"), "app"),
+      fs.writeFile(path.join(bundle, "schema", "config.schema.json"), "{}"),
+      fs.writeFile(path.join(bundle, "sandbox", "synergy-sandbox-linux"), "helper"),
+    ])
+
+    const installScript = path.resolve(import.meta.dir, "..", "install")
+    const command =
+      'install_script="$1"; bundle="$2"; set --; source "$install_script"; install_bundle_contents "$bundle"; has_complete_bundle'
+    const result = Bun.spawnSync({
+      cmd: ["bash", "-c", command, "bash", installScript, bundle],
+      env: { ...process.env, HOME: home, SYNERGY_INSTALL_LIBRARY_MODE: "1", SYNERGY_INSTALL_PLATFORM: "Linux" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(await Bun.file(path.join(home, ".synergy", "sandbox", "synergy-sandbox-linux")).text()).toBe("helper")
+  })
+
+  test("does not treat an existing Linux install without its sandbox helper as complete", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-install-incomplete-"))
+    temporaryDirectories.push(root)
+    const home = path.join(root, "home")
+    await fs.mkdir(path.join(home, ".synergy", "app"), { recursive: true })
+    await fs.mkdir(path.join(home, ".synergy", "schema"), { recursive: true })
+    await fs.writeFile(path.join(home, ".synergy", "app", "index.html"), "app")
+    await fs.writeFile(path.join(home, ".synergy", "schema", "config.schema.json"), "{}")
+
+    const installScript = path.resolve(import.meta.dir, "..", "install")
+    const command = 'install_script="$1"; set --; source "$install_script"; has_complete_bundle'
+    const result = Bun.spawnSync({
+      cmd: ["bash", "-c", command, "bash", installScript],
+      env: { ...process.env, HOME: home, SYNERGY_INSTALL_LIBRARY_MODE: "1", SYNERGY_INSTALL_PLATFORM: "Linux" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    expect(result.exitCode).not.toBe(0)
+  })
+})

--- a/script/release/nodes/validate-local-artifacts.test.ts
+++ b/script/release/nodes/validate-local-artifacts.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { requiredRuntimeArtifactPaths } from "./validate-local-artifacts"
+
+describe("release runtime artifact contract", () => {
+  test("requires the Linux sandbox helper in every Linux package variant", () => {
+    expect(requiredRuntimeArtifactPaths("synergy-linux-x64")).toContain("sandbox/synergy-sandbox-linux")
+    expect(requiredRuntimeArtifactPaths("synergy-linux-x64-baseline-musl")).toContain("sandbox/synergy-sandbox-linux")
+  })
+
+  test("requires the Windows sandbox helper", () => {
+    expect(requiredRuntimeArtifactPaths("synergy-windows-x64")).toContain("sandbox/synergy-sandbox-windows.exe")
+  })
+
+  test("does not require a helper on macOS", () => {
+    expect(requiredRuntimeArtifactPaths("synergy-darwin-arm64")).not.toContain("sandbox/synergy-sandbox-linux")
+    expect(requiredRuntimeArtifactPaths("synergy-darwin-arm64")).not.toContain("sandbox/synergy-sandbox-windows.exe")
+  })
+})

--- a/script/release/nodes/validate-local-artifacts.ts
+++ b/script/release/nodes/validate-local-artifacts.ts
@@ -3,6 +3,14 @@ import fs from "fs"
 import path from "path"
 import { APP_DIST_DIR, SYNERGY_DIR, SYNERGY_DIST_DIR } from "../shared/packages"
 
+export function requiredRuntimeArtifactPaths(name: string): string[] {
+  const binaryRelative = name.includes("windows") ? "bin/synergy.exe" : "bin/synergy"
+  const required = [binaryRelative, "app/index.html", "schema/config.schema.json"]
+  if (name.includes("linux")) required.push("sandbox/synergy-sandbox-linux")
+  if (name.includes("windows")) required.push("sandbox/synergy-sandbox-windows.exe")
+  return required
+}
+
 export async function validateLocalArtifacts(platformPackageNames: string[]) {
   console.log("\n=== validate local artifacts ===\n")
 
@@ -24,8 +32,7 @@ export async function validateLocalArtifacts(platformPackageNames: string[]) {
 
   for (const name of platformPackageNames) {
     const baseDir = path.join(SYNERGY_DIST_DIR, name)
-    const binaryRelative = name.includes("windows") ? "bin/synergy.exe" : "bin/synergy"
-    for (const relative of [binaryRelative, "app/index.html", "schema/config.schema.json"]) {
+    for (const relative of requiredRuntimeArtifactPaths(name)) {
       if (!fs.existsSync(path.join(baseDir, relative))) {
         throw new Error(`missing ${relative} in ${baseDir}`)
       }

--- a/script/release/validate-product-environment.test.ts
+++ b/script/release/validate-product-environment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { generateKeyPairSync } from "node:crypto"
+import { validateProductReleaseEnvironment } from "./validate-product-environment"
+
+function environment() {
+  const pair = generateKeyPairSync("ed25519")
+  const publicJwk = pair.publicKey.export({ format: "jwk" })
+  if (!publicJwk.x) throw new Error("Missing fixture Ed25519 public key")
+  return {
+    NPM_TOKEN: "npm-token",
+    BROWSER_HOST_MANIFEST_SIGNING_KEY: pair.privateKey.export({ format: "der", type: "pkcs8" }).toString("base64"),
+    BROWSER_HOST_MANIFEST_PUBLIC_KEY: Buffer.from(publicJwk.x, "base64url").toString("base64"),
+    APPLE_ID: "release@example.com",
+    APPLE_APP_SPECIFIC_PASSWORD: "app-password",
+    APPLE_TEAM_ID: "team-id",
+    CSC_LINK: "mac-certificate",
+    CSC_KEY_PASSWORD: "mac-certificate-password",
+    WINDOWS_CERTIFICATE: "windows-certificate",
+    WINDOWS_CERTIFICATE_PASSWORD: "windows-certificate-password",
+  }
+}
+
+describe("product release environment", () => {
+  test("accepts complete signing material with a matching Browser Host key pair", () => {
+    expect(() => validateProductReleaseEnvironment(environment())).not.toThrow()
+  })
+
+  test("rejects missing signing material before publishing a candidate", () => {
+    const env = environment()
+    delete (env as Partial<typeof env>).WINDOWS_CERTIFICATE
+    expect(() => validateProductReleaseEnvironment(env)).toThrow(/WINDOWS_CERTIFICATE/)
+  })
+
+  test("rejects a mismatched Browser Host key pair", () => {
+    const env = environment()
+    env.BROWSER_HOST_MANIFEST_PUBLIC_KEY = environment().BROWSER_HOST_MANIFEST_PUBLIC_KEY
+    expect(() => validateProductReleaseEnvironment(env)).toThrow(/do not match/)
+  })
+})

--- a/script/release/validate-product-environment.ts
+++ b/script/release/validate-product-environment.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env bun
+
+import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto"
+
+const REQUIRED_RELEASE_ENV = [
+  "NPM_TOKEN",
+  "BROWSER_HOST_MANIFEST_SIGNING_KEY",
+  "BROWSER_HOST_MANIFEST_PUBLIC_KEY",
+  "APPLE_ID",
+  "APPLE_APP_SPECIFIC_PASSWORD",
+  "APPLE_TEAM_ID",
+  "CSC_LINK",
+  "CSC_KEY_PASSWORD",
+  "WINDOWS_CERTIFICATE",
+  "WINDOWS_CERTIFICATE_PASSWORD",
+] as const
+
+export function validateProductReleaseEnvironment(env: Record<string, string | undefined>): void {
+  const missing = REQUIRED_RELEASE_ENV.filter((name) => !env[name]?.trim())
+  if (missing.length > 0) throw new Error(`Product release environment is missing: ${missing.join(", ")}`)
+
+  const privateKey = createPrivateKey({
+    key: Buffer.from(env.BROWSER_HOST_MANIFEST_SIGNING_KEY!, "base64"),
+    format: "der",
+    type: "pkcs8",
+  })
+  const publicKeyBytes = Buffer.from(env.BROWSER_HOST_MANIFEST_PUBLIC_KEY!, "base64")
+  if (publicKeyBytes.byteLength !== 32) {
+    throw new Error("BROWSER_HOST_MANIFEST_PUBLIC_KEY must be a 32-byte raw Ed25519 public key")
+  }
+  const spkiPrefix = Buffer.from("302a300506032b6570032100", "hex")
+  const publicKey = createPublicKey({ key: Buffer.concat([spkiPrefix, publicKeyBytes]), format: "der", type: "spki" })
+  const challenge = Buffer.from("synergy-browser-host-release-key-pair")
+  const signature = sign(null, challenge, privateKey)
+  if (!verify(null, challenge, publicKey, signature)) {
+    throw new Error("Browser Host manifest signing and public keys do not match")
+  }
+}
+
+if (import.meta.main) {
+  validateProductReleaseEnvironment(process.env)
+  console.log("Product release signing environment is valid")
+}


### PR DESCRIPTION
## Summary

- build Linux x64/arm64 glibc+musl and Windows x64 sandbox helpers before Stable compilation, validate their executable format, and embed the matching SHA-256 in each runtime
- preserve helpers through npm, curl, and Desktop packaging; declare Bubblewrap for Debian and report it as a portable Linux prerequisite
- fail product releases before candidate publication when helper assets, Browser Host trust keys, or signing material are incomplete
- discover current Playwright and Windows Chromium layouts, and keep Stable Windows Desktop/runtime on x64 while retaining x64/arm64 Browser Host artifacts

## Verification

- `bun run workflow:check`
- `bun run quality:quick`
- release-focused suites: 113 passed, 0 failed
- Desktop full suite: 78 passed, 2 platform smoke tests skipped, 0 failed
- `bash -n install`
- GitHub CI: all 11 checks passed, including clean full tests and native Linux x64/arm64 plus Windows x64 helper builds

## Local environment note

A local full-graph run encountered an unchanged Plugin Kit Solid fixture failure and a host-specific proxy-hit assertion. Neither test file differs from `origin/dev`; the clean GitHub CI run passes both the non-Synergy package tests and the complete Synergy test suite.
