### PR TITLE
fix(release): wait for npm registry convergence

### DIFF
--- a/script/release/shared/runtime.ts
+++ b/script/release/shared/runtime.ts
@@ -84,10 +84,16 @@ export async function npmVersionExists(name: string, version: string) {
   return response.ok
 }
 
+export const NPM_REGISTRY_WAIT_ATTEMPTS = 60
+export const NPM_REGISTRY_WAIT_DELAY_MS = 5_000
+
 export async function waitForNpmVersion(
   name: string,
   version: string,
-  { attempts = 12, delay = 5_000 }: { attempts?: number; delay?: number } = {},
+  {
+    attempts = NPM_REGISTRY_WAIT_ATTEMPTS,
+    delay = NPM_REGISTRY_WAIT_DELAY_MS,
+  }: { attempts?: number; delay?: number } = {},
 ) {
   for (let attempt = 1; attempt <= attempts; attempt++) {
     if (await npmVersionExists(name, version)) {
@@ -109,9 +115,24 @@ export async function npmDistTagList(name: string): Promise<Record<string, strin
   return (await response.json()) as Record<string, string>
 }
 
-export async function npmTagMatches(name: string, tag: string, version: string) {
-  const tags = await npmDistTagList(name)
-  return tags[tag] === version
+export async function npmTagMatches(
+  name: string,
+  tag: string,
+  version: string,
+  {
+    attempts = NPM_REGISTRY_WAIT_ATTEMPTS,
+    delay = NPM_REGISTRY_WAIT_DELAY_MS,
+  }: { attempts?: number; delay?: number } = {},
+) {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const tags = await npmDistTagList(name)
+    if (tags[tag] === version) return true
+    if (attempt < attempts) {
+      console.log(`waiting for ${name}@${version} to be tagged ${tag} (${attempt}/${attempts})`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+  return false
 }
 
 export async function npmEnsureDistTag(name: string, version: string, tag: string) {

--- a/test/script/release/npm-registry-waits.test.ts
+++ b/test/script/release/npm-registry-waits.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import {
+  NPM_REGISTRY_WAIT_ATTEMPTS,
+  NPM_REGISTRY_WAIT_DELAY_MS,
+  npmTagMatches,
+} from "../../../script/release/shared/runtime"
+
+describe("release npm registry waits", () => {
+  test("uses a five minute registry visibility budget", () => {
+    expect(NPM_REGISTRY_WAIT_ATTEMPTS * NPM_REGISTRY_WAIT_DELAY_MS).toBe(5 * 60_000)
+  })
+
+  test("waits for a dist-tag to converge", async () => {
+    let calls = 0
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => {
+      calls += 1
+      return Response.json({ next: calls === 1 ? "3.0.0" : "3.0.1" })
+    }) as typeof fetch
+    try {
+      expect(await npmTagMatches("@ericsanchezok/synergy-sdk", "next", "3.0.1", { attempts: 2, delay: 1 })).toBe(true)
+      expect(calls).toBe(2)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Increase npm registry visibility polling from one minute to five minutes.
- Poll dist-tag convergence instead of failing immediately after a publish or reconcile.
- Add release script tests for the five-minute budget and tag polling.

## Tests
- `bun run release:test`
- `bun run format:check`
- `bun run typecheck`