### PR TITLE
feat(observability): restore Linux runtime memory attribution

### DIFF
--- a/packages/synergy/src/observability/linux-runtime-memory.ts
+++ b/packages/synergy/src/observability/linux-runtime-memory.ts
@@ -1,0 +1,114 @@
+import { heapStats } from "bun:jsc"
+
+export namespace LinuxRuntimeMemory {
+  const DEFAULT_INTERVAL_MS = 60_000
+  const TOP_TYPE_LIMIT = 12
+  let lastSampleAt = 0
+  let last: Snapshot | undefined
+  let previousTypeCounts = new Map<string, number>()
+
+  export interface ObjectTypeCount {
+    type: string
+    count: number
+    delta: number
+  }
+
+  export interface Snapshot {
+    sampledAt: number
+    jscHeapSizeBytes: number
+    jscHeapCapacityBytes: number
+    jscExtraMemoryBytes: number
+    objectCount: number
+    protectedObjectCount: number
+    allocatorRssBytes?: number
+    allocatorCommittedBytes?: number
+    allocatorReservedBytes?: number
+    allocatorAbandonedPages?: number
+    topObjectTypes: ObjectTypeCount[]
+    growingObjectTypes: ObjectTypeCount[]
+  }
+
+  interface HeapStatsSnapshot {
+    heapSize: number
+    heapCapacity: number
+    extraMemorySize: number
+    objectCount: number
+    protectedObjectCount: number
+    objectTypeCounts: Record<string, number>
+    mimalloc?: {
+      process?: { rss_current?: number }
+      committed?: { current?: number }
+      reserved?: { current?: number }
+      pages_abandoned?: { current?: number }
+    }
+  }
+
+  export function sample(
+    input: {
+      now?: number
+      force?: boolean
+      env?: NodeJS.ProcessEnv
+      platform?: NodeJS.Platform
+      readStats?: () => HeapStatsSnapshot
+    } = {},
+  ): Snapshot | undefined {
+    if ((input.platform ?? process.platform) !== "linux") return
+    const now = input.now ?? Date.now()
+    const interval = envNumber(input.env?.SYNERGY_LINUX_HEAP_STATS_INTERVAL_MS) ?? DEFAULT_INTERVAL_MS
+    if (!input.force && last && now - lastSampleAt < interval) return last
+
+    try {
+      const stats = input.readStats?.() ?? (heapStats() as HeapStatsSnapshot)
+      const counts = new Map(Object.entries(stats.objectTypeCounts).map(([type, count]) => [type, finite(count)]))
+      const ranked = [...counts].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      const growth = ranked
+        .map(([type, count]) => ({ type, count, delta: count - (previousTypeCounts.get(type) ?? 0) }))
+        .filter((item) => item.delta > 0)
+        .sort((a, b) => b.delta - a.delta || b.count - a.count || a.type.localeCompare(b.type))
+      const mimalloc = stats.mimalloc
+      last = {
+        sampledAt: now,
+        jscHeapSizeBytes: finite(stats.heapSize),
+        jscHeapCapacityBytes: finite(stats.heapCapacity),
+        jscExtraMemoryBytes: finite(stats.extraMemorySize),
+        objectCount: finite(stats.objectCount),
+        protectedObjectCount: finite(stats.protectedObjectCount),
+        allocatorRssBytes: optionalFinite(mimalloc?.process?.rss_current),
+        allocatorCommittedBytes: optionalFinite(mimalloc?.committed?.current),
+        allocatorReservedBytes: optionalFinite(mimalloc?.reserved?.current),
+        allocatorAbandonedPages: optionalFinite(mimalloc?.pages_abandoned?.current),
+        topObjectTypes: ranked.slice(0, TOP_TYPE_LIMIT).map(([type, count]) => ({
+          type,
+          count,
+          delta: count - (previousTypeCounts.get(type) ?? 0),
+        })),
+        growingObjectTypes: growth.slice(0, TOP_TYPE_LIMIT),
+      }
+      previousTypeCounts = counts
+      lastSampleAt = now
+      return last
+    } catch {
+      return last
+    }
+  }
+
+  export function resetForTest() {
+    lastSampleAt = 0
+    last = undefined
+    previousTypeCounts = new Map()
+  }
+
+  function envNumber(value: string | undefined) {
+    if (!value) return undefined
+    const parsed = Number(value)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+  }
+
+  function finite(value: number) {
+    return Number.isFinite(value) && value >= 0 ? value : 0
+  }
+
+  function optionalFinite(value: number | undefined) {
+    return value !== undefined && Number.isFinite(value) && value >= 0 ? value : undefined
+  }
+}

