### PR TITLE
fix(app): add a friendly renderer recovery page

### DIFF
--- a/packages/app/PRODUCT.md
+++ b/packages/app/PRODUCT.md
@@ -118,6 +118,8 @@ Tool audit icons are a quiet exception rail, not a status badge on every tool ca
 
 First-party tool-card titles should lead with a concise action phrase that tells the user what Synergy is doing, such as Read file, Search web, or Execute command. Use state phrases only for actual results or lifecycle states; do not expose a bare medium or object category such as Web, Shell, Session, or Blueprint as an action title. Preserve canonical product and technical names inside the action phrase.
 
+A renderer recovery page should lead with a calm explanation, state that server-side tasks remain safe, and make reloading the interface the clear primary action. Keep raw diagnostics available in a collapsed technical-details disclosure so recovery guidance, not debug output, owns the initial view.
+
 Message-flow errors should remain compact by default: show a single-line error preview in a neutral workbench row with a restrained critical marker, and place the complete error text, tool input, and copy action in the shared grounded details dialog. Raw diagnostics should not expand inline and dominate the surrounding session work.
 
 User prompts inside a turn may render as a compact right-aligned bubble with matching prompt attachments, but the turn header, tool/result timeline, media results, and diffs must keep their workbench-width timeline structure and original part order.

