### PR TITLE
fix(app): consume draft workbench state once

### DIFF
--- a/packages/app/src/context/layout/index.tsx
+++ b/packages/app/src/context/layout/index.tsx
@@ -13,7 +13,7 @@ import { createScrollPersistence, type SessionScroll } from "./scroll"
 import { retry } from "@ericsanchezok/synergy-util/retry"
 import { computeDefaultWorkspaceWidth } from "./workspace"
 import type { WorkbenchPanelSurface, WorkbenchPanelTab } from "@/plugin/registries/workbench-panel-registry"
-import type { WorkbenchSurfaceState } from "../workbench/panel-model"
+import { transferWorkbenchStateOnce, type WorkbenchSurfaceState } from "../workbench/panel-model"
 import { migrateWorkbenchLayout } from "../workbench/layout-migration"
 import { createInitialLayoutDefaults } from "./defaults"
 import { reconcile } from "solid-js/store"
@@ -1299,16 +1299,9 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         }
       },
       transferWorkbenchState(from: string, to: string) {
-        if (from === to) return
-        const source = store.workbenchSurfaces[from]
-        if (!source) return
-        const target = store.workbenchSurfaces[to]
-        const targetHasTabs = [target?.side, target?.bottom].some((surface) => (surface?.tabs?.length ?? 0) > 0)
-        if (targetHasTabs) return
         setStore(
           produce((draft) => {
-            draft.workbenchSurfaces[to] = source
-            delete draft.workbenchSurfaces[from]
+            transferWorkbenchStateOnce(draft.workbenchSurfaces, from, to)
           }),
         )
       },

--- a/packages/app/src/context/workbench/panel-model.ts
+++ b/packages/app/src/context/workbench/panel-model.ts
@@ -13,6 +13,25 @@ export interface WorkbenchSurfaceState {
   resized?: boolean
 }
 
+export type WorkbenchSurfacesState = {
+  side?: WorkbenchSurfaceState
+  bottom?: WorkbenchSurfaceState
+}
+
+export function transferWorkbenchStateOnce(
+  surfaces: Record<string, WorkbenchSurfacesState | undefined>,
+  from: string,
+  to: string,
+) {
+  if (from === to) return
+  const source = surfaces[from]
+  if (!source) return
+  const target = surfaces[to]
+  const targetHasTabs = [target?.side, target?.bottom].some((surface) => (surface?.tabs?.length ?? 0) > 0)
+  if (!targetHasTabs) surfaces[to] = source
+  delete surfaces[from]
+}
+
 export interface OpenWorkbenchPanelInput {
   panelId: string
   cardinality: WorkbenchPanelCardinality

--- a/packages/app/test/context/workbench/panel-model.test.ts
+++ b/packages/app/test/context/workbench/panel-model.test.ts
@@ -5,6 +5,7 @@ import {
   moveWorkbenchPanelTab,
   openWorkbenchPanelTab,
   resolveWorkbenchEscapeAction,
+  transferWorkbenchStateOnce,
   updateWorkbenchPanelTab,
 } from "../../../src/context/workbench/panel-model"
 
@@ -270,5 +271,40 @@ describe("workbench panel launchability", () => {
         cardinality: "multi",
       }),
     ).toBe(true)
+  })
+})
+
+describe("workbench state transfer", () => {
+  test("consumes draft state without overwriting a populated destination", () => {
+    const draft = {
+      side: { opened: true, active: "draft-file", tabs: [{ id: "draft-file", panelId: "file" }] },
+    }
+    const destination = {
+      side: { opened: true, active: "notes", tabs: [{ id: "notes", panelId: "notes" }] },
+    }
+    const surfaces = {
+      home: draft,
+      "home/session-1": destination,
+    }
+
+    transferWorkbenchStateOnce(surfaces, "home", "home/session-1")
+
+    expect(surfaces.home).toBeUndefined()
+    expect(surfaces["home/session-1"]).toBe(destination)
+  })
+
+  test("moves draft state into an empty destination exactly once", () => {
+    const draft = {
+      side: { opened: true, active: "draft-file", tabs: [{ id: "draft-file", panelId: "file" }] },
+    }
+    const surfaces: Record<string, typeof draft> = { home: draft }
+
+    transferWorkbenchStateOnce(surfaces, "home", "home/session-1")
+
+    expect(surfaces.home).toBeUndefined()
+    expect(surfaces["home/session-1"]).toBe(draft)
+
+    transferWorkbenchStateOnce(surfaces, "home", "home/session-2")
+    expect(surfaces["home/session-2"]).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- consume draft workbench layout state after the composer transitions to a real session
- preserve an already populated destination session layout instead of overwriting it
- add regression coverage proving stale draft state cannot leak into a later non-first conversation

## Root cause

`transferWorkbenchState` returned early when the destination session already contained tabs. That preserved the destination correctly, but left the composer-scoped source entry in persisted `workbenchSurfaces`. A later conversation start could then reuse the abandoned draft layout and reopen the Desktop Side Workspace.

The transfer is now explicitly one-shot: an empty destination receives the draft state; a populated destination wins; in both cases the draft source is consumed.

## Testing

- `bun run typecheck` in `packages/app`
- `bun test test/context/workbench/panel-model.test.ts test/context/workbench/layout-migration.test.ts test/context/layout/defaults.test.ts` — 27 pass
- `bun run test` in `packages/app` — 1197 pass, 0 fail across 183 files, plus 2 build contract tests
- `bun run lint` — 0 warnings, 0 errors across 2606 files
- Prettier check on all changed files

## Context

Follow-up to the Desktop Side Workspace startup behavior addressed around #790, #811, and #842.