### PR TITLE
fix(app): align quick switcher model availability

### DIFF
--- a/packages/app/src/components/provider/model-catalog.ts
+++ b/packages/app/src/components/provider/model-catalog.ts
@@ -9,6 +9,27 @@ export function isSelectableModel(model: Pick<Model, "status" | "catalogState">)
   return model.status !== "deprecated" && model.catalogState !== "retained"
 }
 
+export function listSelectableConnectedModels(
+  providers: readonly Provider[],
+  connectedProviderIDs: readonly string[],
+  providerID?: string,
+) {
+  const connected = new Set(connectedProviderIDs)
+
+  return providers.flatMap((provider) => {
+    if (!connected.has(provider.id) || (providerID && provider.id !== providerID)) return []
+
+    return Object.values(provider.models)
+      .filter(isSelectableModel)
+      .map((model) => ({
+        ...model,
+        provider,
+        name: model.name.replace("(latest)", "").trim(),
+        latest: model.name.includes("(latest)"),
+      }))
+  })
+}
+
 export function resolveSessionModel(providers: Provider[], ref: ModelRef | undefined) {
   if (!ref) return undefined
   const provider = providers.find((candidate) => candidate.id === ref.providerID)

--- a/packages/app/src/components/provider/model-manager.tsx
+++ b/packages/app/src/components/provider/model-manager.tsx
@@ -3,6 +3,7 @@ import { createMemo, Show, type Component } from "solid-js"
 import { List } from "@ericsanchezok/synergy-ui/list"
 import { Switch } from "@ericsanchezok/synergy-ui/switch"
 import { Tag } from "@ericsanchezok/synergy-ui/tag"
+import { listSelectableConnectedModels } from "@/components/provider/model-catalog"
 import { compareProviderIDs, type ProviderRecommendationMap } from "@/components/provider/provider-recommendation"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLocal, type LocalModel, type ModelKey } from "@/context/local"
@@ -191,24 +192,11 @@ export const ConnectedModelManager: Component<{
   const providers = useProviders()
 
   const models = createMemo(() =>
-    providers
-      .all()
-      .flatMap((p) =>
-        Object.values(p.models).map((m) => ({
-          ...m,
-          provider: p,
-          name: m.name.replace("(latest)", "").trim(),
-          latest: m.name.includes("(latest)"),
-        })),
-      )
-      .filter((model) =>
-        providers
-          .connected()
-          .map((p) => p.id)
-          .includes(model.provider.id),
-      )
-      .filter((model) => (props.provider ? model.provider.id === props.provider : true))
-      .sort((a, b) => a.name.localeCompare(b.name)),
+    listSelectableConnectedModels(
+      providers.all(),
+      providers.connected().map((provider) => provider.id),
+      props.provider,
+    ).sort((a, b) => a.name.localeCompare(b.name)),
   )
 
   const local = optionalLocal()

--- a/packages/app/test/components/provider/model-catalog.test.ts
+++ b/packages/app/test/components/provider/model-catalog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import type { ProviderListResponse } from "@ericsanchezok/synergy-sdk"
-import { isSelectableModel, resolveSessionModel } from "../../../src/components/provider/model-catalog"
+import {
+  isSelectableModel,
+  listSelectableConnectedModels,
+  resolveSessionModel,
+} from "../../../src/components/provider/model-catalog"
 
 type Provider = ProviderListResponse["all"][number]
 
@@ -52,5 +56,23 @@ describe("provider model catalog selection", () => {
     })
 
     expect(resolved?.model).toBe(retained)
+  })
+
+  test("quick-switcher management lists only selectable models from connected providers", () => {
+    const connected = provider({
+      active: { ...baseModel, id: "active", catalogState: "active" },
+      retained: { ...baseModel, id: "retained", catalogState: "retained" },
+      deprecated: { ...baseModel, id: "deprecated", status: "deprecated" },
+    })
+    const disconnected = {
+      ...provider({
+        other: { ...baseModel, id: "other", catalogState: "active" },
+      }),
+      id: "disconnected",
+    }
+
+    expect(listSelectableConnectedModels([connected, disconnected], ["provider"]).map((model) => model.id)).toEqual([
+      "active",
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- use the same selectable-model rule for Settings quick-switch management and dialog model selection
- exclude retained, deprecated, and disconnected models from the Settings toggle list
- add a behavioral regression test for the candidate list

## Why

Settings previously allowed retained or deprecated models to be enabled even though dialog switchers always filtered them out.

Closes #888

## Validation

- `bun test --cwd packages/app test/components/provider/model-catalog.test.ts`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app test`
- `bun run quality:quick` (with an isolated `SYNERGY_HOME`)
