### PR TITLE
fix(plugin): verify official artifact identity by manifest id, not display name

### DIFF
--- a/packages/synergy/src/plugin/marketplace-registry.ts
+++ b/packages/synergy/src/plugin/marketplace-registry.ts
@@ -26,6 +26,14 @@ export namespace PluginMarketplaceRegistry {
 
   export const DEFAULT_REGISTRY_URL: string = PLUGIN_MARKETPLACE_DEFAULTS.registryUrl
 
+  export class ArtifactVerificationError extends Error {
+    readonly code = "plugin_artifact_verification_failed"
+  }
+
+  function verificationError(message: string): ArtifactVerificationError {
+    return new ArtifactVerificationError(message)
+  }
+
   const Risk = z.enum(["low", "medium", "high"])
   const RuntimeMode = z.literal("process")
   const Author = z.object({
@@ -608,11 +616,11 @@ export namespace PluginMarketplaceRegistry {
   export async function verifyOfficialArtifact(id: string, version: string): Promise<VerifiedArtifact> {
     const config = await currentConfig()
     const entry = await getOfficialEntry(id)
-    if (!entry) throw new Error(`Official registry plugin not found: ${id}`)
+    if (!entry) throw verificationError(`Official registry plugin not found: ${id}`)
     if (entry.yankedVersions?.includes(version))
-      throw new Error(`Official registry version is yanked: ${id}@${version}`)
+      throw verificationError(`Official registry version is yanked: ${id}@${version}`)
     const target = entry.versions.find((candidate) => candidate.version === version)
-    if (!target) throw new Error(`Official registry version not found: ${id}@${version}`)
+    if (!target) throw verificationError(`Official registry version not found: ${id}@${version}`)
 
     const { tarballPath, signaturePath } = await ensureDownloaded(
       target,
@@ -626,42 +634,42 @@ export namespace PluginMarketplaceRegistry {
       checkRequiredTarballFiles(tarballPath)
 
       const signature = readSignatureFile(tarballPath)
-      if (!signature) throw new Error(`Remote plugin artifact signature is missing or invalid`)
+      if (!signature) throw verificationError(`Remote plugin artifact signature is missing or invalid`)
       const trustedSignature = target.signature
-      if (!trustedSignature) throw new Error(`Official registry version is missing reviewed signature metadata`)
+      if (!trustedSignature) throw verificationError(`Official registry version is missing reviewed signature metadata`)
       if (trustedSignature.algorithm !== signature.algorithm) {
-        throw new Error(`Remote plugin artifact signature algorithm mismatch`)
+        throw verificationError(`Remote plugin artifact signature algorithm mismatch`)
       }
       if (trustedSignature.signer !== signature.signer) {
-        throw new Error(`Remote plugin artifact signature signer mismatch`)
+        throw verificationError(`Remote plugin artifact signature signer mismatch`)
       }
-      if (signature.pluginId !== id) throw new Error(`Remote plugin artifact signature plugin id mismatch`)
-      if (signature.version !== version) throw new Error(`Remote plugin artifact signature version mismatch`)
+      if (signature.pluginId !== id) throw verificationError(`Remote plugin artifact signature plugin id mismatch`)
+      if (signature.version !== version) throw verificationError(`Remote plugin artifact signature version mismatch`)
       if (signature.payload.tarballHash !== tarballHash) {
-        throw new Error(`Remote plugin artifact signature tarball hash mismatch`)
+        throw verificationError(`Remote plugin artifact signature tarball hash mismatch`)
       }
       if (signature.payload.manifestHash !== target.manifestHash) {
-        throw new Error(`Remote plugin artifact signature manifest hash mismatch`)
+        throw verificationError(`Remote plugin artifact signature manifest hash mismatch`)
       }
       if (signature.payload.permissionsHash !== target.permissionsHash) {
-        throw new Error(`Remote plugin artifact signature permissions hash mismatch`)
+        throw verificationError(`Remote plugin artifact signature permissions hash mismatch`)
       }
 
       extractedDir = await extractArchive(tarballPath)
       const manifestPath = path.join(extractedDir, "plugin.json")
       const manifest = PluginManifest.parse(JSON.parse(await Bun.file(manifestPath).text())) as PluginManifestType
-      if (manifest.name !== id) throw new Error(`Remote plugin artifact manifest name mismatch`)
-      if (manifest.version !== version) throw new Error(`Remote plugin artifact manifest version mismatch`)
+      if (manifest.id !== id) throw verificationError(`Remote plugin artifact manifest id mismatch`)
+      if (manifest.version !== version) throw verificationError(`Remote plugin artifact manifest version mismatch`)
 
       const capabilities = baseCapabilities(manifest)
       const manifestHash = computeManifestHash(manifest)
       const permissionsHash = computePermissionsHash(manifest, capabilities)
-      if (manifestHash !== target.manifestHash) throw new Error(`Remote plugin artifact manifest hash mismatch`)
+      if (manifestHash !== target.manifestHash) throw verificationError(`Remote plugin artifact manifest hash mismatch`)
       if (permissionsHash !== target.permissionsHash)
-        throw new Error(`Remote plugin artifact permissions hash mismatch`)
+        throw verificationError(`Remote plugin artifact permissions hash mismatch`)
 
       const signatureValid = await verifySignatureWithPublicKey(tarballPath, signature, trustedSignature.signer)
-      if (!signatureValid) throw new Error(`Remote plugin artifact signature verification failed`)
+      if (!signatureValid) throw verificationError(`Remote plugin artifact signature verification failed`)
 
       return {
         entry,

--- a/packages/synergy/src/server/plugin-routes.ts
+++ b/packages/synergy/src/server/plugin-routes.ts
@@ -23,6 +23,7 @@ import {
   ApprovalApproveBodySchema,
   ApprovalReviewSchema,
 } from "../plugin/consent/approval-service"
+import { PluginMarketplaceRegistry } from "../plugin/marketplace-registry"
 import { PluginInstallationTransaction } from "../plugin/installation-transaction"
 import { reload } from "../plugin/lifecycle"
 import { readApprovals } from "../plugin/consent/approval-store"
@@ -357,6 +358,8 @@ export const ApiPluginRoute = new Hono()
         if (err instanceof ApprovalPluginNotFoundError)
           return context.json({ code: err.code, message: err.message }, 404)
         if (err instanceof ApprovalInvalidError) return context.json({ code: err.code, message: err.message }, 422)
+        if (err instanceof PluginMarketplaceRegistry.ArtifactVerificationError)
+          return context.json({ code: err.code, message: err.message }, 422)
         throw err
       }
     },
@@ -400,6 +403,8 @@ export const ApiPluginRoute = new Hono()
         }
         if (err instanceof ApprovalPluginNotFoundError)
           return context.json({ code: err.code, message: err.message }, 422)
+        if (err instanceof PluginMarketplaceRegistry.ArtifactVerificationError)
+          return context.json({ code: err.code, message: err.message }, 422)
         throw err
       }
     },
@@ -442,6 +447,8 @@ export const ApiPluginRoute = new Hono()
           }
         }
         if (err instanceof ApprovalPluginNotFoundError)
+          return context.json({ code: err.code, message: err.message }, 422)
+        if (err instanceof PluginMarketplaceRegistry.ArtifactVerificationError)
           return context.json({ code: err.code, message: err.message }, 422)
         throw err
       }

