### PR TITLE
fix(session): bound active session memory

### DIFF
--- a/docs/architecture/llm-loop.md
+++ b/docs/architecture/llm-loop.md
@@ -20,7 +20,7 @@ During ownership:
 - all loop writes update that cache and durable storage;
 - cache and recall state are released when the loop exits.
 
-The message cache is valid because the active loop is the sole session writer. On a cold read, history loading scans ordered message info, applies rollback events, finds the latest committed compaction boundary, and loads parts only for the boundary root, retained summaries, and active suffix. Completed compaction reprojects the cache immediately so pre-boundary parts are released. Structural changes that incremental maintenance cannot model invalidate the cache and force an authoritative working-set reread; full transcript paths remain disk-backed.
+The message cache is valid because the active loop is the sole session writer. On a cold read, history loading scans ordered message info, applies rollback events, finds the latest committed compaction boundary, and loads parts only for the boundary root, retained summaries, and active suffix. Completed compaction reprojects the cache immediately so pre-boundary parts are released. Structural changes that incremental maintenance cannot model invalidate the cache and force an authoritative working-set reread; full transcript paths remain disk-backed. The process-wide cache byte budget is also a hard ceiling for each session entry: an oversized working set remains disk-backed instead of defeating aggregate eviction.
 
 ## Root Selection
 
@@ -260,6 +260,8 @@ It operates on the loop's existing immutable working-set snapshot, and its `Sess
 Text, reasoning, and tool parts are persisted throughout the step. Streaming text/reasoning writes are coalesced at a short write-behind interval; terminal and discrete updates flush immediately. Before a turn finalizes, pending writes are flushed so a missing terminal callback cannot silently lose accumulated text.
 
 Every `LLM.stream()` consumer takes one owned full stream, text stream, or text promise through the shared `LLM` ownership helpers. Those helpers immediately cancel the residual branch retained by the AI SDK's internal stream tee and settle that cancellation after the consumed branch finishes. Normal turn completion also removes the session-abort listener and closes the per-turn combined signal; settled streams cannot remain anchored until the whole session exits.
+
+After a normally settled model turn, the loop clears large prompt, tool, projection, and provenance containers in place before dropping its local references. In-place clearing is required because the JavaScript runtime may keep values captured across an `await` reachable through the async frame even after local reassignment. A timed-out processor may still be consuming its input, so that abandoned path drops loop references without mutating the shared containers.
 
 Provider SSE input passes through a 16 MiB per-event **SSE event parser bound** before it enters the AI SDK parser. The bound terminates an event whose encoded bytes exceed that threshold, preventing unbounded parser state for one unterminated event; it is not a limit on the total response, transport chunk size, or process memory. Streamed tool-call input is bounded independently at 1 MiB for both incremental deltas and final-only provider calls, and an oversized call is rejected before tool execution with terminal tool and assistant errors.
 

--- a/docs/architecture/session-and-messages.md
+++ b/docs/architecture/session-and-messages.md
@@ -146,6 +146,8 @@ Transcript consumers use the ordered message array as the chronology. Current me
 
 `Session.messagePage()` and `GET /session/:sessionID/message/page` (`operationId: session.messagePage`) provide additive cursor-based pagination over effective session history. The existing `Session.messages()` and `GET /session/:sessionID/message` remain unchanged and are the correct path for runtime loops, export, preview, and flat consumers that need the complete message array or a simple tail slice.
 
+Pagination scans lightweight message info to establish effective history, cursor position, and referenced roots, then hydrates parts only for the selected page and those roots with bounded concurrency. Legacy records whose canonical semantics depend on parts are hydrated during read-time derivation; current records outside the requested page are not.
+
 ### Query parameters
 
 | Parameter | Type     | Meaning                                                                                  |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -457,7 +457,7 @@ Domain files are the durable configuration contract. Environment variables are p
 | `SYNERGY_EXPERIMENTAL_LSP_TOOL=1`    | Register the experimental direct LSP tool                                                    |
 | `SYNERGY_DISABLE_MESSAGE_CACHE=1`    | Bypass the loop-scoped model-working-set cache and reconstruct it from storage on every read |
 | `SYNERGY_VERIFY_MESSAGE_CACHE=1`     | Compare the cached model working set with storage and fall back when they diverge            |
