### PR TITLE
fix(provider): stabilize Copilot authentication flows

### DIFF
--- a/packages/app/src/components/provider/ProviderConnectionFlow.tsx
+++ b/packages/app/src/components/provider/ProviderConnectionFlow.tsx
@@ -7,7 +7,7 @@ import { TextField } from "@ericsanchezok/synergy-ui/text-field"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { iife } from "@ericsanchezok/synergy-util/iife"
-import { createMemo, For, Match, onMount, Show, Switch } from "solid-js"
+import { createMemo, For, Match, onCleanup, onMount, Show, Switch } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { useLingui } from "@lingui/solid"
 import { providerFlow } from "@/locales/messages"
@@ -16,6 +16,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { usePlatform } from "@/context/platform"
 import { providerConnectCopy, providerConnectReason, providerCTA } from "./provider-recommendation"
+import { resolveProviderAuthMethods, runProviderDeviceCallback } from "./provider-connection-model"
 
 export { compareProviderIDs, providerConnectCopy } from "./provider-recommendation"
 
@@ -38,14 +39,12 @@ export function ProviderConnectionFlow(props: {
   const provider = createMemo(() => globalSync.data.provider.all.find((x) => x.id === props.providerID))
   const providerName = createMemo(() => props.providerName ?? provider()?.name ?? props.providerID)
   const profiles = createMemo(() => globalSync.data.provider.profiles)
-  const methods = createMemo<ProviderAuthMethod[]>(
-    () =>
-      globalSync.data.provider_auth[props.providerID] ?? [
-        {
-          type: "api",
-          label: _(providerFlow.methodApiDefaultLabel),
-        },
-      ],
+  const methods = createMemo<ProviderAuthMethod[]>(() =>
+    resolveProviderAuthMethods({
+      registry: globalSync.data.provider_auth,
+      providerID: props.providerID,
+      fallbackLabel: _(providerFlow.methodApiDefaultLabel),
+    }),
   )
   const connected = createMemo(
     () => props.connectedOverride ?? globalSync.data.provider.connected.includes(props.providerID),
@@ -366,19 +365,32 @@ export function ProviderConnectionFlow(props: {
                     return instructions
                   })
 
-                  onMount(async () => {
+                  const controller = new AbortController()
+                  let active = true
+                  onCleanup(() => {
+                    active = false
+                    controller.abort()
+                  })
+
+                  onMount(() => {
                     if (store.authorization?.url) platform.openLink(store.authorization.url)
-                    const result = await globalSDK.client.provider.oauth.callback({
-                      providerID: props.providerID,
-                      method: store.methodIndex,
+                    void runProviderDeviceCallback({
+                      callback: () =>
+                        globalSDK.client.provider.oauth.callback(
+                          {
+                            providerID: props.providerID,
+                            method: store.methodIndex,
+                          },
+                          { signal: controller.signal, throwOnError: true },
+                        ),
+                      complete,
+                      active: () => active,
+                      onError: () => {
+                        setStore("state", "error")
+                        setStore("error", _(providerFlow.authTimeout))
+                      },
+                      onComplete: resetMethod,
                     })
-                    if (result.error) {
-                      setStore("state", "error")
-                      setStore("error", _(providerFlow.authTimeout))
-                      return
-                    }
-                    await complete()
-                    resetMethod()
                   })
 
                   return (

--- a/packages/app/src/components/provider/provider-connection-model.ts
+++ b/packages/app/src/components/provider/provider-connection-model.ts
@@ -1,0 +1,33 @@
+import type { ProviderAuthMethod } from "@ericsanchezok/synergy-sdk/client"
+
+export function resolveProviderAuthMethods(input: {
+  registry: Record<string, ProviderAuthMethod[]>
+  providerID: string
+  fallbackLabel: string
+}): ProviderAuthMethod[] {
+  return (
+    input.registry[input.providerID] ?? [
+      {
+        type: "api",
+        label: input.fallbackLabel,
+      },
+    ]
+  )
+}
+
+export async function runProviderDeviceCallback(input: {
+  callback: () => Promise<unknown>
+  complete: () => Promise<void>
+  active: () => boolean
+  onError: () => void
+  onComplete: () => void
+}) {
+  try {
+    await input.callback()
+    if (!input.active()) return
+    await input.complete()
+    if (input.active()) input.onComplete()
+  } catch {
+    if (input.active()) input.onError()
+  }
+}

--- a/packages/app/src/components/settings/panels/ProvidersPanel.tsx
+++ b/packages/app/src/components/settings/panels/ProvidersPanel.tsx
@@ -304,11 +304,15 @@ export function ProvidersPanel(props: {
                     when={provider().health?.recovery !== "update_environment"}
                     fallback={<p class="providers-connect-copy">{_(envRecoveryFallbackDesc)}</p>}
                   >
-                    <ProviderConnectionFlow
-                      providerID={provider().id}
-                      intent={providerNeedsAction(provider().health) ? "recover" : "connect"}
-                      compact
-                    />
+                    <Show keyed when={provider().id}>
+                      {(providerID) => (
+                        <ProviderConnectionFlow
+                          providerID={providerID}
+                          intent={providerNeedsAction(provider().health) ? "recover" : "connect"}
+                          compact
+                        />
+                      )}
+                    </Show>
                   </Show>
                 </div>
               </div>

--- a/packages/app/test/components/provider/provider-connection-model.test.ts
+++ b/packages/app/test/components/provider/provider-connection-model.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import {
+  resolveProviderAuthMethods,
+  runProviderDeviceCallback,
+} from "../../../src/components/provider/provider-connection-model"
+
+describe("provider connection model", () => {
+  test("preserves both GitHub Copilot authentication methods", () => {
+    const methods = resolveProviderAuthMethods({
+      registry: {
+        "github-copilot": [
+          { type: "oauth", label: "Login with GitHub Copilot" },
+          { type: "api", label: "GitHub token" },
+        ],
+      },
+      providerID: "github-copilot",
+      fallbackLabel: "API key",
+    })
+
+    expect(methods).toEqual([
+      { type: "oauth", label: "Login with GitHub Copilot" },
+      { type: "api", label: "GitHub token" },
+    ])
+  })
+
+  test("reports device callback failures instead of leaving the waiting state active", async () => {
+    let completed = false
+    let failed = false
+
+    await runProviderDeviceCallback({
+      callback: () => Promise.reject(new Error("callback failed")),
+      complete: async () => {
+        completed = true
+      },
+      active: () => true,
+      onError: () => {
+        failed = true
+      },
+      onComplete: () => {
+        completed = true
+      },
+    })
+
+    expect(failed).toBe(true)
+    expect(completed).toBe(false)
+  })
+
+  test("does not update an authentication flow after it is unmounted", async () => {
+    let failed = false
+    let completed = false
+
+    await runProviderDeviceCallback({
+      callback: () => Promise.reject(new Error("aborted")),
+      complete: async () => {
+        completed = true
+      },
+      active: () => false,
+      onError: () => {
+        failed = true
+      },
+      onComplete: () => {
+        completed = true
+      },
+    })
+
+    expect(failed).toBe(false)
+    expect(completed).toBe(false)
+  })
+})

--- a/packages/synergy/src/provider/auth.ts
+++ b/packages/synergy/src/provider/auth.ts
@@ -17,6 +17,13 @@ import { Provider } from "./provider"
 import { RuntimeReload } from "@/runtime/reload"
 import { authHook } from "@/plugin/auth-provider"
 
+type AutoOauthResult = Extract<AuthOuathResult, { method: "auto" }>
+type PendingOauthResult =
+  | Extract<AuthOuathResult, { method: "code" }>
+  | (Omit<AutoOauthResult, "callback"> & {
+      callback(signal?: AbortSignal): ReturnType<AutoOauthResult["callback"]>
+    })
+
 export namespace ProviderAuth {
   async function reloadProvider(reason: string) {
     if (ScopeContext.tryScope()) {
@@ -133,7 +140,7 @@ export namespace ProviderAuth {
       },
     }
     const methods: Record<string, AuthHook> = { ...builtinMethods, ...pluginMethods }
-    return { methods, pending: {} as Record<string, AuthOuathResult> }
+    return { methods, pending: {} as Record<string, PendingOauthResult> }
   })
 
   export const Method = z
@@ -246,22 +253,23 @@ export namespace ProviderAuth {
       providerID: z.string(),
       method: z.number(),
       code: z.string().optional(),
+      signal: z.instanceof(AbortSignal).optional(),
     }),
     async (input) => {
-      const match = await state().then((s) => s.pending[input.providerID])
+      const s = await state()
+      const match = s.pending[input.providerID]
       if (!match) throw new OauthMissing({ providerID: input.providerID })
       let result
-
       if (match.method === "code") {
         if (!input.code) throw new OauthCodeMissing({ providerID: input.providerID })
         result = await match.callback(input.code)
+      } else {
+        delete s.pending[input.providerID]
+        result = await match.callback(input.signal)
       }
 
-      if (match.method === "auto") {
-        result = await match.callback()
-      }
-
-      if (result?.type === "success") {
+      if (result.type === "success") {
+        if (match.method === "code") delete s.pending[input.providerID]
         await persistResult(input.providerID, result, "web")
         return
       }

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -5,6 +5,7 @@ import z from "zod"
 import { ProviderAuthRecovery } from "./auth-recovery"
 import type { ProviderProfile } from "./profile"
 import { normalizeImageMediaTypes } from "./image-capability"
+import { ProviderDeviceCode } from "./device-code"
 
 export namespace CopilotProvider {
   export const PROVIDER_ID = "github-copilot"
@@ -78,16 +79,16 @@ export namespace CopilotProvider {
     const userCode = payload.user_code
     const verificationURI = payload.verification_uri ?? `${base}/login/device`
     const intervalSeconds = Math.max(1, Number(payload.interval ?? 5))
-    const expiresIn = Math.max(60, Number(payload.expires_in ?? 300))
+    const expiresIn = ProviderDeviceCode.expirySeconds(payload.expires_in)
     return {
       url: verificationURI,
       method: "auto",
       instructions: String(userCode ?? ""),
-      async callback() {
+      async callback(signal?: AbortSignal) {
         const deadline = Date.now() + expiresIn * 1000
         let interval = intervalSeconds
-        while (Date.now() < deadline) {
-          await Bun.sleep(interval * 1000)
+        while (Date.now() < deadline && !signal?.aborted) {
+          if (!(await ProviderDeviceCode.wait(interval * 1000, signal))) return { type: "failed" }
           const poll = await fetchFn(`${base}/login/oauth/access_token`, {
             method: "POST",
             headers: {
@@ -100,8 +101,10 @@ export namespace CopilotProvider {
               device_code: String(deviceCode),
               grant_type: "urn:ietf:params:oauth:grant-type:device_code",
             }),
-            signal: AbortSignal.timeout(15_000),
-          })
+            signal: ProviderDeviceCode.requestSignal(signal),
+          }).catch(() => undefined)
+          if (signal?.aborted) return { type: "failed" }
+          if (!poll) continue
           const result = await safeJson(poll)
           if (typeof result.access_token === "string") {
             return {

--- a/packages/synergy/src/provider/device-code.ts
+++ b/packages/synergy/src/provider/device-code.ts
@@ -1,0 +1,39 @@
+export namespace ProviderDeviceCode {
+  const DEFAULT_EXPIRY_SECONDS = 900
+  const MIN_EXPIRY_SECONDS = 60
+  const MAX_EXPIRY_SECONDS = 900
+  const REQUEST_TIMEOUT_MS = 15_000
+
+  export function expirySeconds(value: unknown) {
+    const parsed = Number(value ?? DEFAULT_EXPIRY_SECONDS)
+    if (!Number.isFinite(parsed)) return DEFAULT_EXPIRY_SECONDS
+    return Math.min(MAX_EXPIRY_SECONDS, Math.max(MIN_EXPIRY_SECONDS, parsed))
+  }
+
+  export async function wait(ms: number, signal?: AbortSignal): Promise<boolean> {
+    if (!signal) {
+      await Bun.sleep(ms)
+      return true
+    }
+    if (signal.aborted) return false
+    return new Promise((resolve) => {
+      const abort = () => {
+        clearTimeout(timeout)
+        signal.removeEventListener("abort", abort)
+        resolve(false)
+      }
+      const timeout = setTimeout(() => {
+        signal.removeEventListener("abort", abort)
+        resolve(true)
+      }, ms)
+      signal.addEventListener("abort", abort, { once: true })
+      if (signal.aborted) abort()
+      timeout.unref?.()
+    })
+  }
+
+  export function requestSignal(signal?: AbortSignal) {
+    const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    return signal ? AbortSignal.any([signal, timeout]) : timeout
+  }
+}

--- a/packages/synergy/src/provider/github.ts
+++ b/packages/synergy/src/provider/github.ts
@@ -3,6 +3,7 @@ import { NamedError } from "@ericsanchezok/synergy-util/error"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin/auth"
 import z from "zod"
 import { ProviderAuthHealth } from "./auth-health"
+import { ProviderDeviceCode } from "./device-code"
 
 export namespace GitHubProvider {
   export const PROVIDER_ID = "github"
@@ -111,16 +112,16 @@ export namespace GitHubProvider {
     const userCode = payload.user_code
     const verificationURI = payload.verification_uri ?? "https://github.com/login/device"
     const intervalSeconds = Math.max(1, Number(payload.interval ?? 5))
-    const expiresIn = Math.max(60, Number(payload.expires_in ?? 300))
+    const expiresIn = ProviderDeviceCode.expirySeconds(payload.expires_in)
     return {
       url: verificationURI,
       method: "auto",
       instructions: String(userCode ?? ""),
-      async callback() {
+      async callback(signal?: AbortSignal) {
         const deadline = Date.now() + expiresIn * 1000
         let interval = intervalSeconds
-        while (Date.now() < deadline) {
-          await Bun.sleep(interval * 1000)
+        while (Date.now() < deadline && !signal?.aborted) {
+          if (!(await ProviderDeviceCode.wait(interval * 1000, signal))) return { type: "failed" }
           const poll = await fetchFn("https://github.com/login/oauth/access_token", {
             method: "POST",
             headers: {
@@ -133,8 +134,10 @@ export namespace GitHubProvider {
               device_code: String(deviceCode),
               grant_type: "urn:ietf:params:oauth:grant-type:device_code",
             }),
-            signal: AbortSignal.timeout(15_000),
-          })
+            signal: ProviderDeviceCode.requestSignal(signal),
+          }).catch(() => undefined)
+          if (signal?.aborted) return { type: "failed" }
+          if (!poll) continue
           const result = await safeJson(poll)
           if (typeof result.access_token === "string") {
             const account = await fetchAccount(result.access_token, fetchFn).catch(() => undefined)

--- a/packages/synergy/src/server/provider.ts
+++ b/packages/synergy/src/server/provider.ts
@@ -262,6 +262,7 @@ export const ProviderRoute = new Hono()
         providerID,
         method,
         code,
+        signal: c.req.raw.signal,
       })
       return c.json(true)
     },

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -6,6 +6,10 @@ import { CopilotProvider } from "../../src/provider/copilot"
 import { ProviderCatalog } from "../../src/provider/catalog"
 import { MiniMaxProvider } from "../../src/provider/minimax"
 import { GitHubProvider } from "../../src/provider/github"
+import { ProviderAuth } from "../../src/provider/auth"
+import { ProviderDeviceCode } from "../../src/provider/device-code"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
 
 const originalFetch = globalThis.fetch
 const originalGHToken = process.env.GH_TOKEN
@@ -213,6 +217,162 @@ test("github copilot device login exchanges a GitHub token for Copilot models", 
   )
 
   expect(models).toEqual(["gpt-5.4-mini", "claude-sonnet-4.6"])
+})
+
+test("github copilot device login recovers from a transient polling timeout", async () => {
+  let polls = 0
+  const authorize = await CopilotProvider.authorizeDeviceCode(
+    CopilotProvider.PROVIDER_ID,
+    asFetch(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/login/device/code")) {
+        return jsonResponse({
+          device_code: "device-transient",
+          user_code: "TIME-OUT1",
+          verification_uri: "https://github.com/login/device",
+          interval: 1,
+          expires_in: 60,
+        })
+      }
+      if (url.endsWith("/login/oauth/access_token")) {
+        polls++
+        if (polls === 1) throw new DOMException("poll timed out", "TimeoutError")
+        return jsonResponse({ access_token: "github-recovered-token" })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    }),
+  )
+
+  if (authorize.method !== "auto") throw new Error("expected auto device flow")
+  await expect(authorize.callback()).resolves.toEqual({
+    type: "success",
+    provider: CopilotProvider.PROVIDER_ID,
+    key: "github-recovered-token",
+  })
+  expect(polls).toBe(2)
+})
+
+test("provider auth stops a cancelled device callback before polling", async () => {
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      let polls = 0
+      globalThis.fetch = asFetch(async (input) => {
+        const url = String(input)
+        if (url.endsWith("/login/device/code")) {
+          return jsonResponse({
+            device_code: "device-cancelled",
+            user_code: "STOP-NOW",
+            verification_uri: "https://github.com/login/device",
+            interval: 1,
+            expires_in: 60,
+          })
+        }
+        if (url.endsWith("/login/oauth/access_token")) {
+          polls++
+          return jsonResponse({ access_token: "unexpected-token" })
+        }
+        throw new Error(`unexpected URL ${url}`)
+      })
+
+      const input = { providerID: CopilotProvider.PROVIDER_ID, method: 0 }
+      await ProviderAuth.authorize(input)
+      const controller = new AbortController()
+      controller.abort()
+
+      const result = await ProviderAuth.callback({ ...input, signal: controller.signal }).catch((error) => error)
+      expect(result).toBeInstanceOf(ProviderAuth.OauthCallbackFailed)
+      expect(polls).toBe(0)
+    },
+  })
+})
+
+test("device login caps an upstream expiry at fifteen minutes", () => {
+  expect(ProviderDeviceCode.expirySeconds(3600)).toBe(900)
+  expect(ProviderDeviceCode.expirySeconds(undefined)).toBe(900)
+})
+
+test("a completed device callback preserves a newer pending authorization", async () => {
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      let authorizations = 0
+      let releaseFirstPoll = () => {}
+      const firstPollStarted = new Promise<void>((resolveStarted) => {
+        globalThis.fetch = asFetch(async (input, init) => {
+          const url = String(input)
+          if (url.endsWith("/login/device/code")) {
+            authorizations++
+            return jsonResponse({
+              device_code: `device-${authorizations}`,
+              user_code: `FLOW-${authorizations}`,
+              verification_uri: "https://github.com/login/device",
+              interval: 1,
+              expires_in: 60,
+            })
+          }
+          if (url.endsWith("/login/oauth/access_token")) {
+            const deviceCode = (init?.body as URLSearchParams).get("device_code")
+            if (deviceCode === "device-1") {
+              resolveStarted()
+              await new Promise<void>((resolvePoll) => {
+                releaseFirstPoll = resolvePoll
+              })
+              return jsonResponse({ access_token: "first-token" })
+            }
+            return jsonResponse({ error: "expired_token" })
+          }
+          throw new Error(`unexpected URL ${url}`)
+        })
+      })
+
+      const input = { providerID: CopilotProvider.PROVIDER_ID, method: 0 }
+      await ProviderAuth.authorize(input)
+      const firstCallback = ProviderAuth.callback(input)
+      await firstPollStarted
+      await ProviderAuth.authorize(input)
+      releaseFirstPoll()
+      await firstCallback
+
+      const controller = new AbortController()
+      controller.abort()
+      const second = await ProviderAuth.callback({ ...input, signal: controller.signal }).catch((error) => error)
+      expect(second).toBeInstanceOf(ProviderAuth.OauthCallbackFailed)
+    },
+  })
+})
+
+test("provider auth consumes a failed device callback before another callback can reuse it", async () => {
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      globalThis.fetch = asFetch(async (input) => {
+        const url = String(input)
+        if (url.endsWith("/login/device/code")) {
+          return jsonResponse({
+            device_code: "device-failed",
+            user_code: "FAIL-ONCE",
+            verification_uri: "https://github.com/login/device",
+            interval: 1,
+            expires_in: 60,
+          })
+        }
+        if (url.endsWith("/login/oauth/access_token")) return jsonResponse({ error: "expired_token" })
+        throw new Error(`unexpected URL ${url}`)
+      })
+
+      const input = { providerID: CopilotProvider.PROVIDER_ID, method: 0 }
+      await ProviderAuth.authorize(input)
+      const first = await ProviderAuth.callback(input).catch((error) => error)
+      expect(first).toBeInstanceOf(ProviderAuth.OauthCallbackFailed)
+
+      const second = await ProviderAuth.callback(input).catch((error) => error)
+      expect(second).toBeInstanceOf(ProviderAuth.OauthMissing)
+    },
+  })
 })
 
 test("github copilot model catalog preserves API vision capabilities", async () => {

--- a/packages/synergy/test/server/provider-route.test.ts
+++ b/packages/synergy/test/server/provider-route.test.ts
@@ -5,6 +5,7 @@ import path from "path"
 import { Server } from "../../src/server/server"
 import { Auth } from "../../src/provider/api-key"
 import { CodexProvider } from "../../src/provider/codex"
+import { CopilotProvider } from "../../src/provider/copilot"
 import { tmpdir } from "../fixture/fixture"
 import { Provider } from "../../src/provider/provider"
 import { ProviderCatalog } from "../../src/provider/catalog"
@@ -221,7 +222,7 @@ test("/provider returns custom providers without recommendation metadata", async
   expect(body.profiles["custom-provider"].recommendation).toBeUndefined()
 })
 
-test("/provider/auth exposes Codex OAuth and import methods", async () => {
+test("/provider/auth exposes built-in OAuth and alternate credential methods", async () => {
   const app = Server.App()
   const response = await app.request("/provider/auth")
   expect(response.status).toBe(200)
@@ -230,6 +231,14 @@ test("/provider/auth exposes Codex OAuth and import methods", async () => {
   expect(body[CodexProvider.PROVIDER_ID]).toEqual([
     { type: "oauth", label: "Login with ChatGPT" },
     { type: "import", label: "Import Codex CLI credentials" },
+  ])
+  expect(body[CopilotProvider.PROVIDER_ID]).toEqual([
+    { type: "oauth", label: "Login with GitHub Copilot" },
+    { type: "api", label: "GitHub token" },
+  ])
+  expect(body[CopilotProvider.ENTERPRISE_PROVIDER_ID]).toEqual([
+    { type: "oauth", label: "Login with GitHub Copilot Enterprise" },
+    { type: "api", label: "GitHub token" },
   ])
 })
 


### PR DESCRIPTION
## Summary

- remount the provider connection flow when the selected provider changes so GitHub Copilot consistently exposes browser authorization and GitHub token login
- handle device callback failures explicitly and stop frontend or backend polling when the connection flow is abandoned
- recover from transient GitHub polling failures, bound device authorization lifetimes, and preserve newer concurrent authorization attempts
- add behavioral coverage for Copilot authentication methods, cancellation, retry, expiry bounds, and pending-state races

## Testing

- `bun test test/provider/oauth-providers.test.ts` from `packages/synergy` — 16 passed
- `bun test test/server/provider-route.test.ts` from `packages/synergy` — 8 passed
- `bun test test/components/provider/` from `packages/app` — 12 passed
- `bun test test/script/test-layout-check.test.ts` — 3 passed
- `bun run format:check`
- `bun run lint`
- `bun turbo typecheck`
- `bun run skill:check`
- `bun run package-guide:check`
- `bun run test-layout:check`
- `bun run localization:check`
- `bun run monorepo:check`
- `bun run package:check`