### PR TITLE
fix: honor channel model variants

### DIFF
--- a/docs/product/connections.md
+++ b/docs/product/connections.md
@@ -19,6 +19,8 @@ The provider contract supports:
 
 Feishu/Lark is the current built-in provider. It owns Feishu-specific deduplication, mentions, group behavior, media transfer, cards, and reconnect handling while the Channel core owns endpoint/session routing and outbound delivery.
 
+Each Feishu/Lark account can set a default model and one of that model's exposed variants. The account selection is written onto each inbound root message so the session header and provider request agree. A conversation-level `/model` override takes precedence over the account default; because that override selects a different model, it does not inherit the account model's variant.
+
 Channel sessions default to the `autonomous` control profile. An inbound message therefore receives either an allowed result or a clear denial; it never stalls on an approval dialog visible only in another client.
 
 ## Holos Identity

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -148,6 +148,8 @@ Automatic reasoning variants are derived from model identity (`model.id`, API mo
 
 `role_variant` selects a variant name for a model role only when the resolved model exposes that same variant. If a provider-managed reasoning model exposes no automatic variants, `role_variant: { "thinking": "max" }` does not synthesize provider options; the request uses the provider's default reasoning behavior. Explicit model `variants` configured under a provider model are merged after automatic defaults, so they can add or override named variants for that model.
 
+Feishu/Lark account configuration may pair an explicit `model` with `variant`. The Settings Channel model selector lists the same model variants used by model roles, and the selected variant is sent only while that account model is effective. A conversation-level `/model` override takes precedence and does not reuse the account model's variant.
+
 ## Control Profiles and Sandbox
 
 `controlProfile` selects `guarded`, `autonomous`, or `full_access`. Session and agent settings can override the global value through the resolution order documented in [Execution Boundaries](../architecture/execution-boundaries.md).

--- a/packages/app/PRODUCT.md
+++ b/packages/app/PRODUCT.md
@@ -74,6 +74,7 @@ Library settings should explain learning, memory recall, and experience reuse as
 Library settings should always identify the effective embedding model. A user-configured remote model takes precedence and should be labeled as configured; the bundled local model is the visible default fallback only when no remote embedding API key is configured. Keep local download-source and file-status controls subordinate to that effective-model row, and do not expose API keys or private connection details in the summary.
 
 Model settings should keep role routing and quick-switcher visibility together in one Models page. Specialist model roles are the first section; connected models and their quick-switch toggles are the second section. Avoid reopening a separate Manage Models modal from inside Settings.
+Channel account model overrides should pair the model and variant selectors in one row. Variant choices come from the selected model's current catalog entry, and changing to a model that does not expose the saved variant clears that stale choice.
 
 Provider settings should behave like a connection workspace, not a config editor. Keep provider discovery, selected-provider detail, and login flows together in the Providers page; provider quota, billing, and account-health details belong in Usage. The provider list should scroll inside its own column so the selected detail remains anchored. Do not expose raw provider allow/deny text lists in the primary settings UI.
 

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -544,8 +544,12 @@ export function SettingsPanel(props: SettingsPanelProps) {
       <ChannelsPanel
         channels={settings.channels}
         providers={providerGroups()}
+        popoverLayer={settingsPopoverLayer()}
         onChannelToggle={(index, value) => setSettings("channels", "feishuAccounts", index, "enabled", value)}
         onChannelModelChange={(index, model) => setSettings("channels", "feishuAccounts", index, "model", model)}
+        onChannelVariantChange={(index, variant) =>
+          setSettings("channels", "feishuAccounts", index, "variant", variant)
+        }
       />
     ),
     email: () => (

--- a/packages/app/src/components/settings/channel-account-model.ts
+++ b/packages/app/src/components/settings/channel-account-model.ts
@@ -1,0 +1,11 @@
+import type { ProviderGroup } from "./types"
+
+export function channelAccountVariantKeys(modelRef: string, providers: ProviderGroup[]): string[] {
+  const separator = modelRef.indexOf("/")
+  if (separator === -1) return []
+
+  const providerID = modelRef.slice(0, separator)
+  const modelID = modelRef.slice(separator + 1)
+  const provider = providers.find((item) => item.providerId === providerID)
+  return provider?.models.find((item) => item.id === modelID)?.variantKeys ?? []
+}

--- a/packages/app/src/components/settings/components/AccountToggleCard.tsx
+++ b/packages/app/src/components/settings/components/AccountToggleCard.tsx
@@ -4,7 +4,9 @@ import { Switch } from "@ericsanchezok/synergy-ui/switch"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { List } from "@ericsanchezok/synergy-ui/list"
+import { channelAccountVariantKeys } from "../channel-account-model"
 import type { AccountToggle, ProviderGroup } from "../types"
+import { ModelVariantPicker } from "./ModelVariantPicker"
 import { SettingRow } from "./SettingRow"
 
 const useDefaultLabel = { id: "settings.accountToggle.useDefault", message: "Use default" }
@@ -28,6 +30,7 @@ type ModelPickOption = {
   label: string
   description: string
   value: string
+  variantKeys: string[]
 }
 
 export function AccountToggleCard(props: {
@@ -36,8 +39,10 @@ export function AccountToggleCard(props: {
   accounts: AccountToggle[]
   emptyLabel: string
   providers: ProviderGroup[]
+  popoverLayer?: HTMLElement
   onToggle: (index: number, value: boolean) => void
   onModelChange: (index: number, model: string) => void
+  onVariantChange: (index: number, variant: string) => void
 }) {
   const { _ } = useLingui()
   const modelOptions = createMemo<ModelPickOption[]>(() => [
@@ -48,6 +53,7 @@ export function AccountToggleCard(props: {
       label: _(useDefaultLabel),
       description: _(inheritDesc),
       value: "",
+      variantKeys: [],
     },
     ...props.providers.flatMap((provider) =>
       provider.models.map((model) => ({
@@ -57,6 +63,7 @@ export function AccountToggleCard(props: {
         label: model.name,
         description: provider.providerName,
         value: `${provider.providerId}/${model.id}`,
+        variantKeys: model.variantKeys,
       })),
     ),
   ])
@@ -83,6 +90,7 @@ export function AccountToggleCard(props: {
             const displayText = createMemo(() =>
               account.model ? (selectedLabel().get(account.model) ?? account.model) : _(useDefaultLabel),
             )
+            const availableVariants = createMemo(() => channelAccountVariantKeys(account.model, props.providers))
 
             return (
               <div class="ds-setting-subsection">
@@ -98,44 +106,55 @@ export function AccountToggleCard(props: {
                     </div>
                     <span class="settings-model-description">{_(modelOverrideDesc)}</span>
                   </div>
-                  <KobaltePopover open={pickerOpen()} onOpenChange={setPickerOpen} placement="bottom-end" gutter={8}>
-                    <KobaltePopover.Trigger
-                      type="button"
-                      class="settings-model-trigger"
-                      aria-label={_(selectModelAria(account.key))}
-                    >
-                      <span class="settings-model-trigger-text">
-                        <span class="settings-model-trigger-title">{displayText()}</span>
-                      </span>
-                      <Icon name="chevron-down" size="small" class="settings-model-trigger-icon" />
-                    </KobaltePopover.Trigger>
-                    <KobaltePopover.Content class="settings-model-picker-popover flex flex-col border border-border-base bg-surface-raised-stronger-non-alpha shadow-lg outline-none overflow-hidden">
-                      <KobaltePopover.Title class="sr-only">{_(selectModelAria(account.key))}</KobaltePopover.Title>
-                      <List<ModelPickOption>
-                        class="settings-model-picker-list"
-                        search={{ placeholder: _(searchModelsPlaceholder), autofocus: true }}
-                        emptyMessage={_(noModelResults)}
-                        key={(option) => option.key}
-                        items={modelOptions}
-                        current={currentOption()}
-                        filterKeys={["label", "description", "value"]}
-                        groupBy={(option) => option.group}
-                        sortGroupsBy={sortModelGroups}
-                        onSelect={(option) => {
-                          if (!option) return
-                          props.onModelChange(index(), option.value)
-                          setPickerOpen(false)
-                        }}
+                  <div class="settings-model-selector">
+                    <KobaltePopover open={pickerOpen()} onOpenChange={setPickerOpen} placement="bottom-end" gutter={8}>
+                      <KobaltePopover.Trigger
+                        type="button"
+                        class="settings-model-trigger"
+                        aria-label={_(selectModelAria(account.key))}
                       >
-                        {(option) => (
-                          <div class="settings-model-option">
-                            <span class="settings-model-option-title">{option.label}</span>
-                            <span class="settings-model-option-detail">{option.description}</span>
-                          </div>
-                        )}
-                      </List>
-                    </KobaltePopover.Content>
-                  </KobaltePopover>
+                        <span class="settings-model-trigger-text">
+                          <span class="settings-model-trigger-title">{displayText()}</span>
+                        </span>
+                        <Icon name="chevron-down" size="small" class="settings-model-trigger-icon" />
+                      </KobaltePopover.Trigger>
+                      <KobaltePopover.Content class="settings-model-picker-popover flex flex-col border border-border-base bg-surface-raised-stronger-non-alpha shadow-lg outline-none overflow-hidden">
+                        <KobaltePopover.Title class="sr-only">{_(selectModelAria(account.key))}</KobaltePopover.Title>
+                        <List<ModelPickOption>
+                          class="settings-model-picker-list"
+                          search={{ placeholder: _(searchModelsPlaceholder), autofocus: true }}
+                          emptyMessage={_(noModelResults)}
+                          key={(option) => option.key}
+                          items={modelOptions}
+                          current={currentOption()}
+                          filterKeys={["label", "description", "value"]}
+                          groupBy={(option) => option.group}
+                          sortGroupsBy={sortModelGroups}
+                          onSelect={(option) => {
+                            if (!option) return
+                            props.onModelChange(index(), option.value)
+                            if (!option.variantKeys.includes(account.variant)) {
+                              props.onVariantChange(index(), "")
+                            }
+                            setPickerOpen(false)
+                          }}
+                        >
+                          {(option) => (
+                            <div class="settings-model-option">
+                              <span class="settings-model-option-title">{option.label}</span>
+                              <span class="settings-model-option-detail">{option.description}</span>
+                            </div>
+                          )}
+                        </List>
+                      </KobaltePopover.Content>
+                    </KobaltePopover>
+                    <ModelVariantPicker
+                      value={account.variant}
+                      availableVariants={availableVariants()}
+                      popoverLayer={props.popoverLayer}
+                      onChange={(variant) => props.onVariantChange(index(), variant)}
+                    />
+                  </div>
                 </div>
               </div>
             )

--- a/packages/app/src/components/settings/components/ModelRoleRow.tsx
+++ b/packages/app/src/components/settings/components/ModelRoleRow.tsx
@@ -8,10 +8,8 @@ import { createMemo, createSignal, For, Show } from "solid-js"
 import { Portal } from "solid-js/web"
 import type { ModelKey, ModelsStore, ProviderGroup } from "../types"
 import { createProviderModelIndex, fieldLabel, modelRoleCopy, resolveModelRoleDraftDisplay } from "../model-role-draft"
+import { ModelVariantPicker } from "./ModelVariantPicker"
 
-const variantDefault = { id: "settings.modelRole.variant.default", message: "Default" }
-const variantDesc = { id: "settings.modelRole.variant.desc", message: "Use the role default" }
-const variantRoleDesc = { id: "settings.modelRole.variant.role", message: "Role variant" }
 const noAgentsUse = { id: "settings.modelRole.noAgentsUse", message: "No agents directly use this role." }
 const usedByLabel = { id: "settings.modelRole.usedBy", message: "Used by" }
 const fallbackChainLabel = { id: "settings.modelRole.fallbackChain", message: "Fallback" }
@@ -22,7 +20,6 @@ const searchModelsPlaceholder = {
   message: "Search models",
 }
 const noModelResultsLabel = { id: "settings.modelRole.noModelResults", message: "No model results" }
-const selectVariantLabel = { id: "settings.modelRole.selectVariant", message: "Select model variant" }
 const detailsAriaLabel = { id: "settings.modelRole.details.ariaLabel", message: "{label} details" }
 const systemAgentLabel = { id: "settings.modelRole.system", message: "system" }
 const overrideAgentLabel = { id: "settings.modelRole.override", message: "override" }
@@ -51,13 +48,6 @@ type ModelPickerOption =
       ref: ModelRef
     }
 
-type ModelVariantOption = {
-  key: string
-  label: string
-  description: string
-  value: string
-}
-
 export function ModelRoleRow(props: {
   summary: ModelRoleSummary
   value: string
@@ -72,7 +62,6 @@ export function ModelRoleRow(props: {
 }) {
   const { _ } = useLingui()
   const [pickerOpen, setPickerOpen] = createSignal(false)
-  const [variantPickerOpen, setVariantPickerOpen] = createSignal(false)
   const [detailsOpen, setDetailsOpen] = createSignal(false)
 
   const providerIndex = createMemo(() => createProviderModelIndex(props.providers))
@@ -117,26 +106,6 @@ export function ModelRoleRow(props: {
     if (!props.value) return options()[0]
     return options().find((option) => option.value === props.value)
   })
-
-  const variantOptions = createMemo<ModelVariantOption[]>(() => [
-    { key: "default", label: _(variantDefault), description: _(variantDesc), value: "" },
-    ...props.availableVariants.map((variant) => ({
-      key: variant,
-      label: variant,
-      description: _(variantRoleDesc),
-      value: variant,
-    })),
-  ])
-
-  const currentVariantOption = createMemo(() =>
-    variantOptions().find((option) => option.value === (props.roleVariant ?? "")),
-  )
-
-  function selectModelVariantOption(option: ModelVariantOption | undefined) {
-    if (!option) return
-    props.onVariantChange?.(option.value)
-    setVariantPickerOpen(false)
-  }
 
   function selectModelRoleOption(option: ModelPickerOption | undefined) {
     if (!option) return
@@ -256,42 +225,15 @@ export function ModelRoleRow(props: {
             )}
           </Show>
         </KobaltePopover>
-        <Show when={props.availableVariants.length > 0 && props.onVariantChange}>
-          <KobaltePopover
-            open={variantPickerOpen()}
-            onOpenChange={setVariantPickerOpen}
-            placement="bottom-end"
-            gutter={8}
-          >
-            <KobaltePopover.Trigger type="button" class="settings-model-variant" aria-label={_(selectVariantLabel)}>
-              <span class="settings-model-variant-label">{currentVariantOption()?.label ?? _(variantDefault)}</span>
-              <Icon name="chevron-down" size="small" class="settings-model-trigger-icon" />
-            </KobaltePopover.Trigger>
-            <Show when={props.popoverLayer}>
-              {(layer) => (
-                <Portal mount={layer()}>
-                  <KobaltePopover.Content class="settings-model-variant-popover flex flex-col border border-border-base bg-surface-raised-stronger-non-alpha shadow-lg outline-none overflow-hidden">
-                    <KobaltePopover.Title class="sr-only">{_(selectVariantLabel)}</KobaltePopover.Title>
-                    <List<ModelVariantOption>
-                      class="settings-model-picker-list"
-                      key={(option) => option.key}
-                      items={variantOptions}
-                      current={currentVariantOption()}
-                      filterKeys={["label", "description", "value"]}
-                      onSelect={selectModelVariantOption}
-                    >
-                      {(option) => (
-                        <div class="settings-model-option">
-                          <span class="settings-model-option-title">{option.label}</span>
-                          <span class="settings-model-option-detail">{option.description}</span>
-                        </div>
-                      )}
-                    </List>
-                  </KobaltePopover.Content>
-                </Portal>
-              )}
-            </Show>
-          </KobaltePopover>
+        <Show when={props.onVariantChange}>
+          {(onVariantChange) => (
+            <ModelVariantPicker
+              value={props.roleVariant}
+              availableVariants={props.availableVariants}
+              popoverLayer={props.popoverLayer}
+              onChange={onVariantChange()}
+            />
+          )}
         </Show>
       </div>
     </div>

--- a/packages/app/src/components/settings/components/ModelVariantPicker.tsx
+++ b/packages/app/src/components/settings/components/ModelVariantPicker.tsx
@@ -1,0 +1,79 @@
+import { useLingui } from "@lingui/solid"
+import { Popover as KobaltePopover } from "@kobalte/core/popover"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
+import { List } from "@ericsanchezok/synergy-ui/list"
+import { createMemo, createSignal, Show } from "solid-js"
+import { Portal } from "solid-js/web"
+
+const variantDefault = { id: "settings.modelRole.variant.default", message: "Default" }
+const variantDesc = { id: "settings.modelRole.variant.desc", message: "Use the role default" }
+const variantRoleDesc = { id: "settings.modelRole.variant.role", message: "Role variant" }
+const selectVariantLabel = { id: "settings.modelRole.selectVariant", message: "Select model variant" }
+
+type ModelVariantOption = {
+  key: string
+  label: string
+  description: string
+  value: string
+}
+
+export function ModelVariantPicker(props: {
+  value?: string
+  availableVariants: string[]
+  popoverLayer?: HTMLElement
+  onChange: (variant: string) => void
+}) {
+  const { _ } = useLingui()
+  const [open, setOpen] = createSignal(false)
+  const options = createMemo<ModelVariantOption[]>(() => [
+    { key: "default", label: _(variantDefault), description: _(variantDesc), value: "" },
+    ...props.availableVariants.map((variant) => ({
+      key: variant,
+      label: variant,
+      description: _(variantRoleDesc),
+      value: variant,
+    })),
+  ])
+  const current = createMemo(() => options().find((option) => option.value === (props.value ?? "")))
+
+  function select(option: ModelVariantOption | undefined) {
+    if (!option) return
+    props.onChange(option.value)
+    setOpen(false)
+  }
+
+  const content = () => (
+    <KobaltePopover.Content class="settings-model-variant-popover flex flex-col border border-border-base bg-surface-raised-stronger-non-alpha shadow-lg outline-none overflow-hidden">
+      <KobaltePopover.Title class="sr-only">{_(selectVariantLabel)}</KobaltePopover.Title>
+      <List<ModelVariantOption>
+        class="settings-model-picker-list"
+        key={(option) => option.key}
+        items={options}
+        current={current()}
+        filterKeys={["label", "description", "value"]}
+        onSelect={select}
+      >
+        {(option) => (
+          <div class="settings-model-option">
+            <span class="settings-model-option-title">{option.label}</span>
+            <span class="settings-model-option-detail">{option.description}</span>
+          </div>
+        )}
+      </List>
+    </KobaltePopover.Content>
+  )
+
+  return (
+    <Show when={props.availableVariants.length > 0}>
+      <KobaltePopover open={open()} onOpenChange={setOpen} placement="bottom-end" gutter={8}>
+        <KobaltePopover.Trigger type="button" class="settings-model-variant" aria-label={_(selectVariantLabel)}>
+          <span class="settings-model-variant-label">{current()?.label ?? _(variantDefault)}</span>
+          <Icon name="chevron-down" size="small" class="settings-model-trigger-icon" />
+        </KobaltePopover.Trigger>
+        <Show when={props.popoverLayer} fallback={content()}>
+          {(layer) => <Portal mount={layer()}>{content()}</Portal>}
+        </Show>
+      </KobaltePopover>
+    </Show>
+  )
+}

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -357,7 +357,8 @@ function buildChannelPatch(cfg: Config, state: SettingsState, patch: Record<stri
       const account = newChannel.feishu.accounts[entry.key]
       if (!account) continue
       account.enabled = entry.enabled
-      ;(account as Record<string, unknown>).model = entry.model || undefined
+      account.model = entry.model || undefined
+      account.variant = entry.model ? entry.variant || undefined : undefined
     }
   }
   if (JSON.stringify(newChannel) !== JSON.stringify(currentChannel)) patch.channel = newChannel

--- a/packages/app/src/components/settings/hooks/useSettingsForm.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.ts
@@ -162,7 +162,8 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
       ? Object.entries(cfg.channel.feishu.accounts).map(([key, account]) => ({
           key,
           enabled: account.enabled !== false,
-          model: ((account as Record<string, unknown>).model as string) ?? "",
+          model: account.model ?? "",
+          variant: account.variant ?? "",
         }))
       : [],
   })

--- a/packages/app/src/components/settings/panels/ChannelsPanel.tsx
+++ b/packages/app/src/components/settings/panels/ChannelsPanel.tsx
@@ -19,8 +19,10 @@ const emptyFeishuLabel = { id: "settings.channels.feishu.empty", message: "No Fe
 export function ChannelsPanel(props: {
   channels: ChannelSettings
   providers: ProviderGroup[]
+  popoverLayer?: HTMLElement
   onChannelToggle: (index: number, value: boolean) => void
   onChannelModelChange: (index: number, model: string) => void
+  onChannelVariantChange: (index: number, variant: string) => void
 }) {
   const { _ } = useLingui()
   return (
@@ -32,8 +34,10 @@ export function ChannelsPanel(props: {
           accounts={props.channels.feishuAccounts}
           emptyLabel={_(emptyFeishuLabel)}
           providers={props.providers}
+          popoverLayer={props.popoverLayer}
           onToggle={props.onChannelToggle}
           onModelChange={props.onChannelModelChange}
+          onVariantChange={props.onChannelVariantChange}
         />
       </SettingsSection>
     </SettingsPage>

--- a/packages/app/src/components/settings/types.ts
+++ b/packages/app/src/components/settings/types.ts
@@ -186,6 +186,7 @@ export type AccountToggle = {
   key: string
   enabled: boolean
   model: string
+  variant: string
 }
 
 export type ChannelSettings = {

--- a/packages/app/test/components/settings/components/AccountToggleCard.test.ts
+++ b/packages/app/test/components/settings/components/AccountToggleCard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { channelAccountVariantKeys } from "../../../../src/components/settings/channel-account-model"
+
+describe("Feishu account model selection", () => {
+  test("exposes the selected model variants for the account effort control", () => {
+    const providers = [
+      {
+        providerId: "openai-codex",
+        providerName: "OpenAI Codex",
+        models: [{ id: "gpt-5.6-sol", name: "GPT-5.6 Sol", variantKeys: ["low", "high"] }],
+      },
+    ]
+
+    expect(channelAccountVariantKeys("openai-codex/gpt-5.6-sol", providers)).toEqual(["low", "high"])
+    expect(channelAccountVariantKeys("", providers)).toEqual([])
+    expect(channelAccountVariantKeys("openai-codex/unknown", providers)).toEqual([])
+  })
+})

--- a/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
@@ -4,6 +4,42 @@ import { buildPatch } from "../../../../src/components/settings/hooks/useConfigP
 import { defaultSettingsState } from "../../../../src/components/settings/types"
 
 describe("settings config patch", () => {
+  test("persists a Feishu account model variant", () => {
+    const state = defaultSettingsState("enter")
+    state.channels.feishuAccounts = [
+      {
+        key: "default",
+        enabled: true,
+        model: "openai-codex/gpt-5.6-sol",
+        variant: "high",
+      },
+    ]
+
+    const patch = buildPatch({
+      cfg: {
+        channel: {
+          feishu: {
+            type: "feishu",
+            accounts: {
+              default: {
+                appId: "app",
+                appSecret: "secret",
+                model: "openai-codex/gpt-5.6-sol",
+              },
+            },
+          },
+        },
+      } as Config,
+      state,
+      originalMcps: {},
+    })
+
+    expect((patch.channel as Config["channel"])?.feishu?.accounts.default).toMatchObject({
+      model: "openai-codex/gpt-5.6-sol",
+      variant: "high",
+    })
+  })
+
   test("model role drafts only materialize as server patch fields", () => {
     const state = defaultSettingsState("enter")
     state.models.model = "openai/gpt-5.5"

--- a/packages/app/test/components/settings/hooks/useSettingsForm.test.ts
+++ b/packages/app/test/components/settings/hooks/useSettingsForm.test.ts
@@ -67,6 +67,37 @@ describe("settings form Cortex concurrency", () => {
   })
 })
 
+describe("settings form channel model variants", () => {
+  test("hydrates the configured account model variant", () => {
+    expect(
+      initializedChannels({
+        channel: {
+          feishu: {
+            type: "feishu",
+            accounts: {
+              default: {
+                appId: "app",
+                appSecret: "secret",
+                model: "openai-codex/gpt-5.6-sol",
+                variant: "high",
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      feishuAccounts: [
+        {
+          key: "default",
+          enabled: true,
+          model: "openai-codex/gpt-5.6-sol",
+          variant: "high",
+        },
+      ],
+    })
+  })
+})
+
 function initializedRuntime(config: Record<string, unknown>) {
   const [settings, setSettings] = createStore(defaultSettingsState("enter"))
 
@@ -83,6 +114,24 @@ function initializedRuntime(config: Record<string, unknown>) {
   })
 
   return settings.runtime
+}
+
+function initializedChannels(config: Record<string, unknown>) {
+  const [settings, setSettings] = createStore(defaultSettingsState("enter"))
+
+  ensureInit({
+    cfg: config as Config,
+    setName: "global",
+    refreshing: () => false,
+    initialized: () => false,
+    initializedForSet: undefined,
+    sendShortcut: () => "enter",
+    setSettings,
+    setInitialized: () => undefined,
+    originalMcpsRef: { current: {} },
+  })
+
+  return settings.channels
 }
 
 function storageWithModel(value: unknown): Storage {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2713,10 +2713,6 @@ export type McpLocalConfig = {
     [key: string]: string
   }
   /**
-   * Enable or disable the MCP server on startup
-   */
-  enabled?: boolean
-  /**
    * Deprecated legacy timeout in ms for MCP operations. Prefer connectTimeout/listTimeout/callTimeout.
    */
   timeout?: number
@@ -2748,6 +2744,10 @@ export type McpLocalConfig = {
   toolFilter?: McpToolFilterConfig
   tools?: McpToolsConfig
   toolCache?: McpToolCacheConfig
+  /**
+   * Enable or disable the MCP server on startup
+   */
+  enabled?: boolean
 }
 
 export type McpOAuthConfig = {
@@ -2774,10 +2774,6 @@ export type McpRemoteConfig = {
    * URL of the remote MCP server
    */
   url: string
-  /**
-   * Enable or disable the MCP server on startup
-   */
-  enabled?: boolean
   /**
    * Headers to send with the request
    */
@@ -2820,6 +2816,10 @@ export type McpRemoteConfig = {
   toolFilter?: McpToolFilterConfig
   tools?: McpToolsConfig
   toolCache?: McpToolCacheConfig
+  /**
+   * Enable or disable the MCP server on startup
+   */
+  enabled?: boolean
 }
 
 /**
@@ -2906,6 +2906,10 @@ export type ChannelFeishuAccountConfig = {
    * Model to use for this account in providerID/modelID format (e.g. openai/gpt-4o)
    */
   model?: string
+  /**
+   * Model variant to use with this account model (e.g. low, high, max)
+   */
+  variant?: string
   /**
    * Resolve sender display names via Feishu contact API
    */
@@ -7792,27 +7796,6 @@ export type EventAgendaItemDeleted = {
   }
 }
 
-export type EventCortexTaskCreated = {
-  type: "cortex.task.created"
-  properties: {
-    task: CortexTask
-  }
-}
-
-export type EventCortexTaskCompleted = {
-  type: "cortex.task.completed"
-  properties: {
-    task: CortexTask
-  }
-}
-
-export type EventCortexTasksUpdated = {
-  type: "cortex.tasks.updated"
-  properties: {
-    tasks: Array<CortexTask>
-  }
-}
-
 export type EventSynergyLinkTargetCreated = {
   type: "synergy_link.target.created"
   properties: {
@@ -7831,6 +7814,27 @@ export type EventSynergyLinkTargetRemoved = {
   type: "synergy_link.target.removed"
   properties: {
     id: string
+  }
+}
+
+export type EventCortexTaskCreated = {
+  type: "cortex.task.created"
+  properties: {
+    task: CortexTask
+  }
+}
+
+export type EventCortexTaskCompleted = {
+  type: "cortex.task.completed"
+  properties: {
+    task: CortexTask
+  }
+}
+
+export type EventCortexTasksUpdated = {
+  type: "cortex.tasks.updated"
+  properties: {
+    tasks: Array<CortexTask>
   }
 }
 
@@ -8061,12 +8065,12 @@ export type Event =
   | EventAgendaItemCreated
   | EventAgendaItemUpdated
   | EventAgendaItemDeleted
-  | EventCortexTaskCreated
-  | EventCortexTaskCompleted
-  | EventCortexTasksUpdated
   | EventSynergyLinkTargetCreated
   | EventSynergyLinkTargetUpdated
   | EventSynergyLinkTargetRemoved
+  | EventCortexTaskCreated
+  | EventCortexTaskCompleted
+  | EventCortexTasksUpdated
   | EventPluginEvent
   | EventCommandExecuted
   | EventFileWatcherUpdated

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -26506,9 +26506,11 @@
           },
           "command": {
             "description": "Command and arguments to run the MCP server",
+            "minItems": 1,
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "cwd": {
@@ -26524,10 +26526,6 @@
             "additionalProperties": {
               "type": "string"
             }
-          },
-          "enabled": {
-            "description": "Enable or disable the MCP server on startup",
-            "type": "boolean"
           },
           "timeout": {
             "description": "Deprecated legacy timeout in ms for MCP operations. Prefer connectTimeout/listTimeout/callTimeout.",
@@ -26579,6 +26577,10 @@
           },
           "toolCache": {
             "$ref": "#/components/schemas/McpToolCacheConfig"
+          },
+          "enabled": {
+            "description": "Enable or disable the MCP server on startup",
+            "type": "boolean"
           }
         },
         "required": ["type", "command"],
@@ -26612,11 +26614,8 @@
           },
           "url": {
             "description": "URL of the remote MCP server",
-            "type": "string"
-          },
-          "enabled": {
-            "description": "Enable or disable the MCP server on startup",
-            "type": "boolean"
+            "type": "string",
+            "format": "uri"
           },
           "headers": {
             "description": "Headers to send with the request",
@@ -26690,6 +26689,10 @@
           },
           "toolCache": {
             "$ref": "#/components/schemas/McpToolCacheConfig"
+          },
+          "enabled": {
+            "description": "Enable or disable the MCP server on startup",
+            "type": "boolean"
           }
         },
         "required": ["type", "url"],
@@ -26813,6 +26816,10 @@
           },
           "model": {
             "description": "Model to use for this account in providerID/modelID format (e.g. openai/gpt-4o)",
+            "type": "string"
+          },
+          "variant": {
+            "description": "Model variant to use with this account model (e.g. low, high, max)",
             "type": "string"
           },
           "resolveSenderNames": {
@@ -40547,6 +40554,64 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.synergy_link.target.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "synergy_link.target.created"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "$ref": "#/components/schemas/SynergyLinkTarget"
+              }
+            },
+            "required": ["target"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.synergy_link.target.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "synergy_link.target.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "$ref": "#/components/schemas/SynergyLinkTarget"
+              }
+            },
+            "required": ["target"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.synergy_link.target.removed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "synergy_link.target.removed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^target_[0-9a-f-]{36}$"
+              }
+            },
+            "required": ["id"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "Event.cortex.task.created": {
         "type": "object",
         "properties": {
@@ -40603,64 +40668,6 @@
               }
             },
             "required": ["tasks"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.synergy_link.target.created": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "synergy_link.target.created"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "target": {
-                "$ref": "#/components/schemas/SynergyLinkTarget"
-              }
-            },
-            "required": ["target"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.synergy_link.target.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "synergy_link.target.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "target": {
-                "$ref": "#/components/schemas/SynergyLinkTarget"
-              }
-            },
-            "required": ["target"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.synergy_link.target.removed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "synergy_link.target.removed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^target_[0-9a-f-]{36}$"
-              }
-            },
-            "required": ["id"]
           }
         },
         "required": ["type", "properties"]
@@ -41310,15 +41317,6 @@
             "$ref": "#/components/schemas/Event.agenda.item.deleted"
           },
           {
-            "$ref": "#/components/schemas/Event.cortex.task.created"
-          },
-          {
-            "$ref": "#/components/schemas/Event.cortex.task.completed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.cortex.tasks.updated"
-          },
-          {
             "$ref": "#/components/schemas/Event.synergy_link.target.created"
           },
           {
@@ -41326,6 +41324,15 @@
           },
           {
             "$ref": "#/components/schemas/Event.synergy_link.target.removed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.cortex.task.created"
+          },
+          {
+            "$ref": "#/components/schemas/Event.cortex.task.completed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.cortex.tasks.updated"
           },
           {
             "$ref": "#/components/schemas/Event.plugin.event"

--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -18,6 +18,7 @@ import { SessionInteraction } from "../session/interaction"
 import { SessionInvoke, InvokeInput } from "../session/invoke"
 
 import { ChannelCommand } from "./command"
+import { resolveChannelAccountInvocation } from "./model-selection"
 import { createStatusReactionController } from "./status-reactions"
 import {
   Info as InfoSchema,
@@ -236,7 +237,7 @@ export namespace Channel {
       accountId,
       accountConfig,
       channelConfig,
-      onMessage: (ctx) => handleMessage(provider, ctx, scope),
+      onMessage: (ctx) => handleMessage(provider, ctx, scope, accountConfig),
       signal: abort.signal,
       onDisconnect: (reason) => {
         if (abort.signal.aborted) return
@@ -355,7 +356,12 @@ export namespace Channel {
     reconnects.set(key, timer)
   }
 
-  async function handleMessage(provider: Provider, ctx: MessageContext, scope: Scope): Promise<void> {
+  async function handleMessage(
+    provider: Provider,
+    ctx: MessageContext,
+    scope: Scope,
+    accountConfig: unknown,
+  ): Promise<void> {
     await ScopeContext.provide({
       scope,
       fn: async () => {
@@ -450,9 +456,10 @@ export namespace Channel {
           streaming.start(),
         ])
         const sessionID = session.id
-        const sessionModel = session.modelOverride
-          ? { providerID: session.modelOverride.providerID, modelID: session.modelOverride.modelID }
-          : undefined
+        const accountInvocation = resolveChannelAccountInvocation({
+          accountConfig,
+          sessionModelOverride: session.modelOverride,
+        })
 
         let activeTextMessageId: string | null = null
         const assistantTranscript = new Map<string, string>()
@@ -523,7 +530,7 @@ export namespace Channel {
         try {
           const result = await SessionInvoke.invoke({
             sessionID,
-            model: sessionModel,
+            ...accountInvocation,
             parts: buildPromptParts(ctx),
           })
 

--- a/packages/synergy/src/channel/model-selection.ts
+++ b/packages/synergy/src/channel/model-selection.ts
@@ -1,0 +1,27 @@
+import { Provider } from "../provider/provider"
+
+type ModelRef = {
+  providerID: string
+  modelID: string
+}
+
+export function resolveChannelAccountInvocation(input: { accountConfig: unknown; sessionModelOverride?: ModelRef }): {
+  model?: ModelRef
+  variant?: string
+} {
+  if (input.sessionModelOverride) {
+    return { model: input.sessionModelOverride }
+  }
+
+  if (!input.accountConfig || typeof input.accountConfig !== "object") return {}
+  const account = input.accountConfig as Record<string, unknown>
+  if (typeof account.model !== "string") return {}
+
+  const model = Provider.parseModel(account.model)
+  if (!model.providerID || !model.modelID) return {}
+
+  return {
+    model,
+    ...(typeof account.variant === "string" && account.variant ? { variant: account.variant } : {}),
+  }
+}

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -86,6 +86,7 @@ export const ChannelFeishuAccount = z
       .string()
       .optional()
       .describe("Model to use for this account in providerID/modelID format (e.g. openai/gpt-4o)"),
+    variant: z.string().optional().describe("Model variant to use with this account model (e.g. low, high, max)"),
     resolveSenderNames: z
       .boolean()
       .optional()

--- a/packages/synergy/src/skill/builtin/synergy-config/references/channels.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/references/channels.txt
@@ -36,6 +36,8 @@ Channels integrate Synergy with external messaging platforms.
           "streamingThrottleMs": 100,
           "groupSessionScope": "group",
           "inboundDebounceMs": 0,
+          "model": "openai/gpt-5",
+          "variant": "high",
           "resolveSenderNames": true,
           "replyInThread": false
         }
@@ -52,6 +54,7 @@ Channels integrate Synergy with external messaging platforms.
 | `domain` | auto | `"feishu"` (China) or `"lark"` (international) |
 | `botOpenId` | (none) | Bot open_id used to verify real @mentions in group chats |
 | `model` | (none) | Model override in `providerID/modelID` format (e.g. `openai/gpt-4o`) |
+| `variant` | (none) | Variant exposed by the selected account model (e.g. `low`, `high`, `max`) |
 | `enabled` | true | Enable this account |
 | `allowDM` | true | Allow direct messages |
 | `allowGroup` | true | Allow group messages |
@@ -115,4 +118,6 @@ Holos config belongs in `100-holos.jsonc`, not in channels. Do not edit model, p
 - **Bot not responding in DM** — check `allowDM` is true; verify the user has permission to message the bot
 - **Streaming not working** — check `streaming` is true; clients without streaming-card support can use `streaming: false`
 - **Sender names showing as IDs** — set `resolveSenderNames: true` and ensure the app has `contact:user.base:readonly` scope
+- **Account model ignored** — verify `model` uses `providerID/modelID`; a conversation-level `/model` command overrides the account default until a new conversation is started
+- **Effort selector missing** — the selected account model must expose variants in the active provider catalog; models without variants use provider defaults
 - **Webhook not receiving events** — verify the Feishu app's event subscription URL is correct and publicly accessible; check the server is running and the `/api/channel/feishu/webhook` endpoint responds

--- a/packages/synergy/test/channel/model-selection.test.ts
+++ b/packages/synergy/test/channel/model-selection.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { Config } from "../../src/config/config"
+import { resolveChannelAccountInvocation } from "../../src/channel/model-selection"
+
+describe("channel account model selection", () => {
+  test("accepts a model variant in Feishu account config", () => {
+    const result = Config.ChannelFeishuAccount.parse({
+      appId: "app",
+      appSecret: "secret",
+      model: "openai-codex/gpt-5.6-sol",
+      variant: "high",
+    })
+
+    expect(result.variant).toBe("high")
+  })
+
+  test("uses the configured account model and variant for an unoverridden session", () => {
+    expect(
+      resolveChannelAccountInvocation({
+        accountConfig: {
+          model: "openai-codex/gpt-5.6-sol",
+          variant: "high",
+        },
+      }),
+    ).toEqual({
+      model: { providerID: "openai-codex", modelID: "gpt-5.6-sol" },
+      variant: "high",
+    })
+  })
+
+  test("keeps an explicit session model ahead of the account default", () => {
+    expect(
+      resolveChannelAccountInvocation({
+        accountConfig: {
+          model: "openai-codex/gpt-5.6-sol",
+          variant: "high",
+        },
+        sessionModelOverride: { providerID: "deepseek", modelID: "deepseek-v4-pro" },
+      }),
+    ).toEqual({
+      model: { providerID: "deepseek", modelID: "deepseek-v4-pro" },
+    })
+  })
+
+  test("does not apply a variant without a valid account model", () => {
+    expect(resolveChannelAccountInvocation({ accountConfig: { variant: "high" } })).toEqual({})
+    expect(resolveChannelAccountInvocation({ accountConfig: { model: "invalid", variant: "high" } })).toEqual({})
+  })
+})

--- a/packages/ui/test/semantic-icon.test.ts
+++ b/packages/ui/test/semantic-icon.test.ts
@@ -26,6 +26,8 @@ const rawIconExceptionReasons: Record<string, string> = {
     "Settings select trigger uses a structural disclosure chevron.",
   "packages/app/src/components/settings/components/ModelRoleRow.tsx":
     "Settings model selectors use structural disclosure chevrons.",
+  "packages/app/src/components/settings/components/ModelVariantPicker.tsx":
+    "Settings variant selectors use a structural disclosure chevron.",
   "packages/ui/src/components/collapsible.tsx": "Shared primitive drag/disclosure affordance.",
   "packages/ui/src/components/dialog.tsx": "Shared dialog primitive close affordance.",
   "packages/ui/src/components/dag-graph.tsx": "Graph node detail uses a structural drag/grip affordance.",


### PR DESCRIPTION
## Summary

- honor the configured Feishu/Lark account model for inbound channel turns and persist the effective model on the root message
- add account-level model variant/effort configuration using the same variant catalog and picker as model roles
- preserve conversation `/model` precedence without leaking the account model's variant to a different model
- update generated SDK contracts and channel/configuration documentation

## Diagnosis

Runtime evidence confirmed this was not a header-only display issue: the fallback model provider handled the channel request. The account model was persisted by Settings but the channel delivery path never forwarded the account configuration into `SessionInvoke`.

## Verification

- `bun run quality` (14/14 Turbo tasks; core suite 5229 passed, 2 platform skips, 0 failed)
- `bun run quality:quick` after rebasing onto the latest `dev`
- `cd packages/synergy && bun run test:changed` (2922 passed, 2 platform skips, 0 failed)
- focused backend channel tests, frontend settings tests, semantic icon policy test, app production build, and generated SDK typecheck
