### PR TITLE
fix(session): preserve agent retry input

### DIFF
--- a/packages/synergy/src/session/processor.ts
+++ b/packages/synergy/src/session/processor.ts
@@ -841,11 +841,6 @@ export namespace SessionProcessor {
                 ...agentTurnInput
               } = streamInput
               const stream = await AgentTurn.stream(agentTurnInput)
-              agentTurnInput.system?.splice(0)
-              agentTurnInput.lateSystem?.splice(0)
-              agentTurnInput.messages?.splice(0)
-              agentTurnInput.toolDefinitions?.splice(0)
-              agentTurnInput.activeToolIDs?.splice(0)
               SessionManager.setExecutionPhase(input.sessionID, "running_agent")
               streamInput.memoryTurn?.streamStarted()
               SessionMemoryPressure.probe("processor.after_llm_stream", {
@@ -1440,6 +1435,11 @@ export namespace SessionProcessor {
                   messageID: input.assistantMessage.id,
                 })
               }
+              agentTurnInput.system?.splice(0)
+              agentTurnInput.lateSystem?.splice(0)
+              agentTurnInput.messages?.splice(0)
+              agentTurnInput.toolDefinitions?.splice(0)
+              agentTurnInput.activeToolIDs?.splice(0)
               if (deferredToolCalls.length > 0) {
                 SessionManager.setExecutionPhase(input.sessionID, "authorizing_tools")
               }

--- a/packages/synergy/test/session/processor.test.ts
+++ b/packages/synergy/test/session/processor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { APICallError } from "ai"
 import { TimeoutConfig } from "../../src/util/timeout-config"
 import { Config } from "../../src/config/config"
 import { ExperienceEncoder } from "../../src/library/experience-encoder"
@@ -369,7 +370,7 @@ describe("SessionProcessor execution layering", () => {
     expect(keys).not.toContain("memoryTurn")
   })
 
-  test("releases model request collections after the Agent layer takes ownership", async () => {
+  test("releases model request collections after the Agent turn settles", async () => {
     let system: unknown[] | undefined
     let messages: unknown[] | undefined
     let toolDefinitions: unknown[] | undefined
@@ -393,6 +394,52 @@ describe("SessionProcessor execution layering", () => {
     expect(system).toEqual([])
     expect(messages).toEqual([])
     expect(toolDefinitions).toEqual([])
+  })
+
+  test("preserves model request collections for a retryable Agent failure", async () => {
+    const attempts: Array<{
+      system: unknown[]
+      lateSystem: unknown[]
+      messages: unknown[]
+      toolDefinitions: unknown[]
+      activeToolIDs: unknown[]
+    }> = []
+    const agentInput = {
+      system: ["system"],
+      lateSystem: ["runtime"],
+      messages: [{ role: "user", content: "message" }],
+      toolDefinitions: [{ id: "probe", description: "probe", inputSchema: { type: "object" } }],
+      activeToolIDs: ["probe"],
+    }
+    const expected = structuredClone(agentInput)
+
+    await runSettlementScenario({
+      messageID: "msg_layer_retry",
+      async *stream() {
+        if (attempts.length === 1) {
+          throw new APICallError({
+            message: "The operation timed out.",
+            url: "https://provider.invalid",
+            requestBodyValues: {},
+            isRetryable: true,
+            responseHeaders: { "retry-after-ms": "1" },
+          })
+        }
+        yield { type: "finish" }
+      },
+      inspectAgentInput(input) {
+        attempts.push({
+          system: [...(input.system as unknown[])],
+          lateSystem: [...(input.lateSystem as unknown[])],
+          messages: [...(input.messages as unknown[])],
+          toolDefinitions: [...(input.toolDefinitions as unknown[])],
+          activeToolIDs: [...(input.activeToolIDs as unknown[])],
+        })
+      },
+      agentInput,
+    })
+
+    expect(attempts).toEqual([expected, expected])
   })
 })
 


### PR DESCRIPTION
## Summary
- keep model request collections alive while a provider attempt can still retry
- release prompt, history, and tool-definition arrays only after the Agent stream settles successfully
- add a regression test proving retryable provider failures receive the original context on every attempt

## Root cause
The Agent boundary shallow-copied the processor input and immediately cleared the copied array fields after worker admission. Those arrays were still shared with the retry loop's `streamInput`, so a retryable provider timeout retried with empty system context, history, and tool definitions. The context-free retry could then settle as a generic reply such as “How can I help?”.

## Validation
- `bun test test/session/processor.test.ts` — 48 passed
- `bun test test/session/retry.test.ts test/session/agent-turn-protocol.test.ts` — 31 passed
- `bun run typecheck` in `packages/synergy` — passed
- `bun run quality:quick` — passed

## Broader changed-test note
`bun test --changed=origin/dev --dots` completed with 2675 passed, 1 skipped, and 2 unrelated failures. The Cortex notification case passed when rerun alone. The proxy-routing case reproduces unchanged on the clean base commit, so it is a pre-existing baseline failure.
