### PR TITLE
fix(session): collect pressured Linux turn releases

### DIFF
--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -1052,11 +1052,20 @@ loop_stop() does not end the Light Loop directly — a reviewer will audit your 
             postRequestedStop = postResult === "stop"
           }
         }
-        await SessionMemoryPressure.maybeCollect({
-          sessionID,
-          messageID: processor.message.id,
-          phase: "session.turn.after_post_jobs",
-        })
+        if (process.platform === "linux") {
+          SessionMemoryPressure.signalRelease({
+            sessionID,
+            messageID: processor.message.id,
+            phase: "session.turn.after_post_jobs",
+            linuxOnly: true,
+          })
+        } else {
+          await SessionMemoryPressure.maybeCollect({
+            sessionID,
+            messageID: processor.message.id,
+            phase: "session.turn.after_post_jobs",
+          })
+        }
         if (postRequestedStop) break
 
         if (result === "stop") {

--- a/packages/synergy/src/session/llm-memory.ts
+++ b/packages/synergy/src/session/llm-memory.ts
@@ -106,6 +106,7 @@ export namespace LLMTurnMemory {
       streamStarted() {
         if (released || entry.streamActive) return
         entry.streamActive = true
+        SessionMemoryPressure.streamStarted()
         checkpoint(entry, "stream.started")
         entry.timer = setInterval(() => checkpoint(entry, "stream.periodic"), CHECKPOINT_INTERVAL_MS)
         entry.timer.unref()
@@ -135,6 +136,7 @@ export namespace LLMTurnMemory {
       streamDisposed() {
         if (released || !entry.streamActive) return
         entry.streamActive = false
+        SessionMemoryPressure.streamDisposed()
         if (entry.timer) clearInterval(entry.timer)
         entry.timer = undefined
         checkpoint(entry, "stream.disposed")
@@ -142,6 +144,7 @@ export namespace LLMTurnMemory {
       release() {
         if (released) return
         released = true
+        if (entry.streamActive) SessionMemoryPressure.streamDisposed()
         if (entry.timer) clearInterval(entry.timer)
         entry.timer = undefined
         entry.streamActive = false
@@ -237,7 +240,10 @@ export namespace LLMTurnMemory {
   }
 
   export function resetForTest() {
-    for (const entry of active.values()) if (entry.timer) clearInterval(entry.timer)
+    for (const entry of active.values()) {
+      if (entry.timer) clearInterval(entry.timer)
+      if (entry.streamActive) SessionMemoryPressure.streamDisposed()
+    }
     active.clear()
     recent.length = 0
     snapshotForTest = undefined
@@ -345,6 +351,9 @@ export namespace LLMTurnMemory {
       ...(current.cgroupCurrentBytes === undefined || start.cgroupCurrentBytes === undefined
         ? {}
         : { cgroupCurrentBytes: current.cgroupCurrentBytes - start.cgroupCurrentBytes }),
+      ...(current.cgroupWorkingSetBytes === undefined || start.cgroupWorkingSetBytes === undefined
+        ? {}
+        : { cgroupWorkingSetBytes: current.cgroupWorkingSetBytes - start.cgroupWorkingSetBytes }),
     }
   }
 

--- a/packages/synergy/src/session/memory-pressure.ts
+++ b/packages/synergy/src/session/memory-pressure.ts
@@ -12,15 +12,18 @@ export namespace SessionMemoryPressure {
     externalBytes: number
     arrayBuffersBytes: number
     cgroupCurrentBytes?: number
+    cgroupWorkingSetBytes?: number
     cgroupHighBytes?: number
     cgroupMaxBytes?: number
   }
 
   export type Thresholds = {
     minIntervalMs: number
+    fullMinIntervalMs: number
     heapUsedSoftBytes: number
     externalSoftBytes: number
     arrayBuffersSoftBytes: number
+    cgroupSoftBytes: number
     rssCriticalBytes: number
     heapUsedCriticalBytes: number
     externalCriticalBytes: number
@@ -33,6 +36,7 @@ export namespace SessionMemoryPressure {
     | { action: "skip"; reason: "interval"; critical: boolean; nextEligibleAt: number }
     | { action: "normal"; reason: "interval_elapsed"; critical: false }
     | { action: "critical"; reason: "critical_pressure"; critical: true }
+    | { action: "linux_release_full"; reason: "linux_release_pressure"; critical: boolean }
 
   type PressureLevel = "normal" | "soft" | "critical"
 
@@ -44,6 +48,9 @@ export namespace SessionMemoryPressure {
     snapshot?: () => Snapshot | Promise<Snapshot>
     collect?: (synchronous: boolean) => void | Promise<void>
     env?: NodeJS.ProcessEnv
+    platform?: NodeJS.Platform
+    releaseBoundary?: boolean
+    linuxOnly?: boolean
   }
 
   type CollectionResult = {
@@ -57,6 +64,8 @@ export namespace SessionMemoryPressure {
   type ReleaseResult = CollectionResult & { releaseCount: number }
 
   let lastGCAt = 0
+  let lastFullGCAt = 0
+  let activeStreamCount = 0
   let collectionInFlight: Promise<CollectionResult> | undefined
   let cachedCgroupDir: string | undefined | null
   let pendingRelease: { count: number; input: CollectionInput } | undefined
@@ -86,12 +95,16 @@ export namespace SessionMemoryPressure {
       finitePositive(snapshot?.cgroupHighBytes) ??
       (finitePositive(snapshot?.cgroupMaxBytes) ? Math.floor(snapshot!.cgroupMaxBytes! * 0.9) : undefined) ??
       Math.floor(10.5 * GIB)
+    const cgroupSoftDefault =
+      finitePositive(snapshot?.cgroupHighBytes) ?? finitePositive(snapshot?.cgroupMaxBytes) ?? Math.floor(11 * GIB)
 
     return {
       minIntervalMs: envNumber(env.SYNERGY_SESSION_GC_MIN_INTERVAL_MS) ?? 10_000,
+      fullMinIntervalMs: envNumber(env.SYNERGY_SESSION_GC_FULL_MIN_INTERVAL_MS) ?? 30_000,
       heapUsedSoftBytes: envNumber(env.SYNERGY_SESSION_GC_HEAP_USED_SOFT_BYTES) ?? Math.floor(1.25 * GIB),
       externalSoftBytes: envNumber(env.SYNERGY_SESSION_GC_EXTERNAL_SOFT_BYTES) ?? Math.floor(1 * GIB),
       arrayBuffersSoftBytes: envNumber(env.SYNERGY_SESSION_GC_ARRAY_BUFFERS_SOFT_BYTES) ?? Math.floor(1 * GIB),
+      cgroupSoftBytes: envNumber(env.SYNERGY_SESSION_GC_CGROUP_SOFT_BYTES) ?? Math.floor(cgroupSoftDefault * 0.6),
       rssCriticalBytes: envNumber(env.SYNERGY_SESSION_GC_RSS_CRITICAL_BYTES) ?? Math.floor(9.5 * GIB),
       heapUsedCriticalBytes: envNumber(env.SYNERGY_SESSION_GC_HEAP_USED_CRITICAL_BYTES) ?? Math.floor(1.75 * GIB),
       externalCriticalBytes: envNumber(env.SYNERGY_SESSION_GC_EXTERNAL_CRITICAL_BYTES) ?? Math.floor(1.5 * GIB),
@@ -132,7 +145,8 @@ export namespace SessionMemoryPressure {
     if (
       snapshot.heapUsedBytes >= thresholds.heapUsedSoftBytes ||
       snapshot.externalBytes >= thresholds.externalSoftBytes ||
-      snapshot.arrayBuffersBytes >= thresholds.arrayBuffersSoftBytes
+      snapshot.arrayBuffersBytes >= thresholds.arrayBuffersSoftBytes ||
+      (snapshot.cgroupWorkingSetBytes ?? 0) >= thresholds.cgroupSoftBytes
     )
       return "soft"
     return "normal"
@@ -156,13 +170,28 @@ export namespace SessionMemoryPressure {
     const thresholds = resolveThresholds(input.env, before)
     const pressure = pressureLevel(before, thresholds)
     const collect = input.collect ?? defaultCollect
-    const decision = decide({
+    let decision = decide({
       snapshot: before,
       thresholds,
       now,
       lastGCAt,
       gcAvailable: input.collect !== undefined || typeof Bun.gc === "function",
     })
+    const platform = input.platform ?? process.platform
+    const fullEligibleAt = lastFullGCAt + thresholds.fullMinIntervalMs
+    const linuxReleaseFull =
+      platform === "linux" &&
+      input.releaseBoundary === true &&
+      activeStreamCount === 0 &&
+      pressure !== "normal" &&
+      (lastFullGCAt === 0 || now >= fullEligibleAt)
+    if (linuxReleaseFull && decision.action !== "unavailable") {
+      decision = {
+        action: "linux_release_full",
+        reason: "linux_release_pressure",
+        critical: pressure === "critical",
+      }
+    }
 
     if (decision.action === "skip" || decision.action === "unavailable") {
       log.debug("gc skipped", {
@@ -176,8 +205,10 @@ export namespace SessionMemoryPressure {
       return { decision, before, thresholds, pressure }
     }
 
-    await collect(false)
+    const synchronous = decision.action === "linux_release_full"
+    await collect(synchronous)
     lastGCAt = now
+    if (synchronous) lastFullGCAt = now
     const after = input.snapshot ? await input.snapshot() : currentSnapshot()
     log.info("gc completed", {
       sessionID: input.sessionID,
@@ -187,11 +218,14 @@ export namespace SessionMemoryPressure {
       before,
       after,
       thresholds,
+      collection: synchronous ? "full" : "normal",
     })
     return { decision, before, after, thresholds, pressure }
   }
 
   export function signalRelease(input: CollectionInput) {
+    if (input.linuxOnly && (input.platform ?? process.platform) !== "linux") return
+    input = { ...input, releaseBoundary: true }
     if (pendingRelease) {
       pendingRelease.count++
       pendingRelease.input = input
@@ -253,9 +287,19 @@ export namespace SessionMemoryPressure {
     })
   }
 
-  export function resetForTest(lastRunAt = 0) {
+  export function streamStarted() {
+    activeStreamCount++
+  }
+
+  export function streamDisposed() {
+    activeStreamCount = Math.max(0, activeStreamCount - 1)
+  }
+
+  export function resetForTest(lastRunAt = 0, lastFullRunAt = 0) {
     if (releaseTimer) clearTimeout(releaseTimer)
     lastGCAt = lastRunAt
+    lastFullGCAt = lastFullRunAt
+    activeStreamCount = 0
     collectionInFlight = undefined
     cachedCgroupDir = undefined
     pendingRelease = undefined
@@ -270,13 +314,18 @@ export namespace SessionMemoryPressure {
   async function cgroupMemory() {
     const dir = await cgroupDir()
     if (!dir) return {}
-    const [current, high, max] = await Promise.all([
+    const [current, high, max, stat] = await Promise.all([
       readNumberFile(`${dir}/memory.current`),
       readNumberFile(`${dir}/memory.high`),
       readNumberFile(`${dir}/memory.max`),
+      readKeyValueFile(`${dir}/memory.stat`),
     ])
+    const reclaimable = stat === undefined ? undefined : (stat.inactive_file ?? 0) + (stat.slab_reclaimable ?? 0)
     return {
       ...(current !== undefined ? { cgroupCurrentBytes: current } : {}),
+      ...(current !== undefined && reclaimable !== undefined
+        ? { cgroupWorkingSetBytes: Math.max(0, current - reclaimable) }
+        : {}),
       ...(high !== undefined ? { cgroupHighBytes: high } : {}),
       ...(max !== undefined ? { cgroupMaxBytes: max } : {}),
     }
@@ -310,6 +359,22 @@ export namespace SessionMemoryPressure {
       if (!text || text === "max") return undefined
       const value = Number(text)
       return Number.isFinite(value) && value > 0 ? value : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  async function readKeyValueFile(path: string) {
+    try {
+      const file = Bun.file(path)
+      if (!(await file.exists())) return undefined
+      const result: Record<string, number> = {}
+      for (const line of (await file.text()).split("\n")) {
+        const [key, raw] = line.trim().split(/\s+/, 2)
+        const value = Number(raw)
+        if (key && Number.isFinite(value) && value >= 0) result[key] = value
+      }
+      return Object.keys(result).length > 0 ? result : undefined
     } catch {
       return undefined
     }

--- a/packages/synergy/src/session/tool-scheduler.ts
+++ b/packages/synergy/src/session/tool-scheduler.ts
@@ -2,6 +2,7 @@ import type { ModelMessage, Tool as AITool, ToolCallOptions } from "ai"
 import { availableParallelism } from "os"
 import { Log } from "@/util/log"
 import { ObservabilityMetrics } from "@/observability/metrics"
+import { SessionMemoryPressure } from "./memory-pressure"
 import type { SessionProcessor } from "./processor"
 
 export type ToolTaskState = "queued" | "running" | "completed" | "failed" | "cancelled" | "interrupted"
@@ -317,6 +318,16 @@ export class ToolTaskScheduler {
       })
       task.input.signal.removeEventListener("abort", onAbort)
       this.activeTasks.delete(task.key)
+      const memory = SessionMemoryPressure.currentSnapshot()
+      const thresholds = SessionMemoryPressure.resolveThresholds(process.env, memory)
+      if (SessionMemoryPressure.pressureLevel(memory, thresholds) !== "normal") {
+        SessionMemoryPressure.signalRelease({
+          phase: "tool.execution.complete",
+          sessionID: task.input.sessionID,
+          messageID: task.input.messageID,
+          linuxOnly: true,
+        })
+      }
     }
   }
 

--- a/packages/synergy/test/session/memory-pressure.test.ts
+++ b/packages/synergy/test/session/memory-pressure.test.ts
@@ -3,9 +3,11 @@ import { SessionMemoryPressure } from "../../src/session/memory-pressure"
 
 const env = {
   SYNERGY_SESSION_GC_MIN_INTERVAL_MS: "10000",
+  SYNERGY_SESSION_GC_FULL_MIN_INTERVAL_MS: "30000",
   SYNERGY_SESSION_GC_HEAP_USED_SOFT_BYTES: "500",
   SYNERGY_SESSION_GC_EXTERNAL_SOFT_BYTES: "500",
   SYNERGY_SESSION_GC_ARRAY_BUFFERS_SOFT_BYTES: "500",
+  SYNERGY_SESSION_GC_CGROUP_SOFT_BYTES: "500",
   SYNERGY_SESSION_GC_RSS_CRITICAL_BYTES: "1000",
   SYNERGY_SESSION_GC_HEAP_USED_CRITICAL_BYTES: "1000",
   SYNERGY_SESSION_GC_EXTERNAL_CRITICAL_BYTES: "1000",
@@ -82,6 +84,99 @@ describe("SessionMemoryPressure", () => {
     expect(result?.releaseCount).toBe(2)
     expect(result?.decision.action).toBe("normal")
     expect(calls).toEqual([false])
+  })
+
+  test("uses full GC for a pressured Linux release boundary", async () => {
+    const calls: boolean[] = []
+    SessionMemoryPressure.signalRelease({
+      phase: "session.turn.complete",
+      platform: "linux",
+      now: () => 12_000,
+      snapshot: () => ({ ...healthySnapshot, externalBytes: 700 }),
+      collect: (synchronous) => {
+        calls.push(synchronous)
+      },
+      env,
+    })
+
+    const result = await SessionMemoryPressure.flushReleaseSignalsForTest()
+    expect(result?.decision.action).toBe("linux_release_full")
+    expect(calls).toEqual([true])
+  })
+
+  test("does not change non-Linux release collection", async () => {
+    const calls: boolean[] = []
+    SessionMemoryPressure.signalRelease({
+      phase: "session.turn.complete",
+      platform: "darwin",
+      now: () => 12_000,
+      snapshot: () => ({ ...healthySnapshot, externalBytes: 700 }),
+      collect: (synchronous) => {
+        calls.push(synchronous)
+      },
+      env,
+    })
+
+    const result = await SessionMemoryPressure.flushReleaseSignalsForTest()
+    expect(result?.decision.action).toBe("normal")
+    expect(calls).toEqual([false])
+  })
+
+  test("does not run full GC while a provider stream is active", async () => {
+    const calls: boolean[] = []
+    SessionMemoryPressure.streamStarted()
+    SessionMemoryPressure.signalRelease({
+      phase: "tool.execution.complete",
+      platform: "linux",
+      now: () => 12_000,
+      snapshot: () => ({ ...healthySnapshot, externalBytes: 700 }),
+      collect: (synchronous) => {
+        calls.push(synchronous)
+      },
+      env,
+    })
+
+    const result = await SessionMemoryPressure.flushReleaseSignalsForTest()
+    SessionMemoryPressure.streamDisposed()
+    expect(result?.decision.action).toBe("normal")
+    expect(calls).toEqual([false])
+  })
+
+  test("keeps Linux full GC behind its independent cooldown", async () => {
+    const calls: boolean[] = []
+    const signal = (now: number) => ({
+      phase: "session.turn.complete",
+      platform: "linux" as const,
+      now: () => now,
+      snapshot: () => ({ ...healthySnapshot, externalBytes: 700 }),
+      collect: (synchronous: boolean) => {
+        calls.push(synchronous)
+      },
+      env,
+    })
+
+    SessionMemoryPressure.signalRelease(signal(12_000))
+    await SessionMemoryPressure.flushReleaseSignalsForTest()
+    SessionMemoryPressure.signalRelease(signal(22_001))
+    const second = await SessionMemoryPressure.flushReleaseSignalsForTest()
+
+    expect(second?.decision.action).toBe("normal")
+    expect(calls).toEqual([true, false])
+  })
+
+  test("ignores Linux-only release signals on other platforms", async () => {
+    SessionMemoryPressure.signalRelease({
+      phase: "tool.execution.complete",
+      platform: "darwin",
+      linuxOnly: true,
+      snapshot: () => healthySnapshot,
+      collect: () => {
+        throw new Error("must not collect")
+      },
+      env,
+    })
+
+    expect(await SessionMemoryPressure.flushReleaseSignalsForTest()).toBeUndefined()
   })
 
   test("keeps released-history collection behind the minimum interval", async () => {
@@ -195,6 +290,9 @@ describe("SessionMemoryPressure", () => {
   test("classifies soft pressure before the critical boundary", () => {
     const thresholds = SessionMemoryPressure.resolveThresholds(env, healthySnapshot)
     expect(SessionMemoryPressure.pressureLevel({ ...healthySnapshot, heapUsedBytes: 700 }, thresholds)).toBe("soft")
+    expect(SessionMemoryPressure.pressureLevel({ ...healthySnapshot, cgroupWorkingSetBytes: 700 }, thresholds)).toBe(
+      "soft",
+    )
     expect(SessionMemoryPressure.pressureLevel(healthySnapshot, thresholds)).toBe("normal")
   })
 


### PR DESCRIPTION
## Summary

- coalesce Linux tool/turn completion signals instead of running a collection per session
- use full GC only at a completed release boundary under soft or critical pressure
- derive cgroup soft pressure from working set (`memory.current - inactive_file - slab_reclaimable`) rather than reclaimable file/slab cache
- track active provider streams so a release cannot trigger full GC while streaming
- enforce a separate 30 second full-GC cooldown
- preserve existing macOS and Windows behavior

Related to #815 and #813. This PR intentionally does not close either issue.

## Scope

This does not compress prompts, reduce concurrency, queue heavy tools, or change tool decisions. Normal low-pressure tool completions do not create a GC timer. Linux turn completion performs the cgroup check; other platforms retain the existing asynchronous collection path.

## Verification

- `bun test test/session/memory-pressure.test.ts test/session/llm-memory.test.ts test/session/tool-scheduler.test.ts test/session/invoke.test.ts` (60 passed)
- `bun run typecheck` in `packages/synergy`
- repository Prettier, oxlint, Turbo typecheck, and sherif pre-push gates

No production service restart was performed.