--- a/packages/app/src/app-i18n.ts
+++ b/packages/app/src/app-i18n.ts
@@ -32,13 +32,19 @@ export const AP = {
   commandCategorySuggested: { id: "app.command.category.suggested", message: "Suggested" },
 
   // ── pages/error.tsx ─────────────────────────────────────────────────
-  errorTitle: { id: "app.error.title", message: "Something went wrong" },
+  errorTitle: { id: "app.error.title", message: "Synergy needs a quick refresh" },
   errorSubtitle: {
     id: "app.error.subtitle",
-    message: "An error occurred while loading the application.",
+    message: "The interface ran into a problem and cannot continue displaying this view.",
   },
+  errorTaskSafety: {
+    id: "app.error.taskSafety",
+    message:
+      "Your running tasks are safe. Reloading only refreshes this interface and will not stop work on the server.",
+  },
+  errorReloadInterface: { id: "app.error.reloadInterface", message: "Reload interface" },
+  errorTechnicalDetails: { id: "app.error.technicalDetails", message: "Technical details" },
   errorDetailsLabel: { id: "app.error.detailsLabel", message: "Error Details" },
-  errorRestart: { id: "app.error.restart", message: "Restart" },
   errorReport: {
     id: "app.error.report",
     message: "Report this issue on GitHub",

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -2024,6 +2024,11 @@ msgstr "Failed to initialize provider \"{providerID}\". Check credentials and co
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.reloadInterface"
+msgstr "Reload interface"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.report"
 msgstr "Report this issue on GitHub"
 
@@ -2031,11 +2036,6 @@ msgstr "Report this issue on GitHub"
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.responseBody"
 msgstr "Response body:"
-
-#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
- *  Translate at use time via `useLocale().i18n._(descriptor)`.
-msgid "app.error.restart"
-msgstr "Restart"
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
@@ -2050,11 +2050,21 @@ msgstr "Status: {code}"
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.subtitle"
-msgstr "An error occurred while loading the application."
+msgstr "The interface ran into a problem and cannot continue displaying this view."
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.taskSafety"
+msgstr "Your running tasks are safe. Reloading only refreshes this interface and will not stop work on the server."
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.technicalDetails"
+msgstr "Technical details"
 
 #. ── pages/error.tsx ─────────────────────────────────────────────────
 msgid "app.error.title"
-msgstr "Something went wrong"
+msgstr "Synergy needs a quick refresh"
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -2024,17 +2024,17 @@ msgstr ""
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.reloadInterface"
+msgstr ""
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.report"
 msgstr ""
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.responseBody"
-msgstr ""
-
-#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
- *  Translate at use time via `useLocale().i18n._(descriptor)`.
-msgid "app.error.restart"
 msgstr ""
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
@@ -2050,6 +2050,16 @@ msgstr ""
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.subtitle"
+msgstr ""
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.taskSafety"
+msgstr ""
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.technicalDetails"
 msgstr ""
 
 #. ── pages/error.tsx ─────────────────────────────────────────────────

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -2024,6 +2024,11 @@ msgstr "无法初始化提供商“{providerID}”。请检查凭据和配置。
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.reloadInterface"
+msgstr "重新加载界面"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.report"
 msgstr "在 GitHub 上报告此问题"
 
@@ -2031,11 +2036,6 @@ msgstr "在 GitHub 上报告此问题"
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.responseBody"
 msgstr "响应正文："
-
-#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
- *  Translate at use time via `useLocale().i18n._(descriptor)`.
-msgid "app.error.restart"
-msgstr "重启"
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
@@ -2050,11 +2050,21 @@ msgstr "状态：{code}"
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.
 msgid "app.error.subtitle"
-msgstr "加载应用时发生错误。"
+msgstr "界面遇到问题，暂时无法继续显示。"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.taskSafety"
+msgstr "正在运行的任务是安全的。重新加载只会刷新界面，不会停止服务器上的工作。"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.error.technicalDetails"
+msgstr "技术详情"
 
 #. ── pages/error.tsx ─────────────────────────────────────────────────
 msgid "app.error.title"
-msgstr "出现问题"
+msgstr "Synergy 需要快速刷新"
 
 #. Runtime Lingui descriptors for app shell, entry, commands, and pages.
  *  Translate at use time via `useLocale().i18n._(descriptor)`.

--- a/packages/app/src/pages/error-page-content.tsx
+++ b/packages/app/src/pages/error-page-content.tsx
@@ -1,0 +1,72 @@
+import { useLingui } from "@lingui/solid"
+import { Button } from "@ericsanchezok/synergy-ui/button"
+import { Logo } from "@ericsanchezok/synergy-ui/logo"
+import { TextField } from "@ericsanchezok/synergy-ui/text-field"
+import { Show, type Component } from "solid-js"
+import { AP } from "@/app-i18n"
+
+export interface ErrorPageContentProps {
+  details: string
+  version?: string
+  onReload: () => void
+}
+
+export const ErrorPageContent: Component<ErrorPageContentProps> = (props) => {
+  const { _ } = useLingui()
+
+  return (
+    <div class="relative flex min-h-screen w-full items-center justify-center bg-background-base px-6 py-12 font-sans">
+      <main class="flex w-full max-w-xl flex-col items-center text-center">
+        <Logo class="mb-8 w-24 shrink-0 opacity-20" />
+
+        <div class="flex max-w-lg flex-col items-center gap-3">
+          <h1 class="text-2xl font-semibold tracking-tight text-text-strong">{_(AP.errorTitle)}</h1>
+          <p class="text-base leading-6 text-text-weak">{_(AP.errorSubtitle)}</p>
+        </div>
+
+        <div class="mt-7 w-full rounded-xl border border-border-weaker-base bg-surface-raised-base px-5 py-4 text-left">
+          <p class="text-sm leading-6 text-text-base">{_(AP.errorTaskSafety)}</p>
+        </div>
+
+        <div class="mt-7">
+          <Button variant="primary" size="large" onClick={props.onReload}>
+            {_(AP.errorReloadInterface)}
+          </Button>
+        </div>
+
+        <details class="group mt-8 w-full border-t border-border-weaker-base pt-5 text-left">
+          <summary class="cursor-pointer select-none text-sm font-medium text-text-weak outline-none transition-colors hover:text-text-base focus-visible:text-text-strong">
+            {_(AP.errorTechnicalDetails)}
+          </summary>
+          <div class="mt-4">
+            <TextField
+              value={props.details}
+              readOnly
+              copyable
+              multiline
+              class="max-h-64 w-full font-mono text-xs no-scrollbar"
+              label={_(AP.errorDetailsLabel)}
+              hideLabel
+            />
+          </div>
+        </details>
+
+        <footer class="mt-6 flex flex-col items-center gap-2 text-sm">
+          <a
+            href="https://github.com/SII-Holos/synergy/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-text-interactive-base hover:underline focus-visible:underline"
+          >
+            {_(AP.errorReport)}
+          </a>
+          <Show when={props.version}>
+            {(version) => (
+              <p class="text-xs text-text-weak">{_({ ...AP.errorVersionLabel, values: { version: version() } })}</p>
+            )}
+          </Show>
+        </footer>
+      </main>
+    </div>
+  )
+}

--- a/packages/app/src/pages/error.tsx
+++ b/packages/app/src/pages/error.tsx
@@ -1,10 +1,6 @@
-import { TextField } from "@ericsanchezok/synergy-ui/text-field"
-import { Logo } from "@ericsanchezok/synergy-ui/logo"
-import { Button } from "@ericsanchezok/synergy-ui/button"
-import { Component, Show } from "solid-js"
-import { useLocale } from "@/context/locale"
-import { AP } from "@/app-i18n"
+import { Component } from "solid-js"
 import { usePlatform } from "@/context/platform"
+import { ErrorPageContent } from "./error-page-content"
 
 export type InitError = {
   name: string
@@ -182,44 +178,6 @@ interface ErrorPageProps {
 
 export const ErrorPage: Component<ErrorPageProps> = (props) => {
   const platform = usePlatform()
-  const { i18n } = useLocale()
 
-  return (
-    <div class="relative flex-1 h-screen w-screen min-h-0 flex flex-col items-center justify-center bg-background-base font-sans">
-      <div class="w-2/3 max-w-3xl flex flex-col items-center justify-center gap-8">
-        <Logo class="w-58.5 opacity-12 shrink-0" />
-        <div class="flex flex-col items-center gap-2 text-center">
-          <h1 class="text-lg font-medium text-text-strong">{i18n._(AP.errorTitle.id)}</h1>
-          <p class="text-sm text-text-weak">{i18n._(AP.errorSubtitle.id)}</p>
-        </div>
-        <TextField
-          value={formatError(props.error)}
-          readOnly
-          copyable
-          multiline
-          class="max-h-96 w-full font-mono text-xs no-scrollbar"
-          label={i18n._(AP.errorDetailsLabel.id)}
-          hideLabel
-        />
-        <div class="flex items-center gap-3">
-          <Button size="large" onClick={platform.restart}>
-            {i18n._(AP.errorRestart.id)}
-          </Button>
-        </div>
-        <div class="flex flex-col items-center gap-2">
-          <a
-            href="https://github.com/SII-Holos/synergy/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="flex items-center justify-center gap-1 text-text-interactive-base hover:underline"
-          >
-            {i18n._(AP.errorReport.id)}
-          </a>
-          <Show when={platform.version}>
-            <p class="text-xs text-text-weak">{i18n._(AP.errorVersionLabel.id, { version: platform.version })}</p>
-          </Show>
-        </div>
-      </div>
-    </div>
-  )
+  return <ErrorPageContent details={formatError(props.error)} version={platform.version} onReload={platform.restart} />
 }

--- a/packages/app/test/pages/error-page.test.ts
+++ b/packages/app/test/pages/error-page.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { setupI18n } from "@lingui/core"
+import { AP } from "../../src/app-i18n"
+
+function translate(locale: "en" | "zh-CN") {
+  const i18n = setupI18n()
+  i18n.loadAndActivate({
+    locale,
+    messages:
+      locale === "en"
+        ? {}
+        : {
+            "app.error.title": "Synergy 需要快速刷新",
+            "app.error.subtitle": "界面遇到问题，暂时无法继续显示。",
+            "app.error.taskSafety": "正在运行的任务是安全的。重新加载只会刷新界面，不会停止服务器上的工作。",
+            "app.error.reloadInterface": "重新加载界面",
+            "app.error.technicalDetails": "技术详情",
+            "app.error.report": "在 GitHub 上报告此问题",
+            "app.error.versionLabel": "版本：{version}",
+          },
+  })
+  return {
+    title: i18n._(AP.errorTitle),
+    subtitle: i18n._(AP.errorSubtitle),
+    safety: i18n._(AP.errorTaskSafety),
+    reload: i18n._(AP.errorReloadInterface),
+    details: i18n._(AP.errorTechnicalDetails),
+  }
+}
+
+describe("error page recovery copy", () => {
+  test("prioritizes recovery and task safety over diagnostics", () => {
+    const copy = translate("en")
+
+    expect(copy.title).toBe("Synergy needs a quick refresh")
+    expect(copy.subtitle).toBe("The interface ran into a problem and cannot continue displaying this view.")
+    expect(copy.safety).toContain("Your running tasks are safe.")
+    expect(copy.safety).toContain("Reloading only refreshes this interface")
+    expect(copy.reload).toBe("Reload interface")
+    expect(copy.details).toBe("Technical details")
+  })
+
+  test("provides complete Simplified Chinese recovery guidance", () => {
+    const copy = translate("zh-CN")
+
+    expect(copy.title).toBe("Synergy 需要快速刷新")
+    expect(copy.subtitle).toBe("界面遇到问题，暂时无法继续显示。")
+    expect(copy.safety).toContain("正在运行的任务是安全的")
+    expect(copy.reload).toBe("重新加载界面")
+    expect(copy.details).toBe("技术详情")
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Replaces the debug-first renderer crash screen with a calm recovery page that:

- explains what happened in user-facing language;
- makes clear that server-side tasks remain safe;
- provides a prominent interface reload action;
- keeps raw diagnostics available in a collapsed, copyable disclosure;
- ships complete English, Simplified Chinese, and pseudo-locale catalog updates.

Closes #755.

## Why?

The previous page led with raw error output and a generic restart action. It looked like an internal debug surface and did not explain whether active work was safe.

## How was it tested?

- `cd packages/app && bun test test/pages/error-page.test.ts`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/ui test`
- `bun run --cwd packages/app build`
- `bun run localization:check`
- `bun run quality:quick`
- Browser visual checks at 1440×900 and 390×844; no horizontal overflow and technical details remain collapsed initially.

## Checklist

- [x] `bun run quality:quick` passes
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] New tests live under the owning package's `test/` directory
- [x] `bun run package:check` passes
- [x] `bun run localization:check` passes
- [x] Product documentation updated
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included
