### PR TITLE
feat(observability): measure Agent worker memory after stream disposal

### DIFF
--- a/packages/synergy/src/performance/catalog.ts
+++ b/packages/synergy/src/performance/catalog.ts
@@ -53,8 +53,32 @@ export namespace PerformanceCatalog {
     metric("agent.turn.duration", "Agent turn latency", "ms", "duration", "p95", "session", "backend", ["reason"]),
     metric("agent.ipc.request_bytes", "Agent IPC request bytes", "bytes", "size", "avg", "session", "backend", []),
     metric("agent.ipc.event_bytes", "Agent IPC event bytes", "bytes", "size", "avg", "session", "backend", []),
-    metric("agent.worker.rss", "Agent worker RSS", "bytes", "gauge", "latest", "session", "process", []),
-    metric("agent.worker.heap_used", "Agent worker heap used", "bytes", "gauge", "latest", "session", "process", []),
+    metric("agent.worker.rss", "Agent worker RSS", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric("agent.worker.heap_used", "Agent worker heap used", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric("agent.worker.heap_total", "Agent worker heap total", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric("agent.worker.external", "Agent worker external memory", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric(
+      "agent.worker.array_buffers",
+      "Agent worker ArrayBuffer memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "session",
+      "process",
+      ["phase", "turns"],
+    ),
     metric("agent.worker.crash", "Agent worker crashes", "count", "counter", "sum", "session", "process", [
       "exitCode",
       "signal",

--- a/packages/synergy/src/session/agent-turn/protocol.ts
+++ b/packages/synergy/src/session/agent-turn/protocol.ts
@@ -5,7 +5,7 @@ import { Runtime as ScopeRuntime } from "@/scope/types"
 import { Workspace } from "../types"
 
 export namespace AgentTurnProtocol {
-  export const VERSION = 1
+  export const VERSION = 2
   export const REQUEST_MAX_BYTES = 64 * 1024 * 1024
   export const EVENT_MAX_BYTES = 2 * 1024 * 1024
   export const IPC_FRAME_MAX_BYTES = 2 * 1024 * 1024
@@ -155,6 +155,17 @@ export namespace AgentTurnProtocol {
     .strict()
   export type TurnEnvelope = z.infer<typeof TurnEnvelopeSchema>
 
+  export const WorkerMemory = z
+    .object({
+      rssBytes: z.number().nonnegative(),
+      heapUsedBytes: z.number().nonnegative(),
+      heapTotalBytes: z.number().nonnegative(),
+      externalBytes: z.number().nonnegative(),
+      arrayBuffersBytes: z.number().nonnegative(),
+    })
+    .strict()
+  export type WorkerMemory = z.infer<typeof WorkerMemory>
+
   export type HostToWorker =
     | { type: "run-start"; requestId: string; totalBytes: number; chunkCount: number }
     | { type: "run-chunk"; requestId: string; index: number; data: Uint8Array }
@@ -165,7 +176,7 @@ export namespace AgentTurnProtocol {
     | { type: "ping" }
 
   export type WorkerToHost =
-    | { type: "ready"; protocolVersion: number; pid: number }
+    | { type: "ready"; protocolVersion: number; pid: number; memory: WorkerMemory }
     | { type: "run-ready"; requestId: string }
     | { type: "chunk-ack"; requestId: string; index: number }
     | { type: "started"; requestId: string; contextUsageDraft?: unknown }
@@ -174,15 +185,22 @@ export namespace AgentTurnProtocol {
         type: "complete"
         requestId: string
         turns: number
-        memory: { rssBytes: number; heapUsedBytes: number }
+        memoryBeforeDispose: WorkerMemory
+        memory: WorkerMemory
         usage?: unknown
       }
-    | { type: "error"; requestId: string; error: SerializedError }
+    | {
+        type: "error"
+        requestId: string
+        error: SerializedError
+        memoryBeforeDispose?: WorkerMemory
+        memory?: WorkerMemory
+      }
     | {
         type: "heartbeat"
         requestId?: string
         turns: number
-        memory: { rssBytes: number; heapUsedBytes: number }
+        memory: WorkerMemory
       }
     | { type: "pong" }
 
@@ -229,6 +247,7 @@ export namespace AgentTurnProtocol {
         type: z.literal("ready"),
         protocolVersion: z.number().int().positive(),
         pid: z.number().int().positive(),
+        memory: WorkerMemory,
       })
       .strict(),
     z.object({ type: z.literal("run-ready"), requestId: z.string() }).strict(),
@@ -253,17 +272,26 @@ export namespace AgentTurnProtocol {
         type: z.literal("complete"),
         requestId: z.string(),
         turns: z.number().int().nonnegative(),
-        memory: z.object({ rssBytes: z.number().nonnegative(), heapUsedBytes: z.number().nonnegative() }).strict(),
+        memoryBeforeDispose: WorkerMemory,
+        memory: WorkerMemory,
         usage: z.unknown().optional(),
       })
       .strict(),
-    z.object({ type: z.literal("error"), requestId: z.string(), error: SerializedError }).strict(),
+    z
+      .object({
+        type: z.literal("error"),
+        requestId: z.string(),
+        error: SerializedError,
+        memoryBeforeDispose: WorkerMemory.optional(),
+        memory: WorkerMemory.optional(),
+      })
+      .strict(),
     z
       .object({
         type: z.literal("heartbeat"),
         requestId: z.string().optional(),
         turns: z.number().int().nonnegative(),
-        memory: z.object({ rssBytes: z.number().nonnegative(), heapUsedBytes: z.number().nonnegative() }).strict(),
+        memory: WorkerMemory,
       })
       .strict(),
     z.object({ type: z.literal("pong") }).strict(),

--- a/packages/synergy/src/session/agent-turn/runner.ts
+++ b/packages/synergy/src/session/agent-turn/runner.ts
@@ -38,6 +38,9 @@ function memory() {
   return {
     rssBytes: usage.rss,
     heapUsedBytes: usage.heapUsed,
+    heapTotalBytes: usage.heapTotal,
+    externalBytes: usage.external,
+    arrayBuffersBytes: usage.arrayBuffers,
   }
 }
 
@@ -131,7 +134,9 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
   const input = envelope.input as unknown as AgentTurnWorkerInput
   let ownedStream: ReturnType<typeof LLM.takeFullStream> | undefined
   let usage: Awaited<LLM.StreamOutput["usage"]> | undefined
-  let terminal: AgentTurnProtocol.WorkerToHost
+  let terminal:
+    | { type: "complete"; requestId: string; turns: number; usage?: unknown }
+    | { type: "error"; requestId: string; error: AgentTurnProtocol.SerializedError }
 
   try {
     await ScopeContext.provide({
@@ -160,7 +165,6 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
       type: "complete",
       requestId: turn.requestId,
       turns,
-      memory: memory(),
       usage,
     }
   } catch (error) {
@@ -170,10 +174,15 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
       error: AgentTurnProtocol.serializeError(error),
     }
   } finally {
+    const memoryBeforeDispose = memory()
     await ownedStream?.dispose().catch(() => {})
     for (const acknowledge of turn.acknowledgements.values()) acknowledge()
     active = undefined
-    send(terminal!)
+    send({
+      ...terminal!,
+      memoryBeforeDispose,
+      memory: memory(),
+    })
     if (shuttingDown) process.exit(0)
   }
 }
@@ -313,4 +322,4 @@ watchManagedParent({
   onParentExit: () => process.exit(0),
 })
 
-send({ type: "ready", protocolVersion: AgentTurnProtocol.VERSION, pid: process.pid })
+send({ type: "ready", protocolVersion: AgentTurnProtocol.VERSION, pid: process.pid, memory: memory() })

--- a/packages/synergy/src/session/agent-turn/worker-pool.ts
+++ b/packages/synergy/src/session/agent-turn/worker-pool.ts
@@ -88,6 +88,9 @@ interface PoolWorker {
   pid?: number
   rssBytes?: number
   heapUsedBytes?: number
+  heapTotalBytes?: number
+  externalBytes?: number
+  arrayBuffersBytes?: number
   lastEventSequence: number
   lastHeartbeatAt: number
 }
@@ -282,6 +285,9 @@ export class AgentWorkerPool {
       queuedBytes: this.queuedBytes,
       rssBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.rssBytes ?? 0), 0),
       heapUsedBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.heapUsedBytes ?? 0), 0),
+      heapTotalBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.heapTotalBytes ?? 0), 0),
+      externalBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.externalBytes ?? 0), 0),
+      arrayBuffersBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.arrayBuffersBytes ?? 0), 0),
     }
   }
 
