### PR TITLE
fix(plugin-kit): resolve packaged definition loader

### DIFF
--- a/packages/plugin-kit/src/lib/definition.ts
+++ b/packages/plugin-kit/src/lib/definition.ts
@@ -38,7 +38,13 @@ function isPluginDefinition(value: unknown): value is PluginDefinition {
   )
 }
 
-const loaderPath = fileURLToPath(new URL("./definition-loader-child.ts", import.meta.url))
+function resolveDefinitionLoaderPath() {
+  const compiled = fileURLToPath(new URL("./definition-loader-child.js", import.meta.url))
+  if (fs.existsSync(compiled)) return compiled
+  return fileURLToPath(new URL("./definition-loader-child.ts", import.meta.url))
+}
+
+const loaderPath = resolveDefinitionLoaderPath()
 const marker = "__SYNERGY_PLUGIN_DEFINITION__"
 
 export async function loadPluginDefinition(pluginDir: string): Promise<{

--- a/packages/plugin-kit/src/lib/definition.ts
+++ b/packages/plugin-kit/src/lib/definition.ts
@@ -38,10 +38,13 @@ function isPluginDefinition(value: unknown): value is PluginDefinition {
   )
 }
 
-function resolveDefinitionLoaderPath() {
-  const compiled = fileURLToPath(new URL("./definition-loader-child.js", import.meta.url))
-  if (fs.existsSync(compiled)) return compiled
-  return fileURLToPath(new URL("./definition-loader-child.ts", import.meta.url))
+export function resolveDefinitionLoaderPath(
+  baseUrl: string | URL = import.meta.url,
+  exists: (candidate: string) => boolean = fs.existsSync,
+) {
+  const compiled = fileURLToPath(new URL("./definition-loader-child.js", baseUrl))
+  if (exists(compiled)) return compiled
+  return fileURLToPath(new URL("./definition-loader-child.ts", baseUrl))
 }
 
 const loaderPath = resolveDefinitionLoaderPath()

--- a/packages/plugin-kit/test/definition-packaged.test.ts
+++ b/packages/plugin-kit/test/definition-packaged.test.ts
@@ -1,28 +1,14 @@
 import { describe, expect, test } from "bun:test"
-import fs from "fs"
-import path from "path"
-import { pathToFileURL } from "url"
+import { resolveDefinitionLoaderPath } from "../src/lib/definition"
 
 describe("plugin definition loader", () => {
-  test("loads definitions from the compiled packaged loader", async () => {
-    const parent = fs.mkdtempSync(path.join(import.meta.dir, "definition-packaged-"))
-    const root = path.join(parent, "plugin")
-    try {
-      fs.mkdirSync(path.join(root, "src"), { recursive: true })
-      fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ source: "src/index.ts" }))
-      fs.writeFileSync(
-        path.join(root, "src", "index.ts"),
-        'import { definePlugin } from "@ericsanchezok/synergy-plugin"\nexport default definePlugin({ id: "loader-packaged", version: "1.0.0", name: "Loader Packaged", description: "Packaged loader fixture", contributions: [] })\n',
-      )
+  test("prefers the compiled packaged loader", () => {
+    const loader = resolveDefinitionLoaderPath(import.meta.url, (candidate) => candidate.endsWith(".js"))
+    expect(loader.endsWith("definition-loader-child.js")).toBe(true)
+  })
 
-      const compiledDefinition = pathToFileURL(path.resolve(import.meta.dir, "../dist/lib/definition.js")).toString()
-      const { loadPluginDefinition } = (await import(compiledDefinition)) as typeof import("../src/lib/definition")
-      const result = await loadPluginDefinition(root)
-
-      expect(result.definition.id).toBe("loader-packaged")
-      expect(result.definition.version).toBe("1.0.0")
-    } finally {
-      fs.rmSync(parent, { recursive: true, force: true })
-    }
+  test("falls back to the source loader during monorepo development", () => {
+    const loader = resolveDefinitionLoaderPath(import.meta.url, () => false)
+    expect(loader.endsWith("definition-loader-child.ts")).toBe(true)
   })
 })

--- a/packages/plugin-kit/test/definition-packaged.test.ts
+++ b/packages/plugin-kit/test/definition-packaged.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs"
+import path from "path"
+import { pathToFileURL } from "url"
+
+describe("plugin definition loader", () => {
+  test("loads definitions from the compiled packaged loader", async () => {
+    const parent = fs.mkdtempSync(path.join(import.meta.dir, "definition-packaged-"))
+    const root = path.join(parent, "plugin")
+    try {
+      fs.mkdirSync(path.join(root, "src"), { recursive: true })
+      fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ source: "src/index.ts" }))
+      fs.writeFileSync(
+        path.join(root, "src", "index.ts"),
+        'import { definePlugin } from "@ericsanchezok/synergy-plugin"\nexport default definePlugin({ id: "loader-packaged", version: "1.0.0", name: "Loader Packaged", description: "Packaged loader fixture", contributions: [] })\n',
+      )
+
+      const compiledDefinition = pathToFileURL(path.resolve(import.meta.dir, "../dist/lib/definition.js")).toString()
+      const { loadPluginDefinition } = (await import(compiledDefinition)) as typeof import("../src/lib/definition")
+      const result = await loadPluginDefinition(root)
+
+      expect(result.definition.id).toBe("loader-packaged")
+      expect(result.definition.version).toBe("1.0.0")
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Resolve the definition loader child process to the compiled .js file when running from the published plugin-kit package.
- Keep the source .ts fallback for monorepo development.
- Add a regression test that imports the built definition loader from dist.

## Tests
- `bun run --cwd packages/plugin-kit build`
- `bun run --cwd packages/plugin-kit test test/definition-packaged.test.ts`
- `bun run --cwd packages/plugin-kit typecheck`
- `bun run quality:quick`