### PR TITLE
fix(web): support private-network HTTP capabilities

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] New or moved tests live under the owning package's `test/` directory (or the root `test/` directory for repository tests)
 - [ ] `bun run package:check` passes if package exports, build output, release logic, or publishable packages changed
 - [ ] `bun run workflow:check` passes if `.github/workflows/**`, GitHub Actions config, or CI helper scripts changed
+- [ ] Browser capability or App bootstrap changes pass the browser crypto contract and private HTTP browser smoke
 - [ ] `bun run secrets:check` passes locally or CI Gitleaks covers the change if auth, provider, channel, config, or credential examples changed
 - [ ] SDK regenerated if server routes or schemas changed (`./script/generate.ts`)
 - [ ] `bun run localization:check` passes if product copy, accessibility text, locale-sensitive formatting, or shared UI copy changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: bun install
 
       - name: Install Playwright Chromium
-        run: bunx playwright install chromium
+        run: bun run --cwd packages/app playwright install chromium
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check test layout
         run: bun run test-layout:check
 
+      - name: Check browser crypto contract
+        run: bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts
+
       - name: Check frontend localization
         run: bun run localization:check
 
@@ -95,6 +98,11 @@ jobs:
         run: bun turbo test --filter='!synergy'
         env:
           SYNERGY_LINK_HOME: /tmp/synergy-link-ci-test
+
+      - name: Run private HTTP browser smoke
+        run: |
+          bun run --cwd packages/app build
+          bun packages/app/script/private-http-smoke.ts
 
       - name: Run release contract tests
         run: bun run release:test

--- a/.synergy/command/check.md
+++ b/.synergy/command/check.md
@@ -29,6 +29,14 @@ bun run --cwd packages/app test
 bun run --cwd packages/ui test
 ```
 
+Browser capability or App bootstrap changes also run:
+
+```bash
+bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts
+bun run --cwd packages/app build
+bun packages/app/script/private-http-smoke.ts
+```
+
 Theme changes also run `bun run --cwd packages/ui generate:theme` and verify that no generated artifact changes remain after a second generation.
 
 Localization changes update the catalogs and then run the single repository localization gate:

--- a/.synergy/skill/develop-frontend/SKILL.md
+++ b/.synergy/skill/develop-frontend/SKILL.md
@@ -21,6 +21,13 @@ description: Implement or review Synergy Web and shared UI changes across packag
 5. Preserve Scope/directory parameters, authentication, error semantics, asset URLs, event `seq`/`epoch`, replay, and loading/error states.
 6. For append-only LLM streams, keep the full snapshot as recovery state while imperative renderers track an offset and consume only the appended suffix through the dependency's typed live-update API. Do not rescan the accumulated prefix or insert an independent character-rate playback backlog; reset from a checkpoint only when the append invariant breaks. Derive terminal presentation from explicit part or message lifecycle markers, not coarse session status or the presence of a later timeline part. Key imperative terminal transitions and enhancements by content identity so unrelated sibling updates cannot restart them.
 
+## Preserve Browser Capability Boundaries
+
+1. Route ordinary App/UI identifiers through `generateUUID()` or `generateRandomBytes()` from the shared utility package. Do not call `crypto.randomUUID()` or `crypto.getRandomValues()` directly from browser source.
+2. Use `generateSecureUUID()` or `generateSecureRandomBytes()` for authentication state, nonces, credentials, and other security-sensitive values. A missing secure source must fail only the affected operation; it must never fall back to `Math.random()`.
+3. Keep optional browser APIs out of module-scope startup paths. Gate Clipboard, Notifications, credentials, media, and other Secure Context capabilities at the owning action and provide a local unavailable or error state.
+4. Treat non-loopback private-network HTTP as a supported Web deployment. When capability or bootstrap code changes, verify an actual non-Secure Context rather than relying on localhost.
+
 ## Localize Product UI
 
 Read [Frontend localization](../../../docs/architecture/localization.md) before adding product copy, accessibility text, locale-sensitive formatting, or language settings.
@@ -92,6 +99,13 @@ bun run --cwd packages/app test
 bun run --cwd packages/app typecheck
 bun run --cwd packages/ui test
 bun run --cwd packages/app build
+```
+
+For browser capability or bootstrap changes, also run:
+
+```bash
+bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts
+bun packages/app/script/private-http-smoke.ts
 ```
 
 For localized UI changes, also run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ bun run test:coverage
 
 Frontend package suites run through `bun run --cwd packages/app test` and `bun run --cwd packages/ui test`; both are part of the Turbo test graph.
 
