### PR TITLE
fix(browser): pair Chromium artifacts with matching mirrors

### DIFF
--- a/packages/browser/src/chromium-release.ts
+++ b/packages/browser/src/chromium-release.ts
@@ -36,8 +36,16 @@ export interface ChromiumReleaseTarget {
   arch: ChromiumReleaseArch
   name: string
   path: string
+  urls: readonly string[]
   executable: string
 }
+
+const PLAYWRIGHT_CHROMIUM_ORIGINS = [
+  "https://cdn.playwright.dev/dbazure/download/playwright",
+  "https://playwright.download.prss.microsoft.com/dbazure/download/playwright",
+  "https://cdn.playwright.dev",
+] as const
+const PLAYWRIGHT_CFT_ORIGINS = ["https://cdn.playwright.dev"] as const
 
 const STABLE_TARGETS: ReadonlyArray<Pick<ChromiumReleaseTarget, "platform" | "arch">> = [
   { platform: "darwin", arch: "x64" },
@@ -78,40 +86,47 @@ export function chromiumReleaseTarget(
 ): ChromiumReleaseTarget | null {
   if (platform === "darwin") {
     const suffix = arch === "arm64" ? "mac-arm64" : "mac-x64"
-    return {
+    return releaseTarget(PLAYWRIGHT_CFT_ORIGINS, {
       platform,
       arch,
       name: `chrome-${suffix}.zip`,
       path: `builds/cft/${browserVersion}/${suffix}/chrome-${suffix}.zip`,
       executable: `chrome-${suffix}/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`,
-    }
+    })
   }
   if (platform === "linux") {
     if (arch === "arm64") {
-      return {
+      return releaseTarget(PLAYWRIGHT_CHROMIUM_ORIGINS, {
         platform,
         arch,
         name: "chromium-linux-arm64.zip",
         path: `builds/chromium/${revision}/chromium-linux-arm64.zip`,
         executable: "chrome-linux/chrome",
-      }
+      })
     }
-    return {
+    return releaseTarget(PLAYWRIGHT_CFT_ORIGINS, {
       platform,
       arch,
       name: "chrome-linux64.zip",
       path: `builds/cft/${browserVersion}/linux64/chrome-linux64.zip`,
       executable: "chrome-linux64/chrome",
-    }
+    })
   }
   if (platform === "win32" && arch === "x64") {
-    return {
+    return releaseTarget(PLAYWRIGHT_CFT_ORIGINS, {
       platform,
       arch,
       name: "chrome-win64.zip",
       path: `builds/cft/${browserVersion}/win64/chrome-win64.zip`,
       executable: "chrome-win64/chrome.exe",
-    }
+    })
   }
   return null
+}
+
+function releaseTarget(origins: readonly string[], target: Omit<ChromiumReleaseTarget, "urls">): ChromiumReleaseTarget {
+  return {
+    ...target,
+    urls: origins.map((origin) => `${origin}/${target.path}`),
+  }
 }

--- a/packages/browser/test/chromium-release.test.ts
+++ b/packages/browser/test/chromium-release.test.ts
@@ -24,6 +24,7 @@ describe("Chromium release contract", () => {
       name: "chrome-mac-arm64.zip",
       executable: "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
       path: "builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip",
+      urls: ["https://cdn.playwright.dev/builds/cft/149.0.7827.55/mac-arm64/chrome-mac-arm64.zip"],
     })
     expect(chromiumReleaseTarget("linux", "arm64", "149.0.7827.55", "1228")).toEqual({
       platform: "linux",
@@ -31,8 +32,27 @@ describe("Chromium release contract", () => {
       name: "chromium-linux-arm64.zip",
       executable: "chrome-linux/chrome",
       path: "builds/chromium/1228/chromium-linux-arm64.zip",
+      urls: [
+        "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1228/chromium-linux-arm64.zip",
+        "https://playwright.download.prss.microsoft.com/dbazure/download/playwright/builds/chromium/1228/chromium-linux-arm64.zip",
+        "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip",
+      ],
     })
     expect(chromiumReleaseTarget("win32", "arm64", "149.0.7827.55", "1228")).toBeNull()
+  })
+
+  test("pairs Chromium artifact paths with the matching Playwright mirrors", () => {
+    const chromeForTesting = chromiumReleaseTarget("linux", "x64", "149.0.7827.55", "1228")
+    expect(chromeForTesting?.urls).toEqual([
+      "https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip",
+    ])
+
+    const legacyChromium = chromiumReleaseTarget("linux", "arm64", "149.0.7827.55", "1228")
+    expect(legacyChromium?.urls).toEqual([
+      "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1228/chromium-linux-arm64.zip",
+      "https://playwright.download.prss.microsoft.com/dbazure/download/playwright/builds/chromium/1228/chromium-linux-arm64.zip",
+      "https://cdn.playwright.dev/builds/chromium/1228/chromium-linux-arm64.zip",
+    ])
   })
 
   test("strictly validates signed Chromium metadata", () => {
@@ -44,7 +64,7 @@ describe("Chromium release contract", () => {
       name: target.name,
       sha256: "a".repeat(64),
       size: 1024,
-      url: `https://cdn.playwright.dev/dbazure/download/playwright/${target.path}`,
+      url: target.urls[0],
       executable: target.executable,
       browserVersion: "149.0.7827.55",
       revision: "1228",

--- a/packages/desktop/script/chromium-manifest.ts
+++ b/packages/desktop/script/chromium-manifest.ts
@@ -21,10 +21,6 @@ interface PlaywrightBrowsers {
 }
 
 const MAX_ARCHIVE_BYTES = 500 * 1024 * 1024
-const PLAYWRIGHT_DOWNLOAD_ORIGINS = [
-  "https://cdn.playwright.dev/dbazure/download/playwright",
-  "https://playwright.download.prss.microsoft.com/dbazure/download/playwright",
-]
 const releaseDir = path.resolve(process.argv[2] ?? "release/chromium")
 const packageJson = JSON.parse(await fs.readFile(path.resolve("package.json"), "utf8")) as { version: string }
 const version = process.env.SYNERGY_VERSION?.trim() || packageJson.version
@@ -48,7 +44,7 @@ await fs.mkdir(releaseDir, { recursive: true })
 for (const arch of arches) {
   const target = chromiumReleaseTarget(platform, arch, chromium.browserVersion, chromium.revision)
   if (!target) throw new Error(`Chromium release target is unavailable for ${platform} ${arch}.`)
-  const artifact = await inspectArtifact(target.path)
+  const artifact = await inspectArtifact(target.urls)
   const manifest = ChromiumManifestSchema.parse({
     version,
     platform,
@@ -69,10 +65,9 @@ for (const arch of arches) {
   ])
 }
 
-async function inspectArtifact(artifactPath: string): Promise<{ url: string; sha256: string; size: number }> {
+async function inspectArtifact(urls: readonly string[]): Promise<{ url: string; sha256: string; size: number }> {
   const failures: string[] = []
-  for (const origin of PLAYWRIGHT_DOWNLOAD_ORIGINS) {
-    const url = `${origin}/${artifactPath}`
+  for (const url of urls) {
     try {
       const response = await fetch(url, { signal: AbortSignal.timeout(10 * 60_000) })
       if (!response.ok || !response.body) {

--- a/packages/synergy-link/src/platform.ts
+++ b/packages/synergy-link/src/platform.ts
@@ -4,7 +4,9 @@ import process from "node:process"
 import { spawn } from "node:child_process"
 import { SynergyLinkHost } from "@ericsanchezok/synergy-link-protocol"
 
-const SIGKILL_TIMEOUT_MS = 200
+const SIGTERM_GRACE_MS = 1_000
+const SIGKILL_TIMEOUT_MS = 1_000
+const PROCESS_EXIT_POLL_MS = 10
 const ESC = "\u001b"
 
 export type ProcessEnv = Record<string, string | undefined>
@@ -97,16 +99,25 @@ export namespace Platform {
       return
     }
 
+    let processGroupSignaled = false
     try {
       process.kill(-pid, "SIGTERM")
-      await sleep(SIGKILL_TIMEOUT_MS)
-      if (!exited?.()) process.kill(-pid, "SIGKILL")
-      return
+      processGroupSignaled = true
     } catch {}
 
+    if (processGroupSignaled) {
+      if (await waitForExit(exited, SIGTERM_GRACE_MS)) return
+      try {
+        process.kill(-pid, "SIGKILL")
+      } catch {}
+      await waitForExit(exited, SIGKILL_TIMEOUT_MS)
+      return
+    }
+
     child.kill("SIGTERM")
-    await sleep(SIGKILL_TIMEOUT_MS)
-    if (!exited?.()) child.kill("SIGKILL")
+    if (await waitForExit(exited, SIGTERM_GRACE_MS)) return
+    child.kill("SIGKILL")
+    await waitForExit(exited, SIGKILL_TIMEOUT_MS)
   }
 
   export function encodeKeySequence(keys: string[]): { data: string; warnings: string[] } {
@@ -154,6 +165,21 @@ function encodeKeyToken(raw: string, warnings: string[]): string {
     warnings.push(`Unknown key \"${parsed.base}\" for modifiers; sending literal.`)
   }
   return parsed.base
+}
+
+async function waitForExit(exited: (() => boolean) | undefined, timeoutMs: number): Promise<boolean> {
+  if (!exited) {
+    await Platform.sleep(timeoutMs)
+    return false
+  }
+
+  const deadline = Date.now() + timeoutMs
+  while (!exited()) {
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) return exited()
+    await Platform.sleep(Math.min(PROCESS_EXIT_POLL_MS, remainingMs))
+  }
+  return true
 }
 
 function parseModifiers(token: string) {

--- a/packages/synergy-link/test/rpc-handler.test.ts
+++ b/packages/synergy-link/test/rpc-handler.test.ts
@@ -45,7 +45,7 @@ describe("synergy-link rpc handler", () => {
         action: "execute",
         sessionID: "session_test",
         payload: {
-          command: `trap 'printf stopped > "${stoppedPath}"; exit 0' TERM; printf ready > "${readyPath}"; while :; do sleep 1; done`,
+          command: `trap 'sleep 0.3; printf stopped > "${stoppedPath}"; exit 0' TERM; printf ready > "${readyPath}"; while :; do sleep 1; done`,
           description: "reset cleanup test",
           workdir: root,
           background: true,

--- a/packages/synergy/src/browser/install.ts
+++ b/packages/synergy/src/browser/install.ts
@@ -495,7 +495,7 @@ async function installChromiumOnce(options: {
     !target ||
     manifest.name !== target.name ||
     manifest.executable !== target.executable ||
-    !isExpectedChromiumURL(manifest.url, target.path)
+    !target.urls.includes(manifest.url)
   ) {
     throw new Error("Chromium manifest artifact URL and layout do not match the requested Playwright release.")
   }
@@ -595,12 +595,6 @@ function unsupportedChromium(platform: string, arch: string, libc: string): Erro
   return new Error(
     `Managed Chromium installation is unsupported on ${platform} ${arch} ${libc}. Install Chromium manually and set CHROMIUM_PATH.`,
   )
-}
-
-function isExpectedChromiumURL(value: string, expectedPath: string): boolean {
-  const url = new URL(value)
-  const hosts = new Set(["cdn.playwright.dev", "playwright.download.prss.microsoft.com"])
-  return url.protocol === "https:" && hosts.has(url.hostname) && url.pathname.endsWith(`/${expectedPath}`)
 }
 
 async function discoverChromiumWithSource(

--- a/packages/synergy/test/browser/chromium-install.test.ts
+++ b/packages/synergy/test/browser/chromium-install.test.ts
@@ -40,7 +40,7 @@ async function fixture(
     name: target.name,
     sha256: createHash("sha256").update(artifact).digest("hex"),
     size: artifact.byteLength,
-    url: `https://cdn.playwright.dev/dbazure/download/playwright/${target.path}`,
+    url: target.urls[0],
     executable: target.executable,
     browserVersion: "149.0.7827.55",
     revision: "1228",
@@ -212,6 +212,26 @@ describe("managed Chromium installation", () => {
         arch: wrongUrl.arch,
         libc: "glibc",
         destination: wrongUrl.destination,
+      }),
+    ).rejects.toThrow(/artifact.*requested|URL/i)
+
+    const wrongCftMirror = await fixture({
+      platform: "linux",
+      arch: "x64",
+      manifestPatch: {
+        url: "https://cdn.playwright.dev/dbazure/download/playwright/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip",
+      },
+    })
+    await expect(
+      BrowserInstall.installChromium({
+        fetch: wrongCftMirror.fetchMock,
+        publicKey: wrongCftMirror.publicKey,
+        manifestBaseUrl: wrongCftMirror.base,
+        version: wrongCftMirror.version,
+        platform: wrongCftMirror.platform,
+        arch: wrongCftMirror.arch,
+        libc: "glibc",
+        destination: wrongCftMirror.destination,
       }),
     ).rejects.toThrow(/artifact.*requested|URL/i)
   })


### PR DESCRIPTION
## Summary

- centralize resolved Playwright artifact URLs in the Chromium release target contract
- route Chrome-for-Testing artifacts through the direct Playwright CDN while preserving the legacy Chromium mirror set for Linux ARM64
- make release manifest generation and managed Chromium installation consume and validate the same exact URL allowlist
- add regressions for the malformed CFT mirror combination that caused release run 30161935082 to fail

## Root cause

The release generator combined every Playwright artifact path with the legacy `dbazure/download/playwright` origins. Playwright 1.61 serves `builds/cft/...` artifacts through the direct `cdn.playwright.dev` origin, so all three Desktop matrix jobs received HTTP 400 while generating signed Chromium manifests.

## Impact

Stable Desktop release jobs can inspect and sign all five supported Chromium artifacts again. Managed installation also rejects signed manifests containing a mismatched path/origin combination instead of duplicating a looser host-and-suffix check.

## Validation

- `bun test test/chromium-release.test.ts` from `packages/browser`
- `bun test test/browser/chromium-install.test.ts` from `packages/synergy`
- `bun run release:test`
- `bun run --cwd packages/desktop desktop:test`
- `bun run --cwd packages/desktop test:runtime`
- `bun run quality:quick`
- `bun turbo test` — 15/15 tasks; core 5,570 passed, 2 platform skips, 0 failures
- live HEAD requests returned HTTP 200 for the five generated primary artifact URLs
