### PR TITLE
docs: fix script path formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ See the [development reference](docs/reference/development.md) for source modes,
    bun run localization:check
    ```
 
-3. **Regenerate the SDK if you touched routes.** If your change modifies server routes or route schemas, run `./script/generate.ts` and include the output in your PR.
+3. **Regenerate the SDK if you touched routes.** If your change modifies server routes or route schemas, run `script/generate.ts` and include the output in your PR.
 
 4. **Open your PR against `dev`.** Describe what you changed and why. If it addresses an open issue, reference it.
 


### PR DESCRIPTION
## Description
This PR cleans up path formatting in `CONTRIBUTING.md`.

## Details
Updated `./script/generate.ts` -> `script/generate.ts` under step 3 of the pull request process.