+Browser capability or App bootstrap changes also run the browser crypto contract and the production-build private HTTP browser smoke documented in `packages/app/AGENTS.md`.
+
 Repository gates run from the root:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,14 @@ See the [development reference](docs/reference/development.md) for source modes,
    bun run localization:check
    ```
 
+   Browser capability or App bootstrap changes must also verify the source boundary and a genuine non-loopback HTTP origin:
+
+   ```bash
+   bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts
+   bun run --cwd packages/app build
+   bun packages/app/script/private-http-smoke.ts
+   ```
+
 3. **Regenerate the SDK if you touched routes.** If your change modifies server routes or route schemas, run `./script/generate.ts` and include the output in your PR.
 
 4. **Open your PR against `dev`.** Describe what you changed and why. If it addresses an open issue, reference it.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ bun run --cwd packages/app test
 bun run --cwd packages/ui test
 ```
 
+Browser capability or App bootstrap changes also verify the source boundary and a genuine non-loopback HTTP origin:
+
+```bash
+bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts
+bun run --cwd packages/app build
+bun packages/app/script/private-http-smoke.ts
+```
+
 Tests live under each package's `test/` directory; repository-level tests live under the root `test/` directory. `bun run quality:quick` enforces this layout.
 
 Frontend product copy is extracted into English and Simplified Chinese catalogs, plus a development-only pseudo catalog. Changes to visible text or locale formatting also run:

--- a/docs/operations/open-source-quality.md
+++ b/docs/operations/open-source-quality.md
@@ -4,21 +4,23 @@ Synergy runs a multi-layer quality system that covers formatting, linting, type-
 
 ## Quality Layers
 
-| Layer              | Local command                        | CI job                | Tool                          | Pre-push |
-| ------------------ | ------------------------------------ | --------------------- | ----------------------------- | -------- |
-| Bun version check  | (pre-push only)                      | —                     | `check-bun-version`           | ✅       |
-| Formatting         | `bun run format:check`               | `quality`             | Prettier                      | ✅       |
-| Lint               | `bun run lint`                       | `quality`             | oxlint                        | ✅       |
-| Localization       | `bun run localization:check`         | `quality`             | Lingui + source contract      | —        |
-| Type checking      | `bun run typecheck`                  | `typecheck`           | tsc via turbo                 | ✅       |
-| Monorepo deps      | `bun run monorepo:check`             | `quality`             | sherif                        | ✅       |
-| Dead code          | `bun run deadcode`                   | `quality`             | knip                          | —        |
-| CI workflow lint   | `bun run workflow:check`             | `workflow-validation` | actionlint + zizmor           | —        |
-| Secret scanning    | `bun run secrets:check`              | `secret-scan`         | gitleaks                      | —        |
-| Package validation | `bun run package:check`              | `package-validation`  | publint + attw                | —        |
-| Tests              | `bun turbo test` / `bun run test:ci` | `test`                | Turbo + sequential Bun shards | —        |
-| Desktop checks     | `bun run desktop:test`               | `desktop`             | bun test + build              | —        |
-| Smoke test         | —                                    | `smoke`               | Synergy health check          | —        |
+| Layer                      | Local command                                                                       | CI job                | Tool                          | Pre-push |
+| -------------------------- | ----------------------------------------------------------------------------------- | --------------------- | ----------------------------- | -------- |
+| Bun version check          | (pre-push only)                                                                     | —                     | `check-bun-version`           | ✅       |
+| Formatting                 | `bun run format:check`                                                              | `quality`             | Prettier                      | ✅       |
+| Lint                       | `bun run lint`                                                                      | `quality`             | oxlint                        | ✅       |
+| Browser crypto contract    | `bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts`          | `quality`             | Bun source contract           | —        |
+| Localization               | `bun run localization:check`                                                        | `quality`             | Lingui + source contract      | —        |
+| Type checking              | `bun run typecheck`                                                                 | `typecheck`           | tsc via turbo                 | ✅       |
+| Monorepo deps              | `bun run monorepo:check`                                                            | `quality`             | sherif                        | ✅       |
+| Dead code                  | `bun run deadcode`                                                                  | `quality`             | knip                          | —        |
+| CI workflow lint           | `bun run workflow:check`                                                            | `workflow-validation` | actionlint + zizmor           | —        |
+| Secret scanning            | `bun run secrets:check`                                                             | `secret-scan`         | gitleaks                      | —        |
+| Package validation         | `bun run package:check`                                                             | `package-validation`  | publint + attw                | —        |
+| Tests                      | `bun turbo test` / `bun run test:ci`                                                | `test`                | Turbo + sequential Bun shards | —        |
+| Private HTTP browser smoke | `bun run --cwd packages/app build && bun packages/app/script/private-http-smoke.ts` | `test`                | Playwright Chromium           | —        |
+| Desktop checks             | `bun run desktop:test`                                                              | `desktop`             | bun test + build              | —        |
+| Server health smoke        | —                                                                                   | `smoke`               | Synergy health check          | —        |
 
 ### Pre-push hook (`.husky/pre-push`)
 
@@ -50,35 +52,36 @@ This runs the full suite locally. CI runs the same checks in parallel jobs.
 
 CI runs on push to `dev` / `main` and on pull requests targeting those branches. Jobs run in parallel:
 
