### PR TITLE
fix: build unsigned Windows installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,8 +209,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ matrix.platform == 'win32' && secrets.WINDOWS_CERTIFICATE || secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ matrix.platform == 'win32' && secrets.WINDOWS_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ matrix.platform == 'darwin' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'darwin' && secrets.CSC_KEY_PASSWORD || '' }}
           CSC_INSTALLER_LINK: ${{ matrix.platform == 'darwin' && secrets.CSC_INSTALLER_LINK || '' }}
           CSC_INSTALLER_KEY_PASSWORD: ${{ matrix.platform == 'darwin' && secrets.CSC_INSTALLER_KEY_PASSWORD || '' }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.platform == 'darwin' && 'true' || 'false' }}
@@ -229,8 +229,8 @@ jobs:
           bun run script/browser-host-manifest.ts release/browser-host
         env:
           SYNERGY_BROWSER_HOST_SIGNING_KEY: ${{ secrets.BROWSER_HOST_MANIFEST_SIGNING_KEY }}
-          CSC_LINK: ${{ matrix.platform == 'win32' && secrets.WINDOWS_CERTIFICATE || secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ matrix.platform == 'win32' && secrets.WINDOWS_CERTIFICATE_PASSWORD || secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ matrix.platform == 'darwin' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'darwin' && secrets.CSC_KEY_PASSWORD || '' }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.platform == 'darwin' && 'true' || 'false' }}
 
       - name: Upload desktop artifact bundle

--- a/docs/operations/desktop-release.md
+++ b/docs/operations/desktop-release.md
@@ -86,12 +86,7 @@ macOS:
 - `CSC_INSTALLER_LINK`
 - `CSC_INSTALLER_KEY_PASSWORD`
 
-Windows (optional; configure both values to sign artifacts):
-
-- `WINDOWS_CERTIFICATE`
-- `WINDOWS_CERTIFICATE_PASSWORD`
-
-When both Windows values are absent, the release produces unsigned Windows artifacts. A partial Windows signing configuration fails validation.
+Windows artifacts are currently unsigned. The release workflow does not pass CSC signing material to `electron-builder` on Windows. `WINDOWS_CERTIFICATE` and `WINDOWS_CERTIFICATE_PASSWORD` are reserved for re-enabling Windows signing later.
 
 GitHub upload/update feed:
 
@@ -102,7 +97,7 @@ Browser Host artifact trust:
 - `BROWSER_HOST_MANIFEST_SIGNING_KEY` — base64 PKCS#8 Ed25519 private key used only by the release matrix
 - `BROWSER_HOST_MANIFEST_PUBLIC_KEY` — base64 raw Ed25519 public key embedded in product runtime binaries
 
-PR/package validation works without signing secrets. A product Release validates every required signing secret before publishing a candidate and verifies that the Browser Host private/public key pair matches.
+PR/package validation works without signing secrets. A product Release validates every required macOS signing secret before publishing a candidate and verifies that the Browser Host private/public key pair matches.
 
 ## GitHub Actions Flow
 

--- a/packages/desktop/build/installer.nsh
+++ b/packages/desktop/build/installer.nsh
@@ -2,7 +2,7 @@
   CreateDirectory "$INSTDIR\bin"
   FileOpen $0 "$INSTDIR\bin\synergy.cmd" w
   FileWrite $0 "@echo off$\r$\n"
-  FileWrite $0 "\"$INSTDIR\resources\synergy\bin\synergy.exe\" %*$\r$\n"
+  FileWrite $0 "$\"$INSTDIR\resources\synergy\bin\synergy.exe$\" %*$\r$\n"
   FileClose $0
 
   ReadRegStr $0 HKCU "Environment" "Path"
@@ -74,6 +74,7 @@ Function PathHasEntry
 FunctionEnd
 !endif
 
+!ifdef BUILD_UNINSTALLER
 Function un.RemovePathEntry
   Exch $R1
   Exch
@@ -116,3 +117,4 @@ Function un.RemovePathEntry
     Pop $R1
     Pop $R3
 FunctionEnd
