### PR TITLE
fix: validate Linux release asset names

### DIFF
--- a/docs/operations/desktop-release.md
+++ b/docs/operations/desktop-release.md
@@ -36,7 +36,7 @@ Recommended Desktop installer artifacts:
 - `Synergy-darwin-x64-${version}.pkg`
 - `Synergy-darwin-arm64-${version}.pkg`
 - `Synergy-win32-x64-${version}.exe`
-- `Synergy-linux-x86_64-${version}.deb`
+- `Synergy-linux-amd64-${version}.deb`
 - `Synergy-linux-arm64-${version}.deb`
 - `Synergy-${version}-checksums.txt`
 
@@ -47,6 +47,8 @@ Portable and updater artifacts are still published but are not the full Desktop 
 - macOS `.zip` is required by updater metadata.
 - macOS `.dmg` is an app-bundle artifact and does not install the CLI link.
 - Linux `.AppImage` and `.tar.gz` are portable/debug artifacts and do not install global commands.
+
+Linux x64 artifact names follow each format's native architecture label: `amd64` for `.deb`, `x86_64` for `.AppImage`, and `x64` for `.tar.gz`.
 
 The Linux `.deb` depends on the system `bubblewrap` package. Linux portable artifacts require users to install Bubblewrap separately.
 

--- a/packages/desktop/src/release-assets.ts
+++ b/packages/desktop/src/release-assets.ts
@@ -15,21 +15,30 @@ const DESKTOP_RELEASE_TARGETS: ReadonlyArray<{
   { platform: "linux", arch: "arm64" },
 ]
 
+function desktopArtifactArch(platform: DesktopReleasePlatform, arch: DesktopReleaseArch, extension: string): string {
+  if (platform !== "linux" || arch !== "x64") return arch
+  if (extension === "deb") return "amd64"
+  if (extension === "AppImage") return "x86_64"
+  return arch
+}
+
 export function desktopPrimaryArtifactName(
   version: string,
   platform: DesktopReleasePlatform,
   arch: DesktopReleaseArch,
 ): string {
   const extension = platform === "darwin" ? "pkg" : platform === "win32" ? "exe" : "deb"
-  const artifactArch = platform === "linux" && arch === "x64" ? "x86_64" : arch
+  const artifactArch = desktopArtifactArch(platform, arch, extension)
   return `Synergy-${platform}-${artifactArch}-${version}.${extension}`
 }
 
 export function desktopPortableArtifactNames(version: string): string[] {
   return DESKTOP_RELEASE_TARGETS.flatMap(({ platform, arch }) => {
-    const artifactArch = platform === "linux" && arch === "x64" ? "x86_64" : arch
     const extensions = platform === "darwin" ? ["dmg", "zip"] : platform === "win32" ? ["zip"] : ["AppImage", "tar.gz"]
-    return extensions.map((extension) => `Synergy-${platform}-${artifactArch}-${version}.${extension}`)
+    return extensions.map((extension) => {
+      const artifactArch = desktopArtifactArch(platform, arch, extension)
+      return `Synergy-${platform}-${artifactArch}-${version}.${extension}`
+    })
   })
 }
 

--- a/packages/desktop/test/release-assets.test.ts
+++ b/packages/desktop/test/release-assets.test.ts
@@ -15,7 +15,7 @@ describe("desktop release asset names", () => {
   test("matches the public installer artifact naming contract", () => {
     expect(desktopPrimaryArtifactName("1.2.3", "darwin", "arm64")).toBe("Synergy-darwin-arm64-1.2.3.pkg")
     expect(desktopPrimaryArtifactName("1.2.3", "win32", "x64")).toBe("Synergy-win32-x64-1.2.3.exe")
-    expect(desktopPrimaryArtifactName("1.2.3", "linux", "x64")).toBe("Synergy-linux-x86_64-1.2.3.deb")
+    expect(desktopPrimaryArtifactName("1.2.3", "linux", "x64")).toBe("Synergy-linux-amd64-1.2.3.deb")
     expect(desktopPrimaryArtifactName("1.2.3", "linux", "arm64")).toBe("Synergy-linux-arm64-1.2.3.deb")
   })
 
@@ -24,7 +24,7 @@ describe("desktop release asset names", () => {
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-darwin-x64-1.2.3.pkg")
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-win32-x64-1.2.3.exe")
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).not.toContain("Synergy-win32-arm64-1.2.3.exe")
-    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.deb")
+    expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-amd64-1.2.3.deb")
     expect(expectedDesktopPrimaryArtifacts("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.deb")
   })
 
@@ -32,6 +32,7 @@ describe("desktop release asset names", () => {
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-darwin-arm64-1.2.3.dmg")
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-darwin-arm64-1.2.3.zip")
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-x86_64-1.2.3.AppImage")
+    expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-x64-1.2.3.tar.gz")
     expect(desktopPortableArtifactNames("1.2.3")).toContain("Synergy-linux-arm64-1.2.3.tar.gz")
     expect(desktopPortableArtifactNames("1.2.3")).not.toContain("Synergy-win32-arm64-1.2.3.zip")
   })


### PR DESCRIPTION
## Summary

- Match Linux release validation to electron-builder's target-specific architecture names.
- Expect `amd64` for x64 Debian packages, `x86_64` for x64 AppImages, and `x64` for x64 tar archives.
- Add regression coverage and document the public artifact naming contract.

## Root cause

[Release run 29835457951](https://github.com/SII-Holos/synergy/actions/runs/29835457951) successfully built and uploaded every platform artifact, then failed during finalization because the validator expected `Synergy-linux-x86_64-2.4.4.deb`.

The draft release correctly contains `Synergy-linux-amd64-2.4.4.deb`. The same generic Linux mapping would also have expected an incorrect `x86_64` tar archive after the Debian check was fixed.

## Verification

- `bun test test/release-assets.test.ts`
- `bun run release:test`
- `bun run --cwd packages/desktop desktop:test`
- `bun run --cwd packages/desktop desktop:build`
- Validated all 36 expected Desktop assets against the current v2.4.4 draft release
- `bun run quality:quick`
- Repository pre-push checks