-| Job                   | Purpose                                                                |
-| --------------------- | ---------------------------------------------------------------------- |
-| `quality`             | Formatting, lint, test layout, localization, monorepo deps, dead code  |
-| `typecheck`           | TypeScript type checking                                               |
-| `test`                | Non-Synergy package tests plus sequential fresh-process Synergy shards |
-| `package-validation`  | publint + attw for publishable packages                                |
-| `workflow-validation` | actionlint + zizmor for CI workflow files                              |
-| `secret-scan`         | gitleaks for secrets and credentials                                   |
-| `desktop`             | Desktop typecheck, unit tests, build config validation, runtime smoke  |
-| `smoke`               | Server health check smoke test                                         |
+| Job                   | Purpose                                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| `quality`             | Formatting, lint, browser crypto contract, test layout, localization, monorepo deps, and dead code |
+| `typecheck`           | TypeScript type checking                                                                           |
+| `test`                | Non-Synergy package tests, private HTTP browser smoke, and sequential fresh-process Synergy shards |
+| `package-validation`  | publint + attw for publishable packages                                                            |
+| `workflow-validation` | actionlint + zizmor for CI workflow files                                                          |
+| `secret-scan`         | gitleaks for secrets and credentials                                                               |
+| `desktop`             | Desktop typecheck, unit tests, build config validation, runtime smoke                              |
+| `smoke`               | Server health check smoke test                                                                     |
 
 All jobs must pass for a PR to merge. The `package-validation` and `workflow-validation` jobs are not in the pre-push hook — they require network access or special tooling that is available in CI but may not be installed locally.
 
-The test job excludes `synergy` from the Turbo package pass, then runs the complete Synergy suite as four sequential fresh-process shards from `packages/synergy`. Each attempted shard emits an uploaded JUnit report. Coverage is not collected in the required CI path.
+The test job excludes `synergy` from the Turbo package pass, builds the App, verifies it through a genuine non-loopback HTTP origin, then runs the complete Synergy suite as four sequential fresh-process shards from `packages/synergy`. Each attempted shard emits an uploaded JUnit report. Coverage is not collected in the required CI path.
 
 ## Tool Responsibilities
 
-| Tool              | Responsibility                                                                                      | When to run                                                                                                              |
-| ----------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Prettier          | Repository-wide formatting                                                                          | Every change through `bun run format:check`; write fixes with `bun run format` or `./script/format.ts`                   |
-| oxlint            | Fast JavaScript/TypeScript linting without style-heavy churn                                        | Every change through `bun run lint`; auto-fix safe issues with `bun run lint:fix`                                        |
-| sherif            | Workspace package and dependency consistency                                                        | Every change through `bun run monorepo:check`, especially package manifest edits                                         |
-| knip              | Dead code, unused dependencies, unused scripts, unresolved entries, and catalog hygiene             | CI and explicit local checks through `bun run deadcode`; configure precise entries/ignores for dynamic or generated code |
-| publint           | npm package manifest, exports, and publish-shape validation                                         | Publishable package, release, SDK, plugin, util, or Synergy Link protocol changes through `bun run package:check`        |
-| attw              | TypeScript package resolution validation for published tarballs                                     | Same path as publint through `bun run package:check`                                                                     |
-| actionlint        | GitHub Actions syntax and expression validation                                                     | Workflow changes through `bun run workflow:check` and CI `workflow-validation`                                           |
-| zizmor            | GitHub Actions security analysis                                                                    | Workflow changes through `bun run workflow:check` and CI `workflow-validation`                                           |
-| gitleaks          | Secret and credential scanning                                                                      | Auth/provider/channel/config example changes through `bun run secrets:check`; all PRs through CI `secret-scan`           |
-| Localization gate | Catalog extraction drift, complete zh-CN coverage, strict ICU compilation, and App/UI source policy | Product copy, accessibility text, locale formatting, or shared UI changes through `bun run localization:check`           |
+| Tool                    | Responsibility                                                                                        | When to run                                                                                                              |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Prettier                | Repository-wide formatting                                                                            | Every change through `bun run format:check`; write fixes with `bun run format` or `./script/format.ts`                   |
+| oxlint                  | Fast JavaScript/TypeScript linting without style-heavy churn                                          | Every change through `bun run lint`; auto-fix safe issues with `bun run lint:fix`                                        |
+| sherif                  | Workspace package and dependency consistency                                                          | Every change through `bun run monorepo:check`, especially package manifest edits                                         |
+| knip                    | Dead code, unused dependencies, unused scripts, unresolved entries, and catalog hygiene               | CI and explicit local checks through `bun run deadcode`; configure precise entries/ignores for dynamic or generated code |
+| publint                 | npm package manifest, exports, and publish-shape validation                                           | Publishable package, release, SDK, plugin, util, or Synergy Link protocol changes through `bun run package:check`        |
+| attw                    | TypeScript package resolution validation for published tarballs                                       | Same path as publint through `bun run package:check`                                                                     |
+| actionlint              | GitHub Actions syntax and expression validation                                                       | Workflow changes through `bun run workflow:check` and CI `workflow-validation`                                           |
+| zizmor                  | GitHub Actions security analysis                                                                      | Workflow changes through `bun run workflow:check` and CI `workflow-validation`                                           |
+| gitleaks                | Secret and credential scanning                                                                        | Auth/provider/channel/config example changes through `bun run secrets:check`; all PRs through CI `secret-scan`           |
+| Localization gate       | Catalog extraction drift, complete zh-CN coverage, strict ICU compilation, and App/UI source policy   | Product copy, accessibility text, locale formatting, or shared UI changes through `bun run localization:check`           |
+| Browser crypto contract | Direct browser randomness under App/UI source must use the shared ordinary or strict utility boundary | Browser capability or identifier changes; every PR through CI `quality`                                                  |
 
 ## Package Publishing Validation
 