+!endif

--- a/packages/desktop/test/packaging.test.ts
+++ b/packages/desktop/test/packaging.test.ts
@@ -88,6 +88,7 @@ describe("desktop packaging", () => {
 
     expect(nsisScript).toContain("$INSTDIR\\bin\\synergy.cmd")
     expect(nsisScript).toContain("$INSTDIR\\resources\\synergy\\bin\\synergy.exe")
+    expect(nsisScript).toContain(String.raw`FileWrite $0 "$\"$INSTDIR\resources\synergy\bin\synergy.exe$\" %*$\r$\n"`)
     expect(nsisScript).toContain("WriteRegExpandStr HKCU")
     expect(nsisScript).toContain("$INSTDIR\\bin")
     expect(nsisScript).not.toContain("WriteRegExpandStr HKLM")
@@ -100,6 +101,7 @@ describe("desktop packaging", () => {
     expect(nsisScript).toContain("Call PathHasEntry")
     expect(nsisScript).toContain("StrCmp $R6 $R1 found")
     expect(nsisScript).toContain("!ifndef BUILD_UNINSTALLER\nFunction PathHasEntry")
+    expect(nsisScript).toContain("!ifdef BUILD_UNINSTALLER\nFunction un.RemovePathEntry")
     expect(nsisScript).not.toContain("Call StrStr")
   })
 

--- a/script/release/desktop-packaging.test.ts
+++ b/script/release/desktop-packaging.test.ts
@@ -14,7 +14,7 @@ interface ReleaseWorkflow {
 }
 
 describe("desktop release packaging", () => {
-  test("enables certificate discovery only for macOS packaging", async () => {
+  test("uses macOS signing material only for macOS packaging", async () => {
     const source = await Bun.file(new URL("../../.github/workflows/release.yml", import.meta.url)).text()
     const workflow = Bun.YAML.parse(source) as ReleaseWorkflow
     const steps = workflow.jobs?.stable_desktop_package?.steps ?? []
@@ -22,6 +22,8 @@ describe("desktop release packaging", () => {
 
     for (const name of signingSteps) {
       const step = steps.find((candidate) => candidate.name === name)
+      expect(step?.env?.CSC_LINK).toBe("${{ matrix.platform == 'darwin' && secrets.CSC_LINK || '' }}")
+      expect(step?.env?.CSC_KEY_PASSWORD).toBe("${{ matrix.platform == 'darwin' && secrets.CSC_KEY_PASSWORD || '' }}")
       expect(step?.env?.CSC_IDENTITY_AUTO_DISCOVERY).toBe("${{ matrix.platform == 'darwin' && 'true' || 'false' }}")
     }
   })


### PR DESCRIPTION
## Summary

- Fix the NSIS escaping used to write the quoted Synergy runtime path into `synergy.cmd`.
- Compile installer-only and uninstaller-only PATH helpers in their respective NSIS passes.
- Pass CSC signing material only to macOS packaging so Windows artifacts remain unsigned and cannot fall back to the Apple certificate.
- Add regression coverage and update the Desktop release runbook.

## Root cause

[Release run 29826659067](https://github.com/SII-Holos/synergy/actions/runs/29826659067) completed macOS signing/notarization and Linux packaging successfully, but Windows failed in `Package desktop artifact`.

The launcher line used a backslash-escaped quote where NSIS requires its dollar-prefixed quote escape, causing `FileWrite` to be parsed as four arguments. After correcting that syntax, a real NSIS build also exposed the inverse compiler-pass warning: `un.RemovePathEntry` was included in the installer pass. Electron-builder treats both NSIS warnings and errors as fatal.

The workflow also allowed Windows to fall back to the macOS `CSC_LINK` when no Windows certificate was configured.

## Verification

- `bun run release:test`
- `bun run workflow:check`
- `bun run --cwd packages/desktop desktop:test`
- `bun run --cwd packages/desktop desktop:build`
- Unsigned Windows x64 NSIS cross-build with electron-builder
- `bun run quality:quick`
- Repository pre-push checks