### PR TITLE
fix(app): preserve authoritative session refreshes

### DIFF
--- a/packages/app/src/app-i18n.ts
+++ b/packages/app/src/app-i18n.ts
@@ -161,6 +161,10 @@ export const AP = {
     id: "app.layout.worktree.moveFailed",
     message: "Move to worktree failed",
   },
+  layoutWorktreeRefreshFailed: {
+    id: "app.layout.worktree.refreshFailed",
+    message: "Workspace status refresh failed",
+  },
 
   // ── pages/session.tsx ───────────────────────────────────────────────
   sessionErrorTitle: { id: "app.session.error.title", message: "Couldn’t load conversation" },

--- a/packages/app/src/components/session/session-i18n.ts
+++ b/packages/app/src/components/session/session-i18n.ts
@@ -432,6 +432,7 @@ export const S = {
   worktreeStepSendPrompt: { id: "session.worktree.step.sendPrompt", message: "Send prompt" },
   worktreeStepReturnCheckout: { id: "session.worktree.step.returnCheckout", message: "Return to main checkout" },
   worktreeStepCreateBind: { id: "session.worktree.step.createBind", message: "Create and bind checkout" },
+  worktreeStepRefreshStatus: { id: "session.worktree.step.refreshStatus", message: "Refresh workspace status" },
 
   // worktree-session.ts — factory detail strings
   worktreeDetailPreparingWorktree: {
@@ -450,6 +451,10 @@ export const S = {
   worktreeDetailWorkspaceUpdated: {
     id: "session.worktree.detail.workspaceUpdated",
     message: "Session workspace updated.",
+  },
+  worktreeDetailRefreshingStatus: {
+    id: "session.worktree.detail.refreshingStatus",
+    message: "Loading the updated session workspace.",
   },
   worktreeDetailCreatingConversation: {
     id: "session.worktree.detail.creatingConversation",
@@ -492,6 +497,22 @@ export const S = {
   worktreeDescWorktreeActive: {
     id: "session.worktree.desc.worktreeActive",
     message: "This session now runs in the isolated checkout.",
+  },
+  worktreeTitleRefreshing: {
+    id: "session.worktree.title.refreshing",
+    message: "Refreshing workspace status",
+  },
+  worktreeDescRefreshing: {
+    id: "session.worktree.desc.refreshing",
+    message: "The workspace changed. Updating the session status.",
+  },
+  worktreeTitleRefreshFailed: {
+    id: "session.worktree.title.refreshFailed",
+    message: "Workspace status refresh failed",
+  },
+  worktreeDescRefreshFailed: {
+    id: "session.worktree.desc.refreshFailed",
+    message: "The workspace changed successfully, but Synergy couldn’t refresh the session status. {message}",
   },
   worktreeTitleLeaveFailed: { id: "session.worktree.title.leaveFailed", message: "Leave worktree failed" },
   worktreeTitleMoveFailed: { id: "session.worktree.title.moveFailed", message: "Move to worktree failed" },

--- a/packages/app/src/components/session/worktree-session.test.ts
+++ b/packages/app/src/components/session/worktree-session.test.ts
@@ -9,6 +9,8 @@ import {
   createNewSessionWorkspaceSuccessProgress,
   createWorkspaceTransitionErrorProgress,
   createWorkspaceTransitionLoadingProgress,
+  createWorkspaceTransitionRefreshErrorProgress,
+  createWorkspaceTransitionRefreshProgress,
   createWorkspaceTransitionSuccessProgress,
   defaultNewSessionWorkspaceSelection,
   isSessionRunningForWorkspaceChange,
@@ -119,6 +121,23 @@ describe("workspace transition progress model", () => {
     expect("retry" in error).toBe(false)
     expect("dismiss" in error).toBe(false)
     expect(JSON.parse(JSON.stringify(error))).toEqual(error)
+  })
+
+  test("models status refresh separately after the workspace operation succeeds", () => {
+    const i18n = englishI18n()
+    const refreshing = createWorkspaceTransitionRefreshProgress({ operation: "enter" })
+
+    expect(refreshing).toMatchObject({ phase: "loading", kind: "enter-worktree" })
+    expect(translateProgressCopy(refreshing.title)).toBe("Refreshing workspace status")
+    expect(refreshing.steps.map((step) => [translateDescriptor(step.label, i18n), step.state])).toEqual([
+      ["Refresh workspace status", "active"],
+    ])
+
+    const failed = createWorkspaceTransitionRefreshErrorProgress({ operation: "enter", message: "Network error" })
+    expect(failed).toMatchObject({ phase: "error", kind: "enter-worktree" })
+    expect(translateProgressCopy(failed.title)).toBe("Workspace status refresh failed")
+    expect(translateProgressCopy(failed.description)).toContain("changed successfully")
+    expect(translateProgressCopy(failed.description)).toContain("Network error")
   })
 
   test("creates existing-session leave loading and success states", () => {

--- a/packages/app/src/components/session/worktree-session.ts
+++ b/packages/app/src/components/session/worktree-session.ts
@@ -121,6 +121,24 @@ export function createWorkspaceTransitionLoadingProgress(
     ],
   }
 }
+export function createWorkspaceTransitionRefreshProgress(input: {
+  operation: "enter" | "leave"
+}): SessionTransitionProgress {
+  return {
+    kind: input.operation === "leave" ? "leave-worktree" : "enter-worktree",
+    phase: "loading",
+    title: S.worktreeTitleRefreshing,
+    description: S.worktreeDescRefreshing,
+    steps: [
+      {
+        id: "refresh",
+        label: S.worktreeStepRefreshStatus,
+        detail: S.worktreeDetailRefreshingStatus,
+        state: "active",
+      },
+    ],
+  }
+}
 
 export function createWorkspaceTransitionSuccessProgress(input: {
   operation: "enter" | "leave"
@@ -168,6 +186,18 @@ export function createWorkspaceTransitionErrorProgress(input: {
     phase: "error",
     title: input.operation === "leave" ? S.worktreeTitleLeaveFailed : S.worktreeTitleMoveFailed,
     description: input.message,
+    steps: [],
+  }
+}
+export function createWorkspaceTransitionRefreshErrorProgress(input: {
+  operation: "enter" | "leave"
+  message: string
+}): SessionTransitionProgress {
+  return {
+    kind: input.operation === "leave" ? "leave-worktree" : "enter-worktree",
+    phase: "error",
+    title: S.worktreeTitleRefreshFailed,
+    description: { ...S.worktreeDescRefreshFailed, values: { message: input.message } },
     steps: [],
   }
 }

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -37,6 +37,7 @@ import {
 } from "./sync-resource-freshness"
 import { planBucketEviction } from "./message-eviction"
 import { describeToolPartApply } from "./session-sync-plan"
+import { findSessionByID, findSessionIndex } from "./session-collection"
 import { createSessionMessageLoader } from "./session-message-loader"
 import { SessionPartSnapshotFreshness, type SessionPartSnapshotRequest } from "./session-part-snapshot-freshness"
 import {
@@ -155,11 +156,6 @@ type State = {
   part: {
     [messageID: string]: Part[]
   }
-}
-
-function findSessionByID(sessions: Session[], sessionID: string): Session | undefined {
-  const result = Binary.search(sessions, sessionID, (s) => s.id)
-  return result.found ? sessions[result.index] : undefined
 }
 
 function setPlanBlueprintOfferState(
@@ -1186,13 +1182,13 @@ function createGlobalSync() {
       case "session.updated": {
         const info = event.properties.info as Session
         reconcileCortexFromSession(store, setStore, info)
-        const result = Binary.search(store.session, info.id, (s) => s.id)
+        const index = findSessionIndex(store.session, info.id)
         if (info.time.archived) {
-          if (result.found) {
+          if (index !== -1) {
             setStore(
               "session",
               produce((draft) => {
-                draft.splice(result.index, 1)
+                draft.splice(index, 1)
               }),
             )
             setStore("sessionTotal", Math.max(0, store.sessionTotal - 1))
@@ -1200,11 +1196,11 @@ function createGlobalSync() {
           updatePlanBlueprintOfferState(store, setStore, info.id, { type: "session_removed" })
           break
         }
-        if (result.found) {
+        if (index !== -1) {
           // reconcile (not whole-object replace) so unchanged fields keep their
           // identity; a session.updated that only bumps time.updated must not
           // invalidate memos reading title/status/etc. (issue #319).
-          setStore("session", result.index, reconcile(info))
+          setStore("session", index, reconcile(info))
           if (info.workflow?.kind !== "plan")
             updatePlanBlueprintOfferState(store, setStore, info.id, { type: "plan_exited" })
           else refreshPlanBlueprintOfferFromLoadedParts(store, setStore, info.id)
@@ -1213,7 +1209,7 @@ function createGlobalSync() {
         setStore(
           "session",
           produce((draft) => {
-            draft.splice(result.index, 0, info)
+            draft.unshift(info)
           }),
         )
         setStore("sessionTotal", store.sessionTotal + 1)
@@ -1460,16 +1456,16 @@ function createGlobalSync() {
         // handler; in practice the events carry identical data so the race is benign.
         const transition = resolveWorkspaceTransition(part)
         if (transition.kind !== "none") {
-          const idx = Binary.search(store.session, part.sessionID, (s) => s.id)
-          if (idx.found) {
+          const index = findSessionIndex(store.session, part.sessionID)
+          if (index !== -1) {
             if (transition.kind === "enter") {
-              setStore("session", idx.index, "workspace", transition.workspace)
+              setStore("session", index, "workspace", transition.workspace)
             } else {
               const workspace: SessionWorkspace = {
                 ...transition.workspace,
-                scopeID: store.session[idx.index].scope.id,
+                scopeID: store.session[index].scope.id,
               }
-              setStore("session", idx.index, "workspace", workspace)
+              setStore("session", index, "workspace", workspace)
             }
           }
         }

--- a/packages/app/src/context/layout/index.tsx
+++ b/packages/app/src/context/layout/index.tsx
@@ -10,7 +10,6 @@ import { Scope, Session } from "@ericsanchezok/synergy-sdk"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { same } from "@/utils/same"
 import { createScrollPersistence, type SessionScroll } from "./scroll"
-import { Binary } from "@ericsanchezok/synergy-util/binary"
 import { retry } from "@ericsanchezok/synergy-util/retry"
 import { computeDefaultWorkspaceWidth } from "./workspace"
 import type { WorkbenchPanelSurface, WorkbenchPanelTab } from "@/plugin/registries/workbench-panel-registry"
@@ -28,6 +27,7 @@ import {
 import { createDesktopBadgeSync } from "./desktop-badge"
 import { HOME_SCOPE_KEY } from "@/utils/scope"
 import { planMessagePageApply } from "../session-message-page"
+import { findSessionIndex } from "../session-collection"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 export type AvatarColorKey = (typeof AVATAR_COLOR_KEYS)[number]
@@ -1106,8 +1106,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       })
       setChildStore(
         produce((draft) => {
-          const match = Binary.search(draft.session, session.id, (s) => s.id)
-          if (match.found) draft.session.splice(match.index, 1)
+          const index = findSessionIndex(draft.session, session.id)
+          if (index !== -1) draft.session.splice(index, 1)
         }),
       )
       const existing = navEntries[scopeKey]
@@ -1127,8 +1127,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       const value = pinned ? Date.now() : 0
       setChildStore(
         produce((draft) => {
-          const match = Binary.search(draft.session, session.id, (s) => s.id)
-          if (match.found) draft.session[match.index].pinned = value
+          const index = findSessionIndex(draft.session, session.id)
+          if (index !== -1) draft.session[index].pinned = value
         }),
       )
       const existing = navEntries[scopeKey]

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -4,7 +4,6 @@ import { createSimpleContext } from "@ericsanchezok/synergy-ui/context"
 import { useGlobalSDK } from "./global-sdk"
 import { useGlobalSync } from "./global-sync"
 import { usePlatform } from "@/context/platform"
-import { Binary } from "@ericsanchezok/synergy-util/binary"
 import { EventSessionError } from "@ericsanchezok/synergy-sdk"
 import { makeAudioPlayer } from "@solid-primitives/audio"
 import completionSound from "@ericsanchezok/synergy-ui/audio/staplebops-01.aac"
@@ -13,6 +12,7 @@ import { Persist, persisted } from "@/utils/persist"
 import { resolveNotificationEvent } from "./notification-event"
 import { useLingui } from "@lingui/solid"
 import { messages as AP } from "@/locales/messages"
+import { findSessionByID } from "./session-collection"
 
 type NotificationBase = {
   directory?: string
@@ -93,8 +93,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
         case "session.completion": {
           const sessionID = event.properties.sessionID
           const [syncStore] = globalSync.ensureScopeState(directory)
-          const match = Binary.search(syncStore.session, sessionID, (s) => s.id)
-          const session = match.found ? syncStore.session[match.index] : undefined
+          const session = findSessionByID(syncStore.session, sessionID)
           const notification = resolveNotificationEvent({
             directory,
             event,
@@ -120,8 +119,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
         case "session.error": {
           const sessionID = event.properties.sessionID
           const [syncStore] = globalSync.ensureScopeState(directory)
-          const match = sessionID ? Binary.search(syncStore.session, sessionID, (s) => s.id) : undefined
-          const session = sessionID && match?.found ? syncStore.session[match.index] : undefined
+          const session = sessionID ? findSessionByID(syncStore.session, sessionID) : undefined
           const notification = resolveNotificationEvent({
             directory,
             event,

--- a/packages/app/src/context/session-collection.test.ts
+++ b/packages/app/src/context/session-collection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@ericsanchezok/synergy-sdk/client"
+import { findSessionByID, findSessionIndex } from "./session-collection"
+
+function session(id: string, updated: number): Session {
+  return {
+    id,
+    title: id,
+    scope: { id: "scope_1", type: "directory", directory: "/project" },
+    time: { created: updated, updated },
+  } as unknown as Session
+}
+
+describe("session collection lookup", () => {
+  test("finds sessions by ID when the collection is ordered by recent activity", () => {
+    const sessions = [session("ses_z", 300), session("ses_a", 200), session("ses_m", 100)]
+
+    expect(findSessionIndex(sessions, "ses_z")).toBe(0)
+    expect(findSessionIndex(sessions, "ses_a")).toBe(1)
+    expect(findSessionIndex(sessions, "ses_m")).toBe(2)
+    expect(findSessionByID(sessions, "ses_z")).toBe(sessions[0])
+  })
+
+  test("returns missing results without assuming an insertion order", () => {
+    const sessions = [session("ses_z", 300), session("ses_a", 200)]
+
+    expect(findSessionIndex(sessions, "ses_missing")).toBe(-1)
+    expect(findSessionByID(sessions, "ses_missing")).toBeUndefined()
+  })
+})

--- a/packages/app/src/context/session-collection.ts
+++ b/packages/app/src/context/session-collection.ts
@@ -1,0 +1,10 @@
+type SessionIdentity = { id: string }
+
+export function findSessionIndex(sessions: readonly SessionIdentity[], sessionID: string): number {
+  return sessions.findIndex((session) => session.id === sessionID)
+}
+
+export function findSessionByID<T extends SessionIdentity>(sessions: readonly T[], sessionID: string): T | undefined {
+  const index = findSessionIndex(sessions, sessionID)
+  return index === -1 ? undefined : sessions[index]
+}

--- a/packages/app/src/context/session-sync-plan.test.ts
+++ b/packages/app/src/context/session-sync-plan.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { describeToolPartApply, planSessionSyncReload, refreshSessionAfterPending } from "./session-sync-plan"
+import {
+  describeToolPartApply,
+  planSessionSyncReload,
+  refreshSessionAfterPending,
+  trackSessionSync,
+} from "./session-sync-plan"
 
 describe("planSessionSyncReload (#509)", () => {
   test("short-circuits when session and messages are current", () => {
@@ -127,6 +132,56 @@ describe("refreshSessionAfterPending", () => {
     releasePending()
     await refresh
     expect(calls).toEqual(["refresh"])
+  })
+
+  test("still refreshes authoritative metadata after the stale request fails", async () => {
+    const calls: string[] = []
+
+    await refreshSessionAfterPending(Promise.reject(new Error("stale request failed")), async () => {
+      calls.push("refresh")
+    })
+
+    expect(calls).toEqual(["refresh"])
+  })
+
+  test("propagates an authoritative refresh failure", async () => {
+    const failure = new Error("refresh failed")
+
+    expect(refreshSessionAfterPending(Promise.resolve(), async () => Promise.reject(failure))).rejects.toBe(failure)
+  })
+})
+
+describe("trackSessionSync", () => {
+  test("keeps the replacement request tracked until it settles", async () => {
+    const inflight = new Map<string, Promise<void>>()
+    let releaseFirst!: () => void
+    let releaseReplacement!: () => void
+    const first = trackSessionSync(
+      inflight,
+      "ses_1",
+      new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      }),
+    )
+    const replacement = trackSessionSync(
+      inflight,
+      "ses_1",
+      first.then(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseReplacement = resolve
+          }),
+      ),
+    )
+
+    releaseFirst()
+    await first
+    await Promise.resolve()
+    expect(inflight.get("ses_1")).toBe(replacement)
+
+    releaseReplacement()
+    await replacement
+    expect(inflight.has("ses_1")).toBe(false)
   })
 })
 

--- a/packages/app/src/context/session-sync-plan.ts
+++ b/packages/app/src/context/session-sync-plan.ts
@@ -21,8 +21,22 @@ export async function refreshSessionAfterPending(
   pending: Promise<unknown>,
   refresh: () => Promise<unknown>,
 ): Promise<void> {
-  await pending
+  await pending.catch(() => undefined)
   await refresh()
+}
+
+export function trackSessionSync(
+  inflight: Map<string, Promise<void>>,
+  sessionID: string,
+  request: Promise<unknown>,
+): Promise<void> {
+  const tracked = request
+    .then(() => undefined)
+    .finally(() => {
+      if (inflight.get(sessionID) === tracked) inflight.delete(sessionID)
+    })
+  inflight.set(sessionID, tracked)
+  return tracked
 }
 
 /**

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -9,11 +9,17 @@ import type { Message, PermissionRequest, Session } from "@ericsanchezok/synergy
 import { refreshPlanBlueprintOfferFromLoadedParts, updatePlanBlueprintOfferState } from "./global-sync"
 import { createSessionMessageLoader, type SessionMessageLoadState } from "./session-message-loader"
 import { requestErrorMessage } from "@/utils/error"
-import { planSessionSyncReload, refreshSessionAfterPending, type SessionSyncTrigger } from "./session-sync-plan"
+import {
+  planSessionSyncReload,
+  refreshSessionAfterPending,
+  trackSessionSync,
+  type SessionSyncTrigger,
+} from "./session-sync-plan"
 import type { MessageWindowState } from "./session-message-window"
 import { planMessagePageApply } from "./session-message-page"
 import { loadOlderOrRecoverLatest } from "./session-message-page-recovery"
 import type { SyncResourceRequest } from "./sync-resource-freshness"
+import { findSessionByID, findSessionIndex } from "./session-collection"
 
 type RefreshOptions = { force?: boolean }
 type SessionSyncOptions = { refreshVolatile?: boolean; trigger?: SessionSyncTrigger }
@@ -42,11 +48,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     // blueprint loop refetch (issue #331).
     const sessionReconnectVersions = new Map<string, number>()
 
-    const getSession = (sessionID: string) => {
-      const match = Binary.search(store.session, sessionID, (s) => s.id)
-      if (match.found) return store.session[match.index]
-      return undefined
-    }
+    const getSession = (sessionID: string) => findSessionByID(store.session, sessionID)
 
     const terminalCortexStatuses = new Set(["completed", "error", "cancelled"])
 
@@ -70,17 +72,17 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     const upsertSession = (session: Session) => {
       reconcileCortexFromSession(session)
-      const match = Binary.search(store.session, session.id, (s) => s.id)
-      if (match.found) {
+      const index = findSessionIndex(store.session, session.id)
+      if (index !== -1) {
         // reconcile so a re-fetch of an already-present session preserves object
         // identity and doesn't invalidate downstream memos (issue #319).
-        setStore("session", match.index, reconcile(session))
+        setStore("session", index, reconcile(session))
         return
       }
       setStore(
         "session",
         produce((draft) => {
-          draft.splice(match.index, 0, session)
+          draft.unshift(session)
         }),
       )
     }
@@ -384,27 +386,29 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           const pending = plan.ready ? undefined : inflight.get(sessionID)
           const baseReq =
             pending && options?.trigger?.type === "workspace-transition"
-              ? refreshSessionAfterPending(pending, () => loadSession(sessionID, { force: true }))
+              ? trackSessionSync(
+                  inflight,
+                  sessionID,
+                  refreshSessionAfterPending(pending, async () => {
+                    await loadSession(sessionID, { force: true })
+                    markSessionSynced(sessionID)
+                  }),
+                )
               : (pending ??
                 (plan.ready
                   ? Promise.resolve()
-                  : (() => {
-                      const sessionReq = plan.forceSession ? loadSession(sessionID, { force: true }) : Promise.resolve()
-                      const messagesReq = plan.forceMessages
-                        ? loadLatestMessages(sessionID, { force: true })
-                        : Promise.resolve()
-                      const promise = Promise.all([sessionReq, messagesReq])
-                        .then(() => {
-                          // Session-only reloads (no message fetch) still advance the
-                          // reconnect watermark so later sync() calls can short-circuit.
-                          if (!plan.forceMessages) markSessionSynced(sessionID)
-                        })
-                        .finally(() => {
-                          inflight.delete(sessionID)
-                        })
-                      inflight.set(sessionID, promise)
-                      return promise
-                    })()))
+                  : trackSessionSync(
+                      inflight,
+                      sessionID,
+                      Promise.all([
+                        plan.forceSession ? loadSession(sessionID, { force: true }) : Promise.resolve(),
+                        plan.forceMessages ? loadLatestMessages(sessionID, { force: true }) : Promise.resolve(),
+                      ]).then(() => {
+                        // Session-only reloads (no message fetch) still advance the
+                        // reconnect watermark so later sync() calls can short-circuit.
+                        if (!plan.forceMessages) markSessionSynced(sessionID)
+                      }),
+                    )))
 
           const requests = [baseReq, syncPermissions()]
           if (options?.refreshVolatile) {

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -2679,6 +2679,11 @@ msgstr "Moved to worktree"
 msgid "app.layout.worktree.moveFailed"
 msgstr "Move to worktree failed"
 
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.worktree.refreshFailed"
+msgstr "Workspace status refresh failed"
+
 #. ── Library ───────────────────────────────────────────────────────────────────
 msgid "app.library.category.asset"
 msgstr "Asset"
@@ -11809,6 +11814,16 @@ msgstr "Creating an isolated checkout and binding this session to it."
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.desc.refreshFailed"
+msgstr "The workspace changed successfully, but Synergy couldn’t refresh the session status. {message}"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.desc.refreshing"
+msgstr "The workspace changed. Updating the session status."
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.desc.started"
 msgstr "The workspace is ready and your first message is queued for processing."
 
@@ -11850,6 +11865,11 @@ msgstr "Preparing the worktree and updating this session workspace."
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.detail.promptDispatched"
 msgstr "First prompt dispatched."
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.detail.refreshingStatus"
+msgstr "Loading the updated session workspace."
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
@@ -11940,6 +11960,11 @@ msgstr "Prepare session"
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.step.refreshStatus"
+msgstr "Refresh workspace status"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.step.returnCheckout"
 msgstr "Return to main checkout"
 
@@ -11971,6 +11996,16 @@ msgstr "Move to worktree failed"
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.title.moving"
 msgstr "Moving session to worktree"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.title.refreshFailed"
+msgstr "Workspace status refresh failed"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.title.refreshing"
+msgstr "Refreshing workspace status"
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -2679,6 +2679,11 @@ msgstr ""
 msgid "app.layout.worktree.moveFailed"
 msgstr ""
 
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.worktree.refreshFailed"
+msgstr ""
+
 #. ── Library ───────────────────────────────────────────────────────────────────
 msgid "app.library.category.asset"
 msgstr ""
@@ -11809,6 +11814,16 @@ msgstr ""
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.desc.refreshFailed"
+msgstr ""
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.desc.refreshing"
+msgstr ""
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.desc.started"
 msgstr ""
 
@@ -11849,6 +11864,11 @@ msgstr ""
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.detail.promptDispatched"
+msgstr ""
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.detail.refreshingStatus"
 msgstr ""
 
 #. Runtime Lingui descriptors for session component strings.
@@ -11940,6 +11960,11 @@ msgstr ""
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.step.refreshStatus"
+msgstr ""
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.step.returnCheckout"
 msgstr ""
 
@@ -11970,6 +11995,16 @@ msgstr ""
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.title.moving"
+msgstr ""
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.title.refreshFailed"
+msgstr ""
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.title.refreshing"
 msgstr ""
 
 #. Runtime Lingui descriptors for session component strings.

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -2679,6 +2679,11 @@ msgstr "已移至隔离工作区"
 msgid "app.layout.worktree.moveFailed"
 msgstr "无法移至隔离工作区"
 
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.worktree.refreshFailed"
+msgstr "工作区状态刷新失败"
+
 #. ── Library ───────────────────────────────────────────────────────────────────
 msgid "app.library.category.asset"
 msgstr "资产"
@@ -11809,6 +11814,16 @@ msgstr "正在创建隔离工作区并将此会话移入其中。"
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.desc.refreshFailed"
+msgstr "工作区已成功变更，但 Synergy 无法刷新会话状态。{message}"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.desc.refreshing"
+msgstr "工作区已变更。正在更新会话状态。"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.desc.started"
 msgstr "工作区已就绪，你的第一条消息正在等待处理。"
 
@@ -11850,6 +11865,11 @@ msgstr "正在准备工作树并更新此会话工作区。"
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.detail.promptDispatched"
 msgstr "第一条消息已发送。"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.detail.refreshingStatus"
+msgstr "正在加载更新后的会话工作区。"
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
@@ -11940,6 +11960,11 @@ msgstr "准备会话"
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.step.refreshStatus"
+msgstr "刷新工作区状态"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.step.returnCheckout"
 msgstr "切回主工作区"
 
@@ -11971,6 +11996,16 @@ msgstr "无法移至隔离工作区"
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "session.worktree.title.moving"
 msgstr "正在将会话移至工作树"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.title.refreshFailed"
+msgstr "工作区状态刷新失败"
+
+#. Runtime Lingui descriptors for session component strings.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "session.worktree.title.refreshing"
+msgstr "正在刷新工作区状态"
 
 #. Runtime Lingui descriptors for session component strings.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -48,6 +48,8 @@ import { blueprintNoteCreateFocusRequest } from "@/context/plan-blueprint-offer"
 import {
   createWorkspaceTransitionErrorProgress,
   createWorkspaceTransitionLoadingProgress,
+  createWorkspaceTransitionRefreshErrorProgress,
+  createWorkspaceTransitionRefreshProgress,
   createWorkspaceTransitionSuccessProgress,
   defaultNewSessionWorkspaceSelection,
   normalizePathForCompare,
@@ -188,6 +190,40 @@ function SessionPageContent() {
   const sessionTransitionPending = createMemo(() => isSessionTransitionBlocking(visibleSessionTransition()))
   const clearSessionTransition = sessionTransition.clear
   const setSessionTransition = sessionTransition.set
+  const refreshWorkspaceTransition = (input: {
+    request: SessionWorkspaceTransitionRequest
+    success: SessionTransitionProgress
+    toast: { title: string; description: string }
+  }) => {
+    const { request } = input
+    setSessionTransition(request.sessionID, createWorkspaceTransitionRefreshProgress(request))
+    const retry = () => refreshWorkspaceTransition(input)
+    const run = async () => {
+      try {
+        await sync.session.sync(request.sessionID, { trigger: { type: "workspace-transition" } })
+        setSessionTransition(request.sessionID, input.success, {
+          dismiss: () => clearSessionTransition(request.sessionID),
+        })
+        showToast({ type: "info", ...input.toast })
+      } catch (error) {
+        const message = requestErrorMessage(error)
+        setSessionTransition(
+          request.sessionID,
+          createWorkspaceTransitionRefreshErrorProgress({ operation: request.operation, message }),
+          {
+            retry,
+            dismiss: () => clearSessionTransition(request.sessionID),
+          },
+        )
+        showToast({
+          type: "error",
+          title: i18n._(AP.layoutWorktreeRefreshFailed.id),
+          description: message,
+        })
+      }
+    }
+    void run()
+  }
   const startWorkspaceTransition = (request: SessionWorkspaceTransitionRequest) => {
     if (sessionTransition.get(request.sessionID)?.progress.phase === "loading") return
     const retry = () => startWorkspaceTransition(request)
@@ -196,17 +232,13 @@ function SessionPageContent() {
       try {
         if (request.operation === "leave") {
           await sdk.client.worktree.leave({ directory: request.directory, sessionID: request.sessionID })
-          const progress = createWorkspaceTransitionSuccessProgress({ operation: "leave" })
-          await sync.session
-            .sync(request.sessionID, { trigger: { type: "workspace-transition" } })
-            .catch(() => undefined)
-          setSessionTransition(request.sessionID, progress, {
-            dismiss: () => clearSessionTransition(request.sessionID),
-          })
-          showToast({
-            type: "info",
-            title: i18n._(AP.layoutLeftWorktree.id),
-            description: i18n._(AP.layoutWorktreeLeftToast.id),
+          refreshWorkspaceTransition({
+            request,
+            success: createWorkspaceTransitionSuccessProgress({ operation: "leave" }),
+            toast: {
+              title: i18n._(AP.layoutLeftWorktree.id),
+              description: i18n._(AP.layoutWorktreeLeftToast.id),
+            },
           })
           return
         }
@@ -232,12 +264,11 @@ function SessionPageContent() {
         const description = result.data?.name
           ? i18n._(AP.layoutWorktreeDesc.id, { name: result.data.name })
           : i18n._(AP.layoutWorktreeDescDefault.id)
-        const progress = createWorkspaceTransitionSuccessProgress({ operation: "enter", description })
-        await sync.session.sync(request.sessionID, { trigger: { type: "workspace-transition" } }).catch(() => undefined)
-        setSessionTransition(request.sessionID, progress, {
-          dismiss: () => clearSessionTransition(request.sessionID),
+        refreshWorkspaceTransition({
+          request,
+          success: createWorkspaceTransitionSuccessProgress({ operation: "enter", description }),
+          toast: { title: i18n._(AP.layoutMovedToWorktree.id), description },
         })
-        showToast({ type: "info", title: i18n._(AP.layoutMovedToWorktree.id), description })
       } catch (error) {
         const message = requestErrorMessage(error)
         setSessionTransition(


### PR DESCRIPTION
## Summary

- replace ID-based binary searches over recency-ordered session collections with shared lookup helpers, and prepend newly observed sessions to preserve the server projection
- keep replacement session sync requests tracked and run the authoritative metadata refresh even when the stale pending request rejects
- separate successful worktree mutations from metadata refresh failures so the UI reports the refresh error and retry reruns only the sync

Follow-up to #757.

## Validation

- `bun run --cwd packages/app test`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`