@@ -209,6 +212,14 @@ bun run --cwd packages/ui test
 bun run --cwd packages/app build
 bun turbo test
 bun run quality:quick
+```
+
+Browser capability or bootstrap changes also run the static boundary and genuine non-loopback HTTP smoke:
+
+```bash
+bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts
+bun run --cwd packages/app build
+bun packages/app/script/private-http-smoke.ts
 ```
 
 For product copy, accessibility text, or locale-sensitive formatting, update the catalogs before those package and root gates:

--- a/docs/product/browser.md
+++ b/docs/product/browser.md
@@ -39,6 +39,12 @@ Both represent the same session-owned page and command model. Remote presentatio
 
 Interactive Browser presentation is not an iframe, pseudo-tab, or screenshot-stream fallback. Screenshots remain deliberate artifacts for inspection and agent tools, not the transport for interactive browsing.
 
+## Private-Network Web Access
+
+The remote Web presentation remains available when the Synergy UI is served over ordinary HTTP on a trusted private or overlay network. A non-loopback HTTP origin is not a browser Secure Context, so the App and WebRTC viewer use capability-safe ordinary identifiers rather than requiring `crypto.randomUUID()` during startup or client construction.
+
+Secure-Context-only browser features degrade at their owning action instead of disabling the Browser workspace or crashing the application. Common copy actions use the shared clipboard fallback, clipboard reads or unsupported plugin clipboard actions report a local failure, and system notifications remain silent when the browser API or permission is unavailable. Security-sensitive randomness never uses a weak fallback.
+
 ## Navigation and Network
 
 User address-bar navigation and agent navigation use the same Chromium-backed page. HTTP and HTTPS targets follow the machine's normal network routing, including localhost, private development services, direct IP addresses, and TUN/Fake-IP environments. Agent calls remain governed by the ordinary Browser interaction and network-request capabilities; Browser does not add a second private-network permission.

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@
 - [Activity and statistics](docs/product/activity-and-statistics.md): session, token, cost, model, agent, tool, code-change, and time-series summaries.
 - [Automation](docs/product/automation.md): Agenda schedules, session modes, delivery, recovery, and failure behavior.
 - [Connections](docs/product/connections.md): providers, MCP, Channels, Email, Holos, and Synergy Link.
-- [Browser workspace](docs/product/browser.md): shared human/agent page, native and Web presentations, and safety boundaries.
+- [Browser workspace](docs/product/browser.md): shared human/agent page, native and Web presentations, private-network HTTP support, and safety boundaries.
 
 ## Understand the Runtime
 

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -32,6 +32,7 @@ Read [PRODUCT.md](PRODUCT.md) before changing interaction structure, visual hier
 - Keep only active product fonts in the application bundle. Adding an optional font requires a user-selectable runtime path and a loading strategy; do not import dormant font families from the root `Font` component.
 - Treat mobile drawers as named modal surfaces with initial focus, contained Tab traversal, Escape close, and focus return. Verify dense toolbars at 375 px and do not hide overflow that clips interactive controls.
 - Keep Browser native and remote presentations consistent with [Browser runtime](../../docs/architecture/browser-runtime.md); do not introduce iframe, screenshot-stream, pseudo-tab, or multi-page fallbacks.
+- Route ordinary browser randomness through `@ericsanchezok/synergy-util/uuid`; security-sensitive randomness uses its strict APIs with no weak fallback. Keep optional Secure Context APIs out of module-scope startup paths so private-network HTTP can boot and unsupported actions fail locally.
 
 ## Settings and Plugins
 
@@ -55,6 +56,8 @@ bun run --cwd packages/app typecheck
 bun run --cwd packages/app build
 bun run quality:quick
 ```
+
+Browser capability or bootstrap changes also run `bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts` and, after the production build, `bun packages/app/script/private-http-smoke.ts` from the repository root.
 
 For product copy, accessibility text, locale-sensitive formatting, or language settings, also run:
 

