### PR TITLE
fix(app): keep transition dismissals across session navigation

### DIFF
--- a/packages/app/src/context/session-transition.tsx
+++ b/packages/app/src/context/session-transition.tsx
@@ -68,6 +68,15 @@ export function createSessionTransitionState() {
     })
   }
 
+  const completeHandoff = (sessionID: string, messageID: string) => {
+    const handoff = entries[sessionID]?.handoff
+    if (handoff?.messageID !== messageID) return false
+    set(sessionID, handoff.success, {
+      dismiss: () => dismissHandoff(sessionID, messageID),
+    })
+    return true
+  }
+
   const clearRecovery = (scopeKey: string) => {
     recoveries.delete(scopeKey)
   }
@@ -81,6 +90,7 @@ export function createSessionTransitionState() {
     set,
     clear,
     dismissHandoff,
+    completeHandoff,
     isHandoffDismissed,
     getRecovery: (scopeKey: string) => recoveries.get(scopeKey),
     setRecovery,

--- a/packages/app/src/context/session-transition.tsx
+++ b/packages/app/src/context/session-transition.tsx
@@ -20,6 +20,7 @@ type StoredSessionTransitionEntry = SessionTransitionEntry & {
 export function createSessionTransitionState() {
   const [entries, setEntries] = createStore<Record<string, StoredSessionTransitionEntry>>({})
   const recoveries = new Map<string, NewSessionRecovery>()
+  const dismissedHandoffs = new Map<string, string>()
   let revision = 0
 
   const clear = (sessionID: string) => {
@@ -29,6 +30,13 @@ export function createSessionTransitionState() {
       }),
     )
   }
+
+  const dismissHandoff = (sessionID: string, messageID: string) => {
+    dismissedHandoffs.set(sessionID, messageID)
+    clear(sessionID)
+  }
+
+  const isHandoffDismissed = (sessionID: string, messageID: string) => dismissedHandoffs.get(sessionID) === messageID
 
   const set = (
     sessionID: string,
@@ -72,6 +80,8 @@ export function createSessionTransitionState() {
     get: (sessionID: string): SessionTransitionEntry | undefined => entries[sessionID],
     set,
     clear,
+    dismissHandoff,
+    isHandoffDismissed,
     getRecovery: (scopeKey: string) => recoveries.get(scopeKey),
     setRecovery,
     clearRecovery,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -569,9 +569,7 @@ function SessionPageContent() {
             refreshAttempted: true,
           }) === "ready"
         ) {
-          setSessionTransition(sessionID, handoff.success, {
-            dismiss: () => dismissSessionTransitionHandoff(sessionID, handoff.messageID),
-          })
+          sessionTransition.completeHandoff(sessionID, handoff.messageID)
           return
         }
         showStalledHandoff(sessionID, nextHandoff, requestErrorMessage(error))
@@ -616,9 +614,7 @@ function SessionPageContent() {
       refreshAttempted: entry.handoff.refreshAttempted ?? false,
     })
     if (decision === "ready") {
-      setSessionTransition(sessionID, entry.handoff.success, {
-        dismiss: () => dismissSessionTransitionHandoff(sessionID, entry.handoff!.messageID),
-      })
+      sessionTransition.completeHandoff(sessionID, entry.handoff.messageID)
       return
     }
     if (decision === "stalled") {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -509,10 +509,8 @@ function SessionPageContent() {
   const renderableUserMessages = visibleRoots
   const lastUserMessage = lastRoot
   const lastRenderableUserMessage = lastRoot
-  const dismissedHandoffs = new Set<string>()
   const dismissSessionTransitionHandoff = (sessionID: string, messageID: string) => {
-    dismissedHandoffs.add(`${sessionID}:${messageID}`)
-    clearSessionTransition(sessionID)
+    sessionTransition.dismissHandoff(sessionID, messageID)
   }
   const [handoffNow, setHandoffNow] = createSignal(Date.now())
   const acceptedProgressForHandoff = (handoff: Pick<SessionTransitionHandoff, "workspaceSelection">) => {
@@ -546,7 +544,6 @@ function SessionPageContent() {
   }
   const retrySessionTransitionHandoff = (sessionID: string, handoff: SessionTransitionHandoff) => {
     const accepted = handoff.accepted ?? acceptedProgressForHandoff(handoff)
-    dismissedHandoffs.delete(`${sessionID}:${handoff.messageID}`)
     const nextHandoff = {
       ...handoff,
       acceptedAt: Date.now(),
@@ -590,7 +587,7 @@ function SessionPageContent() {
       inbox: sync.data.inbox[sessionID],
     })
     if (!recovered) return
-    if (dismissedHandoffs.has(`${sessionID}:${recovered.messageID}`)) return
+    if (sessionTransition.isHandoffDismissed(sessionID, recovered.messageID)) return
     const accepted = acceptedProgressForHandoff(recovered)
     setSessionTransition(sessionID, accepted, undefined, {
       ...recovered,

--- a/packages/app/test/context/session-transition.test.ts
+++ b/packages/app/test/context/session-transition.test.ts
@@ -22,6 +22,21 @@ describe("session transition state", () => {
     })
   })
 
+  test("remembers a dismissed handoff across remounted session route consumers", () => {
+    createRoot((dispose) => {
+      const state = createSessionTransitionState()
+      state.set("session-1", createNewSessionTransitionSuccessProgress())
+
+      state.dismissHandoff("session-1", "msg_first")
+
+      const readAfterRouteRemount = () => state.isHandoffDismissed("session-1", "msg_first")
+      expect(state.get("session-1")).toBeUndefined()
+      expect(readAfterRouteRemount()).toBe(true)
+      expect(state.isHandoffDismissed("session-1", "msg_second")).toBe(false)
+      dispose()
+    })
+  })
+
   test("retains the expected root handoff until the session route observes it", () => {
     createRoot((dispose) => {
       const state = createSessionTransitionState()

--- a/packages/app/test/context/session-transition.test.ts
+++ b/packages/app/test/context/session-transition.test.ts
@@ -53,6 +53,41 @@ describe("session transition state", () => {
     })
   })
 
+  test("dismisses a completed handoff after its loading entry is replaced", () => {
+    createRoot((dispose) => {
+      const state = createSessionTransitionState()
+      const handoff = {
+        messageID: "msg_first",
+        success: createNewSessionTransitionSuccessProgress(),
+      } satisfies SessionTransitionHandoff
+      state.set("session-1", createNewSessionTransitionProgress(), undefined, handoff)
+
+      expect(state.completeHandoff("session-1", "msg_first")).toBe(true)
+      expect(() => state.get("session-1")?.actions?.dismiss?.()).not.toThrow()
+      expect(state.get("session-1")).toBeUndefined()
+      expect(state.isHandoffDismissed("session-1", "msg_first")).toBe(true)
+      expect(state.completeHandoff("session-1", "msg_first")).toBe(false)
+      dispose()
+    })
+  })
+
+  test("does not complete a newer handoff from a stale message result", () => {
+    createRoot((dispose) => {
+      const state = createSessionTransitionState()
+      const handoff = {
+        messageID: "msg_second",
+        success: createNewSessionTransitionSuccessProgress(),
+      } satisfies SessionTransitionHandoff
+      const loading = createNewSessionTransitionProgress()
+      state.set("session-1", loading, undefined, handoff)
+
+      expect(state.completeHandoff("session-1", "msg_first")).toBe(false)
+      expect(state.get("session-1")?.progress).toBe(loading)
+      expect(state.get("session-1")?.handoff?.messageID).toBe("msg_second")
+      dispose()
+    })
+  })
+
   test("ignores a stale dismiss after a newer transition replaces the entry", () => {
     createRoot((dispose) => {
       const state = createSessionTransitionState()


### PR DESCRIPTION
## Summary

- retain dismissed session handoffs at the router-level transition provider
- prevent a completed transition card from being reconstructed after navigating away and back
- keep later handoffs in the same session eligible by keying dismissal to the handoff message

## Testing

- `bun test test/context/session-transition.test.ts test/components/session/session-transition-card.test.ts` (from `packages/app`)
- `bun run test` (from `packages/app`)
- `bun run typecheck` (from `packages/app`)
- `bun run quality:quick`