### PR TITLE
fix(library): synthesize users for re-encode jobs

### DIFF
--- a/packages/synergy/src/library/experience-encoder.ts
+++ b/packages/synergy/src/library/experience-encoder.ts
@@ -116,7 +116,7 @@ export namespace ExperienceEncoder {
     const userInfo = userMsg?.info as MessageV2.User | undefined
     const ctx: AgentContext = {
       sessionID,
-      userMsg: userInfo ?? ({} as MessageV2.User),
+      userMsg: userInfo,
       model,
       learning: effectiveLearning,
       signal,
@@ -157,7 +157,6 @@ export namespace ExperienceEncoder {
 
     const ctx: AgentContext = {
       sessionID,
-      userMsg: {} as MessageV2.User,
       model,
       learning: effectiveLearning,
       signal,
@@ -518,7 +517,7 @@ export namespace ExperienceEncoder {
 
   interface AgentContext {
     sessionID: string
-    userMsg: MessageV2.User
+    userMsg?: MessageV2.User
     model: Provider.Model | undefined
     learning: Required<Config.Learning>
     signal?: AbortSignal
@@ -535,7 +534,6 @@ export namespace ExperienceEncoder {
   }
 
   async function runAgent(agentName: string, ctx: AgentContext, content: string): Promise<string> {
-    if (!ctx.userMsg) return ""
     try {
       const result = await AgentCall.text({
         agent: agentName,

--- a/packages/synergy/test/library/experience-reencode.test.ts
+++ b/packages/synergy/test/library/experience-reencode.test.ts
@@ -456,6 +456,18 @@ describe.serial("ExperienceReencode bounded session loading", () => {
           raw: "### User\nRepair the build\n\n### Response\nThe build is repaired.",
         })
         installReencodeModelMocks()
+        let modelUser: MessageV2.User | undefined
+        ;(LLM.stream as any) = mock(async (input: { user: MessageV2.User }) => {
+          modelUser = input.user
+          const text =
+            "1. Read the stored experience\n2. Rebuild the reusable trajectory\n3. Persist the fresh embedding"
+          return {
+            textStream: (async function* () {
+              yield text
+            })(),
+            text: Promise.resolve(text),
+          }
+        })
 
         let embeddingSignal: AbortSignal | undefined
         ;(Embedding.generate as any) = mock(async (input: { id: string; signal?: AbortSignal }) => {
@@ -478,6 +490,11 @@ describe.serial("ExperienceReencode bounded session loading", () => {
         expect(finished).toMatchObject({ status: "completed", totalCount: 1, okCount: 1, failedCount: 0 })
         expect(messageReads).toBe(0)
         expect(embeddingSignal).toBeInstanceOf(AbortSignal)
+        expect(modelUser).toMatchObject({
+          id: expect.any(String),
+          sessionID: session.id,
+          role: "user",
+        })
       },
     })
   })
@@ -547,12 +564,27 @@ describe.serial("ExperienceReencode bounded session loading", () => {
           raw: "### User\nRecover the stored request\n\n### Response\nThe request was completed.",
         })
         installReencodeModelMocks()
+        let modelUser: MessageV2.User | undefined
+        ;(LLM.stream as any) = mock(async (input: { user: MessageV2.User }) => {
+          modelUser = input.user
+          return {
+            textStream: (async function* () {
+              yield "Bounded maintenance reencode"
+            })(),
+            text: Promise.resolve("Bounded maintenance reencode"),
+          }
+        })
 
         const started = ExperienceReencode.start({ type: "intent", reason: "too-long" })
         const finished = await waitForTerminalJob(started.id)
 
         expect(finished).toMatchObject({ status: "completed", totalCount: 1, okCount: 1, failedCount: 0 })
         expect(LibraryDB.Experience.get("missing-user-message")?.intent).toBe("Bounded maintenance reencode")
+        expect(modelUser).toMatchObject({
+          id: expect.any(String),
+          sessionID: session.id,
+          role: "user",
+        })
       },
     })
   })


### PR DESCRIPTION
## Summary

- stop passing empty objects as `MessageV2.User` during stored-content experience repair
- let `AgentCall.text()` synthesize a schema-valid temporary user when history is unavailable
- cover both intent and script fast paths with downstream user-envelope assertions

Fixes #866.

## Root cause

Maintenance re-encode intentionally avoids hydrating complete session history when stored `user_input` or `raw` content is sufficient. Those paths supplied `{}` as a user message. Since `AgentCall.text()` received a truthy `user`, it skipped its normal synthesis path, and the worker protocol rejected `input.user.id` before the LLM request.

## Changes

| File | Change |
|---|---|
| `packages/synergy/src/library/experience-encoder.ts` | Make encoder user context optional and rely on AgentCall synthesis when absent |
| `packages/synergy/test/library/experience-reencode.test.ts` | Assert valid generated users for stored-content intent and script repairs |

## Verification

- `bun test test/library/experience-reencode.test.ts` (21 passed)
- `bun run typecheck` in `packages/synergy`
- Prettier on changed files
- Oxlint on changed files
- `git diff --check`

## Scope

No changes to candidate classification, prompts, repair concurrency, history-loading policy, embedding, or model selection.