### PR TITLE
fix(plugin-kit): resolve definition-loader-child extension at runtime

### DIFF
--- a/packages/plugin-kit/src/lib/definition.ts
+++ b/packages/plugin-kit/src/lib/definition.ts
@@ -38,7 +38,10 @@ function isPluginDefinition(value: unknown): value is PluginDefinition {
   )
 }
 
-const loaderPath = fileURLToPath(new URL("./definition-loader-child.ts", import.meta.url))
+const loaderUrl = new URL("./definition-loader-child", import.meta.url)
+const loaderPathTs = fileURLToPath(new URL(loaderUrl.href + ".ts"))
+const loaderPathJs = fileURLToPath(new URL(loaderUrl.href + ".js"))
+const loaderPath = fs.existsSync(loaderPathTs) ? loaderPathTs : loaderPathJs
 const marker = "__SYNERGY_PLUGIN_DEFINITION__"
 
 export async function loadPluginDefinition(pluginDir: string): Promise<{


### PR DESCRIPTION
## Summary
- `loadPluginDefinition` in `packages/plugin-kit/src/lib/definition.ts` hardcoded `./definition-loader-child.ts` as the loader path, which only works in source form
- When plugin-kit is consumed as a compiled npm package, only `.js` exists in `dist/` — the `.ts` reference fails with "Module not found"
- Fix: probe `.ts` first, fall back to `.js`, so both `bun dev` and installed plugin-kit consumers work

## Verification
- `bun test` in `packages/plugin-kit`: all pass
- `bun run typecheck` in workflow: all pass (turbo typecheck matrix)
- Manual end-to-end: plugin validate + build + pack on both `synergy-meme-plugin` and `synergy-frontend-kit` with the fix applied, all passing