--- a/packages/synergy/test/server/plugin-official-install.test.ts
+++ b/packages/synergy/test/server/plugin-official-install.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test"
+import { subtle } from "node:crypto"
+import path from "path"
+import fs from "fs"
+import { tmpdir } from "../fixture/fixture"
+import { Global } from "../../src/global"
+import { ScopeContext } from "../../src/scope/context"
+import { Server } from "../../src/server/server"
+import { Scope } from "../../src/scope"
+import { Config } from "../../src/config/config"
+import { PLUGIN_MARKETPLACE_DEFAULTS } from "../../src/config/schema"
+import { PluginMarketplaceRegistry } from "../../src/plugin/marketplace-registry"
+import { computeManifestHash, computePermissionsHash } from "../../src/plugin/consent/approval-store"
+import { PluginManifest, type PluginManifest as PluginManifestType } from "@ericsanchezok/synergy-plugin"
+import { sha256File } from "../../src/util/crypto"
+import { Log } from "../../src/util/log"
+
+Log.init({ print: false })
+
+const PLUGIN_ID = "official-test-plugin"
+const PLUGIN_VERSION = "1.0.0"
+const REGISTRY_URL = "https://registry.test/synergy/plugins/registry.json"
+
+async function generateKeyPair() {
+  const key = (await subtle.generateKey("Ed25519" as any, true, ["sign", "verify"])) as CryptoKeyPair
+  const privateRaw = await subtle.exportKey("pkcs8", key.privateKey)
+  const publicRaw = await subtle.exportKey("raw", key.publicKey)
+  return {
+    privateKey: Buffer.from(privateRaw as ArrayBuffer).toString("hex"),
+    publicKey: Buffer.from(publicRaw as ArrayBuffer).toString("hex"),
+  }
+}
+
+function buildManifest(displayName: string): PluginManifestType {
+  return PluginManifest.parse({
+    manifestVersion: 1,
+    apiVersion: "3.0",
+    id: PLUGIN_ID,
+    name: displayName,
+    version: PLUGIN_VERSION,
+    description: "Official registry install test plugin",
+    capabilities: [],
+    contributions: [{ kind: "skill", id: "greeting", skill: { name: "greeting" } }],
+    artifacts: { generation: "test-generation" },
+  }) as PluginManifestType
+}
+
+async function buildSignedArtifact(displayName: string) {
+  const key = await generateKeyPair()
+  const manifest = buildManifest(displayName)
+  const manifestHash = computeManifestHash(manifest)
+  const permissionsHash = computePermissionsHash(manifest, [])
+
+  const dir = fs.mkdtempSync(path.join(Global.Path.cache, "official-install-fixture-"))
+  const staging = path.join(dir, "payload")
+  fs.mkdirSync(staging, { recursive: true })
+  await Bun.write(path.join(staging, "plugin.json"), JSON.stringify(manifest, null, 2))
+  await Bun.write(path.join(staging, "integrity.json"), JSON.stringify({ files: {} }))
+  await Bun.write(
+    path.join(staging, "permissions.summary.json"),
+    JSON.stringify({ pluginId: PLUGIN_ID, version: PLUGIN_VERSION, permissions: [] }),
+  )
+  const tarballPath = path.join(dir, `${PLUGIN_ID}-${PLUGIN_VERSION}.synergy-plugin.tgz`)
+  const packed = Bun.spawnSync(["tar", "-czf", tarballPath, "-C", staging, "."], { stdout: "pipe", stderr: "pipe" })
+  if (packed.exitCode !== 0) throw new Error(`Failed to pack fixture tarball: ${packed.stderr}`)
+
+  const tarballHash = sha256File(tarballPath)
+  const payload = { tarballHash, manifestHash, permissionsHash }
+  const privateKey = await subtle.importKey("pkcs8", Buffer.from(key.privateKey, "hex"), "Ed25519" as any, false, [
+    "sign",
+  ])
+  const signature = await subtle.sign("Ed25519" as any, privateKey, new TextEncoder().encode(JSON.stringify(payload)))
+  const metadata = {
+    signatureVersion: 1,
+    pluginId: PLUGIN_ID,
+    version: PLUGIN_VERSION,
+    algorithm: "ed25519",
+    signer: key.publicKey,
+    signature: Buffer.from(signature as ArrayBuffer).toString("hex"),
+    signedAt: Date.now(),
+    payload,
+  }
+  await Bun.write(`${tarballPath}.sig`, JSON.stringify(metadata, null, 2))
+
+  return {
+    dir,
+    tarballPath,
+    tarballHash,
+    manifestHash,
+    permissionsHash,
+    signer: key.publicKey,
+  }
+}
+
+async function writeOfficialCache(artifact: Awaited<ReturnType<typeof buildSignedArtifact>>) {
+  const paths = PluginMarketplaceRegistry.cachePaths(REGISTRY_URL)
+  fs.mkdirSync(paths.entries, { recursive: true })
+  const publishedAt = new Date("2026-07-20T00:00:00.000Z").toISOString()
+  await Bun.write(
+    paths.registry,
+    JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: publishedAt,
+      plugins: [
+        {
+          id: PLUGIN_ID,
+          name: PLUGIN_ID,
+          description: "Official registry install test plugin",
+          repo: "https://github.com/SII-Holos/official-test-plugin",
+          entry: "plugins/official-test-plugin.json",
+          author: { name: "SII Holos" },
+          verified: true,
+          official: true,
+          keywords: ["synergy-plugin", "official"],
+          latestVersion: PLUGIN_VERSION,
+          updatedAt: publishedAt,
+          risk: "low",
+          runtimeMode: "process",
+          tools: [],
+          uiSurfaces: [],
+        },
+      ],
+    }),
+  )
+  await Bun.write(
+    path.join(paths.entries, `${PLUGIN_ID}.json`),
+    JSON.stringify({
+      schemaVersion: 1,
+      id: PLUGIN_ID,
+      name: PLUGIN_ID,
+      description: "Official registry install test plugin",
+      repo: "https://github.com/SII-Holos/official-test-plugin",
+      author: { name: "SII Holos" },
+      verified: true,
+      official: true,
+      keywords: ["synergy-plugin", "official"],
+      versions: [
+        {
+          version: PLUGIN_VERSION,
+          downloadUrl: `file://${artifact.tarballPath}`,
+          signatureUrl: `file://${artifact.tarballPath}.sig`,
+          signature: { algorithm: "ed25519", signer: artifact.signer },
+          integrity: `sha256-${artifact.tarballHash}`,
+          manifestHash: artifact.manifestHash,
+          permissionsHash: artifact.permissionsHash,
+          risk: "low",
+          runtimeMode: "process",
+          permissionsSummary: [],
+          tools: [],
+          uiSurfaces: [],
+          publishedAt,
+        },
+      ],
+      yankedVersions: [],
+    }),
+  )
+}
+
+async function withOfficialRegistry<T>(
+  artifact: Awaited<ReturnType<typeof buildSignedArtifact>>,
+  fn: () => Promise<T>,
+) {
+  const previousDomain = await Config.domainGet("plugins")
+  await writeOfficialCache(artifact)
+  try {
+    await Config.domainUpdate(
+      "plugins",
+      {
+        ...previousDomain,
+        pluginMarketplace: {
+          ...PLUGIN_MARKETPLACE_DEFAULTS,
+          enabled: true,
+          registryUrl: REGISTRY_URL,
+        },
+      },
+      { mode: "replace-domain" },
+    )
+    await Config.reload("global")
+    return await ScopeContext.provide({ scope: Scope.home(), fn })
+  } finally {
+    await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
+    await Config.reload("global")
+  }
+}
+
+describe("official registry install verification", () => {
+  test("accepts an artifact whose manifest display name differs from the registry id", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const artifact = await buildSignedArtifact("Official Test Plugin")
+    try {
+      await withOfficialRegistry(artifact, async () => {
+        const verified = await PluginMarketplaceRegistry.verifyOfficialArtifact(PLUGIN_ID, PLUGIN_VERSION)
+        expect(verified.manifest.id).toBe(PLUGIN_ID)
+        expect(verified.manifest.name).toBe("Official Test Plugin")
+      })
+    } finally {
+      fs.rmSync(artifact.dir, { recursive: true, force: true })
+    }
+  })
+
+  test("registry install returns 422 with the verification message instead of a 500", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const artifact = await buildSignedArtifact("Official Test Plugin")
+    try {
+      await withOfficialRegistry(artifact, async () => {
+        const app = Server.App()
+        const res = await app.request("/api/plugins/registry/install", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: PLUGIN_ID, version: "9.9.9", source: "official" }),
+        })
+        expect(res.status).toBe(422)
+        const body = await res.json()
+        expect(body.code).toBe("plugin_artifact_verification_failed")
+        expect(body.message).toBe(`Official registry version not found: ${PLUGIN_ID}@9.9.9`)
+      })
+    } finally {
+      fs.rmSync(artifact.dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Official marketplace installs failed with a bare 500 for every plugin whose manifest display name differs from its registry slug id (both current official plugins: `synergy-frontend-kit`, `synergy-meme-plugin`), because `verifyOfficialArtifact` compared the registry id against `manifest.name`.
- Compare `manifest.id` instead, matching the identity checks in `loader.ts` and `approval-service.ts`; the manifest schema treats `name` as a free-form display name (1–128 chars) while `id` is the slug.
- Introduce `PluginMarketplaceRegistry.ArtifactVerificationError` and map it to 422 with the concrete verification message in the registry install/update/approve routes, replacing the opaque "Internal server error" surfaced in the plugin detail dialog.

## Tests
- New `test/server/plugin-official-install.test.ts`: a fully signed local fixture proves an artifact with display name "Official Test Plugin" passes verification under registry id `official-test-plugin`, and that a failing install returns 422 with `plugin_artifact_verification_failed` and the specific reason.
- Existing suites pass: `plugin-registry-routes`, `signature`, `installation-transaction` (27 tests); package typecheck clean.

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>