@@ -351,6 +357,7 @@ export class AgentWorkerPool {
       worker.startupFailureEligible = false
       worker.pid = message.pid
       worker.lastHeartbeatAt = Date.now()
+      this.recordWorkerMemory(worker, message.memory, "ready")
       this.consecutiveStartupFailures = 0
       this.startupCircuitError = undefined
       this.ensureWorkers()
@@ -362,25 +369,8 @@ export class AgentWorkerPool {
         this.terminateForProtocol(worker, "heartbeat referenced an unowned turn")
         return
       }
-      worker.rssBytes = message.memory.rssBytes
-      worker.heapUsedBytes = message.memory.heapUsedBytes
+      this.recordWorkerMemory(worker, message.memory, "heartbeat")
       worker.lastHeartbeatAt = Date.now()
-      ObservabilityMetrics.record({
-        name: "agent.worker.rss",
-        value: message.memory.rssBytes,
-        unit: "bytes",
-        module: "session",
-        processId: worker.id,
-        pid: worker.pid,
-      })
-      ObservabilityMetrics.record({
-        name: "agent.worker.heap_used",
-        value: message.memory.heapUsedBytes,
-        unit: "bytes",
-        module: "session",
-        processId: worker.id,
-        pid: worker.pid,
-      })
       if (
         message.memory.rssBytes >= this.options.maxRssBytes ||
         message.memory.heapUsedBytes >= this.options.maxHeapBytes
@@ -467,6 +457,10 @@ export class AgentWorkerPool {
     }
     if (message.type === "error") {
       const error = AgentTurnProtocol.deserializeError(message.error)
+      if (message.memoryBeforeDispose) {
+        this.recordWorkerMemory(worker, message.memoryBeforeDispose, "turn.before_dispose", task)
+      }
+      if (message.memory) this.recordWorkerMemory(worker, message.memory, "turn.after_dispose", task)
       task.resolveUsage(undefined)
       if (task.started) task.stream.fail(error)
       else task.reject(error)
@@ -479,8 +473,8 @@ export class AgentWorkerPool {
         return
       }
       worker.turns = message.turns
-      worker.rssBytes = message.memory.rssBytes
-      worker.heapUsedBytes = message.memory.heapUsedBytes
+      this.recordWorkerMemory(worker, message.memoryBeforeDispose, "turn.before_dispose", task)
+      this.recordWorkerMemory(worker, message.memory, "turn.after_dispose", task)
       task.resolveUsage(message.usage as Awaited<LLM.StreamOutput["usage"]> | undefined)
       task.stream.complete()
       const recycle =
@@ -608,6 +602,38 @@ export class AgentWorkerPool {
     if (drain) this.drain()
   }
 
+  private recordWorkerMemory(
+    worker: PoolWorker,
+    memory: AgentTurnProtocol.WorkerMemory,
+    phase: "ready" | "heartbeat" | "turn.before_dispose" | "turn.after_dispose",
+    task?: PoolTask,
+  ): void {
+    worker.rssBytes = memory.rssBytes
+    worker.heapUsedBytes = memory.heapUsedBytes
+    worker.heapTotalBytes = memory.heapTotalBytes
+    worker.externalBytes = memory.externalBytes
+    worker.arrayBuffersBytes = memory.arrayBuffersBytes
+    for (const [name, value] of Object.entries({
+      "agent.worker.rss": memory.rssBytes,
+      "agent.worker.heap_used": memory.heapUsedBytes,
+      "agent.worker.heap_total": memory.heapTotalBytes,
+      "agent.worker.external": memory.externalBytes,
+      "agent.worker.array_buffers": memory.arrayBuffersBytes,
+    })) {
+      ObservabilityMetrics.record({
+        name,
+        value,
+        unit: "bytes",
+        module: "session",
+        sessionID: task?.sessionID,
+        messageID: task?.messageID,
+        processId: worker.id,
+        pid: worker.pid,
+        labels: { phase, turns: worker.turns },
+      })
+    }
+  }
+
   private recycle(worker: PoolWorker, reason: "max_turns" | "rss" | "heap"): void {
     if (worker.stopping || this.stopping) return
     worker.stopping = true
@@ -733,7 +759,7 @@ export class AgentWorkerPool {
     }
   }
 
-  private terminateForMemory(worker: PoolWorker, memory: { rssBytes: number; heapUsedBytes: number }): void {
+  private terminateForMemory(worker: PoolWorker, memory: AgentTurnProtocol.WorkerMemory): void {
     if (worker.stopping || this.stopping) return
     worker.stopping = true
     const reason = memory.rssBytes >= this.options.maxRssBytes ? "rss" : "heap"

--- a/packages/synergy/test/session/agent-turn-protocol.test.ts
+++ b/packages/synergy/test/session/agent-turn-protocol.test.ts
@@ -3,6 +3,34 @@ import { APICallError } from "ai"
 import { AgentTurnProtocol } from "../../src/session/agent-turn/protocol"
 
 describe("AgentTurnProtocol", () => {
+  test("requires complete worker memory snapshots at lifecycle boundaries", () => {
+    const memory: AgentTurnProtocol.WorkerMemory = {
+      rssBytes: 100,
+      heapUsedBytes: 80,
+      heapTotalBytes: 90,
+      externalBytes: 20,
+      arrayBuffersBytes: 10,
+    }
+
+    expect(
+      AgentTurnProtocol.parseWorkerToHost({
+        type: "complete",
+        requestId: "turn",
+        turns: 1,
+        memoryBeforeDispose: { ...memory, externalBytes: 40 },
+        memory,
+      }),
+    ).toMatchObject({ type: "complete", memory: { arrayBuffersBytes: 10 } })
+    expect(() =>
+      AgentTurnProtocol.parseWorkerToHost({
+        type: "complete",
+        requestId: "turn",
+        turns: 1,
+        memory: { rssBytes: 100, heapUsedBytes: 80 },
+      }),
+    ).toThrow()
+  })
+
   test("accepts a request at the configured byte boundary and rejects a larger request", () => {
     const base = {
       type: "run" as const,

--- a/packages/synergy/test/session/agent-worker-pool.test.ts
+++ b/packages/synergy/test/session/agent-worker-pool.test.ts
@@ -14,6 +14,16 @@ interface FakeWorker {
   exit(code?: number | null, signal?: string | null): void
 }
 
+function workerMemory(rssBytes = 1, heapUsedBytes = 1): AgentTurnProtocol.WorkerMemory {
+  return {
+    rssBytes,
+    heapUsedBytes,
+    heapTotalBytes: heapUsedBytes + 1,
+    externalBytes: 1,
+    arrayBuffersBytes: 1,
+  }
+}
+
 function fakeWorkers() {
   const workers: FakeWorker[] = []
   const spawn = (options: SpawnAgentWorkerProcessOptions): AgentWorkerProcess => {
@@ -37,7 +47,12 @@ function fakeWorkers() {
       sent,
       host,
       ready() {
-        options.onMessage({ type: "ready", protocolVersion: 1, pid: 1000 + workers.indexOf(worker) })
+        options.onMessage({
+          type: "ready",
+          protocolVersion: AgentTurnProtocol.VERSION,
+          pid: 1000 + workers.indexOf(worker),
+          memory: workerMemory(),
+        })
       },
       receive(message) {
         options.onMessage(message)
@@ -140,7 +155,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: run.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     expect((await done).done).toBe(true)
     await pool.stop()
@@ -209,7 +225,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: secondRun.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     const second = await secondPromise
     expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
@@ -302,7 +319,7 @@ describe("AgentWorkerPool", () => {
     const turn = inScope(() => pool.run(input(new AbortController().signal)))
 
     try {
-      fake.workers[0].receive({ type: "ready", protocolVersion: 0, pid: 1000 })
+      fake.workers[0].receive({ type: "ready", protocolVersion: 0, pid: 1000, memory: workerMemory() })
       expect(delays).toEqual([])
       expect(fake.workers).toHaveLength(2)
 
@@ -349,7 +366,8 @@ describe("AgentWorkerPool", () => {
         type: "complete",
         requestId: run.requestId,
         turns: 1,
-        memory: { rssBytes: 1, heapUsedBytes: 1 },
+        memoryBeforeDispose: workerMemory(2, 2),
+        memory: workerMemory(),
       })
       const stream = await recoveredTurn
       expect((await stream.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
@@ -419,7 +437,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: firstRun.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     expect((await first.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
     expect(fake.workers).toHaveLength(2)
@@ -432,7 +451,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: secondRun.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     const second = await secondPromise
     expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
@@ -494,7 +514,7 @@ describe("AgentWorkerPool", () => {
       type: "heartbeat",
       requestId: run.requestId,
       turns: 0,
-      memory: { rssBytes: 32, heapUsedBytes: 65 },
+      memory: workerMemory(32, 65),
     })
 
     await expect(stream.fullStream[Symbol.asyncIterator]().next()).rejects.toThrow("Agent worker exited")


### PR DESCRIPTION
## Summary
- measure Agent worker RSS, heap, external, and ArrayBuffer memory before and after stream disposal
- report ready, heartbeat, pre-dispose, and post-dispose phases through existing observability metrics
- expose aggregate worker memory categories without changing GC or scheduling

## Safety
- observability-only: no full GC, release barrier, worker recycling, concurrency, prompt, or output behavior changes
- protocol version is bumped so mixed worker/host binaries fail fast
- error and cancellation frames remain compatible while optionally carrying terminal memory

## Verification
- `bun test test/session/agent-turn-protocol.test.ts test/session/agent-worker-pool.test.ts` (26 passed)
- `bun run typecheck` in `packages/synergy`
- `bun run format:check`
- `bun run lint`
- pre-push monorepo typecheck

Related to #814 and parent investigation #813. This PR does not implement the GC or recycle policies tracked separately.