### PR TITLE
fix: recover from corrupt sessions and oversized workspaces

### DIFF
--- a/docs/architecture/session-and-messages.md
+++ b/docs/architecture/session-and-messages.md
@@ -359,6 +359,8 @@ Recovery covers:
 
 An interrupted assistant that never reached terminal persistence is completed with an explicit error during repair. Recovery state is surfaced as `recovering`; it is not presented as ordinary busy work.
 
+Startup pending-reply reconciliation isolates failures by session. An unreadable history remains pending and is reported as a warning, while recovery continues for other sessions so one corrupt record cannot prevent the global runtime from starting.
+
 ### Abort status synchronization
 
 When a running session is aborted, `signalAbort()` signals the owning controller and sets the phase to `stopping` but does not publish events or repair durable state. The abort HTTP route additionally calls `repairAfterAbort()` to repair the persisted incomplete assistant message and synchronize the frontend status.

--- a/docs/architecture/workspace-and-files.md
+++ b/docs/architecture/workspace-and-files.md
@@ -41,6 +41,8 @@ Search has three independent modes:
 - content — bounded fixed-string ripgrep results
 - symbol — active LSP workspace-symbol results, with an explicit unavailable capability when no LSP client is active
 
+File-index scans preserve complete paths collected before a subprocess output limit or scan timeout and mark the search response as truncated. A workspace that is too large for one bounded index scan therefore returns partial file matches instead of failing the route with a 500 response.
+
 The current public workspace-file routes are read/browse/search/status contracts. Agent write operations use the governed tool pipeline rather than an unguarded file-service write route.
 
 ## File Workbench Ownership and Bounds

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -1903,30 +1903,34 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
 
     const sessionIDs = await SessionManager.listPendingReply(input?.scopeID)
     for (const sessionID of sessionIDs) {
-      const session = await SessionManager.getSession(sessionID)
-      if (!session) continue
-      if (session.agenda) continue
+      try {
+        const session = await SessionManager.getSession(sessionID)
+        if (!session) continue
+        if (session.agenda) continue
 
-      const messages = await effectiveCompactedMessages(sessionID)
-      const pendingReply = SessionProgress.pendingReply(messages)
+        const messages = await effectiveCompactedMessages(sessionID)
+        const pendingReply = SessionProgress.pendingReply(messages)
 
-      if (session.pendingReply !== pendingReply) {
-        await Session.update(sessionID, (draft) => {
-          draft.pendingReply = pendingReply || undefined
-        })
-      }
-
-      if (!pendingReply) continue
-
-      if (!SessionManager.isRunning(sessionID)) {
-        const repaired = await repairAfterAbort(sessionID)
-        if (repaired) {
-          log.info("repaired incomplete assistant during startup recovery", { sessionID })
-          continue
+        if (session.pendingReply !== pendingReply) {
+          await Session.update(sessionID, (draft) => {
+            draft.pendingReply = pendingReply || undefined
+          })
         }
-      }
 
-      log.info("pending reply found; automatic assistant resume is disabled", { sessionID })
+        if (!pendingReply) continue
+
+        if (!SessionManager.isRunning(sessionID)) {
+          const repaired = await repairAfterAbort(sessionID)
+          if (repaired) {
+            log.info("repaired incomplete assistant during startup recovery", { sessionID })
+            continue
+          }
+        }
+
+        log.info("pending reply found; automatic assistant resume is disabled", { sessionID })
+      } catch (error) {
+        log.warn("pending session startup recovery failed", { sessionID, error })
+      }
     }
   }
 

--- a/packages/synergy/src/workspace-file/indexer.ts
+++ b/packages/synergy/src/workspace-file/indexer.ts
@@ -3,10 +3,12 @@ import { ScopedState } from "../scope/scoped-state"
 import { ScopeContext } from "../scope/context"
 import { Ripgrep } from "../file/ripgrep"
 import { WorkspaceFileService } from "./service"
+import { ProcessOutput } from "../process/output"
 
 type Entry = {
   files: string[]
   dirs: string[]
+  truncated: boolean
   fetching: boolean
   fetchedAt: number
 }
@@ -36,20 +38,29 @@ function scanSignal(signal: AbortSignal | undefined) {
   return signal ? AbortSignal.any([signal, AbortSignal.timeout(30_000)]) : AbortSignal.timeout(30_000)
 }
 
