### PR TITLE
fix: bundle Solid compiler in runtime builds

### DIFF
--- a/.synergy/skill/change-plugin-runtime/SKILL.md
+++ b/.synergy/skill/change-plugin-runtime/SKILL.md
@@ -26,12 +26,13 @@ description: Add, modify, or review Synergy Plugin API 3 definitions, generated 
 10. Use host-declared observer/transform/guard hook points with deterministic ordering and contribution-level degradation.
 11. For trusted UI, enforce approval, UI API major, plugin-kit Solid compilation, host runtime linking, named exports, artifact hash, Scope/Session context, and one disposer per registration. Resource identity includes opaque `id/title/state`; reuse the same panel/resource tab and keep distinct resources separate. Keep themes and icons as validated, namespaced data contributions; themes use the shared structured JSON schema, never arbitrary CSS.
 12. Preserve transactional install/update/remove rollback and explicit lifecycle failure semantics. Synergy must not guess how to migrate or delete plugin-owned business data.
+13. Keep compiler dependencies reachable from the packaged Synergy CLI statically analyzable so Bun includes them in standalone executables. A package dependency in `node_modules` is not sufficient for runtime `require()` from `/$bunfs`.
 
 ## Verify
 
 1. Add or update behavior tests at the owning boundary: descriptor/schema, plugin-kit build/validate/pack/sign, metadata-only discovery, approval, transaction rollback, runtime generation, operation/event/hook contract, server route, or Web registration lifecycle.
 2. Cover duplicate IDs, undeclared capabilities, handler mismatch, invalid schemas/hashes, disabled Scope, timeout/cancel/crash, stale generation, trusted UI export/runtime mismatch, upgrade failure, and force uninstall when relevant.
-3. Run public package typecheck/build, inspect a packed artifact, run focused host/Web tests, regenerate OpenAPI/SDK or config schema when their sources change, and finish with `bun run quality:quick`.
+3. Run public package typecheck/build, inspect a packed artifact, and verify a compiled standalone executable can invoke compiler-backed commands. Run focused host/Web tests, regenerate OpenAPI/SDK or config schema when their sources change, and finish with `bun run quality:quick`.
 4. Update the canonical plugin docs and this Skill in the same change. Delete obsolete guidance instead of appending migration caveats to current-state docs.
 
 ## Handoff

--- a/docs/plugins/ui-contributions.md
+++ b/docs/plugins/ui-contributions.md
@@ -31,7 +31,7 @@ workbenchPanel({
 })
 ```
 
-The component exports a Solid component that receives `{ context: PluginSurfaceContext }` in source templates. plugin-kit compiles all trusted components into one named-export UI bundle, externalizes `solid-js`, `solid-js/web`, and `solid-js/store`, rewrites those imports to the host's shared runtime, and records the bundle hash. Bundles that include a private Solid runtime, use unsupported Solid subpaths, bypass host linking, or omit an export are rejected.
+The component exports a Solid component that receives `{ context: PluginSurfaceContext }` in source templates. plugin-kit compiles all trusted components into one named-export UI bundle, externalizes `solid-js`, `solid-js/web`, and `solid-js/store`, rewrites those imports to the host's shared runtime, and records the bundle hash. The plugin-kit CLI and standalone Synergy runtime include the compiler, so plugin projects do not install Babel presets. Bundles that include a private Solid runtime, use unsupported Solid subpaths, bypass host linking, or omit an export are rejected.
 
 Trusted code runs in the Synergy App context after explicit approval. This is a trust decision, not a sandbox claim.
 

--- a/packages/plugin-kit/src/lib/solid-compiler.ts
+++ b/packages/plugin-kit/src/lib/solid-compiler.ts
@@ -1,8 +1,6 @@
 import { transformAsync, type PluginItem } from "@babel/core"
-import { createRequire } from "node:module"
 import type { BunPlugin, Loader } from "bun"
 
-const require = createRequire(import.meta.url)
 const solidPreset = require("babel-preset-solid") as PluginItem
 
 export function solidCompilerPlugin(): BunPlugin {

--- a/packages/plugin-kit/test/dependencies.test.ts
+++ b/packages/plugin-kit/test/dependencies.test.ts
@@ -7,4 +7,53 @@ describe("plugin-kit runtime dependencies", () => {
     const packageJson = path.resolve(import.meta.dir, "../node_modules/@babel/preset-typescript/package.json")
     expect(fs.existsSync(packageJson)).toBe(true)
   })
+
+  test("compiles Solid UI from a standalone executable", async () => {
+    const root = fs.mkdtempSync(path.join(import.meta.dir, "standalone-fixture-"))
+    try {
+      const entry = path.join(root, "entry.ts")
+      const source = path.join(root, "panel.tsx")
+      const executable = path.join(root, process.platform === "win32" ? "compiler.exe" : "compiler")
+      const compiler = path
+        .relative(root, path.resolve(import.meta.dir, "../src/lib/solid-compiler.ts"))
+        .split(path.sep)
+        .join("/")
+      const compilerSpecifier = compiler.startsWith(".") ? compiler : `./${compiler}`
+      fs.writeFileSync(
+        entry,
+        `import { solidCompilerPlugin } from ${JSON.stringify(compilerSpecifier)}
+const result = await Bun.build({
+  entrypoints: [process.argv[2]],
+  target: "browser",
+  write: false,
+  external: ["solid-js", "solid-js/web", "solid-js/store"],
+  plugins: [solidCompilerPlugin()],
+})
+if (!result.success) throw new AggregateError(result.logs, "Solid compilation failed")
+console.log("compiled")
+`,
+      )
+      fs.writeFileSync(source, `export default function Panel() { return <div>ready</div> }\n`)
+
+      const result = await Bun.build({
+        entrypoints: [entry],
+        compile: { outfile: executable },
+      })
+      expect(result.success).toBe(true)
+
+      const child = Bun.spawn([executable, source], { stdout: "pipe", stderr: "pipe" })
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ])
+      expect({ exitCode, stdout, stderr }).toEqual({
+        exitCode: 0,
+        stdout: "compiled\n",
+        stderr: "",
+      })
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  }, 30_000)
 })


### PR DESCRIPTION
## Summary

- remove `createRequire(import.meta.url)` from the Solid compiler so Bun can include `babel-preset-solid` and its transitive plugins in standalone Synergy executables
- add a regression test that compiles and runs a standalone executable, then uses it to compile Solid TSX
- document that plugin authors do not install Babel presets and record the standalone compiler verification rule

## Root cause

Release runtime builds succeeded, but the Linux x64 artifact failed its `synergy --version` smoke test because `createRequire()` deferred `babel-preset-solid` resolution until execution from `/$bunfs`, where no external `node_modules` exists.

## Verification

- `TMPDIR=/private/tmp bun test` in `packages/plugin-kit` (6 passed)
- `bun run build` in `packages/plugin-kit`
- `bun run quality:quick`
- `SYNERGY_BUILD_TARGETS=darwin-arm64,linux-x64 bun run ./packages/synergy/script/build.ts --skip-install`
- packaged darwin-arm64 `synergy --version` smoke test

Related failure: https://github.com/SII-Holos/synergy/actions/runs/29803465497/job/88549211118