### PR TITLE
fix(tools): enforce hard execution deadlines

### DIFF
--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -1,5 +1,6 @@
 import { Global } from "@/global"
 import { type Tool as AITool, tool, jsonSchema, type ToolCallOptions, type JSONSchema7 } from "ai"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import z from "zod"
 import { Agent } from "@/agent/agent"
 import { Identifier } from "@/id/id"
@@ -611,14 +612,15 @@ export namespace ToolResolver {
 
   function startToolTimeout(ctx: Tool.Context, timeoutMs: number) {
     const timing = toolTiming(ctx)
-    const timeout = new AbortController()
-    const timer = setTimeout(() => timeout.abort(), timeoutMs)
-    if (typeof timer === "object" && "unref" in timer) timer.unref()
+    const deadline = ToolTimeout.executionDeadline({
+      signal: timing.sessionAbort,
+      timeoutMs,
+    })
     timing.toolTimeoutCleanup = () => {
-      clearTimeout(timer)
+      deadline.dispose()
       timing.toolTimeoutCleanup = undefined
     }
-    return AbortSignal.any([timing.sessionAbort, timeout.signal])
+    return deadline
   }
 
   function disposeToolTimeout(ctx: Tool.Context) {
@@ -1522,7 +1524,8 @@ export namespace ToolResolver {
                   args: args as Record<string, any>,
                   toolTimeoutMs,
                 })
-                const combinedAbort = startToolTimeout(ctx, toolTimeoutMs)
+                const deadline = startToolTimeout(ctx, toolTimeoutMs)
+                const combinedAbort = deadline.signal
                 ctx.abort = combinedAbort
                 await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>, toolTimeout)
                 await toolTrace.phase("tool.execution.started", "execution started", {
@@ -1589,7 +1592,7 @@ export namespace ToolResolver {
                 )
                 await toolTrace.phase("plugin.runtime.before.end", "plugin before end")
                 await toolTrace.phase("tool.execute.start", "tool execute start")
-                const result = await item.execute(args, toolCtx)
+                const result = await deadline.run(item.execute(args, toolCtx))
                 Tool.validateAttachmentResult(item.id, result)
                 await toolTrace.phase("tool.execute.end", "tool execute end", {
                   outputChars: result.output.length,
@@ -1775,7 +1778,8 @@ export namespace ToolResolver {
                     toolTimeoutMs,
                     mcpCallTimeoutMs: MCP.toolCallTimeout(key),
                   })
-                  const combinedAbort = startToolTimeout(ctx, toolTimeoutMs)
+                  const deadline = startToolTimeout(ctx, toolTimeoutMs)
+                  const combinedAbort = deadline.signal
                   ctx.abort = combinedAbort
                   await markExecutionStarted(runtimeInput, ctx, args as Record<string, any>, toolTimeout)
                   await toolTrace.phase("tool.execution.started", "execution started", {
@@ -1798,7 +1802,9 @@ export namespace ToolResolver {
                   await toolTrace.phase("plugin.runtime.before.end", "plugin before end")
 
                   await toolTrace.phase("tool.execute.start", "tool execute start")
-                  const result = await execute(args, { ...opts, abortSignal: combinedAbort })
+                  const result = (await deadline.run(
+                    execute(args, { ...opts, abortSignal: combinedAbort }),
+                  )) as CallToolResult
                   await toolTrace.phase("tool.execute.end", "tool execute end", {
                     contentCount: result.content.length,
                   })

--- a/packages/synergy/src/tool/timeout.ts
+++ b/packages/synergy/src/tool/timeout.ts
@@ -18,6 +18,12 @@ export namespace ToolTimeout {
     source: Source
   }
 
+  export interface ExecutionDeadline {
+    signal: AbortSignal
+    run<T>(operation: Promise<T>): Promise<T>
+    dispose(): void
+  }
+
   export const DEFAULTS = {
     globMs: 15_000,
     listMs: 15_000,
@@ -51,6 +57,43 @@ export namespace ToolTimeout {
       ...(operationTimeoutMs !== undefined ? { operationTimeoutMs } : {}),
       displayMs: operationTimeoutMs ?? input.toolTimeoutMs,
       source: operationTimeoutMs !== undefined ? (input.source ?? "wait") : "tool_timeout",
+    }
+  }
+
+  export function executionDeadline(input: {
+    signal: AbortSignal
+    timeoutMs: number
+    label?: string
+  }): ExecutionDeadline {
+    const timeout = new AbortController()
+    const signal = AbortSignal.any([input.signal, timeout.signal])
+    const timer = setTimeout(() => {
+      timeout.abort(
+        new DOMException(`${input.label ?? "Tool execution"} timed out after ${input.timeoutMs}ms.`, "TimeoutError"),
+      )
+    }, input.timeoutMs)
+    if (typeof timer === "object" && "unref" in timer) timer.unref()
+
+    let disposed = false
+    return {
+      signal,
+      run<T>(operation: Promise<T>) {
+        if (signal.aborted) {
+          return Promise.reject(signal.reason ?? new DOMException("Tool execution aborted.", "AbortError"))
+        }
+        return new Promise<T>((resolve, reject) => {
+          const onAbort = () => {
+            reject(signal.reason ?? new DOMException("Tool execution aborted.", "AbortError"))
+          }
+          signal.addEventListener("abort", onAbort, { once: true })
+          operation.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort))
+        })
+      },
+      dispose() {
+        if (disposed) return
+        disposed = true
+        clearTimeout(timer)
+      },
     }
   }
 

--- a/packages/synergy/test/tool/timeout.test.ts
+++ b/packages/synergy/test/tool/timeout.test.ts
@@ -13,6 +13,26 @@ function metadata(tool: string, args: Record<string, any> = {}, mcpCallTimeoutMs
 }
 
 describe("ToolTimeout", () => {
+  test("enforces a hard deadline when execution ignores abort", async () => {
+    const parent = new AbortController()
+    const deadline = ToolTimeout.executionDeadline({
+      signal: parent.signal,
+      timeoutMs: 10,
+      label: "Test tool",
+    })
+
+    try {
+      const operation = new Promise<never>(() => {})
+      await expect(deadline.run(operation)).rejects.toMatchObject({
+        name: "TimeoutError",
+        message: "Test tool timed out after 10ms.",
+      })
+      expect(deadline.signal.aborted).toBe(true)
+    } finally {
+      deadline.dispose()
+    }
+  })
+
   test("uses operation timeout for search tools", () => {
     expect(metadata("glob")).toMatchObject({
       toolTimeoutMs,


### PR DESCRIPTION
## Summary

- make configured tool deadlines terminal even when an implementation ignores abort
- keep cooperative cancellation by passing the same combined abort signal to the tool
- apply the hard deadline contract to both builtin and MCP execution paths
- add a regression test with an execution promise that never settles

Fixes #857.

## Root cause

`ToolResolver` previously only aborted a signal at the configured deadline, then continued awaiting the original execution promise. A blocked `file_search` path that did not settle on abort therefore remained `running` indefinitely. The incident call exceeded its recorded 150-second timeout and continued emitting heartbeats beyond 450 seconds.

## Changes

| File | Change |
|---|---|
| `packages/synergy/src/tool/timeout.ts` | Add a disposable execution deadline that combines cancellation with a hard promise boundary |
| `packages/synergy/src/session/tool-resolver.ts` | Run builtin and MCP execution promises through that deadline |
| `packages/synergy/test/tool/timeout.test.ts` | Verify a never-settling operation rejects with `TimeoutError` |

## Verification

- `bun test test/tool/timeout.test.ts` (7 passed)
- `bun run typecheck` in `packages/synergy`
- Prettier check on changed files
- Oxlint on changed files
- `git diff --check`

## Scope

This prevents permanent session blockage without reducing search scope, permissions, or concurrency. It does not claim to identify the exact internal file-index/Git-status await from the incident; stage-level cancellation and telemetry can be improved separately.