-async function scan(input?: { signal?: AbortSignal }): Promise<{ files: string[]; dirs: string[] }> {
+async function scan(input?: {
+  signal?: AbortSignal
+}): Promise<{ files: string[]; dirs: string[]; truncated: boolean }> {
   const files: string[] = []
   const dirs = new Set<string>()
   const signal = scanSignal(input?.signal)
-  for await (const file of Ripgrep.files({ cwd: root(), signal })) {
-    if (signal.aborted) break
-    const relative = cleanRelative(file)
-    if (!relative) continue
-    files.push(relative)
-    addParents(dirs, relative)
+  let truncated = false
+  try {
+    for await (const file of Ripgrep.files({ cwd: root(), signal })) {
+      if (signal.aborted) break
+      const relative = cleanRelative(file)
+      if (!relative) continue
+      files.push(relative)
+      addParents(dirs, relative)
+    }
+  } catch (error) {
+    if (error instanceof ProcessOutput.LimitError) truncated = true
+    else throw error
   }
   return {
     files: files.toSorted(),
     dirs: Array.from(dirs).toSorted(),
+    truncated: truncated || signal.aborted,
   }
 }
 
@@ -57,6 +68,7 @@ export namespace WorkspaceFileIndexer {
   const state = ScopedState.create<Entry>(() => ({
     files: [],
     dirs: [],
+    truncated: false,
     fetching: false,
     fetchedAt: 0,
   }))
@@ -68,6 +80,7 @@ export namespace WorkspaceFileIndexer {
       const next = await scan({ signal: options?.signal })
       entry.files = next.files
       entry.dirs = next.dirs
+      entry.truncated = next.truncated
       entry.fetchedAt = Date.now()
     } finally {
       entry.fetching = false
@@ -83,6 +96,7 @@ export namespace WorkspaceFileIndexer {
     return {
       files: entry.files,
       dirs: entry.dirs,
+      truncated: entry.truncated,
       fetching: entry.fetching,
       fetchedAt: entry.fetchedAt,
     }

--- a/packages/synergy/src/workspace-file/search.ts
+++ b/packages/synergy/src/workspace-file/search.ts
@@ -70,6 +70,7 @@ async function searchFiles(input: {
     ? fuzzysort.go(input.query, filtered, { limit: searchLimit })
     : filtered.slice(0, searchLimit).map((target, index) => ({ target, score: -index }))
   const page = matches.slice(offset, offset + input.limit)
+  const pageLimited = offset + page.length < matches.length
   const output = await Promise.all(
     page.map(async (match) => {
       const target = match.target
@@ -92,8 +93,8 @@ async function searchFiles(input: {
     kind: "files",
     query: input.query,
     items: output,
-    nextCursor: offset + page.length < matches.length ? String(offset + page.length) : undefined,
-    truncated: offset + page.length < matches.length,
+    nextCursor: pageLimited ? String(offset + page.length) : undefined,
+    truncated: snapshot.truncated || pageLimited,
   }
 }
 

--- a/packages/synergy/test/session/working.test.ts
+++ b/packages/synergy/test/session/working.test.ts
@@ -569,6 +569,45 @@ describe("SessionWorking", () => {
       })
     })
 
+    test("resumePending isolates unreadable sessions during startup recovery", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const corrupt = await Session.create({ id: Identifier.create("session", false, 1) })
+          const user = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            sessionID: corrupt.id,
+            role: "user",
+            agent: "test",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            time: { created: Date.now() },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            sessionID: corrupt.id,
+            messageID: user.id,
+            type: "attachment",
+            mime: "application/octet-stream",
+            url: "data:broken",
+          })
+          await Session.update(corrupt.id, (draft) => {
+            draft.pendingReply = true
+          })
+
+          const stale = await Session.create({ id: Identifier.create("session", false, 2) })
+          await Session.update(stale.id, (draft) => {
+            draft.pendingReply = true
+          })
+
+          await SessionInvoke.resumePending({ scopeID: ScopeContext.current.scope.id })
+
+          expect((await Session.get(corrupt.id)).pendingReply).toBe(true)
+          expect((await Session.get(stale.id)).pendingReply).toBeUndefined()
+        },
+      })
+    })
+
     test("resumePending reconciles interrupted Cortex delegation state after restart", async () => {
       await using tmp = await tmpdir({ git: true })
       await ScopeContext.provide({

--- a/packages/synergy/test/workspace-file/service.test.ts
+++ b/packages/synergy/test/workspace-file/service.test.ts
@@ -11,6 +11,7 @@ import { WorkspaceFileService } from "../../src/workspace-file/service"
 import { WorkspaceFileStatus } from "../../src/workspace-file/status"
 import { LSP } from "../../src/lsp"
 import { Ripgrep } from "../../src/file/ripgrep"
+import { ProcessOutput } from "../../src/process/output"
 import { tmpdir } from "../fixture/fixture"
 
 function isSymlinkPrivilegeError(error: unknown) {
@@ -328,6 +329,31 @@ describe("WorkspaceFileSearch", () => {
         })
         expect(result.items.some((item) => item.kind === "file" && item.type === "directory")).toBe(true)
         expect(result.items.some((item) => item.kind === "file" && item.path.endsWith(".md"))).toBe(false)
+      },
+    )
+  })
+
+  test("returns partial file results when the index output safety limit is reached", async () => {
+    await withWorkspace(
+      async (dir) => {
+        await Bun.write(path.join(dir, "partial.ts"), "export const partial = true")
+      },
+      async () => {
+        const originalFiles = Ripgrep.files
+        ;(Ripgrep as any).files = async function* () {
+          yield "partial.ts"
+          throw new ProcessOutput.LimitError("max_output_bytes", 20 * 1024 * 1024)
+        }
+
+        try {
+          const result = await WorkspaceFileSearch.search({ kind: "files", query: "partial", limit: 10 })
+          expect(result.items).toHaveLength(1)
+          expect(result.items[0]).toMatchObject({ kind: "file", path: "partial.ts" })
+          expect(result.truncated).toBe(true)
+          expect(result.nextCursor).toBeUndefined()
+        } finally {
+          ;(Ripgrep as any).files = originalFiles
+        }
       },
     )
   })


### PR DESCRIPTION
## Summary

- isolate pending-session recovery failures so one unreadable history cannot stop global runtime startup
- preserve complete file-index results when bounded ripgrep output or scan time is exhausted, returning a truncated response instead of HTTP 500
- add regression coverage and document both recovery boundaries

## Testing

- `cd packages/synergy && bun run typecheck`
- `cd packages/synergy && bun test test/session/invoke.test.ts test/session/working.test.ts test/workspace-file/service.test.ts`
- `bun run quality:quick`
- isolated `bun dev desktop --managed` smoke test, including health, root, and scope bootstrap requests