--- a/packages/synergy/src/observability/resources.ts
+++ b/packages/synergy/src/observability/resources.ts
@@ -9,6 +9,7 @@ import { ObservabilityRedaction } from "./redaction"
 import { ProcessRegistry } from "@/process/registry"
 import { ProcessMemory } from "@/process/memory-usage"
 import { ServiceMemory } from "@/process/service-memory"
+import { LinuxRuntimeMemory } from "./linux-runtime-memory"
 
 type PublicServiceMemory = NonNullable<ObservabilitySchema.ResourceSample["serviceMemory"]>
 
@@ -29,6 +30,9 @@ export namespace ObservabilityResources {
   let sampleIntervalMs: number | undefined
   const io = { appReadBytes: 0, appWrittenBytes: 0, appReadOps: 0, appWriteOps: 0 }
   const rssWindow: Array<{ time: number; rss: number }> = []
+  let previousCgroupEvents: ServiceMemory.CgroupV2["events"]
+  let previousPressureTotals: { some?: number; full?: number } | undefined
+  let lastRuntimeMetricSampleAt = 0
 
   export function addRead(bytes: number) {
     io.appReadBytes += Math.max(0, bytes)
@@ -108,6 +112,8 @@ export namespace ObservabilityResources {
     ObservabilityStore.insertResource(sample)
     recordChildProcesses(now, config.resourceSampleIntervalMs, childProcesses)
     recordResourceMetrics(memory, utilizationRatio, lagMs)
+    recordServiceMemoryMetrics(cgroup)
+    recordLinuxRuntimeMetrics()
     detectPressure(sample, config)
   }
 
@@ -125,6 +131,8 @@ export namespace ObservabilityResources {
     if (timer) clearInterval(timer)
     timer = undefined
     sampleIntervalMs = undefined
+    previousCgroupEvents = undefined
+    previousPressureTotals = undefined
   }
 
   export function reconfigure() {
@@ -231,6 +239,162 @@ export namespace ObservabilityResources {
       module: "process",
       source: "process",
     })
+  }
+
+  function recordServiceMemoryMetrics(cgroup: ServiceMemory.CgroupV2 | undefined) {
+    if (!cgroup) return
+    const labels = { source: "cgroup_v2", platform: "linux" }
+    recordOptionalMetrics(
+      {
+        "service.memory.current": cgroup.currentBytes,
+        "service.memory.peak": cgroup.peakBytes,
+        "service.memory.high": cgroup.highBytes,
+        "service.memory.max": cgroup.maxBytes,
+        "service.memory.swap": cgroup.swapCurrentBytes,
+        "service.memory.anon": cgroup.stat?.anonBytes,
+        "service.memory.file": cgroup.stat?.fileBytes,
+        "service.memory.kernel": cgroup.stat?.kernelBytes,
+        "service.memory.slab": cgroup.stat?.slabBytes,
+        "service.memory.file.active": cgroup.stat?.activeFileBytes,
+        "service.memory.file.inactive": cgroup.stat?.inactiveFileBytes,
+        "service.memory.slab.reclaimable": cgroup.stat?.slabReclaimableBytes,
+        "service.memory.slab.unreclaimable": cgroup.stat?.slabUnreclaimableBytes,
+        "service.memory.reclaimable": cgroup.stat?.reclaimableBytes,
+        "service.memory.working_set": cgroup.stat?.workingSetBytes,
+      },
+      "bytes",
+      labels,
+    )
+    recordOptionalMetrics(
+      {
+        "service.memory.events.low": cgroup.events?.low,
+        "service.memory.events.high": cgroup.events?.high,
+        "service.memory.events.max": cgroup.events?.max,
+        "service.memory.events.oom": cgroup.events?.oom,
+        "service.memory.events.oom_kill": cgroup.events?.oomKill,
+        "service.memory.events.oom_group_kill": cgroup.events?.oomGroupKill,
+      },
+      "count",
+      labels,
+    )
+    recordOptionalMetrics(
+      {
+        "service.memory.pressure.some.avg10": cgroup.pressure?.some?.avg10,
+        "service.memory.pressure.some.avg60": cgroup.pressure?.some?.avg60,
+        "service.memory.pressure.some.avg300": cgroup.pressure?.some?.avg300,
+        "service.memory.pressure.full.avg10": cgroup.pressure?.full?.avg10,
+        "service.memory.pressure.full.avg60": cgroup.pressure?.full?.avg60,
+        "service.memory.pressure.full.avg300": cgroup.pressure?.full?.avg300,
+      },
+      "percent",
+      labels,
+    )
+
+    if (previousCgroupEvents && cgroup.events) {
+      recordOptionalMetrics(
+        {
+          "service.memory.events.low.delta": counterDelta(cgroup.events.low, previousCgroupEvents.low),
+          "service.memory.events.high.delta": counterDelta(cgroup.events.high, previousCgroupEvents.high),
+          "service.memory.events.max.delta": counterDelta(cgroup.events.max, previousCgroupEvents.max),
+          "service.memory.events.oom.delta": counterDelta(cgroup.events.oom, previousCgroupEvents.oom),
+          "service.memory.events.oom_kill.delta": counterDelta(cgroup.events.oomKill, previousCgroupEvents.oomKill),
+          "service.memory.events.oom_group_kill.delta": counterDelta(
+            cgroup.events.oomGroupKill,
+            previousCgroupEvents.oomGroupKill,
+          ),
+        },
+        "count",
+        labels,
+      )
+    }
+    previousCgroupEvents = cgroup.events ? { ...cgroup.events } : undefined
+
+    const pressureTotals = {
+      some: cgroup.pressure?.some?.totalMicros,
+      full: cgroup.pressure?.full?.totalMicros,
+    }
+    if (previousPressureTotals) {
+      recordOptionalMetrics(
+        {
+          "service.memory.pressure.some.stall_delta": counterDelta(pressureTotals.some, previousPressureTotals.some),
+          "service.memory.pressure.full.stall_delta": counterDelta(pressureTotals.full, previousPressureTotals.full),
+        },
+        "microseconds",
+        labels,
+      )
+    }
+    previousPressureTotals = pressureTotals
+  }
+
+  function recordLinuxRuntimeMetrics() {
+    const runtime = LinuxRuntimeMemory.sample()
+    if (!runtime || runtime.sampledAt === lastRuntimeMetricSampleAt) return
+    lastRuntimeMetricSampleAt = runtime.sampledAt
+    const labels = { platform: "linux" }
+    recordOptionalMetrics(
+      {
+        "runtime.jsc.heap_size": runtime.jscHeapSizeBytes,
+        "runtime.jsc.heap_capacity": runtime.jscHeapCapacityBytes,
+        "runtime.jsc.extra_memory": runtime.jscExtraMemoryBytes,
+        "runtime.allocator.rss": runtime.allocatorRssBytes,
+        "runtime.allocator.committed": runtime.allocatorCommittedBytes,
+        "runtime.allocator.reserved": runtime.allocatorReservedBytes,
+      },
+      "bytes",
+      labels,
+    )
+    recordOptionalMetrics(
+      {
+        "runtime.jsc.object_count": runtime.objectCount,
+        "runtime.jsc.protected_object_count": runtime.protectedObjectCount,
+        "runtime.allocator.abandoned_pages": runtime.allocatorAbandonedPages,
+      },
+      "count",
+      labels,
+    )
+    for (const item of runtime.topObjectTypes) {
+      ObservabilityMetrics.record({
+        name: "runtime.jsc.object_type.count",
+        value: item.count,
+        unit: "count",
+        module: "process",
+        source: "process",
+        labels: { ...labels, objectType: item.type },
+      })
+    }
+    for (const item of runtime.growingObjectTypes) {
+      ObservabilityMetrics.record({
+        name: "runtime.jsc.object_type.growth",
+        value: item.delta,
+        unit: "count",
+        module: "process",
+        source: "process",
+        labels: { ...labels, objectType: item.type, total: item.count },
+      })
+    }
+  }
+
+  function recordOptionalMetrics(
+    values: Record<string, number | undefined>,
+    unit: ObservabilitySchema.Unit,
+    labels: Record<string, string>,
+  ) {
+    for (const [name, value] of Object.entries(values)) {
+      if (value === undefined || !Number.isFinite(value)) continue
+      ObservabilityMetrics.record({
+        name,
+        value,
+        unit,
+        module: "process",
+        source: "process",
+        labels,
+      })
+    }
+  }
+
+  function counterDelta(current: number | undefined, previous: number | undefined) {
+    if (current === undefined || previous === undefined) return undefined
+    return current >= previous ? current - previous : current
   }
 
   function detectPressure(

--- a/packages/synergy/src/performance/catalog.ts
+++ b/packages/synergy/src/performance/catalog.ts
@@ -234,6 +234,163 @@ export namespace PerformanceCatalog {
     }),
     metric("process.memory.external", "External memory", "bytes", "gauge", "latest", "process", "process", []),
     metric("process.memory.array_buffers", "ArrayBuffer memory", "bytes", "gauge", "latest", "process", "process", []),
+    metric("service.memory.current", "Service cgroup memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.peak", "Service peak memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.high", "Service memory high threshold", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.max", "Service memory maximum", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.swap", "Service swap memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.anon", "Service anonymous memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.file", "Service file memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.kernel", "Service kernel memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric("service.memory.slab", "Service slab memory", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    metric(
+      "service.memory.file.active",
+      "Service active file memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["source", "platform"],
+    ),
+    metric(
+      "service.memory.file.inactive",
+      "Service inactive file memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["source", "platform"],
+    ),
+    metric(
+      "service.memory.slab.reclaimable",
+      "Service reclaimable slab",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["source", "platform"],
+    ),
+    metric(
+      "service.memory.slab.unreclaimable",
+      "Service unreclaimable slab",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["source", "platform"],
+    ),
+    metric(
+      "service.memory.reclaimable",
+      "Service reclaimable memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["source", "platform"],
+    ),
+    metric("service.memory.working_set", "Service working set", "bytes", "gauge", "latest", "process", "process", [
+      "source",
+      "platform",
+    ]),
+    ...memoryCounterMetrics(),
+    ...memoryPressureMetrics(),
+    metric("runtime.jsc.heap_size", "JSC heap size", "bytes", "gauge", "latest", "process", "process", ["platform"]),
+    metric("runtime.jsc.heap_capacity", "JSC heap capacity", "bytes", "gauge", "latest", "process", "process", [
+      "platform",
+    ]),
+    metric("runtime.jsc.extra_memory", "JSC extra memory", "bytes", "gauge", "latest", "process", "process", [
+      "platform",
+    ]),
+    metric("runtime.jsc.object_count", "JSC object count", "count", "gauge", "latest", "process", "process", [
+      "platform",
+    ]),
+    metric(
+      "runtime.jsc.protected_object_count",
+      "JSC protected object count",
+      "count",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["platform"],
+    ),
+    metric("runtime.jsc.object_type.count", "JSC object type count", "count", "gauge", "latest", "process", "process", [
+      "platform",
+      "objectType",
+    ]),
+    metric(
+      "runtime.jsc.object_type.growth",
+      "JSC object type growth",
+      "count",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["platform", "objectType", "total"],
+    ),
+    metric("runtime.allocator.rss", "Allocator RSS", "bytes", "gauge", "latest", "process", "process", ["platform"]),
+    metric(
+      "runtime.allocator.committed",
+      "Allocator committed memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["platform"],
+    ),
+    metric(
+      "runtime.allocator.reserved",
+      "Allocator reserved memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["platform"],
+    ),
+    metric(
+      "runtime.allocator.abandoned_pages",
+      "Allocator abandoned pages",
+      "count",
+      "gauge",
+      "latest",
+      "process",
+      "process",
+      ["platform"],
+    ),
     metric("process.cpu.utilization", "CPU utilization", "ratio", "ratio", "avg", "process", "process", []),
     metric("process.event_loop.lag", "Event-loop lag", "ms", "duration", "p95", "process", "process", []),
     metric("process.active.count", "Active processes", "count", "gauge", "latest", "process", "process", [], {
@@ -368,11 +525,22 @@ export namespace PerformanceCatalog {
   export const chartMetricNames = [
     "process.cpu.utilization",
     "process.event_loop.lag",
+    "service.memory.current",
+    "service.memory.working_set",
+    "service.memory.reclaimable",
+    "service.memory.anon",
+    "service.memory.file",
+    "service.memory.pressure.some.avg10",
+    "service.memory.pressure.full.avg10",
     "process.memory.rss",
     "process.memory.heap_used",
     "process.memory.heap_total",
     "process.memory.external",
     "process.memory.array_buffers",
+    "runtime.jsc.heap_size",
+    "runtime.jsc.extra_memory",
+    "runtime.allocator.rss",
+    "runtime.allocator.committed",
     "http.request.duration",
     "session.turn.duration",
     "session.turn.active",
@@ -383,6 +551,8 @@ export namespace PerformanceCatalog {
   ]
   export const defaultMetricNames = [
     "http.request.duration",
+    "service.memory.current",
+    "service.memory.working_set",
     "process.memory.rss",
     "process.memory.heap_used",
     "process.cpu.utilization",
@@ -431,5 +601,65 @@ export namespace PerformanceCatalog {
       status: opts.status ?? "emitted",
       aliases: opts.aliases,
     }
+  }
+
+  function memoryCounterMetrics() {
+    const names = ["low", "high", "max", "oom", "oom_kill", "oom_group_kill"]
+    return names.flatMap((event) => [
+      metric(
+        `service.memory.events.${event}`,
+        `Service memory ${event} events`,
+        "count",
+        "gauge",
+        "latest",
+        "process",
+        "process",
+        ["source", "platform"],
+      ),
+      metric(
+        `service.memory.events.${event}.delta`,
+        `Service memory ${event} event delta`,
+        "count",
+        "counter",
+        "sum",
+        "process",
+        "process",
+        ["source", "platform"],
+      ),
+    ])
+  }
+
+  function memoryPressureMetrics() {
+    const averages = ["avg10", "avg60", "avg300"]
+    const result: MetricInfo[] = []
+    for (const kind of ["some", "full"]) {
+      for (const average of averages) {
+        result.push(
+          metric(
+            `service.memory.pressure.${kind}.${average}`,
+            `Service memory PSI ${kind} ${average}`,
+            "percent",
+            "gauge",
+            "latest",
+            "process",
+            "process",
+            ["source", "platform"],
+          ),
+        )
+      }
+      result.push(
+        metric(
+          `service.memory.pressure.${kind}.stall_delta`,
+          `Service memory PSI ${kind} stall delta`,
+          "microseconds",
+          "counter",
+          "sum",
+          "process",
+          "process",
+          ["source", "platform"],
+        ),
+      )
+    }
+    return result
   }
 }

--- a/packages/synergy/src/process/service-memory.ts
+++ b/packages/synergy/src/process/service-memory.ts
@@ -16,6 +16,12 @@ export namespace ServiceMemory {
       fileBytes?: number
       kernelBytes?: number
       slabBytes?: number
+      activeFileBytes?: number
+      inactiveFileBytes?: number
+      slabReclaimableBytes?: number
+      slabUnreclaimableBytes?: number
+      reclaimableBytes?: number
+      workingSetBytes?: number
     }
     events?: {
       low?: number
@@ -23,7 +29,19 @@ export namespace ServiceMemory {
       max?: number
       oom?: number
       oomKill?: number
+      oomGroupKill?: number
     }
+    pressure?: {
+      some?: Pressure
+      full?: Pressure
+    }
+  }
+
+  export type Pressure = {
+    avg10?: number
+    avg60?: number
+    avg300?: number
+    totalMicros?: number
   }
 
   export type Measurement = {
@@ -48,6 +66,13 @@ export namespace ServiceMemory {
     if (currentBytes === undefined) return undefined
     const stat = readKeyValues(path.join(directory, "memory.stat"))
     const events = readKeyValues(path.join(directory, "memory.events"))
+    const pressure = readPressure(path.join(directory, "memory.pressure"))
+    const inactiveFileBytes = stat?.inactive_file
+    const slabReclaimableBytes = stat?.slab_reclaimable
+    const reclaimableBytes =
+      inactiveFileBytes === undefined && slabReclaimableBytes === undefined
+        ? undefined
+        : (inactiveFileBytes ?? 0) + (slabReclaimableBytes ?? 0)
     return {
       currentBytes,
       ...optional("highBytes", readNumber(path.join(directory, "memory.high"))),
@@ -61,6 +86,15 @@ export namespace ServiceMemory {
               ...optional("fileBytes", stat.file),
               ...optional("kernelBytes", stat.kernel),
               ...optional("slabBytes", stat.slab),
+              ...optional("activeFileBytes", stat.active_file),
+              ...optional("inactiveFileBytes", inactiveFileBytes),
+              ...optional("slabReclaimableBytes", slabReclaimableBytes),
+              ...optional("slabUnreclaimableBytes", stat.slab_unreclaimable),
+              ...optional("reclaimableBytes", reclaimableBytes),
+              ...optional(
+                "workingSetBytes",
+                reclaimableBytes === undefined ? undefined : Math.max(0, currentBytes - reclaimableBytes),
+              ),
             },
           }
         : {}),
@@ -72,9 +106,11 @@ export namespace ServiceMemory {
               ...optional("max", events.max),
               ...optional("oom", events.oom),
               ...optional("oomKill", events.oom_kill),
+              ...optional("oomGroupKill", events.oom_group_kill),
             },
           }
         : {}),
+      ...(pressure ? { pressure } : {}),
     }
   }
 
@@ -157,6 +193,31 @@ export namespace ServiceMemory {
         if (key && Number.isFinite(value) && value >= 0) result[key] = value
       }
       return Object.keys(result).length ? result : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  function readPressure(file: string): CgroupV2["pressure"] | undefined {
+    try {
+      const result: NonNullable<CgroupV2["pressure"]> = {}
+      for (const line of readFileSync(file, "utf8").split("\n")) {
+        const [kind, ...fields] = line.trim().split(/\s+/)
+        if (kind !== "some" && kind !== "full") continue
+        const values: Record<string, number> = {}
+        for (const field of fields) {
+          const [key, raw] = field.split("=", 2)
+          const value = Number(raw)
+          if (key && Number.isFinite(value) && value >= 0) values[key] = value
+        }
+        result[kind] = {
+          ...optional("avg10", values.avg10),
+          ...optional("avg60", values.avg60),
+          ...optional("avg300", values.avg300),
+          ...optional("totalMicros", values.total),
+        }
+      }
+      return result.some || result.full ? result : undefined
     } catch {
       return undefined
     }

--- a/packages/synergy/test/observability/linux-runtime-memory.test.ts
+++ b/packages/synergy/test/observability/linux-runtime-memory.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { LinuxRuntimeMemory } from "../../src/observability/linux-runtime-memory"
+
+function stats(input: { arrays: number; strings: number; heapSize?: number }) {
+  return {
+    heapSize: input.heapSize ?? 1_000,
+    heapCapacity: 2_000,
+    extraMemorySize: 300,
+    objectCount: input.arrays + input.strings,
+    protectedObjectCount: 4,
+    objectTypeCounts: { Array: input.arrays, String: input.strings },
+    mimalloc: {
+      process: { rss_current: 4_000 },
+      committed: { current: 3_000 },
+      reserved: { current: 5_000 },
+      pages_abandoned: { current: 2 },
+    },
+  }
+}
+
+describe("LinuxRuntimeMemory", () => {
+  beforeEach(() => LinuxRuntimeMemory.resetForTest())
+
+  test("does not read runtime heap statistics on non-Linux platforms", () => {
+    let reads = 0
+    const sample = LinuxRuntimeMemory.sample({
+      platform: "darwin",
+      readStats: () => {
+        reads++
+        return stats({ arrays: 1, strings: 1 })
+      },
+    })
+
+    expect(sample).toBeUndefined()
+    expect(reads).toBe(0)
+  })
+
+  test("caches Linux samples and reports object-type growth", () => {
+    let reads = 0
+    const readStats = () => {
+      reads++
+      return reads === 1 ? stats({ arrays: 10, strings: 5 }) : stats({ arrays: 13, strings: 4, heapSize: 1_200 })
+    }
+
+    const first = LinuxRuntimeMemory.sample({ platform: "linux", now: 1_000, readStats })
+    const cached = LinuxRuntimeMemory.sample({ platform: "linux", now: 30_000, readStats })
+    const second = LinuxRuntimeMemory.sample({ platform: "linux", now: 61_001, readStats })
+
+    expect(reads).toBe(2)
+    expect(cached).toBe(first)
+    expect(first).toMatchObject({
+      jscHeapSizeBytes: 1_000,
+      jscExtraMemoryBytes: 300,
+      allocatorCommittedBytes: 3_000,
+      allocatorReservedBytes: 5_000,
+    })
+    expect(second?.growingObjectTypes).toContainEqual({ type: "Array", count: 13, delta: 3 })
+    expect(second?.growingObjectTypes.some((item) => item.type === "String")).toBe(false)
+  })
+})

--- a/packages/synergy/test/process/service-memory.test.ts
+++ b/packages/synergy/test/process/service-memory.test.ts
@@ -20,16 +20,47 @@ describe("ServiceMemory", () => {
     writeFileSync(path.join(directory, "memory.max"), "max\n")
     writeFileSync(path.join(directory, "memory.peak"), "3000\n")
     writeFileSync(path.join(directory, "memory.swap.current"), "400\n")
-    writeFileSync(path.join(directory, "memory.stat"), "anon 500\nfile 250\nkernel 125\nslab 75\n")
-    writeFileSync(path.join(directory, "memory.events"), "low 1\nhigh 2\nmax 3\noom 4\noom_kill 5\n")
+    writeFileSync(
+      path.join(directory, "memory.stat"),
+      [
+        "anon 500",
+        "file 250",
+        "kernel 125",
+        "slab 75",
+        "active_file 100",
+        "inactive_file 80",
+        "slab_reclaimable 20",
+        "slab_unreclaimable 55",
+      ].join("\n"),
+    )
+    writeFileSync(path.join(directory, "memory.events"), "low 1\nhigh 2\nmax 3\noom 4\noom_kill 5\noom_group_kill 6\n")
+    writeFileSync(
+      path.join(directory, "memory.pressure"),
+      "some avg10=0.10 avg60=0.20 avg300=0.30 total=400\nfull avg10=0.01 avg60=0.02 avg300=0.03 total=40\n",
+    )
 
     expect(await ServiceMemory.readCgroupV2(directory)).toEqual({
       currentBytes: 1000,
       highBytes: 2000,
       peakBytes: 3000,
       swapCurrentBytes: 400,
-      stat: { anonBytes: 500, fileBytes: 250, kernelBytes: 125, slabBytes: 75 },
-      events: { low: 1, high: 2, max: 3, oom: 4, oomKill: 5 },
+      stat: {
+        anonBytes: 500,
+        fileBytes: 250,
+        kernelBytes: 125,
+        slabBytes: 75,
+        activeFileBytes: 100,
+        inactiveFileBytes: 80,
+        slabReclaimableBytes: 20,
+        slabUnreclaimableBytes: 55,
+        reclaimableBytes: 100,
+        workingSetBytes: 900,
+      },
+      events: { low: 1, high: 2, max: 3, oom: 4, oomKill: 5, oomGroupKill: 6 },
+      pressure: {
+        some: { avg10: 0.1, avg60: 0.2, avg300: 0.3, totalMicros: 400 },
+        full: { avg10: 0.01, avg60: 0.02, avg300: 0.03, totalMicros: 40 },
+      },
     })
   })
 


### PR DESCRIPTION
## Summary
- report Linux service-cgroup working set, reclaimable memory, pressure, and OOM counters
- attribute Bun/JSC heap and allocator state without changing non-Linux behavior
- expose the new measurements through the existing Performance catalog

## Safety
- observability-only; no GC, scheduling, concurrency, prompt, or output policy changes
- non-Linux platforms retain the existing process-tree fallback
- excludes the local-only sandbox allowlist commit

## Verification
- `bun test test/process/service-memory.test.ts test/observability/linux-runtime-memory.test.ts` (6 passed)
- `bun run typecheck` in `packages/synergy`
- `bun run format:check`
- `bun run lint`
- pre-push monorepo typecheck

Related to #777 and #813. This PR does not close either investigation.