### PR TITLE
fix(plugin-kit): complete canonical marketplace releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
       - name: Build Synergy runtime for desktop package
         run: bun run ./packages/synergy/script/build.ts
         env:
+          NODE_OPTIONS: --max-old-space-size=4096
           SYNERGY_VERSION: ${{ needs.stable_candidate.outputs.version }}
           SYNERGY_CHANNEL: stable
           SYNERGY_BUILD_TARGETS: ${{ matrix.runtime_targets }}

--- a/packages/plugin-kit/src/lib/market-entry.ts
+++ b/packages/plugin-kit/src/lib/market-entry.ts
@@ -269,7 +269,7 @@ export function registryEntry(input: {
   return {
     schemaVersion: 1,
     id: manifest.id,
-    name: manifest.name,
+    name: manifest.id,
     description: manifest.description,
     repo,
     ...(manifest.homepage ? { homepage: manifest.homepage } : {}),

--- a/packages/plugin-kit/test/build.test.ts
+++ b/packages/plugin-kit/test/build.test.ts
@@ -375,6 +375,7 @@ export default definePlugin({
 import { definePlugin } from "@ericsanchezok/synergy-plugin"
 export default definePlugin({
   id: "capability-risk-fixture",
+  name: "Capability Risk Fixture",
   version: "1.0.0",
   description: "Capability risk fixture",
   capabilities: [{ id: "asset.write" }, { id: "shell.execute" }],
@@ -410,6 +411,7 @@ await signPluginTarball(process.argv[2])
         signatureUrl: "https://example.com/capability-risk-fixture.tgz.sig",
         publishedAt: "2026-07-22T00:00:00.000Z",
       })
+      expect(entry.name).toBe("capability-risk-fixture")
       expect(entry.versions[0]?.risk).toBe("high")
       expect(entry.versions[0]?.permissionsSummary).toEqual([
         expect.objectContaining({ key: "asset.write", risk: "medium" }),

--- a/test/script/release/desktop-packaging.test.ts
+++ b/test/script/release/desktop-packaging.test.ts
@@ -36,11 +36,13 @@ describe("desktop release packaging", () => {
     const buildIndex = steps.findIndex((step) => step.name === "Build Synergy runtime for desktop package")
     const prepareIndex = steps.findIndex((step) => step.name === "Prepare Synergy runtime for desktop package")
     const packageIndex = steps.findIndex((step) => step.name === "Package desktop artifact")
+    const buildStep = steps[buildIndex]
     const prepareStep = steps[prepareIndex]
 
     expect(buildIndex).toBeGreaterThanOrEqual(0)
     expect(prepareIndex).toBeGreaterThan(buildIndex)
     expect(packageIndex).toBeGreaterThan(prepareIndex)
+    expect(buildStep?.env?.NODE_OPTIONS).toBe("--max-old-space-size=4096")
     expect(prepareStep?.run).toBe("bun run ./script/release/prepare-desktop-runtime.ts")
     expect(prepareStep?.env?.SYNERGY_BUILD_TARGETS).toBe("${{ matrix.runtime_targets }}")
   })


### PR DESCRIPTION
## Summary
- keep Marketplace registry name aligned with the canonical plugin id while allowing a distinct display name
- add a behavioral regression test for display-name plugins
- give the desktop release runtime build a 4 GiB Node heap after the macOS 3.0.5 candidate hit the default 1.9 GiB limit
- add a release workflow contract assertion for the heap setting

## Verification
- bun test in packages/plugin-kit (17 passed)
- bun run typecheck in packages/plugin-kit
- bun run release:test (19 passed)
- pre-push formatting, lint, typecheck, and package policy gates