### PR TITLE
fix(release): avoid immutable npm version collisions

### DIFF
--- a/docs/operations/desktop-release.md
+++ b/docs/operations/desktop-release.md
@@ -106,11 +106,13 @@ PR/package validation works without signing secrets. A product Release validates
 Product release keeps the existing candidate/finalize model:
 
 1. `stable_sandbox_assets` builds Linux x64/arm64 helpers for glibc and musl plus the Windows x64 helper, then uploads target-keyed assets. It never commits generated hashes.
-2. `stable_candidate` validates signing material, downloads the helper assets, runs `script/release/stable-start.ts`, publishes npm candidates, builds core runtime assets, creates the draft GitHub Release, and uploads release state. Missing helpers or Browser Host trust material fail before publication.
+2. `stable_candidate` validates signing material, downloads the helper assets, selects the requested bump after the highest stable version already published by any release-managed npm package, runs `script/release/stable-start.ts`, publishes npm candidates, builds core runtime assets, creates the draft GitHub Release, and uploads release state. This prevents an immutable package version from being reused after a dist-tag rollback. Missing helpers or Browser Host trust material fail before publication.
 3. `stable_desktop_package` runs a three-way desktop matrix for macOS, Windows, and Linux. macOS and Linux build x64/arm64 Desktop artifacts; Windows builds x64 Desktop artifacts. Every platform still builds x64/arm64 minimal Browser Host zips.
 4. Each desktop matrix job rewrites package versions to the candidate version, builds matching Synergy runtimes with the Browser Host public key and helper hash embedded, packages Desktop, signs each Browser Host manifest with the independent Ed25519 signing key, and uploads the full platform bundle.
 5. `stable_desktop_publish` downloads all desktop artifacts, generates `Synergy-${version}-checksums.txt`, and uploads the desktop assets to the draft GitHub Release.
 6. `stable_finalize` verifies npm candidates, runtime assets, recommended Desktop installer artifacts, portable artifacts, checksum, and updater metadata by reading the draft GitHub Release assets, then promotes npm tags and publishes the GitHub Release.
+
+Registry read-after-write checks use cache-busted, no-store requests. A successful npm write is not verified through a previously cached version or dist-tag response.
 
 ## Failure Recovery
 

--- a/script/release/package-only.ts
+++ b/script/release/package-only.ts
@@ -3,7 +3,13 @@
 import { $ } from "bun"
 import { snapshotFiles, restoreFiles } from "./shared/files"
 import { VERSION_MANAGED_PACKAGE_PATHS, NPM_REGISTRY } from "./shared/packages"
-import { configureNpmAuth, npmTagMatches, npmVersionExists } from "./shared/runtime"
+import {
+  bumpHighestStableVersion,
+  configureNpmAuth,
+  npmPackageVersions,
+  npmTagMatches,
+  npmVersionExists,
+} from "./shared/runtime"
 import type { DependencyVersionMap } from "./shared/package-manifest"
 import { bunInstall } from "./nodes/bun-install"
 import { generateSdk } from "./nodes/generate-sdk"
@@ -78,19 +84,11 @@ async function latestVersion(packageName: string): Promise<string | null> {
   return data.version ?? null
 }
 
-function bumpVersion(version: string, bump: string): string {
-  const [major = 0, minor = 0, patch = 0] = version.split(".").map((item) => Number(item) || 0)
-  if (bump === "major") return `${major + 1}.0.0`
-  if (bump === "minor") return `${major}.${minor + 1}.0`
-  return `${major}.${minor}.${patch + 1}`
-}
-
 async function computeTargetVersion(packageName: string, bump: string): Promise<string> {
-  const latest = await latestVersion(packageName)
-  if (latest) return bumpVersion(latest, bump)
-
-  const synergyLatest = await latestVersion("@ericsanchezok/synergy")
-  if (synergyLatest) return bumpVersion(synergyLatest, bump)
+  const publishedVersions = await npmPackageVersions(packageName)
+  if (publishedVersions.length > 0) return bumpHighestStableVersion(publishedVersions, bump)
+  const synergyVersions = await npmPackageVersions("@ericsanchezok/synergy")
+  if (synergyVersions.length > 0) return bumpHighestStableVersion(synergyVersions, bump)
   return "0.1.0"
 }
 