-| `SYNERGY_SESSION_CACHE_MAX_BYTES`    | Set the aggregate model-working-set cache byte budget; the default is 256 MiB                |
+| `SYNERGY_SESSION_CACHE_MAX_BYTES`    | Set the aggregate and per-session model-working-set cache byte budget; defaults to 256 MiB   |
 | `SYNERGY_DISABLE_LSP_REAP=1`         | Keep idle LSP clients instead of reaping and recreating them on demand                       |
 | `SYNERGY_LSP_MAX_CLIENTS_PER_SERVER` | Set the per-language-server client cap; the minimum is one and the default is two            |
 

--- a/packages/synergy/src/session/history.ts
+++ b/packages/synergy/src/session/history.ts
@@ -12,11 +12,12 @@ import { Log } from "@/util/log"
 import { MessageV2 } from "./message-v2"
 import { SessionMessageCache } from "./message-cache"
 import { applyModelWorkingSetProjection, modelWorkingSetProjection } from "./model-working-set"
-
-const log = Log.create({ service: "session.history" })
 import { SessionManager } from "./manager"
 import { Snapshot } from "./snapshot"
 import type { Info } from "./types"
+
+const log = Log.create({ service: "session.history" })
+const PAGE_HYDRATION_CONCURRENCY = 16
 
 export namespace SessionHistory {
   const { asScopeID, asSessionID, asHistoryID, asMessageID } = Identifier
@@ -387,14 +388,26 @@ export namespace SessionHistory {
     cursor?: string
     limit?: number
   }): Promise<MessagePage> {
-    const raw = await rawMessages({ sessionID: input.sessionID })
-    const messages = applyEvents(raw, await readEvents(input.sessionID))
+    const [infos, events] = await Promise.all([readMessageInfo(input.sessionID), readEvents(input.sessionID)])
+    const loadedParts = new Map<string, MessageV2.Part[]>()
+    const loadParts = async (messageID: string) => {
+      const cached = loadedParts.get(messageID)
+      if (cached) return cached
+      const parts = await MessageV2.parts({ sessionID: input.sessionID, messageID }).catch((error) => {
+        log.warn("skipping unreadable message parts", { sessionID: input.sessionID, messageID, error: String(error) })
+        return [] as MessageV2.Part[]
+      })
+      loadedParts.set(messageID, parts)
+      return parts
+    }
+    const canonicalInfos = await deriveInfoSemantics(infos, loadParts)
+    const messages = applyEventsToInfo(canonicalInfos, events)
     const total = messages.length
     let end = total
 
     if (input.cursor) {
       const cursor = decodeMessagePageCursor(input.cursor)
-      end = messages.findIndex((message) => message.info.id === cursor.a)
+      end = messages.findIndex((message) => message.id === cursor.a)
       if (end === -1) {
         throw new MessagePageCursorStaleError({
           message: "Session message cursor no longer exists in effective history",
@@ -405,21 +418,36 @@ export namespace SessionHistory {
 
     const limit = input.limit ?? 200
     const start = Math.max(0, end - limit)
-    const items = messages.slice(start, end)
-    const included = new Set(items.map((message) => message.info.id))
+    const itemInfos = messages.slice(start, end)
+    const included = new Set(itemInfos.map((message) => message.id))
     const rootIDs = new Set(
-      items
-        .map((message) => message.info.rootID)
+      itemInfos
+        .map((message) => message.rootID)
         .filter((rootID): rootID is string => !!rootID && !included.has(rootID)),
     )
-    const referencedRoots = rootIDs.size ? messages.filter((message) => rootIDs.has(message.info.id)) : []
+    const referencedRootInfos = rootIDs.size ? messages.filter((message) => rootIDs.has(message.id)) : []
+    const selectedIDs = new Set([...included, ...referencedRootInfos.map((message) => message.id)])
+    const selected = messages.filter((message) => selectedIDs.has(message.id))
+    const hydrated = await mapWithConcurrency(selected, PAGE_HYDRATION_CONCURRENCY, async (info) => ({
+      info,
+      parts: await loadParts(info.id),
+    }))
+    const byID = new Map(MessageV2.deriveSemantics(hydrated).map((message) => [message.info.id, message]))
+    const items = itemInfos.flatMap((info) => {
+      const message = byID.get(info.id)
+      return message ? [message] : []
+    })
+    const referencedRoots = referencedRootInfos.flatMap((info) => {
+      const message = byID.get(info.id)
+      return message ? [message] : []
+    })
     const hasMore = start > 0
-    const oldest = items[0]
+    const oldest = itemInfos[0]
 
     return {
       items,
       referencedRoots,
-      nextCursor: hasMore && oldest ? encodeMessagePageCursor({ v: 1, a: oldest.info.id, d: "before" }) : null,
+      nextCursor: hasMore && oldest ? encodeMessagePageCursor({ v: 1, a: oldest.id, d: "before" }) : null,
       hasMore,
       total,
     }
@@ -482,17 +510,40 @@ export namespace SessionHistory {
     loadParts: (messageID: string) => Promise<MessageV2.Part[]>,
   ) {
     if (activeRollbacks(events).length === 0) return messages
+    return deriveInfoSemantics(messages, loadParts)
+  }
+
+  async function deriveInfoSemantics(
+    messages: MessageV2.Info[],
+    loadParts: (messageID: string) => Promise<MessageV2.Part[]>,
+  ) {
     const legacy = new Set(
-      messages.flatMap((message) => (message.role === "user" && message.isRoot === undefined ? [message.id] : [])),
+      messages.flatMap((message) => {
+        if (message.role !== "user") return []
+        if (message.isRoot !== undefined && message.rootID !== undefined) return []
+        return [message.id]
+      }),
     )
-    if (legacy.size === 0) return messages
-    const withParts = await Promise.all(
-      messages.map(async (info) => ({
-        info,
-        parts: legacy.has(info.id) ? await loadParts(info.id) : [],
-      })),
-    )
+    const needsDerivation = legacy.size > 0 || messages.some((message) => message.rootID === undefined)
+    if (!needsDerivation) return messages
+    const withParts = await mapWithConcurrency(messages, PAGE_HYDRATION_CONCURRENCY, async (info) => ({
+      info,
+      parts: legacy.has(info.id) ? await loadParts(info.id) : [],
+    }))
     return MessageV2.deriveSemantics(withParts).map((message) => message.info)
+  }
+
+  async function mapWithConcurrency<T, U>(items: T[], concurrency: number, fn: (item: T) => Promise<U>) {
+    const result = new Array<U>(items.length)
+    let next = 0
+    const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (next < items.length) {
+        const index = next++
+        result[index] = await fn(items[index])
+      }
+    })
+    await Promise.all(workers)
+    return result
   }
 
   function applyEventsToInfo(messages: MessageV2.Info[], events: Event[]) {
@@ -616,7 +667,10 @@ export namespace SessionHistory {
     const messages = await Storage.readMany<MessageV2.Info>(
       ids.map((id) => StoragePath.messageInfo(scopeID, asSessionID(sessionID), asMessageID(id))),
     )
-    return messages.filter((msg): msg is MessageV2.Info => !!msg).sort(MessageV2.compareStorageOrder)
+    return messages
+      .filter((msg): msg is MessageV2.Info => !!msg)
+      .map(MessageV2.canonicalMessage)
+      .sort(MessageV2.compareStorageOrder)
   }
 
   function canUnrollbackInfo(messages: MessageV2.Info[], event: RollbackEvent) {

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -835,19 +835,42 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
 
         let streamInput: LLM.StreamInput | undefined
         function releaseTurnReferences(mutateStreamInput: boolean) {
+          if (mutateStreamInput) {
+            toolDefinitions.length = 0
+            systemParts.length = 0
+            lateSystemParts.length = 0
+            modelSessionMessages.length = 0
+            modelProjection.messages.length = 0
+            for (const contributions of Object.values(modelProjection.provenance.categories)) {
+              contributions.length = 0
+            }
+            preparedMessages.length = 0
+            promptPlan?.system.splice(0)
+            promptPlan?.lateSystem?.splice(0)
+            promptPlan?.messages.splice(0)
+            promptPlan?.toolDefinitions.splice(0)
+            resolvedTools?.activeToolIDs.splice(0)
+            if (resolvedTools) {
+              for (const id of Object.keys(resolvedTools.tools)) delete resolvedTools.tools[id]
+            }
+            activeToolIDs.clear()
+            for (const provenance of [plannedHistoryProvenance, contextUsageProvenance]) {
+              for (const contributions of Object.values(provenance.categories)) contributions.length = 0
+            }
+            if (streamInput) {
+              streamInput.system.splice(0)
+              streamInput.lateSystem?.splice(0)
+              streamInput.messages.splice(0)
+              for (const id of Object.keys(streamInput.tools)) delete streamInput.tools[id]
+              streamInput.activeToolIDs?.splice(0)
+            }
+          }
           toolDefinitions = []
           systemParts = []
           lateSystemParts = []
           modelSessionMessages = []
           preparedMessages = []
           promptDecision = undefined
-          if (mutateStreamInput && streamInput) {
-            streamInput.system = []
-            streamInput.lateSystem = undefined
-            streamInput.messages = []
-            streamInput.tools = {}
-            streamInput.activeToolIDs = undefined
-          }
           promptPlan = undefined
           resolvedTools = undefined
           streamInput = undefined
@@ -1026,7 +1049,7 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
       }
 
       if (processedRootID) {
-        const messages = await Session.messages({ sessionID })
+        const messages = await SessionHistory.modelMessages({ sessionID })
         const terminalReply = SessionProgress.findTerminalReply(messages, processedRootID)
         if (terminalReply?.info.role === "assistant" && terminalReply.info.id !== previousTerminalReplyID) {
           await Session.recordCompletionNotice(sessionID, { publishEvent: !terminalReply.info.error })

--- a/packages/synergy/src/session/message-cache.ts
+++ b/packages/synergy/src/session/message-cache.ts
@@ -62,8 +62,13 @@ export namespace SessionMessageCache {
   export function set(sessionID: string, messages: MessageV2.WithParts[]) {
     if (!active.has(sessionID)) return
     const workingSet = projectModelWorkingSet(messages)
+    const size = estimateList(workingSet)
+    if (size > byteBudget()) {
+      drop(sessionID)
+      return
+    }
     cache.set(sessionID, workingSet)
-    setSize(sessionID, estimateList(workingSet))
+    setSize(sessionID, size)
     touch(sessionID)
     evict(sessionID)
   }
@@ -176,13 +181,13 @@ export namespace SessionMessageCache {
     sizes.set(sessionID, current + bytes)
   }
 
-  // Evict least-recently-used entries until under budget, never evicting the
-  // session currently being written (it would just re-read on the next step and
-  // thrash). A single over-budget session is left resident: shrinking its own
-  // working set would force a disk re-read every step.
+  // Evict least-recently-used entries until under budget. The current writer is
+  // protected only while its own entry fits the budget; a single oversized
+  // working set must not make the aggregate limit ineffective.
   function evict(protect: string) {
     const budget = byteBudget()
     if (totalBytes <= budget) return
+    if ((sizes.get(protect) ?? 0) > budget) drop(protect)
     for (let i = 0; i < lru.length && totalBytes > budget; ) {
       const victim = lru[i]
       if (victim === protect) {

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -570,8 +570,8 @@ describe("SessionInvoke system prompt assembly", () => {
       ;(ToolResolver.definitions as any) = mock(async () => [])
       ;(ToolResolver.resolveWithAvailability as any) = mock(async () => ({ tools: {}, activeToolIDs: [] }))
       ;(PromptBudgeter.buildPlan as any) = mock(async (input: Parameters<typeof PromptBudgeter.buildPlan>[0]) => {
-        capturedSystem = input.system
-        capturedLateSystem = input.lateSystem
+        capturedSystem = [...input.system]
+        capturedLateSystem = input.lateSystem ? [...input.lateSystem] : undefined
         return {
           system: input.system,
           systemCacheBreakpoint: input.systemCacheBreakpoint,
@@ -668,7 +668,7 @@ describe("SessionInvoke context usage provenance", () => {
       toolDefinitions,
       activeToolIDs: ["active_tool"],
       onProcess: async (input) => {
-        toolContributions = input.contextUsageProvenance.categories.toolActivity
+        toolContributions = [...input.contextUsageProvenance.categories.toolActivity]
       },
     })
 
@@ -701,7 +701,7 @@ describe("SessionInvoke context usage provenance", () => {
         toolDefinitions: input.toolDefinitions,
       }),
       onProcess: async (input) => {
-        conversationContributions = input.contextUsageProvenance.categories.conversation
+        conversationContributions = [...input.contextUsageProvenance.categories.conversation]
       },
     })
 
@@ -1294,6 +1294,34 @@ describe("SessionInvoke completion notices", () => {
     }
   })
 
+  test("records completion without loading the full session history", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalMessages = Session.messages
+    let activeSessionID = ""
+    const restore = installBasicLoopMocks()
+    ;(Session.messages as any) = mock(async () => {
+      throw new Error("full session history must not be loaded after root completion")
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect((await Session.get(session.id)).completionNotice.unreadCount).toBe(1)
+        },
+      })
+    } finally {
+      ;(Session.messages as any) = originalMessages
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
   test("silent session completion leaves unread false", async () => {
     await using tmp = await tmpdir({ git: true })
     let activeSessionID = ""
@@ -1392,6 +1420,51 @@ describe("SessionInvoke completion notices", () => {
 })
 
 describe("SessionInvoke turn lifecycle", () => {
+  test("clears prompt containers in place after processor completion", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    let retainedMessages: unknown[] | undefined
+    let retainedSystem: unknown[] | undefined
+    let retainedToolIDs: string[] | undefined
+    let retainedTools: Record<string, unknown> | undefined
+    const restore = installBasicLoopMocks({
+      toolDefinitions: [
+        {
+          id: "memory_probe",
+          description: "Large prompt lifecycle probe",
+          inputSchema: { type: "object", properties: {} },
+          execute: async () => ({ output: "ok", title: "probe", metadata: {} }),
+        } as ToolResolver.Definition,
+      ],
+      activeToolIDs: ["memory_probe"],
+      onProcess(input) {
+        retainedMessages = input.messages
+        retainedSystem = input.system
+        retainedToolIDs = input.activeToolIDs
+        retainedTools = input.tools
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+          await SessionInvoke.loop.force(session.id)
+        },
+      })
+
+      expect(retainedMessages?.length).toBe(0)
+      expect(retainedSystem?.length).toBe(0)
+      expect(retainedToolIDs?.length).toBe(0)
+      expect(Object.keys(retainedTools ?? {})).toEqual([])
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
   test("keeps the loop message cache populated across pre-jobs", async () => {
     await using tmp = await tmpdir({ git: true })
     let activeSessionID = ""

--- a/packages/synergy/test/session/message-cache.test.ts
+++ b/packages/synergy/test/session/message-cache.test.ts
@@ -169,7 +169,7 @@ describe("SessionMessageCache", () => {
     const B = "ses_evict_b"
     const previous = process.env.SYNERGY_SESSION_CACHE_MAX_BYTES
     // Tiny budget so a single populated session already approaches it.
-    process.env.SYNERGY_SESSION_CACHE_MAX_BYTES = "300"
+    process.env.SYNERGY_SESSION_CACHE_MAX_BYTES = "700"
     try {
       const big = (sid: string): MessageV2.WithParts => ({
         info: { id: "msg_1", sessionID: sid, role: "user" } as any,
@@ -190,6 +190,26 @@ describe("SessionMessageCache", () => {
     } finally {
       SessionMessageCache.disable(A)
       SessionMessageCache.disable(B)
+      if (previous === undefined) delete process.env.SYNERGY_SESSION_CACHE_MAX_BYTES
+      else process.env.SYNERGY_SESSION_CACHE_MAX_BYTES = previous
+    }
+  })
+
+  test("does not retain one session whose working set exceeds the byte budget", () => {
+    const previous = process.env.SYNERGY_SESSION_CACHE_MAX_BYTES
+    process.env.SYNERGY_SESSION_CACHE_MAX_BYTES = "300"
+    try {
+      SessionMessageCache.enable(SID)
+      SessionMessageCache.set(SID, [
+        {
+          info: { id: "msg_1", sessionID: SID, role: "user" } as any,
+          parts: [part("prt_1", "msg_1", "x".repeat(500))],
+        },
+      ])
+
+      expect(SessionMessageCache.get(SID)).toBeUndefined()
+    } finally {
+      SessionMessageCache.disable(SID)
       if (previous === undefined) delete process.env.SYNERGY_SESSION_CACHE_MAX_BYTES
       else process.env.SYNERGY_SESSION_CACHE_MAX_BYTES = previous
     }

--- a/packages/synergy/test/session/message-page.test.ts
+++ b/packages/synergy/test/session/message-page.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { Identifier } from "../../src/id/id"
 import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
@@ -175,6 +175,40 @@ describe("session message cursor pages", () => {
         }
       },
     })
+  })
+
+  test("does not hydrate parts outside the requested page", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const originalParts = MessageV2.parts
+    const loadedMessageIDs: string[] = []
+    ;(MessageV2.parts as any) = mock(async (input: Parameters<typeof MessageV2.parts>[0]) => {
+      loadedMessageIDs.push(input.messageID)
+      return originalParts(input)
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({ title: "Bounded page hydration" })
+          const ids = [1, 2, 3, 4].map((value) => legacyMessageID(value))
+          for (const [index, id] of ids.entries()) {
+            await writeUser(session.id, id, 1_000 + index)
+          }
+
+          const latest = await Session.messagePage({ sessionID: session.id, limit: 2 })
+
+          expect(latest.items.map((message) => message.info.id)).toEqual(ids.slice(2))
+          expect(latest.total).toBe(4)
+          expect(latest.hasMore).toBe(true)
+          expect(loadedMessageIDs).toEqual(ids.slice(2))
+
+          await Session.remove(session.id)
+        },
+      })
+    } finally {
+      ;(MessageV2.parts as any) = originalParts
+    }
   })
 
   test("rejects malformed, unsupported, and stale cursors", async () => {


### PR DESCRIPTION
## Summary

- enforce the model working-set cache budget as both an aggregate limit and a per-session hard ceiling
- paginate session history from lightweight message info and hydrate only page items plus referenced roots with bounded concurrency
- use the compaction-aware model history when checking root task completion instead of loading the full transcript
- clear prompt, tool, projection, and provenance containers in place after settled model turns to reduce retention across async frames

## Rationale

The observed failure is process-wide rather than a corrupt-session or model context-length failure. Bun uses JavaScriptCore, and values captured across await can remain reachable through an async frame after local reassignment; in-place container clearing avoids retaining their large contents. This is a mitigation for the runtime behavior tracked in https://github.com/oven-sh/bun/issues/28741, not a claim that the engine-level issue is fixed here.

## Verification

- bun test test/session/message-cache.test.ts test/session/message-page.test.ts test/session/invoke.test.ts: 48 passed
- adjacent history, rollback, compaction, message, memory-pressure, and stream-lifecycle suites: 53 passed
- bun run quality:quick: passed
- bun run test:changed: 2896 passed, 2 skipped; one unrelated config test exceeded its 5 second timeout under suite load and passed standalone, while test/provider/proxy.test.ts fails identically on the unmodified origin/dev baseline