--- a/packages/app/script/private-http-smoke.ts
+++ b/packages/app/script/private-http-smoke.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { networkInterfaces, tmpdir } from "node:os"
+import path from "node:path"
+import { chromium } from "playwright"
+
+const appDirectory = path.resolve(import.meta.dir, "..")
+const repositoryRoot = path.resolve(appDirectory, "../..")
+const synergyDirectory = path.join(repositoryRoot, "packages", "synergy")
+const appDist = path.join(appDirectory, "dist", "index.html")
+
+if (!(await Bun.file(appDist).exists())) {
+  throw new Error("packages/app/dist is missing; run `bun run --cwd packages/app build` first")
+}
+
+const hostname = nonLoopbackIPv4()
+const port = reservePort(hostname)
+const temporaryRoot = await mkdtemp(path.join(tmpdir(), "synergy-private-http-"))
+const workspace = path.join(temporaryRoot, "workspace")
+let server: ReturnType<typeof Bun.spawn> | undefined
+let serverOutput: ReturnType<typeof captureTail> | undefined
+let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined
+
+try {
+  await mkdir(path.join(temporaryRoot, ".synergy"), { recursive: true })
+  await mkdir(workspace, { recursive: true })
+
+  server = Bun.spawn({
+    cmd: [
+      process.execPath,
+      "run",
+      "--conditions=browser",
+      "./src/index.ts",
+      "server",
+      "--port",
+      String(port),
+      "--hostname",
+      hostname,
+      "--non-interactive",
+      "--no-banner",
+    ],
+    cwd: synergyDirectory,
+    env: isolatedEnvironment(temporaryRoot, workspace, hostname),
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const stdout = server.stdout
+  const stderr = server.stderr
+  if (!(stdout instanceof ReadableStream) || !(stderr instanceof ReadableStream)) {
+    throw new Error("Temporary Synergy server output pipes are unavailable")
+  }
+  serverOutput = captureTail(stdout, stderr)
+  await waitForHealth(`http://${hostname}:${port}`, server)
+
+  browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+  const pageErrors: string[] = []
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+
+  const url = `http://${hostname}:${port}`
+  const response = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60_000 })
+  if (!response?.ok()) throw new Error(`Private HTTP navigation failed with status ${response?.status() ?? "unknown"}`)
+
+  await page.waitForFunction(() => document.getElementById("synergy-app-boot") === null, undefined, { timeout: 60_000 })
+  const result = await page.evaluate(() => ({
+    isSecureContext: globalThis.isSecureContext,
+    randomUUID: typeof globalThis.crypto?.randomUUID,
+    getRandomValues: typeof globalThis.crypto?.getRandomValues,
+    rootChildren: document.getElementById("root")?.childElementCount ?? 0,
+  }))
+
+  if (result.isSecureContext) throw new Error(`Expected a non-Secure Context at ${url}`)
+  if (result.randomUUID !== "undefined") throw new Error(`Expected crypto.randomUUID to be unavailable at ${url}`)
+  if (result.getRandomValues !== "function")
+    throw new Error(`Expected crypto.getRandomValues to remain available at ${url}`)
+  if (result.rootChildren === 0) throw new Error("Synergy App root did not render")
+  if (pageErrors.length > 0) throw new Error(`Synergy App raised page errors: ${pageErrors.join("; ")}`)
+
+  console.log(JSON.stringify({ url, ...result, pageErrors }, null, 2))
+} catch (error) {
+  const detail = serverOutput?.value ? `\nServer output:\n${sanitize(serverOutput.value, temporaryRoot)}` : ""
+  throw new Error(`${error instanceof Error ? error.message : String(error)}${detail}`, { cause: error })
+} finally {
+  await browser?.close().catch(() => {})
+  if (server && server.exitCode === null) await stopProcess(server)
+  await serverOutput?.done.catch(() => {})
+  await rm(temporaryRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+}
+
+function nonLoopbackIPv4() {
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (entry.family === "IPv4" && !entry.internal && entry.address !== "0.0.0.0") return entry.address
+    }
+  }
+  throw new Error("A non-loopback IPv4 address is required for the private HTTP smoke test")
+}
+
+function reservePort(hostname: string) {
+  const probe = Bun.serve({ hostname, port: 0, fetch: () => new Response(null, { status: 503 }) })
+  const port = probe.port
+  probe.stop(true)
+  return port
+}
+
+function isolatedEnvironment(home: string, cwd: string, hostname: string) {
+  const env: Record<string, string> = {}
+  for (const key of [
+    "PATH",
+    "PATHEXT",
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TZ",
+  ]) {
+    const value = process.env[key]
+    if (value !== undefined) env[key] = value
+  }
+  return {
+    ...env,
+    SYNERGY_HOME: home,
+    SYNERGY_CWD: cwd,
+    SYNERGY_CONFIG_CONTENT: "{}",
+    SYNERGY_DISABLE_LSP_DOWNLOAD: "1",
+    NO_PROXY: `localhost,127.0.0.1,::1,${hostname}`,
+  }
+}
+
+async function waitForHealth(baseUrl: string, child: ReturnType<typeof Bun.spawn>) {
+  const deadline = Date.now() + 60_000
+  let lastError = ""
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`Synergy server exited during startup with code ${child.exitCode}`)
+    try {
+      const response = await fetch(`${baseUrl}/global/health`, { signal: AbortSignal.timeout(1_000) })
+      if (response.ok) return
+      lastError = `HTTP ${response.status}`
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+    await Bun.sleep(250)
+  }
+  throw new Error(`Timed out waiting for temporary Synergy health${lastError ? `: ${lastError}` : ""}`)
+}
+
+function captureTail(...streams: ReadableStream<Uint8Array>[]) {
+  let value = ""
+  const done = Promise.all(
+    streams.map(async (stream) => {
+      const decoder = new TextDecoder()
+      const reader = stream.getReader()
+      while (true) {
+        const item = await reader.read()
+        if (item.done) break
+        value = (value + decoder.decode(item.value, { stream: true })).slice(-16_384)
+      }
+      reader.releaseLock()
+    }),
+  ).then(() => undefined)
+  return {
+    get value() {
+      return value
+    },
+    done,
+  }
+}
+
+async function stopProcess(child: ReturnType<typeof Bun.spawn>) {
+  if (child.exitCode !== null) return
+  child.kill()
+  const exited = await Promise.race([child.exited.then(() => true), Bun.sleep(5_000).then(() => false)])
+  if (exited) return
+  child.kill("SIGKILL")
+  await child.exited
+}
+
+function sanitize(value: string, root: string) {
+  return value.replaceAll(root, "<temporary-home>").slice(-8_192)
+}