--- a/script/release/shared/runtime.ts
+++ b/script/release/shared/runtime.ts
@@ -2,6 +2,7 @@ import { $ } from "bun"
 import path from "path"
 import { currentRepo } from "../../shared/current-repo"
 import {
+  FIXED_REGISTRY_PACKAGES,
   NPM_REGISTRY,
   RELEASE_STATE_DIR,
   RELEASE_TAG_PREFIX,
@@ -10,11 +11,10 @@ import {
   REPO_ROOT,
 } from "./packages"
 
-const SYNERGY_NPM_PACKAGE = "@ericsanchezok/synergy"
-
 const rootPkgPath = path.join(REPO_ROOT, "package.json")
 const rootPkg = await Bun.file(rootPkgPath).json()
 const expectedBunVersion = rootPkg.packageManager?.split("@")[1]
+let registryRequestSequence = 0
 
 if (!expectedBunVersion) {
   throw new Error("packageManager field not found in root package.json")
@@ -80,7 +80,7 @@ export async function retry<T>(
 }
 
 export async function npmVersionExists(name: string, version: string) {
-  const response = await fetch(`${NPM_REGISTRY}/${name}/${version}`)
+  const response = await npmRegistryFetch(`/${name}/${version}`)
   return response.ok
 }
 
@@ -108,7 +108,7 @@ export async function waitForNpmVersion(
 }
 
 export async function npmDistTagList(name: string): Promise<Record<string, string>> {
-  const response = await fetch(`${NPM_REGISTRY}/-/package/${name}/dist-tags`)
+  const response = await npmRegistryFetch(`/-/package/${name}/dist-tags`)
   if (!response.ok) {
     throw new Error(`failed to fetch dist-tags for ${name}: ${response.status} ${response.statusText}`)
   }
@@ -147,18 +147,61 @@ export async function npmPromoteToLatest(name: string, version: string) {
   await retry(() => $`npm dist-tag add ${`${name}@${version}`} latest`)
 }
 
-export async function computeStableVersion(bump: string) {
-  const response = await fetch(`${NPM_REGISTRY}/${SYNERGY_NPM_PACKAGE}/latest`)
+function npmRegistryUrl(pathname: string) {
+  const url = new URL(pathname, NPM_REGISTRY)
+  registryRequestSequence += 1
+  url.searchParams.set("cache-bust", `${Date.now()}-${registryRequestSequence}`)
+  return url
+}
+
+async function npmRegistryFetch(pathname: string) {
+  return await fetch(npmRegistryUrl(pathname), {
+    cache: "no-store",
+    headers: {
+      "cache-control": "no-cache, no-store",
+      pragma: "no-cache",
+    },
+  })
+}
+
+export async function npmPackageVersions(name: string): Promise<string[]> {
+  const response = await npmRegistryFetch(`/${name}`)
+  if (response.status === 404) return []
   if (!response.ok) {
-    throw new Error(`failed to fetch latest stable version: ${response.status} ${response.statusText}`)
+    throw new Error(`failed to fetch published versions for ${name}: ${response.status} ${response.statusText}`)
   }
-  const data = (await response.json()) as { version?: string }
-  const version = data.version ?? "0.1.0"
-  const [major = 0, minor = 0, patch = 0] = version.split(".").map((item) => Number(item) || 0)
+  const data = (await response.json()) as { versions?: Record<string, unknown> }
+  return Object.keys(data.versions ?? {})
+}
+
+function parseStableVersion(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) return null
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+function compareStableVersions(left: [number, number, number], right: [number, number, number]) {
+  return left[0] - right[0] || left[1] - right[1] || left[2] - right[2]
+}
+
+export function bumpHighestStableVersion(versions: Iterable<string>, bump: string) {
+  let highest: [number, number, number] = [0, 1, 0]
+  for (const version of versions) {
+    const parsed = parseStableVersion(version)
+    if (parsed && compareStableVersions(parsed, highest) > 0) {
+      highest = parsed
+    }
+  }
+  const [major, minor, patch] = highest
   const normalized = bump.toLowerCase()
   if (normalized === "major") return `${major + 1}.0.0`
   if (normalized === "minor") return `${major}.${minor + 1}.0`
   return `${major}.${minor}.${patch + 1}`
+}
+
+export async function computeStableVersion(bump: string) {
+  const publishedVersions = await Promise.all(FIXED_REGISTRY_PACKAGES.map((name) => npmPackageVersions(name)))
+  return bumpHighestStableVersion(publishedVersions.flat(), bump)
 }
 
 export function computeDevVersion(channel: string) {

--- a/test/script/release/npm-registry-waits.test.ts
+++ b/test/script/release/npm-registry-waits.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import {
+  computeStableVersion,
   NPM_REGISTRY_WAIT_ATTEMPTS,
   NPM_REGISTRY_WAIT_DELAY_MS,
   npmTagMatches,
+  npmVersionExists,
 } from "../../../script/release/shared/runtime"
+import { FIXED_REGISTRY_PACKAGES } from "../../../script/release/shared/packages"
 
 describe("release npm registry waits", () => {
   test("uses a five minute registry visibility budget", () => {
@@ -20,6 +23,47 @@ describe("release npm registry waits", () => {
     try {
       expect(await npmTagMatches("@ericsanchezok/synergy-sdk", "next", "3.0.1", { attempts: 2, delay: 1 })).toBe(true)
       expect(calls).toBe(2)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("bypasses stale registry caches between version probes", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input, init) => {
+      requests.push({ url: String(input), init })
+      return new Response(null, { status: requests.length === 1 ? 404 : 200 })
+    }) as typeof fetch
+    try {
+      expect(await npmVersionExists("@ericsanchezok/synergy-plugin-kit", "3.0.2")).toBe(false)
+      expect(await npmVersionExists("@ericsanchezok/synergy-plugin-kit", "3.0.2")).toBe(true)
+      expect(requests).toHaveLength(2)
+      expect(requests[0]?.url).not.toBe(requests[1]?.url)
+      expect(new URL(requests[0]!.url).searchParams.has("cache-bust")).toBe(true)
+      expect(requests[0]?.init?.cache).toBe("no-store")
+      expect(new Headers(requests[0]?.init?.headers).get("cache-control")).toContain("no-cache")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("bumps after the highest published managed package version", async () => {
+    const originalFetch = globalThis.fetch
+    const requestedPackages = new Set<string>()
+    globalThis.fetch = (async (input) => {
+      const url = new URL(String(input))
+      const packageName = decodeURIComponent(url.pathname.slice(1))
+      requestedPackages.add(packageName)
+      const versions =
+        packageName === "@ericsanchezok/synergy-plugin-kit"
+          ? { "3.0.0": {}, "3.0.1": {}, "0.0.0-dev-20260724": {} }
+          : { "3.0.0": {} }
+      return Response.json({ versions })
+    }) as typeof fetch
+    try {
+      expect(await computeStableVersion("patch")).toBe("3.0.2")
+      expect(requestedPackages).toEqual(new Set(FIXED_REGISTRY_PACKAGES))
     } finally {
       globalThis.fetch = originalFetch
     }


### PR DESCRIPTION
## Summary
- select stable release versions after the highest stable version already published by any managed npm package
- make package-only releases advance past immutable published versions even when dist-tags were rolled back
- bypass stale npm registry caches during version and dist-tag verification

## Verification
- `bun test --config /dev/null test/script/release/npm-registry-waits.test.ts`
- `bun run release:test`
- `bun run format:check`
- `bun run typecheck`
- `bun run quality:quick`
- live registry calculation returns `3.0.2` for a patch release
- `bun run quality` reached the app suite; all release and repository gates passed, while one unnamed app hook hit the existing 5-second timeout. The app suite reproduced the same single timeout on rerun; all six hook-owning test files pass together (27/27), so clean CI is the final environment check.