### PR TITLE
fix(process): release local handles after stdio close

### DIFF
--- a/packages/synergy/src/session/shell.ts
+++ b/packages/synergy/src/session/shell.ts
@@ -186,7 +186,7 @@ async function shellInSession(input: ShellInput, lease: SessionManager.LoopLease
 
   let output = ""
 
-  proc.stdout?.on("data", (chunk) => {
+  const appendOutput = (chunk: Buffer) => {
     output += chunk.toString()
     if (part.state.status === "running") {
       part.state.metadata = {
@@ -196,19 +196,10 @@ async function shellInSession(input: ShellInput, lease: SessionManager.LoopLease
       }
       Session.updatePart(part)
     }
-  })
+  }
 
-  proc.stderr?.on("data", (chunk) => {
-    output += chunk.toString()
-    if (part.state.status === "running") {
-      part.state.metadata = {
-        ...part.state.metadata,
-        output: output,
-        description: "",
-      }
-      Session.updatePart(part)
-    }
-  })
+  proc.stdout?.on("data", appendOutput)
+  proc.stderr?.on("data", appendOutput)
 
   let aborted = false
   let exited = false
@@ -228,9 +219,11 @@ async function shellInSession(input: ShellInput, lease: SessionManager.LoopLease
   abort.addEventListener("abort", abortHandler, { once: true })
 
   await new Promise<void>((resolve) => {
-    proc.on("close", () => {
+    proc.once("close", () => {
       exited = true
       abort.removeEventListener("abort", abortHandler)
+      proc.stdout?.off("data", appendOutput)
+      proc.stderr?.off("data", appendOutput)
       resolve()
     })
   })

--- a/packages/synergy/src/tool/bash/local.ts
+++ b/packages/synergy/src/tool/bash/local.ts
@@ -460,6 +460,7 @@ export const LocalBashBackend = {
     let timeoutMarkerAdded = false
     let hardCeilingReached = false
     let exited = false
+    let finalized = false
     let childError: Error | undefined
     let resolveChildFinished: (result: "exited" | "error") => void = () => {}
     const childFinished = new Promise<"exited" | "error">((resolve) => {
@@ -508,11 +509,21 @@ export const LocalBashBackend = {
         ? "The command was interrupted: bash hard ceiling timed out."
         : `The command was interrupted: command timed out after ${params.timeoutSeconds}s.`
 
+    const releaseChildReferences = () => {
+      child.stdout?.off("data", append)
+      child.stderr?.off("data", append)
+      regProc.child = undefined
+      regProc.stdin = undefined
+    }
+
     child.once("error", (error) => {
+      if (finalized) return
+      finalized = true
       childError = error
       exited = true
       cleanupAllTimers()
       ProcessRegistry.remove(regProc.id)
+      releaseChildReferences()
       cleanupExecutionArtifacts()
       void trace(
         "bash.child.error",
@@ -534,6 +545,18 @@ export const LocalBashBackend = {
     child.once("exit", (code, signal) => {
       exited = true
       cleanupAllTimers()
+      void trace("bash.child.exit", {
+        exitCode: code,
+        exitSignal: signal,
+        outputChars: ProcessRegistry.outputChars(regProc),
+      })
+    })
+
+    child.once("close", (code, signal) => {
+      if (finalized) return
+      finalized = true
+      exited = true
+      cleanupAllTimers()
       if (metadataDirty) flushMetadata()
       const exitSignal = timedOut ? "SIGTERM" : signal
       if (regProc.backgrounded) {
@@ -545,8 +568,9 @@ export const LocalBashBackend = {
       } else {
         ProcessRegistry.remove(regProc.id)
       }
+      releaseChildReferences()
       cleanupExecutionArtifacts()
-      void trace("bash.child.exit", {
+      void trace("bash.child.close", {
         exitCode: code,
         exitSignal: signal,
         outputChars: ProcessRegistry.outputChars(regProc),

--- a/packages/synergy/test/tool/bash.test.ts
+++ b/packages/synergy/test/tool/bash.test.ts
@@ -176,6 +176,52 @@ describe("tool.bash", () => {
     })
   })
 
+  test("keeps reading inherited stdout until the process pipes close", async () => {
+    await withProjectScope(async () => {
+      const allowedCtx = {
+        ...ctx,
+        extra: { ...ctx.extra, shellAllowDetachedDaemons: true },
+      }
+      const result = await LocalBashBackend.execute(
+        {
+          command: "(sleep 0.05; printf late-tail) &",
+          description: "Emit output after the parent exits",
+          backgroundAfterSeconds: 0,
+        },
+        allowedCtx,
+      )
+
+      expect(result.metadata.exit).toBe(0)
+      expect(result.output).toContain("late-tail")
+    })
+  })
+
+  test("clears child handles after an auto-backgrounded process closes", async () => {
+    ProcessRegistry.reset()
+    await withProjectScope(async () => {
+      const result = await LocalBashBackend.execute(
+        {
+          command: sleepCommand(100),
+          description: "Close tracked process",
+          backgroundAfterSeconds: 0.01,
+        },
+        ctx,
+      )
+      const processId = result.metadata.processId!
+      const tracked = ProcessRegistry.get(processId)!
+      expect(tracked.child).toBeDefined()
+
+      for (let attempt = 0; attempt < 50 && !ProcessRegistry.getFinished(processId); attempt++) {
+        await Bun.sleep(10)
+      }
+
+      expect(ProcessRegistry.getFinished(processId)?.status).toBe("completed")
+      expect(tracked.child).toBeUndefined()
+      expect(tracked.stdin).toBeUndefined()
+      ProcessRegistry.remove(processId)
+    })
+  })
+
   test("parallel bash calls return independent inline outputs", async () => {
     await withProjectScope(async () => {
       const bash = await BashTool.init()


### PR DESCRIPTION
## Summary

- finalize local Bash processes on `close`, after stdout and stderr have drained
- remove child stream listeners and release retained child/stdin handles after completion
- remove session-shell stream and abort listeners when its process closes

## Why

`exit` can fire before inherited stdio closes. Keeping completion on `exit` risks either losing tail output or retaining child-process wrappers and listeners after the logical tool lifecycle. This preserves output correctness while releasing those strong references at the actual stdio boundary.

Related to #816 and #813. This PR does not close either issue.

## Verification

- `bun test test/tool/bash.test.ts test/process/registry.test.ts` (53 passed)
- `bun run typecheck` in `packages/synergy`
- repository Prettier, oxlint, Turbo typecheck, and sherif pre-push gates

No service restart or production runtime change was performed.