--- a/packages/app/src/components/workspace/browser/browser-command.ts
+++ b/packages/app/src/components/workspace/browser/browser-command.ts
@@ -1,10 +1,9 @@
 import type { BrowserStoreAPI } from "./browser-store"
 import type { BrowserAPISessionState, BrowserBackendResult } from "@ericsanchezok/synergy-browser"
+import { generateUUID } from "@ericsanchezok/synergy-util/uuid"
 
 export function createBrowserCommandId() {
-  const random = globalThis.crypto?.randomUUID?.()
-  if (random) return `browser_cmd_${random}`
-  return `browser_cmd_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+  return `browser_cmd_${generateUUID()}`
 }
 
 export function shouldResumeBrowserSession(state: BrowserAPISessionState): boolean {

--- a/packages/app/src/components/workspace/browser/browser-store.tsx
+++ b/packages/app/src/components/workspace/browser/browser-store.tsx
@@ -6,6 +6,7 @@ import type {
   BrowserPage as BrowserProtocolPage,
   BrowserPresentationSelection,
 } from "@ericsanchezok/synergy-browser"
+import { generateUUID } from "@ericsanchezok/synergy-util/uuid"
 import { createStore, type SetStoreFunction } from "solid-js/store"
 import { browserDebug, shouldLogBrowserMessage, summarizeBrowserMessage } from "./browser-debug"
 
@@ -82,9 +83,7 @@ export interface SetViewportOptions {
 }
 
 function createBrowserTraceId() {
-  const random = globalThis.crypto?.randomUUID?.()
-  if (random) return `browser_${random}`
-  return `browser_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+  return `browser_${generateUUID()}`
 }
 
 export function createBrowserStore() {

--- a/packages/app/src/utils/id.ts
+++ b/packages/app/src/utils/id.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { generateRandomBytes } from "@ericsanchezok/synergy-util/uuid"
 
 const prefixes = {
   session: "ses",
@@ -74,26 +75,10 @@ function bytesToHex(bytes: Uint8Array): string {
 
 function randomBase62(length: number): string {
   const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-  const bytes = getRandomBytes(length)
+  const bytes = generateRandomBytes(length)
   let result = ""
   for (let i = 0; i < length; i += 1) {
     result += chars[bytes[i] % 62]
   }
   return result
-}
-
-function getRandomBytes(length: number): Uint8Array {
-  const bytes = new Uint8Array(length)
-  const cryptoObj = typeof globalThis !== "undefined" ? globalThis.crypto : undefined
-
-  if (cryptoObj && typeof cryptoObj.getRandomValues === "function") {
-    cryptoObj.getRandomValues(bytes)
-    return bytes
-  }
-
-  for (let i = 0; i < length; i += 1) {
-    bytes[i] = Math.floor(Math.random() * 256)
-  }
-
-  return bytes
 }

--- a/packages/app/src/utils/perf.ts
+++ b/packages/app/src/utils/perf.ts
@@ -1,4 +1,5 @@
 import { recordSessionSwitchTiming } from "@/components/performance/browser-metrics"
+import { generateUUID } from "@ericsanchezok/synergy-util/uuid"
 
 type Nav = {
   id: string
@@ -19,7 +20,7 @@ const key = (dir: string | undefined, to: string) => `${dir ?? ""}:${to}`
 
 const now = () => performance.now()
 
-const uid = () => crypto.randomUUID?.() ?? Math.random().toString(16).slice(2)
+const uid = generateUUID
 
 const navs = new Map<string, Nav>()
 const pending = new Map<string, string>()

--- a/packages/app/test/components/workspace/browser/browser-webrtc.test.ts
+++ b/packages/app/test/components/workspace/browser/browser-webrtc.test.ts
@@ -85,13 +85,28 @@ class FakeRTCPeerConnection {
 
 const originalWebSocket = globalThis.WebSocket
 const originalRTCPeerConnection = globalThis.RTCPeerConnection
+const originalRandomUUID = Object.getOwnPropertyDescriptor(globalThis.crypto, "randomUUID")
 
 describe("BrowserWebRTCClient", () => {
   afterEach(() => {
     globalThis.WebSocket = originalWebSocket
     globalThis.RTCPeerConnection = originalRTCPeerConnection
+    if (originalRandomUUID) Object.defineProperty(globalThis.crypto, "randomUUID", originalRandomUUID)
+    else Reflect.deleteProperty(globalThis.crypto, "randomUUID")
     FakeWebSocket.instances = []
     FakeRTCPeerConnection.instances = []
+  })
+
+  test("constructs when crypto.randomUUID is unavailable", () => {
+    Object.defineProperty(globalThis.crypto, "randomUUID", { configurable: true, value: undefined })
+
+    expect(
+      () =>
+        new BrowserWebRTCClient({
+          signalingUrl: "ws://localhost/browser/webrtc/connect",
+          pageId: "page_1",
+        }),
+    ).not.toThrow()
   })
 
   test("waits for Browser Host readiness before sending an offer", async () => {

--- a/packages/app/test/testing/browser-crypto-contract.test.ts
+++ b/packages/app/test/testing/browser-crypto-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+
+const SOURCE_ROOTS = ["src", "../ui/src"]
+const DIRECT_BROWSER_CRYPTO = /(?:(?:globalThis|window)\.)?crypto\??\.(?:randomUUID|getRandomValues)\b/g
+
+async function browserSources() {
+  const files: Array<{ path: string; source: string }> = []
+  const glob = new Bun.Glob("**/*.{ts,tsx}")
+  for (const root of SOURCE_ROOTS) {
+    for await (const relativePath of glob.scan({ cwd: root })) {
+      const path = `${root}/${relativePath}`
+      files.push({ path, source: await Bun.file(path).text() })
+    }
+  }
+  return files
+}
+
+describe("browser cryptography contract", () => {
+  test("routes browser randomness through the shared utility boundary", async () => {
+    const violations: string[] = []
+    for (const { path, source } of await browserSources()) {
+      for (const match of source.matchAll(DIRECT_BROWSER_CRYPTO)) {
+        violations.push(`${path}: ${match[0]}`)
+      }
+    }
+    expect(violations.sort()).toEqual([])
+  })
+})

--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -10,6 +10,7 @@ import {
   type JSX,
 } from "solid-js"
 import { Dialog as Kobalte } from "@kobalte/core/dialog"
+import { generateUUID } from "@ericsanchezok/synergy-util/uuid"
 
 type DialogElement = () => JSX.Element
 
@@ -45,7 +46,7 @@ function init() {
   }
 
   const mount = (element: DialogElement, owner: Owner, onClose?: () => void) => {
-    const id = Math.random().toString(36).slice(2)
+    const id = generateUUID()
     let dispose: (() => void) | undefined
 
     const node = runWithOwner(owner, () =>

--- a/packages/util/src/uuid.ts
+++ b/packages/util/src/uuid.ts
@@ -9,6 +9,48 @@ export interface UUIDEnvironment {
   random?: () => number
 }
 
+export class SecureRandomUnavailableError extends Error {
+  constructor() {
+    super("Secure randomness requires a usable Web Crypto implementation")
+    this.name = "SecureRandomUnavailableError"
+  }
+}
+
+export function generateRandomBytes(length: number, environment?: UUIDEnvironment): Uint8Array {
+  const bytes = new Uint8Array(length)
+  const webCrypto = environment ? environment.crypto : globalThis.crypto
+
+  try {
+    if (typeof webCrypto?.getRandomValues === "function") return webCrypto.getRandomValues(bytes)
+  } catch {
+    // Ordinary identifiers may use the weak fallback when Web Crypto is unavailable.
+  }
+
+  const random = environment?.random ?? Math.random
+  for (let index = 0; index < bytes.length; index++) bytes[index] = Math.floor(random() * 256)
+  return bytes
+}
+
+export function generateSecureRandomBytes(length: number, environment?: UUIDEnvironment): Uint8Array {
+  const webCrypto = environment ? environment.crypto : globalThis.crypto
+  if (typeof webCrypto?.getRandomValues !== "function") throw new SecureRandomUnavailableError()
+  try {
+    return webCrypto.getRandomValues(new Uint8Array(length))
+  } catch {
+    throw new SecureRandomUnavailableError()
+  }
+}
+
+export function generateSecureUUID(environment?: UUIDEnvironment): string {
+  const webCrypto = environment ? environment.crypto : globalThis.crypto
+  try {
+    if (typeof webCrypto?.randomUUID === "function") return webCrypto.randomUUID()
+  } catch {
+    // Fall through to strict getRandomValues without a weak fallback.
+  }
+  return formatUUID(generateSecureRandomBytes(16, environment))
+}
+
 let fallbackCounter = 0
 
 export function generateUUID(environment?: UUIDEnvironment): string {
@@ -21,12 +63,7 @@ export function generateUUID(environment?: UUIDEnvironment): string {
   }
 
   try {
-    if (typeof webCrypto?.getRandomValues === "function") {
-      const bytes = webCrypto.getRandomValues(new Uint8Array(16))
-      bytes[6] = (bytes[6] & 0x0f) | 0x40
-      bytes[8] = (bytes[8] & 0x3f) | 0x80
-      return formatUUID(bytes)
-    }
+    if (typeof webCrypto?.getRandomValues === "function") return formatUUID(generateSecureRandomBytes(16, environment))
   } catch {
     // Fall through for runtimes without a usable Web Crypto implementation.
   }
@@ -38,6 +75,8 @@ export function generateUUID(environment?: UUIDEnvironment): string {
 }
 
 function formatUUID(bytes: Uint8Array): string {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
   const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
   return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20)].join("-")
 }

--- a/packages/util/test/uuid.test.ts
+++ b/packages/util/test/uuid.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { generateUUID, type UUIDCrypto } from "../src/uuid"
+import {
+  generateRandomBytes,
+  generateSecureRandomBytes,
+  generateSecureUUID,
+  generateUUID,
+  SecureRandomUnavailableError,
+  type UUIDCrypto,
+} from "../src/uuid"
 
 describe("generateUUID", () => {
   test("uses native randomUUID when available", () => {
@@ -43,5 +50,59 @@ describe("generateUUID", () => {
     }
 
     expect(generateUUID(environment)).not.toBe(generateUUID(environment))
+  })
+})
+
+describe("generateRandomBytes", () => {
+  test("uses Web Crypto when available", () => {
+    const crypto: UUIDCrypto = {
+      getRandomValues(bytes) {
+        bytes.fill(0xab)
+        return bytes
+      },
+    }
+
+    expect(generateRandomBytes(4, { crypto })).toEqual(new Uint8Array([0xab, 0xab, 0xab, 0xab]))
+  })
+
+  test("allows a deterministic weak fallback for ordinary identifiers", () => {
+    expect(generateRandomBytes(3, { crypto: undefined, random: () => 0.5 })).toEqual(new Uint8Array([128, 128, 128]))
+  })
+})
+
+describe("secure UUID generation", () => {
+  test("uses native randomUUID when available", () => {
+    expect(generateSecureUUID({ crypto: { randomUUID: () => "secure-native" } })).toBe("secure-native")
+  })
+
+  test("uses getRandomValues without a weak fallback", () => {
+    const crypto: UUIDCrypto = {
+      getRandomValues(bytes) {
+        bytes.fill(0xcd)
+        return bytes
+      },
+    }
+
+    expect(generateSecureUUID({ crypto })).toBe("cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd")
+    expect(generateSecureRandomBytes(3, { crypto })).toEqual(new Uint8Array([0xcd, 0xcd, 0xcd]))
+  })
+
+  test("fails the affected operation when Web Crypto is unavailable", () => {
+    expect(() => generateSecureUUID({ crypto: undefined, random: () => 0.5 })).toThrow(SecureRandomUnavailableError)
+    expect(() => generateSecureRandomBytes(16, { crypto: undefined, random: () => 0.5 })).toThrow(
+      SecureRandomUnavailableError,
+    )
+  })
+
+  test("fails when getRandomValues is exposed but unusable", () => {
+    expect(() =>
+      generateSecureRandomBytes(16, {
+        crypto: {
+          getRandomValues() {
+            throw new DOMException("Blocked", "SecurityError")
+          },
+        },
+      }),
+    ).toThrow(SecureRandomUnavailableError)
   })
 })


### PR DESCRIPTION
## Summary

- route ordinary App and shared UI identifiers through the capability-safe UUID/random-byte boundary
- add strict random APIs that fail instead of using weak entropy for security-sensitive operations
- verify App startup and Browser WebRTC construction without `crypto.randomUUID()`, including a real non-loopback HTTP Chromium smoke in CI
- document private-network HTTP support and the frontend capability-development contract

Closes #752

## Testing

- `bun test test/uuid.test.ts && bun run typecheck && bun run build` (`packages/util`)
- `bun test test/testing/browser-crypto-contract.test.ts test/components/workspace/browser/browser-store.test.ts test/components/workspace/browser/browser-webrtc.test.ts` (`packages/app`)
- `bun run typecheck` (`packages/app`)
- `bun run test` (`packages/app`)
- `bun run test && bun run typecheck` (`packages/ui`)
- `bun run --cwd packages/app build && bun packages/app/script/private-http-smoke.ts`
- `bun run test-layout:check && bun run skill:check && bun run package-guide:check`
- `bun run workflow:check`
- `bun run quality:quick`