### PR TITLE
fix(session): wait for Agent worker turn release

### DIFF
--- a/packages/synergy/src/performance/catalog.ts
+++ b/packages/synergy/src/performance/catalog.ts
@@ -53,8 +53,32 @@ export namespace PerformanceCatalog {
     metric("agent.turn.duration", "Agent turn latency", "ms", "duration", "p95", "session", "backend", ["reason"]),
     metric("agent.ipc.request_bytes", "Agent IPC request bytes", "bytes", "size", "avg", "session", "backend", []),
     metric("agent.ipc.event_bytes", "Agent IPC event bytes", "bytes", "size", "avg", "session", "backend", []),
-    metric("agent.worker.rss", "Agent worker RSS", "bytes", "gauge", "latest", "session", "process", []),
-    metric("agent.worker.heap_used", "Agent worker heap used", "bytes", "gauge", "latest", "session", "process", []),
+    metric("agent.worker.rss", "Agent worker RSS", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric("agent.worker.heap_used", "Agent worker heap used", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric("agent.worker.heap_total", "Agent worker heap total", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric("agent.worker.external", "Agent worker external memory", "bytes", "gauge", "latest", "session", "process", [
+      "phase",
+      "turns",
+    ]),
+    metric(
+      "agent.worker.array_buffers",
+      "Agent worker ArrayBuffer memory",
+      "bytes",
+      "gauge",
+      "latest",
+      "session",
+      "process",
+      ["phase", "turns"],
+    ),
     metric("agent.worker.crash", "Agent worker crashes", "count", "counter", "sum", "session", "process", [
       "exitCode",
       "signal",

--- a/packages/synergy/src/session/agent-turn/protocol.ts
+++ b/packages/synergy/src/session/agent-turn/protocol.ts
@@ -5,7 +5,7 @@ import { Runtime as ScopeRuntime } from "@/scope/types"
 import { Workspace } from "../types"
 
 export namespace AgentTurnProtocol {
-  export const VERSION = 2
+  export const VERSION = 3
   export const REQUEST_MAX_BYTES = 64 * 1024 * 1024
   export const EVENT_MAX_BYTES = 2 * 1024 * 1024
   export const IPC_FRAME_MAX_BYTES = 2 * 1024 * 1024
@@ -197,6 +197,13 @@ export namespace AgentTurnProtocol {
         memory?: WorkerMemory
       }
     | {
+        type: "released"
+        requestId: string
+        turns: number
+        collection: "full" | "none"
+        memory: WorkerMemory
+      }
+    | {
         type: "heartbeat"
         requestId?: string
         turns: number
@@ -284,6 +291,15 @@ export namespace AgentTurnProtocol {
         error: SerializedError,
         memoryBeforeDispose: WorkerMemory.optional(),
         memory: WorkerMemory.optional(),
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("released"),
+        requestId: z.string(),
+        turns: z.number().int().nonnegative(),
+        collection: z.enum(["full", "none"]),
+        memory: WorkerMemory,
       })
       .strict(),
     z

--- a/packages/synergy/src/session/agent-turn/protocol.ts
+++ b/packages/synergy/src/session/agent-turn/protocol.ts
@@ -5,7 +5,7 @@ import { Runtime as ScopeRuntime } from "@/scope/types"
 import { Workspace } from "../types"
 
 export namespace AgentTurnProtocol {
-  export const VERSION = 1
+  export const VERSION = 2
   export const REQUEST_MAX_BYTES = 64 * 1024 * 1024
   export const EVENT_MAX_BYTES = 2 * 1024 * 1024
   export const IPC_FRAME_MAX_BYTES = 2 * 1024 * 1024
@@ -155,6 +155,17 @@ export namespace AgentTurnProtocol {
     .strict()
   export type TurnEnvelope = z.infer<typeof TurnEnvelopeSchema>
 
+  export const WorkerMemory = z
+    .object({
+      rssBytes: z.number().nonnegative(),
+      heapUsedBytes: z.number().nonnegative(),
+      heapTotalBytes: z.number().nonnegative(),
+      externalBytes: z.number().nonnegative(),
+      arrayBuffersBytes: z.number().nonnegative(),
+    })
+    .strict()
+  export type WorkerMemory = z.infer<typeof WorkerMemory>
+
   export type HostToWorker =
     | { type: "run-start"; requestId: string; totalBytes: number; chunkCount: number }
     | { type: "run-chunk"; requestId: string; index: number; data: Uint8Array }
@@ -165,7 +176,7 @@ export namespace AgentTurnProtocol {
     | { type: "ping" }
 
   export type WorkerToHost =
-    | { type: "ready"; protocolVersion: number; pid: number }
+    | { type: "ready"; protocolVersion: number; pid: number; memory: WorkerMemory }
     | { type: "run-ready"; requestId: string }
     | { type: "chunk-ack"; requestId: string; index: number }
     | { type: "started"; requestId: string; contextUsageDraft?: unknown }
@@ -174,15 +185,22 @@ export namespace AgentTurnProtocol {
         type: "complete"
         requestId: string
         turns: number
-        memory: { rssBytes: number; heapUsedBytes: number }
+        memoryBeforeDispose: WorkerMemory
+        memory: WorkerMemory
         usage?: unknown
       }
-    | { type: "error"; requestId: string; error: SerializedError }
+    | {
+        type: "error"
+        requestId: string
+        error: SerializedError
+        memoryBeforeDispose?: WorkerMemory
+        memory?: WorkerMemory
+      }
     | {
         type: "heartbeat"
         requestId?: string
         turns: number
-        memory: { rssBytes: number; heapUsedBytes: number }
+        memory: WorkerMemory
       }
     | { type: "pong" }
 
@@ -229,6 +247,7 @@ export namespace AgentTurnProtocol {
         type: z.literal("ready"),
         protocolVersion: z.number().int().positive(),
         pid: z.number().int().positive(),
+        memory: WorkerMemory,
       })
       .strict(),
     z.object({ type: z.literal("run-ready"), requestId: z.string() }).strict(),
@@ -253,17 +272,26 @@ export namespace AgentTurnProtocol {
         type: z.literal("complete"),
         requestId: z.string(),
         turns: z.number().int().nonnegative(),
-        memory: z.object({ rssBytes: z.number().nonnegative(), heapUsedBytes: z.number().nonnegative() }).strict(),
+        memoryBeforeDispose: WorkerMemory,
+        memory: WorkerMemory,
         usage: z.unknown().optional(),
       })
       .strict(),
-    z.object({ type: z.literal("error"), requestId: z.string(), error: SerializedError }).strict(),
+    z
+      .object({
+        type: z.literal("error"),
+        requestId: z.string(),
+        error: SerializedError,
+        memoryBeforeDispose: WorkerMemory.optional(),
+        memory: WorkerMemory.optional(),
+      })
+      .strict(),
     z
       .object({
         type: z.literal("heartbeat"),
         requestId: z.string().optional(),
         turns: z.number().int().nonnegative(),
-        memory: z.object({ rssBytes: z.number().nonnegative(), heapUsedBytes: z.number().nonnegative() }).strict(),
+        memory: WorkerMemory,
       })
       .strict(),
     z.object({ type: z.literal("pong") }).strict(),

--- a/packages/synergy/src/session/agent-turn/runner.ts
+++ b/packages/synergy/src/session/agent-turn/runner.ts
@@ -44,6 +44,35 @@ function memory() {
   }
 }
 
+function release(requestId: string): void {
+  const collection = process.platform === "linux" ? "full" : "none"
+  if (collection === "full") Bun.gc(true)
+  send({
+    type: "released",
+    requestId,
+    turns,
+    collection,
+    memory: memory(),
+  })
+}
+
+function rejectAndRelease(requestId: string, error: unknown): void {
+  send({
+    type: "error",
+    requestId,
+    error: AgentTurnProtocol.serializeError(error),
+  })
+  queueMicrotask(() => release(requestId))
+}
+
+function reject(requestId: string, error: unknown): void {
+  send({
+    type: "error",
+    requestId,
+    error: AgentTurnProtocol.serializeError(error),
+  })
+}
+
 async function sendEvents(turn: ActiveTurn, events: AgentSDKStreamPart[]): Promise<void> {
   if (events.length === 0) return
   const frame = {
@@ -116,25 +145,28 @@ async function streamEvents(turn: ActiveTurn, stream: AsyncIterable<AgentSDKStre
   await flush()
 }
 
-async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope): Promise<void> {
-  if (active) {
-    send({
-      type: "error",
-      requestId,
-      error: AgentTurnProtocol.serializeError(new Error("Agent worker already owns a turn")),
-    })
-    return
-  }
-  const turn: ActiveTurn = {
-    requestId,
-    controller: new AbortController(),
-    acknowledgements: new Map(),
-  }
-  active = turn
+type Terminal =
+  | {
+      type: "complete"
+      requestId: string
+      turns: number
+      usage?: unknown
+      memoryBeforeDispose: AgentTurnProtocol.WorkerMemory
+      memory: AgentTurnProtocol.WorkerMemory
+    }
+  | {
+      type: "error"
+      requestId: string
+      error: AgentTurnProtocol.SerializedError
+      memoryBeforeDispose: AgentTurnProtocol.WorkerMemory
+      memory: AgentTurnProtocol.WorkerMemory
+    }
+
+async function executeTurn(turn: ActiveTurn, envelope: AgentTurnProtocol.TurnEnvelope): Promise<Terminal> {
   const input = envelope.input as unknown as AgentTurnWorkerInput
   let ownedStream: ReturnType<typeof LLM.takeFullStream> | undefined
   let usage: Awaited<LLM.StreamOutput["usage"]> | undefined
-  let terminal:
+  let result:
     | { type: "complete"; requestId: string; turns: number; usage?: unknown }
     | { type: "error"; requestId: string; error: AgentTurnProtocol.SerializedError }
 
@@ -161,30 +193,47 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
       },
     })
     turns++
-    terminal = {
+    result = {
       type: "complete",
       requestId: turn.requestId,
       turns,
       usage,
     }
   } catch (error) {
-    terminal = {
+    result = {
       type: "error",
       requestId: turn.requestId,
       error: AgentTurnProtocol.serializeError(error),
     }
-  } finally {
-    const memoryBeforeDispose = memory()
-    await ownedStream?.dispose().catch(() => {})
-    for (const acknowledge of turn.acknowledgements.values()) acknowledge()
-    active = undefined
-    send({
-      ...terminal!,
-      memoryBeforeDispose,
-      memory: memory(),
-    })
-    if (shuttingDown) process.exit(0)
   }
+  const memoryBeforeDispose = memory()
+  await ownedStream?.dispose().catch(() => {})
+  for (const acknowledge of turn.acknowledgements.values()) acknowledge()
+  return {
+    ...result!,
+    memoryBeforeDispose,
+    memory: memory(),
+  }
+}
+
+async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope | undefined): Promise<void> {
+  if (active) {
+    reject(requestId, new Error("Agent worker already owns a turn"))
+    return
+  }
+  const turn: ActiveTurn = {
+    requestId,
+    controller: new AbortController(),
+    acknowledgements: new Map(),
+  }
+  active = turn
+  const terminal = await executeTurn(turn, envelope!)
+  envelope = undefined
+  active = undefined
+  send(terminal)
+
+  release(requestId)
+  if (shuttingDown) process.exit(0)
 }
 
 process.on("message", (raw: unknown) => {
@@ -194,21 +243,13 @@ process.on("message", (raw: unknown) => {
       raw && typeof raw === "object" && "requestId" in raw && typeof raw.requestId === "string"
         ? raw.requestId
         : "invalid"
-    send({
-      type: "error",
-      requestId,
-      error: AgentTurnProtocol.serializeError(new Error("Invalid Agent worker protocol message")),
-    })
+    reject(requestId, new Error("Invalid Agent worker protocol message"))
     return
   }
   const message = parsed.data
   if (message.type === "run-start") {
     if (active || pending) {
-      send({
-        type: "error",
-        requestId: message.requestId,
-        error: AgentTurnProtocol.serializeError(new Error("Agent worker already owns a turn transfer")),
-      })
+      reject(message.requestId, new Error("Agent worker already owns a turn transfer"))
       return
     }
     pending = {
@@ -224,22 +265,14 @@ process.on("message", (raw: unknown) => {
   if (message.type === "run-chunk") {
     if (!pending || pending.requestId !== message.requestId || message.index !== pending.chunks.length) {
       pending = undefined
-      send({
-        type: "error",
-        requestId: message.requestId,
-        error: AgentTurnProtocol.serializeError(new Error("Invalid Agent turn request chunk sequence")),
-      })
+      rejectAndRelease(message.requestId, new Error("Invalid Agent turn request chunk sequence"))
       return
     }
     pending.chunks.push(message.data)
     pending.receivedBytes += message.data.byteLength
     if (pending.receivedBytes > pending.totalBytes || pending.chunks.length > pending.chunkCount) {
       pending = undefined
-      send({
-        type: "error",
-        requestId: message.requestId,
-        error: AgentTurnProtocol.serializeError(new Error("Agent turn request transfer exceeded declared bounds")),
-      })
+      rejectAndRelease(message.requestId, new Error("Agent turn request transfer exceeded declared bounds"))
       return
     }
     send({ type: "chunk-ack", requestId: message.requestId, index: message.index })
@@ -254,11 +287,7 @@ process.on("message", (raw: unknown) => {
       transfer.receivedBytes !== transfer.totalBytes ||
       transfer.chunks.length !== transfer.chunkCount
     ) {
-      send({
-        type: "error",
-        requestId: message.requestId,
-        error: AgentTurnProtocol.serializeError(new Error("Incomplete Agent turn request transfer")),
-      })
+      rejectAndRelease(message.requestId, new Error("Incomplete Agent turn request transfer"))
       return
     }
     try {
@@ -266,11 +295,7 @@ process.on("message", (raw: unknown) => {
       const envelope = AgentTurnProtocol.deserializeTurn(bytes)
       void run(message.requestId, envelope)
     } catch (error) {
-      send({
-        type: "error",
-        requestId: message.requestId,
-        error: AgentTurnProtocol.serializeError(error),
-      })
+      rejectAndRelease(message.requestId, error)
     }
     return
   }
@@ -285,11 +310,7 @@ process.on("message", (raw: unknown) => {
   if (message.type === "cancel") {
     if (pending?.requestId === message.requestId) {
       pending = undefined
-      send({
-        type: "error",
-        requestId: message.requestId,
-        error: AgentTurnProtocol.serializeError(new DOMException(message.reason ?? "Agent turn aborted", "AbortError")),
-      })
+      rejectAndRelease(message.requestId, new DOMException(message.reason ?? "Agent turn aborted", "AbortError"))
       return
     }
     if (active?.requestId === message.requestId) {

--- a/packages/synergy/src/session/agent-turn/runner.ts
+++ b/packages/synergy/src/session/agent-turn/runner.ts
@@ -38,6 +38,9 @@ function memory() {
   return {
     rssBytes: usage.rss,
     heapUsedBytes: usage.heapUsed,
+    heapTotalBytes: usage.heapTotal,
+    externalBytes: usage.external,
+    arrayBuffersBytes: usage.arrayBuffers,
   }
 }
 
@@ -131,7 +134,9 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
   const input = envelope.input as unknown as AgentTurnWorkerInput
   let ownedStream: ReturnType<typeof LLM.takeFullStream> | undefined
   let usage: Awaited<LLM.StreamOutput["usage"]> | undefined
-  let terminal: AgentTurnProtocol.WorkerToHost
+  let terminal:
+    | { type: "complete"; requestId: string; turns: number; usage?: unknown }
+    | { type: "error"; requestId: string; error: AgentTurnProtocol.SerializedError }
 
   try {
     await ScopeContext.provide({
@@ -160,7 +165,6 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
       type: "complete",
       requestId: turn.requestId,
       turns,
-      memory: memory(),
       usage,
     }
   } catch (error) {
@@ -170,10 +174,15 @@ async function run(requestId: string, envelope: AgentTurnProtocol.TurnEnvelope):
       error: AgentTurnProtocol.serializeError(error),
     }
   } finally {
+    const memoryBeforeDispose = memory()
     await ownedStream?.dispose().catch(() => {})
     for (const acknowledge of turn.acknowledgements.values()) acknowledge()
     active = undefined
-    send(terminal!)
+    send({
+      ...terminal!,
+      memoryBeforeDispose,
+      memory: memory(),
+    })
     if (shuttingDown) process.exit(0)
   }
 }
@@ -313,4 +322,4 @@ watchManagedParent({
   onParentExit: () => process.exit(0),
 })
 
-send({ type: "ready", protocolVersion: AgentTurnProtocol.VERSION, pid: process.pid })
+send({ type: "ready", protocolVersion: AgentTurnProtocol.VERSION, pid: process.pid, memory: memory() })

--- a/packages/synergy/src/session/agent-turn/worker-pool.ts
+++ b/packages/synergy/src/session/agent-turn/worker-pool.ts
@@ -71,6 +71,8 @@ interface PoolTask {
   reject(error: unknown): void
   resolveUsage(usage: Awaited<LLM.StreamOutput["usage"]> | undefined): void
   started: boolean
+  terminal: boolean
+  terminalReason?: "complete" | "error"
   completed: boolean
   transferCommitted: boolean
   worker?: PoolWorker
@@ -242,6 +244,7 @@ export class AgentWorkerPool {
         reject,
         resolveUsage,
         started: false,
+        terminal: false,
         completed: false,
         transferCommitted: false,
         removeAbortListener: () => signal.removeEventListener("abort", onAbort),
@@ -456,6 +459,12 @@ export class AgentWorkerPool {
       return
     }
     if (message.type === "error") {
+      if (task.terminal) {
+        this.terminateForProtocol(worker, "duplicate turn terminal")
+        return
+      }
+      task.terminal = true
+      task.terminalReason = "error"
       const error = AgentTurnProtocol.deserializeError(message.error)
       if (message.memoryBeforeDispose) {
         this.recordWorkerMemory(worker, message.memoryBeforeDispose, "turn.before_dispose", task)
@@ -464,7 +473,7 @@ export class AgentWorkerPool {
       task.resolveUsage(undefined)
       if (task.started) task.stream.fail(error)
       else task.reject(error)
-      this.finishTask(worker, task, message.type)
+      task.removeAbortListener()
       return
     }
     if (message.type === "complete") {
@@ -472,25 +481,41 @@ export class AgentWorkerPool {
         this.terminateForProtocol(worker, "turn completed before start")
         return
       }
+      if (task.terminal) {
+        this.terminateForProtocol(worker, "duplicate turn terminal")
+        return
+      }
+      task.terminal = true
+      task.terminalReason = "complete"
       worker.turns = message.turns
       this.recordWorkerMemory(worker, message.memoryBeforeDispose, "turn.before_dispose", task)
       this.recordWorkerMemory(worker, message.memory, "turn.after_dispose", task)
       task.resolveUsage(message.usage as Awaited<LLM.StreamOutput["usage"]> | undefined)
       task.stream.complete()
+      task.removeAbortListener()
+      return
+    }
+    if (message.type === "released") {
+      if (!task.terminal) {
+        this.terminateForProtocol(worker, "turn released before terminal result")
+        return
+      }
+      worker.turns = message.turns
+      this.recordWorkerMemory(worker, message.memory, "turn.released", task)
       const recycle =
         message.turns >= this.options.maxTurns ||
         message.memory.rssBytes >= this.options.maxRssBytes ||
         message.memory.heapUsedBytes >= this.options.maxHeapBytes
-      this.finishTask(worker, task, message.type, !recycle)
-      if (recycle) {
-        const reason =
-          message.turns >= this.options.maxTurns
-            ? "max_turns"
-            : message.memory.rssBytes >= this.options.maxRssBytes
-              ? "rss"
-              : "heap"
-        this.recycle(worker, reason)
-      }
+      this.finishTask(worker, task, task.terminalReason ?? "released", !recycle)
+      if (!recycle) return
+      const reason =
+        message.turns >= this.options.maxTurns
+          ? "max_turns"
+          : message.memory.rssBytes >= this.options.maxRssBytes
+            ? "rss"
+            : "heap"
+      this.recycle(worker, reason)
+      return
     }
   }
 
@@ -500,10 +525,12 @@ export class AgentWorkerPool {
     const startupFailure = worker.startupFailureEligible
     const task = worker.task
     if (task && !task.completed) {
-      if (task.started) task.stream.fail(error)
-      else task.reject(error)
+      if (!task.terminal) {
+        if (task.started) task.stream.fail(error)
+        else task.reject(error)
+        task.resolveUsage(undefined)
+      }
       task.completed = true
-      task.resolveUsage(undefined)
       task.removeAbortListener()
     }
     if (!this.stopping && !worker.stopping) {
@@ -605,7 +632,7 @@ export class AgentWorkerPool {
   private recordWorkerMemory(
     worker: PoolWorker,
     memory: AgentTurnProtocol.WorkerMemory,
-    phase: "ready" | "heartbeat" | "turn.before_dispose" | "turn.after_dispose",
+    phase: "ready" | "heartbeat" | "turn.before_dispose" | "turn.after_dispose" | "turn.released",
     task?: PoolTask,
   ): void {
     worker.rssBytes = memory.rssBytes
@@ -734,7 +761,9 @@ export class AgentWorkerPool {
   }
 
   private async disposeTask(task: PoolTask): Promise<void> {
-    if (!task.completed) this.cancel(task.requestId, new DOMException("Agent turn consumer disposed", "AbortError"))
+    if (!task.terminal && !task.completed) {
+      this.cancel(task.requestId, new DOMException("Agent turn consumer disposed", "AbortError"))
+    }
   }
 
   private sweepHealth(now = Date.now()): void {

--- a/packages/synergy/src/session/agent-turn/worker-pool.ts
+++ b/packages/synergy/src/session/agent-turn/worker-pool.ts
@@ -88,6 +88,9 @@ interface PoolWorker {
   pid?: number
   rssBytes?: number
   heapUsedBytes?: number
+  heapTotalBytes?: number
+  externalBytes?: number
+  arrayBuffersBytes?: number
   lastEventSequence: number
   lastHeartbeatAt: number
 }
@@ -282,6 +285,9 @@ export class AgentWorkerPool {
       queuedBytes: this.queuedBytes,
       rssBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.rssBytes ?? 0), 0),
       heapUsedBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.heapUsedBytes ?? 0), 0),
+      heapTotalBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.heapTotalBytes ?? 0), 0),
+      externalBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.externalBytes ?? 0), 0),
+      arrayBuffersBytes: [...this.workers.values()].reduce((sum, worker) => sum + (worker.arrayBuffersBytes ?? 0), 0),
     }
   }
 
@@ -351,6 +357,7 @@ export class AgentWorkerPool {
       worker.startupFailureEligible = false
       worker.pid = message.pid
       worker.lastHeartbeatAt = Date.now()
+      this.recordWorkerMemory(worker, message.memory, "ready")
       this.consecutiveStartupFailures = 0
       this.startupCircuitError = undefined
       this.ensureWorkers()
@@ -362,25 +369,8 @@ export class AgentWorkerPool {
         this.terminateForProtocol(worker, "heartbeat referenced an unowned turn")
         return
       }
-      worker.rssBytes = message.memory.rssBytes
-      worker.heapUsedBytes = message.memory.heapUsedBytes
+      this.recordWorkerMemory(worker, message.memory, "heartbeat")
       worker.lastHeartbeatAt = Date.now()
-      ObservabilityMetrics.record({
-        name: "agent.worker.rss",
-        value: message.memory.rssBytes,
-        unit: "bytes",
-        module: "session",
-        processId: worker.id,
-        pid: worker.pid,
-      })
-      ObservabilityMetrics.record({
-        name: "agent.worker.heap_used",
-        value: message.memory.heapUsedBytes,
-        unit: "bytes",
-        module: "session",
-        processId: worker.id,
-        pid: worker.pid,
-      })
       if (
         message.memory.rssBytes >= this.options.maxRssBytes ||
         message.memory.heapUsedBytes >= this.options.maxHeapBytes
@@ -467,6 +457,10 @@ export class AgentWorkerPool {
     }
     if (message.type === "error") {
       const error = AgentTurnProtocol.deserializeError(message.error)
+      if (message.memoryBeforeDispose) {
+        this.recordWorkerMemory(worker, message.memoryBeforeDispose, "turn.before_dispose", task)
+      }
+      if (message.memory) this.recordWorkerMemory(worker, message.memory, "turn.after_dispose", task)
       task.resolveUsage(undefined)
       if (task.started) task.stream.fail(error)
       else task.reject(error)
@@ -479,8 +473,8 @@ export class AgentWorkerPool {
         return
       }
       worker.turns = message.turns
-      worker.rssBytes = message.memory.rssBytes
-      worker.heapUsedBytes = message.memory.heapUsedBytes
+      this.recordWorkerMemory(worker, message.memoryBeforeDispose, "turn.before_dispose", task)
+      this.recordWorkerMemory(worker, message.memory, "turn.after_dispose", task)
       task.resolveUsage(message.usage as Awaited<LLM.StreamOutput["usage"]> | undefined)
       task.stream.complete()
       const recycle =
@@ -608,6 +602,38 @@ export class AgentWorkerPool {
     if (drain) this.drain()
   }
 
+  private recordWorkerMemory(
+    worker: PoolWorker,
+    memory: AgentTurnProtocol.WorkerMemory,
+    phase: "ready" | "heartbeat" | "turn.before_dispose" | "turn.after_dispose",
+    task?: PoolTask,
+  ): void {
+    worker.rssBytes = memory.rssBytes
+    worker.heapUsedBytes = memory.heapUsedBytes
+    worker.heapTotalBytes = memory.heapTotalBytes
+    worker.externalBytes = memory.externalBytes
+    worker.arrayBuffersBytes = memory.arrayBuffersBytes
+    for (const [name, value] of Object.entries({
+      "agent.worker.rss": memory.rssBytes,
+      "agent.worker.heap_used": memory.heapUsedBytes,
+      "agent.worker.heap_total": memory.heapTotalBytes,
+      "agent.worker.external": memory.externalBytes,
+      "agent.worker.array_buffers": memory.arrayBuffersBytes,
+    })) {
+      ObservabilityMetrics.record({
+        name,
+        value,
+        unit: "bytes",
+        module: "session",
+        sessionID: task?.sessionID,
+        messageID: task?.messageID,
+        processId: worker.id,
+        pid: worker.pid,
+        labels: { phase, turns: worker.turns },
+      })
+    }
+  }
+
   private recycle(worker: PoolWorker, reason: "max_turns" | "rss" | "heap"): void {
     if (worker.stopping || this.stopping) return
     worker.stopping = true
@@ -733,7 +759,7 @@ export class AgentWorkerPool {
     }
   }
 
-  private terminateForMemory(worker: PoolWorker, memory: { rssBytes: number; heapUsedBytes: number }): void {
+  private terminateForMemory(worker: PoolWorker, memory: AgentTurnProtocol.WorkerMemory): void {
     if (worker.stopping || this.stopping) return
     worker.stopping = true
     const reason = memory.rssBytes >= this.options.maxRssBytes ? "rss" : "heap"

--- a/packages/synergy/test/session/agent-turn-protocol.test.ts
+++ b/packages/synergy/test/session/agent-turn-protocol.test.ts
@@ -3,6 +3,34 @@ import { APICallError } from "ai"
 import { AgentTurnProtocol } from "../../src/session/agent-turn/protocol"
 
 describe("AgentTurnProtocol", () => {
+  test("requires complete worker memory snapshots at lifecycle boundaries", () => {
+    const memory: AgentTurnProtocol.WorkerMemory = {
+      rssBytes: 100,
+      heapUsedBytes: 80,
+      heapTotalBytes: 90,
+      externalBytes: 20,
+      arrayBuffersBytes: 10,
+    }
+
+    expect(
+      AgentTurnProtocol.parseWorkerToHost({
+        type: "complete",
+        requestId: "turn",
+        turns: 1,
+        memoryBeforeDispose: { ...memory, externalBytes: 40 },
+        memory,
+      }),
+    ).toMatchObject({ type: "complete", memory: { arrayBuffersBytes: 10 } })
+    expect(() =>
+      AgentTurnProtocol.parseWorkerToHost({
+        type: "complete",
+        requestId: "turn",
+        turns: 1,
+        memory: { rssBytes: 100, heapUsedBytes: 80 },
+      }),
+    ).toThrow()
+  })
+
   test("accepts a request at the configured byte boundary and rejects a larger request", () => {
     const base = {
       type: "run" as const,

--- a/packages/synergy/test/session/agent-turn-protocol.test.ts
+++ b/packages/synergy/test/session/agent-turn-protocol.test.ts
@@ -29,6 +29,15 @@ describe("AgentTurnProtocol", () => {
         memory: { rssBytes: 100, heapUsedBytes: 80 },
       }),
     ).toThrow()
+    expect(
+      AgentTurnProtocol.parseWorkerToHost({
+        type: "released",
+        requestId: "turn",
+        turns: 1,
+        collection: "full",
+        memory,
+      }),
+    ).toMatchObject({ type: "released", collection: "full" })
   })
 
   test("accepts a request at the configured byte boundary and rejects a larger request", () => {

--- a/packages/synergy/test/session/agent-worker-pool.test.ts
+++ b/packages/synergy/test/session/agent-worker-pool.test.ts
@@ -85,6 +85,16 @@ function startTurn(worker: FakeWorker) {
   return start
 }
 
+function releaseTurn(worker: FakeWorker, requestId: string, turns = 1) {
+  worker.receive({
+    type: "released",
+    requestId,
+    turns,
+    collection: "full",
+    memory: workerMemory(),
+  })
+}
+
 const options: AgentWorkerPoolOptions = {
   size: 1,
   maxQueued: 8,
@@ -423,7 +433,7 @@ describe("AgentWorkerPool", () => {
     await pool.stop()
   })
 
-  test("recycles a completed worker before assigning the next queued turn", async () => {
+  test("waits for release before recycling a completed worker or assigning the next turn", async () => {
     const fake = fakeWorkers()
     const pool = new AgentWorkerPool({ ...options, maxTurns: 1 }, fake.spawn)
     const firstPromise = inScope(() => pool.run(input(new AbortController().signal)))
@@ -441,6 +451,10 @@ describe("AgentWorkerPool", () => {
       memory: workerMemory(),
     })
     expect((await first.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
+    expect(fake.workers).toHaveLength(1)
+    expect(fake.workers[0].sent.filter((message) => message.type === "run-start")).toHaveLength(1)
+
+    releaseTurn(fake.workers[0], firstRun.requestId)
     expect(fake.workers).toHaveLength(2)
     expect(fake.workers[0].sent.filter((message) => message.type === "run-start")).toHaveLength(1)
 
@@ -454,6 +468,7 @@ describe("AgentWorkerPool", () => {
       memoryBeforeDispose: workerMemory(2, 2),
       memory: workerMemory(),
     })
+    releaseTurn(fake.workers[1], secondRun.requestId)
     const second = await secondPromise
     expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
     await pool.stop()

--- a/packages/synergy/test/session/agent-worker-pool.test.ts
+++ b/packages/synergy/test/session/agent-worker-pool.test.ts
@@ -14,6 +14,16 @@ interface FakeWorker {
   exit(code?: number | null, signal?: string | null): void
 }
 
+function workerMemory(rssBytes = 1, heapUsedBytes = 1): AgentTurnProtocol.WorkerMemory {
+  return {
+    rssBytes,
+    heapUsedBytes,
+    heapTotalBytes: heapUsedBytes + 1,
+    externalBytes: 1,
+    arrayBuffersBytes: 1,
+  }
+}
+
 function fakeWorkers() {
   const workers: FakeWorker[] = []
   const spawn = (options: SpawnAgentWorkerProcessOptions): AgentWorkerProcess => {
@@ -37,7 +47,12 @@ function fakeWorkers() {
       sent,
       host,
       ready() {
-        options.onMessage({ type: "ready", protocolVersion: 1, pid: 1000 + workers.indexOf(worker) })
+        options.onMessage({
+          type: "ready",
+          protocolVersion: AgentTurnProtocol.VERSION,
+          pid: 1000 + workers.indexOf(worker),
+          memory: workerMemory(),
+        })
       },
       receive(message) {
         options.onMessage(message)
@@ -140,7 +155,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: run.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     expect((await done).done).toBe(true)
     await pool.stop()
@@ -209,7 +225,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: secondRun.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     const second = await secondPromise
     expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
@@ -302,7 +319,7 @@ describe("AgentWorkerPool", () => {
     const turn = inScope(() => pool.run(input(new AbortController().signal)))
 
     try {
-      fake.workers[0].receive({ type: "ready", protocolVersion: 0, pid: 1000 })
+      fake.workers[0].receive({ type: "ready", protocolVersion: 0, pid: 1000, memory: workerMemory() })
       expect(delays).toEqual([])
       expect(fake.workers).toHaveLength(2)
 
@@ -349,7 +366,8 @@ describe("AgentWorkerPool", () => {
         type: "complete",
         requestId: run.requestId,
         turns: 1,
-        memory: { rssBytes: 1, heapUsedBytes: 1 },
+        memoryBeforeDispose: workerMemory(2, 2),
+        memory: workerMemory(),
       })
       const stream = await recoveredTurn
       expect((await stream.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
@@ -419,7 +437,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: firstRun.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     expect((await first.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
     expect(fake.workers).toHaveLength(2)
@@ -432,7 +451,8 @@ describe("AgentWorkerPool", () => {
       type: "complete",
       requestId: secondRun.requestId,
       turns: 1,
-      memory: { rssBytes: 1, heapUsedBytes: 1 },
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
     })
     const second = await secondPromise
     expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
@@ -494,7 +514,7 @@ describe("AgentWorkerPool", () => {
       type: "heartbeat",
       requestId: run.requestId,
       turns: 0,
-      memory: { rssBytes: 32, heapUsedBytes: 65 },
+      memory: workerMemory(32, 65),
     })
 
     await expect(stream.fullStream[Symbol.asyncIterator]().next()).rejects.toThrow("Agent worker exited")

--- a/packages/synergy/test/session/agent-worker-process.test.ts
+++ b/packages/synergy/test/session/agent-worker-process.test.ts
@@ -9,6 +9,7 @@ test("Agent worker subprocess completes the IPC handshake and shuts down", async
   let resolveRunReady!: () => void
   let resolveChunkAck: ((index: number) => void) | undefined
   let resolveTerminal!: (error: AgentTurnProtocol.SerializedError) => void
+  let resolveReleased!: () => void
   let activeRequestID = "turn_transfer_test"
   const ready = new Promise<void>((resolve) => {
     resolveReady = resolve
@@ -22,6 +23,9 @@ test("Agent worker subprocess completes the IPC handshake and shuts down", async
   const terminal = new Promise<AgentTurnProtocol.SerializedError>((resolve) => {
     resolveTerminal = resolve
   })
+  let released = new Promise<void>((resolve) => {
+    resolveReleased = resolve
+  })
   const worker = spawnAgentWorkerProcess({
     onMessage(message) {
       if (message.type === "ready") resolveReady()
@@ -29,6 +33,7 @@ test("Agent worker subprocess completes the IPC handshake and shuts down", async
       if (message.type === "run-ready") resolveRunReady()
       if (message.type === "chunk-ack") resolveChunkAck?.(message.index)
       if (message.type === "error" && message.requestId === activeRequestID) resolveTerminal(message.error)
+      if (message.type === "released" && message.requestId === activeRequestID) resolveReleased()
     },
     onExit() {},
   })
@@ -97,6 +102,7 @@ test("Agent worker subprocess completes the IPC handshake and shuts down", async
     expect(firstError.message).not.toContain('"time"')
     expect(firstError.message).not.toContain('"sandboxes"')
     expect(firstError.message).toContain("model.api.npm")
+    await released
 
     activeRequestID = "turn_transfer_reuse_test"
     const secondRunReady = new Promise<void>((resolve) => {
@@ -104,6 +110,9 @@ test("Agent worker subprocess completes the IPC handshake and shuts down", async
     })
     const secondTerminal = new Promise<AgentTurnProtocol.SerializedError>((resolve) => {
       resolveTerminal = resolve
+    })
+    released = new Promise<void>((resolve) => {
+      resolveReleased = resolve
     })
     worker.send({
       type: "run-start",
@@ -135,6 +144,7 @@ test("Agent worker subprocess completes the IPC handshake and shuts down", async
     expect(secondError.message).not.toContain('"time"')
     expect(secondError.message).not.toContain('"sandboxes"')
     expect(secondError.message).toContain("model.api.npm")
+    await released
   } finally {
     await worker.stop(1_000)
   }


### PR DESCRIPTION
## Status

This is a stacked draft PR and depends on #822. Review the top commit (`fca15ac4`) for the release-barrier change; the earlier commit is the prerequisite worker-memory protocol.

## Summary

- add a distinct `released` worker lifecycle message after terminal result delivery
- keep a worker unavailable until its turn stack, stream, acknowledgements, and envelope references have been released
- run a full Bun GC at that completed-turn boundary on Linux only
- preserve the current behavior on macOS and Windows (`collection: none`)
- report post-release memory and apply existing max-turn/RSS/heap recycle decisions only at that safe boundary

Related to #817 and #813. This PR intentionally does not close either issue.

## Behavior

The caller still receives `complete` or `error` immediately. The pool does not reuse the worker until `released` arrives. Prompt contents, tool output, concurrency limits, and cancellation behavior are unchanged.

## Verification

- rebased on `dev` including #821 event projection
- `bun test test/session/agent-turn-protocol.test.ts test/session/agent-worker-pool.test.ts test/session/agent-worker-process.test.ts` (30 passed)
- `bun run typecheck` in `packages/synergy`
- repository Prettier, oxlint, Turbo typecheck, and sherif pre-push gates

No production service restart was performed.