### PR TITLE
fix(channel): preserve Cortex thread reply anchors

### DIFF
--- a/docs/architecture/cortex.md
+++ b/docs/architecture/cortex.md
@@ -117,6 +117,14 @@ Parent delivery and child persistence are separate:
 
 A running parent is not interrupted with another model call in the middle of its turn. Its completion notice may already be durable in the Inbox; releasing the active session lease asks the shared drive to process that item before any workflow continuation proposal. Callers that need a direct result should await the task, while orchestration features can bind the task to a DAG node.
 
+When the parent session is an external Channel endpoint, Cortex follows the
+task's parent-message lineage to the originating root user message and copies
+its `channelReplyToMessageId` onto the completion notice together with
+`channelPush: true` and `channelReply: true`. The outbound delivery system then
+replies to that specific Channel topic rather than consulting mutable session
+endpoint state. Cortex only opts into reply delivery for a non-app Channel with
+an `accountId` and a valid message-level anchor.
+
 At Synergy startup, durable child sessions left in `queued` or `running` state are changed to `interrupted` and emit the same observer so plugin control planes can make an explicit recovery decision. Cortex then reconciles eligible terminal notifications from child-session state: a missing delivery is restored with the stable key, while an already persisted but unprocessed Inbox item only re-requests the parent drive. Hidden tasks and old or explicitly suppressed records whose notification intent is not `true` do not create or recover parent notifications; workflow-owned silent handoffs follow the separate recovery path below.
 
 Silent Cortex completions do not create parent notifications, but workflow parents still require a durable handoff after the last blocking child becomes terminal. Cortex records a successful parent drive in the child's `deliveryNotifiedAt` field. Startup reconciliation retries unmarked silent handoffs only for the parent's current terminal assistant message and only while BlueprintLoop, Light Loop, or Lattice continuation remains active. The shared continuation gate and Inbox deduplication make this recovery idempotent while preventing old child tasks from waking a later workflow round.

--- a/docs/product/connections.md
+++ b/docs/product/connections.md
@@ -25,6 +25,48 @@ Each Feishu/Lark account can set a default model and one of that model's exposed
 
 Channel sessions default to the `autonomous` control profile. An inbound message therefore receives either an allowed result or a clear denial; it never stalls on an approval dialog visible only in another client.
 
+### Outbound Delivery Anchoring
+
+Outbound channel delivery uses a message-scoped reply anchor instead of a
+generic push when the assistant message carries `channelReply: true`. Each
+inbound Channel root user message records `channelReplyToMessageId` from the
+provider root ID, or from the inbound message ID when no root exists. The
+session endpoint remains stable when a Channel session is reused and does not
+store or refresh this transient routing state.
+
+`ChannelOutbound` reacts to terminal assistant messages. For each new terminal
+assistant it:
+
+1. acquires a lock on the message ID and re-reads the current metadata to
+   prevent duplicate or stale delivery
+2. checks for `channelPush`, `mailbox`, or `channelReply` metadata — without
+   any of these, the assistant is not sent
+3. when `channelReply` is true and no `channelReplyToMessageId` exists on that
+   assistant, logs a warning and drops the message instead of pushing to the
+   chat
+4. calls `provider.replyMessage()` when replying, or `provider.pushMessage()`
+   for a regular push
+5. records `channelOutboundSent: true` on the assistant after successful
+   provider delivery so repeated terminal events do not send it again
+
+### Reply in Thread
+
+The Feishu/Lark provider supports per-account `replyInThread: true` in account
+configuration. When enabled, `provider.replyMessage()` includes
+`reply_in_thread: true` in the request body so the reply appears in a thread
+rather than at the top level of the chat.
+
+### Continuation Delivery
+
+`SessionInvoke` propagates channel delivery metadata through continuation
+steps. When a steer message injected by Cortex (or another source) carries
+`channelPush`, `channelReply`, and `channelReplyToMessageId`, every assistant
+message produced in that continuation round inherits them. An unrelated user
+message that starts a new task root does not inherit the delivery metadata. If
+one continuation contains conflicting reply anchors, it keeps reply intent but
+omits the target so outbound delivery fails closed instead of replying to the
+wrong topic.
+
 ## Holos Identity
 
 Holos is an optional identity and agent-network layer. Synergy can create or import a Holos agent, store multiple local account credentials, select the active identity, and remove an identity from the local account store. The selected agent ID is the network identity used by the connection.

--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -531,6 +531,7 @@ export namespace Channel {
           const result = await SessionInvoke.invoke({
             sessionID,
             ...accountInvocation,
+            metadata: { channelReplyToMessageId: ctx.rootId ?? ctx.messageId },
             parts: buildPromptParts(ctx),
           })
 

--- a/packages/synergy/src/channel/outbound.ts
+++ b/packages/synergy/src/channel/outbound.ts
@@ -1,8 +1,9 @@
 import { Bus } from "@/bus"
 import { Log } from "@/util/log"
+import { Lock } from "@/util/lock"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionManager } from "@/session/manager"
-import { SessionEndpoint } from "@/session/endpoint"
+import { SessionProgress } from "@/session/progress"
 import { Session } from "@/session"
 import { Channel } from "."
 
@@ -21,20 +22,42 @@ export namespace ChannelOutbound {
       if (msg.role !== "assistant") return
 
       const assistant = msg as MessageV2.Assistant
-      if (!assistant.time.completed) return
+      if (!assistant.time.completed || !SessionProgress.isTerminalAssistant(assistant)) return
 
-      const metadata = (assistant.metadata ?? undefined) as Record<string, unknown> | undefined
-      if (!metadata?.mailbox && !metadata?.channelPush) return
+      const eventMetadata = assistant.metadata
+      if (!eventMetadata?.mailbox && !eventMetadata?.channelPush && !eventMetadata?.channelReply) return
+      if (eventMetadata.channelOutboundSent) return
 
+      using _ = await Lock.write(`channel-outbound:${msg.id}`)
+      const current = await MessageV2.get({ sessionID: msg.sessionID, messageID: msg.id }).catch(() => undefined)
+      if (!current || current.info.role !== "assistant") return
+
+      const currentAssistant = current.info as MessageV2.Assistant
+      const metadata = currentAssistant.metadata
+      if (!currentAssistant.time.completed || !SessionProgress.isTerminalAssistant(currentAssistant)) return
+      if (!metadata?.mailbox && !metadata?.channelPush && !metadata?.channelReply) return
       if (metadata.channelOutboundSent) return
 
       const session = await SessionManager.getSession(msg.sessionID).catch(() => undefined)
-      if (!session?.endpoint) return
-      if (session.endpoint.kind !== "channel") return
+      if (!session?.endpoint || session.endpoint.kind !== "channel") return
 
       const channelInfo = session.endpoint.channel
       if (INTERNAL_CHANNEL_TYPES.has(channelInfo.type)) return
-      if (!channelInfo.accountId || !channelInfo.chatId) return
+      if (!channelInfo.accountId) return
+
+      const replyRequired = metadata.channelReply === true
+      const replyToMessageId =
+        typeof metadata.channelReplyToMessageId === "string" && metadata.channelReplyToMessageId.trim()
+          ? metadata.channelReplyToMessageId
+          : undefined
+      if (replyRequired && !replyToMessageId) {
+        log.warn("channel reply skipped without message anchor", {
+          sessionID: msg.sessionID,
+          channelType: channelInfo.type,
+        })
+        return
+      }
+      if (!replyRequired && !channelInfo.chatId) return
 
       const provider = Channel.getProvider(channelInfo.type)
       if (!provider) {
@@ -42,33 +65,38 @@ export namespace ChannelOutbound {
         return
       }
 
-      const parts = await MessageV2.parts({ sessionID: msg.sessionID, messageID: msg.id }).catch(() => [])
-      const text = MessageV2.extractText(parts, { includeSynthetic: false })
+      const text = MessageV2.extractText(current.parts, { includeSynthetic: false })
       if (!text) return
 
       try {
-        await provider.pushMessage({
-          accountId: channelInfo.accountId,
-          chatId: channelInfo.chatId,
-          parts: [{ type: "text", text }],
+        if (replyRequired && replyToMessageId) {
+          await provider.replyMessage({
+            accountId: channelInfo.accountId,
+            messageId: replyToMessageId,
+            parts: [{ type: "text", text }],
+          })
+        } else {
+          await provider.pushMessage({
+            accountId: channelInfo.accountId,
+            chatId: channelInfo.chatId,
+            parts: [{ type: "text", text }],
+          })
+        }
+
+        await Session.mergeMessageMetadata({
+          sessionID: msg.sessionID,
+          messageID: msg.id,
+          metadata: { channelOutboundSent: true },
         })
 
-        await Session.updateMessage({
-          ...assistant,
-          metadata: {
-            ...(metadata ?? {}),
-            channelOutboundSent: true,
-          },
-        })
-
-        log.info("message pushed to channel", {
+        log.info(replyRequired ? "message replied to channel" : "message pushed to channel", {
           sessionID: msg.sessionID,
           channelType: channelInfo.type,
           accountId: channelInfo.accountId,
           chatId: channelInfo.chatId,
         })
       } catch (err) {
-        log.error("channel outbound push failed", {
+        log.error(replyRequired ? "channel outbound reply failed" : "channel outbound push failed", {
           sessionID: msg.sessionID,
           channelType: channelInfo.type,
           chatId: channelInfo.chatId,

--- a/packages/synergy/src/channel/provider/feishu/index.ts
+++ b/packages/synergy/src/channel/provider/feishu/index.ts
@@ -673,6 +673,7 @@ export class FeishuProvider implements ChannelTypes.Provider<Config.ChannelFeish
       body: JSON.stringify({
         content: payload.content,
         msg_type: payload.msgType,
+        ...(account.config.replyInThread ? { reply_in_thread: true } : {}),
       }),
     })
 

--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -901,6 +901,7 @@ export namespace Cortex {
         sessionID: session.id,
         parentSessionID: delegation.parentSessionID,
         description: delegation.description,
+        parentMessageID: delegation.parentMessageID,
         status: delegation.status,
         startedAt: delegation.startedAt,
         completedAt: delegation.completedAt,
@@ -987,6 +988,7 @@ export namespace Cortex {
     id: string
     sessionID: string
     parentSessionID: string
+    parentMessageID: string
     description: string
     status: CortexTypes.TaskStatus
     startedAt: number
@@ -1016,6 +1018,23 @@ export namespace Cortex {
     const session = await Session.get(task.sessionID).catch(() => undefined)
     if (!session?.cortex || session.cortex.taskID !== task.id) return
     if (session.cortex.notifyParentOnComplete !== true) return
+    const parentSession = await Session.get(task.parentSessionID).catch(() => undefined)
+    const parentChannel = parentSession?.endpoint?.kind === "channel" ? parentSession.endpoint.channel : undefined
+    const parentMessage = await MessageV2.get({
+      sessionID: task.parentSessionID,
+      messageID: task.parentMessageID,
+    }).catch(() => undefined)
+    const parentRootID = parentMessage?.info.rootID ?? parentMessage?.info.id
+    const parentRoot = parentRootID
+      ? await MessageV2.get({ sessionID: task.parentSessionID, messageID: parentRootID }).catch(() => undefined)
+      : undefined
+    const channelReplyToMessageId =
+      parentRoot?.info.role === "user" &&
+      typeof parentRoot.info.metadata?.channelReplyToMessageId === "string" &&
+      parentRoot.info.metadata.channelReplyToMessageId.trim()
+        ? parentRoot.info.metadata.channelReplyToMessageId
+        : undefined
+    const replyToChannel = parentChannel?.type !== "app" && !!parentChannel?.accountId && !!channelReplyToMessageId
 
     const delivery = await SessionInbox.deliverUnique({
       sessionID: task.parentSessionID,
@@ -1023,7 +1042,11 @@ export namespace Cortex {
       mode: "steer",
       message: {
         role: "user",
-        metadata: { source: "cortex", sourceSessionID: task.sessionID },
+        metadata: {
+          source: "cortex",
+          sourceSessionID: task.sessionID,
+          ...(replyToChannel ? { channelPush: true, channelReply: true, channelReplyToMessageId } : {}),
+        },
         parts: [{ type: "text", text: notification }],
       },
     })

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -95,6 +95,33 @@ export namespace SessionInvoke {
   const ephemeralToolsByMessage = new Map<string, ToolResolver.EphemeralTool[]>()
   const maxOutputTokensByMessage = new Map<string, number>()
 
+  function channelDeliveryMetadata(messages: MessageV2.WithParts[], afterIndex: number) {
+    let channelPush = false
+    let channelReply = false
+    let channelReplyToMessageId: string | undefined
+    let replyAnchorConflict = false
+    for (let index = afterIndex + 1; index < messages.length; index++) {
+      const info = messages[index].info
+      if (info.role !== "user") continue
+      const metadata = info.metadata
+      if (metadata?.mailbox || metadata?.channelPush || metadata?.channelReply) channelPush = true
+      if (metadata?.channelReply) channelReply = true
+      const replyAnchor =
+        typeof metadata?.channelReplyToMessageId === "string" && metadata.channelReplyToMessageId.trim()
+          ? metadata.channelReplyToMessageId
+          : undefined
+      if (!replyAnchor) continue
+      if (channelReplyToMessageId && channelReplyToMessageId !== replyAnchor) replyAnchorConflict = true
+      else channelReplyToMessageId = replyAnchor
+    }
+    if (!channelPush) return undefined
+    return {
+      channelPush: true,
+      ...(channelReply ? { channelReply: true } : {}),
+      ...(channelReply && channelReplyToMessageId && !replyAnchorConflict ? { channelReplyToMessageId } : {}),
+    }
+  }
+
   async function commandRuntime() {
     return (await import("../command/command")).Command
   }
@@ -471,8 +498,7 @@ export namespace SessionInvoke {
         const maxSteps = agent.steps ?? Infinity
         const isLastStep = step >= maxSteps
 
-        const userMetadata = (R.metadata ?? undefined) as Record<string, unknown> | undefined
-        const channelPush = !!(userMetadata?.mailbox || userMetadata?.channelPush)
+        const deliveryMetadata = channelDeliveryMetadata(msgs, lastFinishedIndex)
         const toolDisplayByName = new Map<string, ToolDisplay>()
         const processor = SessionProcessor.create({
           assistantMessage: (await Session.updateMessage({
@@ -500,7 +526,7 @@ export namespace SessionInvoke {
               created: Date.now(),
             },
             sessionID,
-            ...(channelPush ? { metadata: { channelPush: true } } : {}),
+            ...(deliveryMetadata ? { metadata: deliveryMetadata } : {}),
           })) as MessageV2.Assistant,
           sessionID: sessionID,
           model,

--- a/packages/synergy/test/channel/feishu-provider.test.ts
+++ b/packages/synergy/test/channel/feishu-provider.test.ts
@@ -320,6 +320,47 @@ describe("filterInboundMessage", () => {
   })
 })
 
+describe("Feishu replies", () => {
+  test("requests a threaded reply when the account enables replyInThread", async () => {
+    const originalFetch = globalThis.fetch
+    let requestBody: Record<string, unknown> | undefined
+    globalThis.fetch = (async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return new Response(JSON.stringify({ code: 0, data: { message_id: "msg_reply" } }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    }) as typeof fetch
+
+    try {
+      const provider = new FeishuProvider()
+      const accounts = (
+        provider as unknown as {
+          accounts: Map<string, unknown>
+        }
+      ).accounts
+      accounts.set("acct_test", {
+        config: accountConfig({ replyInThread: true }),
+        channelConfig: {},
+        apiBase: "https://open.feishu.test/open-apis",
+        tokenCache: { token: "token_test", expiresAt: Date.now() + 120_000 },
+      })
+
+      await provider.replyMessage({
+        accountId: "acct_test",
+        messageId: "msg_topic_root",
+        parts: [{ type: "text", text: "Background work finished" }],
+      })
+
+      expect(requestBody).toMatchObject({
+        msg_type: "text",
+        reply_in_thread: true,
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
 describe("Feishu streaming merge", () => {
   test("keeps existing text when a non-prefix rewrite arrives", () => {
     expect(

--- a/packages/synergy/test/channel/outbound.test.ts
+++ b/packages/synergy/test/channel/outbound.test.ts
@@ -1,0 +1,251 @@
+import { expect, test } from "bun:test"
+import { Bus } from "../../src/bus"
+import { Channel } from "../../src/channel"
+import { ChannelOutbound } from "../../src/channel/outbound"
+import type { Provider } from "../../src/channel/types"
+import { Identifier } from "../../src/id/id"
+import { ScopeContext } from "../../src/scope/context"
+import { Session } from "../../src/session"
+import { SessionEndpoint } from "../../src/session/endpoint"
+import { MessageV2 } from "../../src/session/message-v2"
+import { tmpdir } from "../fixture/fixture"
+
+async function waitFor(check: () => boolean, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for channel delivery")
+    await Bun.sleep(10)
+  }
+}
+
+function provider(type: string, calls: { replies: string[]; pushes: string[] }): Provider {
+  return {
+    type,
+    async connect() {},
+    async replyMessage(input) {
+      calls.replies.push(input.messageId)
+      return { messageId: "reply_sent" }
+    },
+    async pushMessage(input) {
+      calls.pushes.push(input.chatId)
+      return { messageId: "push_sent" }
+    },
+    async addReaction() {},
+    createStreamingSession() {
+      return {
+        async start() {},
+        async update() {},
+        async updateToolProgress() {},
+        async close() {},
+        isActive: () => false,
+      }
+    },
+  }
+}
+
+async function completedAssistant(
+  sessionID: string,
+  text: string,
+  finish = "stop",
+  metadata: Record<string, unknown> = {
+    channelPush: true,
+    channelReply: true,
+    channelReplyToMessageId: "msg_topic_root",
+  },
+) {
+  const created = (await Session.updateMessage({
+    id: Identifier.ascending("message"),
+    role: "assistant",
+    parentID: Identifier.ascending("message"),
+    mode: "synergy",
+    agent: "synergy",
+    path: { cwd: ScopeContext.current.directory, root: ScopeContext.current.directory },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: "test-model",
+    providerID: "test-provider",
+    time: { created: Date.now() },
+    sessionID,
+    metadata,
+  } as MessageV2.Assistant)) as MessageV2.Assistant
+  await Session.updatePart({
+    id: Identifier.ascending("part"),
+    messageID: created.id,
+    sessionID,
+    type: "text",
+    text,
+  })
+  return (await Session.updateMessage({
+    ...created,
+    finish,
+    time: { ...created.time, completed: Date.now() },
+  })) as MessageV2.Assistant
+}
+
+test("replies async channel output to the persisted message anchor exactly once", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `outbound-reply-${crypto.randomUUID()}`
+      const calls = { replies: [] as string[], pushes: [] as string[] }
+      Channel.registerProvider(provider(type, calls))
+      const dispose = ChannelOutbound.init()
+      try {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type,
+            accountId: "acct_test",
+            chatId: "chat_test",
+          }),
+        })
+
+        const assistant = await completedAssistant(session.id, "Background work finished")
+        await waitFor(() => calls.replies.length > 0)
+        expect(calls.replies).toEqual(["msg_topic_root"])
+        expect(calls.pushes).toEqual([])
+
+        await Promise.all([
+          Bus.publish(MessageV2.Event.Updated, { info: assistant }),
+          Bus.publish(MessageV2.Event.Updated, { info: assistant }),
+        ])
+        await Bun.sleep(25)
+        expect(calls.replies).toEqual(["msg_topic_root"])
+      } finally {
+        dispose()
+      }
+    },
+  })
+})
+
+test("preserves proactive channel push delivery without a reply intent", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `outbound-push-${crypto.randomUUID()}`
+      const calls = { replies: [] as string[], pushes: [] as string[] }
+      Channel.registerProvider(provider(type, calls))
+      const dispose = ChannelOutbound.init()
+      try {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type,
+            accountId: "acct_test",
+            chatId: "chat_test",
+          }),
+        })
+
+        await completedAssistant(session.id, "Proactive update", "stop", { channelPush: true })
+        await waitFor(() => calls.pushes.length > 0)
+
+        expect(calls.pushes).toEqual(["chat_test"])
+        expect(calls.replies).toEqual([])
+      } finally {
+        dispose()
+      }
+    },
+  })
+})
+
+test("does not downgrade async channel output to a chat push without a reply anchor", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `outbound-no-anchor-${crypto.randomUUID()}`
+      const calls = { replies: [] as string[], pushes: [] as string[] }
+      Channel.registerProvider(provider(type, calls))
+      const dispose = ChannelOutbound.init()
+      try {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type,
+            accountId: "acct_test",
+            chatId: "chat_test",
+          }),
+        })
+
+        await completedAssistant(session.id, "Background work finished", "stop", {
+          channelPush: true,
+          channelReply: true,
+        })
+        expect(calls.replies).toEqual([])
+        await Bun.sleep(25)
+        expect(calls.pushes).toEqual([])
+      } finally {
+        dispose()
+      }
+    },
+  })
+})
+
+test("does not send non-terminal channel assistant steps", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `outbound-tool-step-${crypto.randomUUID()}`
+      const calls = { replies: [] as string[], pushes: [] as string[] }
+      Channel.registerProvider(provider(type, calls))
+      const dispose = ChannelOutbound.init()
+      try {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type,
+            accountId: "acct_test",
+            chatId: "chat_test",
+          }),
+        })
+
+        await completedAssistant(session.id, "Calling a tool", "tool-calls")
+        expect(calls.replies).toEqual([])
+        await Bun.sleep(25)
+        expect(calls.pushes).toEqual([])
+      } finally {
+        dispose()
+      }
+    },
+  })
+})
+
+test("uses the reply anchor carried by each assistant message", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `outbound-message-anchor-${crypto.randomUUID()}`
+      const calls = { replies: [] as string[], pushes: [] as string[] }
+      Channel.registerProvider(provider(type, calls))
+      const dispose = ChannelOutbound.init()
+      try {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type,
+            accountId: "acct_test",
+            chatId: "chat_test",
+          }),
+        })
+
+        await completedAssistant(session.id, "First background result", "stop", {
+          channelPush: true,
+          channelReply: true,
+          channelReplyToMessageId: "msg_first_topic",
+        })
+        await waitFor(() => calls.replies.length === 1)
+
+        await completedAssistant(session.id, "Second background result", "stop", {
+          channelPush: true,
+          channelReply: true,
+          channelReplyToMessageId: "msg_second_topic",
+        })
+        await waitFor(() => calls.replies.length === 2)
+
+        expect(calls.replies).toEqual(["msg_first_topic", "msg_second_topic"])
+        expect(calls.pushes).toEqual([])
+      } finally {
+        dispose()
+      }
+    },
+  })
+})

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -4,6 +4,7 @@ import { CortexTypes } from "../../src/cortex/types"
 import { Bus } from "../../src/bus"
 import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
+import { SessionEndpoint } from "../../src/session/endpoint"
 import { SessionInbox } from "../../src/session/inbox"
 import { SessionInvoke } from "../../src/session/invoke"
 import { SessionManager } from "../../src/session/manager"
@@ -1380,6 +1381,9 @@ describe.serial("Cortex", () => {
             expect(notificationText).not.toContain("completed")
             expect((await Session.get(task.sessionID)).cortex?.deliveryNotifiedAt).toBeNumber()
 
+            expect(notification?.message?.metadata?.channelPush).toBeUndefined()
+            expect(notification?.message?.metadata?.channelReply).toBeUndefined()
+
             await Cortex.reconcileParentNotifications()
 
             expect(await SessionInbox.list(parentSession.id)).toHaveLength(1)
@@ -1390,6 +1394,75 @@ describe.serial("Cortex", () => {
       })
     })
 
+    test("marks completion notifications for reply-capable external channel parents", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const originalInvokeInternal = SessionInvoke.invokeInternal
+          ;(SessionInvoke.invokeInternal as any) = mock(
+            async (input: Parameters<typeof SessionInvoke.invokeInternal>[0]) => {
+              return writeAssistantText(input.sessionID, "completed")
+            },
+          )
+          try {
+            const parentSession = await Session.create({
+              endpoint: SessionEndpoint.fromChannel({
+                type: "feishu",
+                accountId: "acct_test",
+                chatId: "chat_test",
+              }),
+            })
+            const rootID = Identifier.ascending("message")
+            await Session.updateMessage({
+              id: rootID,
+              role: "user",
+              sessionID: parentSession.id,
+              agent: "synergy",
+              model: { providerID: "test-provider", modelID: "test-model" },
+              isRoot: true,
+              rootID,
+              metadata: { channelReplyToMessageId: "msg_original_topic" },
+              time: { created: Date.now() - 1 },
+            })
+            const parentMessageID = Identifier.ascending("message")
+            await Session.updateMessage({
+              id: parentMessageID,
+              role: "assistant",
+              sessionID: parentSession.id,
+              parentID: rootID,
+              rootID,
+              mode: "synergy",
+              agent: "synergy",
+              path: { cwd: tmp.path, root: tmp.path },
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: "test-model",
+              providerID: "test-provider",
+              time: { created: Date.now() },
+            })
+            const task = await Cortex.launch({
+              description: "Notify channel parent",
+              prompt: "Do something",
+              agent: "developer",
+              parentSessionID: parentSession.id,
+              parentMessageID,
+              model: { providerID: "test-provider", modelID: "test-model" },
+            })
+
+            expect((await waitUntilCompleted(task.id))?.status).toBe("completed")
+            const notification = await waitForNotification(parentSession.id, task.id)
+
+            expect(notification?.message?.metadata?.source).toBe("cortex")
+            expect(notification?.message?.metadata?.channelPush).toBe(true)
+            expect(notification?.message?.metadata?.channelReply).toBe(true)
+            expect(notification?.message?.metadata?.channelReplyToMessageId).toBe("msg_original_topic")
+          } finally {
+            ;(SessionInvoke.invokeInternal as any) = originalInvokeInternal
+          }
+        },
+      })
+    })
     test("publishes the terminal task before an idle parent processes its completion notice", async () => {
       await using tmp = await tmpdir({ git: true })
       await ScopeContext.provide({

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -1367,6 +1367,201 @@ describe("SessionInvoke inbox boundaries", () => {
       if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
     }
   })
+
+  test("propagates channel delivery from a cortex steer through every continuation step", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    const assistantMetadata: Array<Record<string, unknown> | undefined> = []
+    const restore = installBasicLoopMocks({
+      onProcess: (_input, assistant, callIndex) => {
+        assistantMetadata.push(assistant.metadata)
+        return callIndex === 1 ? "continue" : "stop"
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          activeSessionID = session.id
+          const rootID = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: rootID,
+            role: "user",
+            sessionID: session.id,
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            isRoot: true,
+            rootID,
+            time: { created: Date.now() - 2 },
+            metadata: { channelReplyToMessageId: "msg_original_topic" },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: rootID,
+            sessionID: session.id,
+            type: "text",
+            text: "initial channel request",
+          })
+          await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "assistant",
+            sessionID: session.id,
+            parentID: rootID,
+            rootID,
+            mode: "synergy",
+            agent: "synergy",
+            path: { cwd: tmp.path, root: tmp.path },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: "test-model",
+            providerID: "test-provider",
+            time: { created: Date.now() - 1, completed: Date.now() - 1 },
+            finish: "stop",
+          })
+          await SessionInbox.deliverUnique({
+            sessionID: session.id,
+            deliveryKey: "cortex:test-channel-delivery",
+            mode: "steer",
+            message: {
+              role: "user",
+              metadata: {
+                source: "cortex",
+                sourceSessionID: "ses_child",
+                channelPush: true,
+                channelReply: true,
+                channelReplyToMessageId: "msg_original_topic",
+              },
+              parts: [{ type: "text", text: "background task completed" }],
+            },
+          })
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect(assistantMetadata).toHaveLength(2)
+          expect(assistantMetadata.every((metadata) => metadata?.channelPush === true)).toBe(true)
+          expect(assistantMetadata.every((metadata) => metadata?.channelReply === true)).toBe(true)
+          expect(
+            assistantMetadata.every((metadata) => metadata?.channelReplyToMessageId === "msg_original_topic"),
+          ).toBe(true)
+
+          const nextRootID = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: nextRootID,
+            role: "user",
+            sessionID: session.id,
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            isRoot: true,
+            rootID: nextRootID,
+            time: { created: Date.now() },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: nextRootID,
+            sessionID: session.id,
+            type: "text",
+            text: "unrelated later request",
+          })
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect(assistantMetadata).toHaveLength(3)
+          expect(assistantMetadata[2]?.channelPush).toBeUndefined()
+          expect(assistantMetadata[2]?.channelReply).toBeUndefined()
+          expect(assistantMetadata[2]?.channelReplyToMessageId).toBeUndefined()
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
+  test("fails closed when one continuation contains conflicting channel reply anchors", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let activeSessionID = ""
+    const assistantMetadata: Array<Record<string, unknown> | undefined> = []
+    const restore = installBasicLoopMocks({
+      onProcess: (_input, assistant) => {
+        assistantMetadata.push(assistant.metadata)
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const session = await Session.create({})
+          activeSessionID = session.id
+          const rootID = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: rootID,
+            role: "user",
+            sessionID: session.id,
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            isRoot: true,
+            rootID,
+            time: { created: Date.now() - 2 },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: rootID,
+            sessionID: session.id,
+            type: "text",
+            text: "initial channel request",
+          })
+          await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            role: "assistant",
+            sessionID: session.id,
+            parentID: rootID,
+            rootID,
+            mode: "synergy",
+            agent: "synergy",
+            path: { cwd: tmp.path, root: tmp.path },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: "test-model",
+            providerID: "test-provider",
+            time: { created: Date.now() - 1, completed: Date.now() - 1 },
+            finish: "stop",
+          })
+
+          for (const [index, channelReplyToMessageId] of ["msg_first_topic", "msg_second_topic"].entries()) {
+            await SessionInbox.deliverUnique({
+              sessionID: session.id,
+              deliveryKey: `cortex:test-channel-conflict:${index}`,
+              mode: "steer",
+              message: {
+                role: "user",
+                metadata: {
+                  source: "cortex",
+                  sourceSessionID: `ses_child_${index}`,
+                  channelPush: true,
+                  channelReply: true,
+                  channelReplyToMessageId,
+                },
+                parts: [{ type: "text", text: `background task ${index} completed` }],
+              },
+            })
+          }
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect(assistantMetadata).toHaveLength(1)
+          expect(assistantMetadata[0]?.channelPush).toBe(true)
+          expect(assistantMetadata[0]?.channelReply).toBe(true)
+          expect(assistantMetadata[0]?.channelReplyToMessageId).toBeUndefined()
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
 })
 
 describe("SessionInvoke coauthor reminder prompt", () => {


### PR DESCRIPTION
## Summary

- bind Channel reply targets to root user and terminal assistant message metadata instead of mutable session endpoint state
- propagate Cortex completion reply anchors through continuation steps while failing closed on missing or conflicting anchors
- support Feishu/Lark threaded replies with `replyInThread` and document the delivery contract

## Testing

- `bun test test/channel/outbound.test.ts test/channel/feishu-provider.test.ts`
- `bun test test/cortex/manager.test.ts test/session/invoke.test.ts`
- `bun run typecheck` (from `packages/synergy`)
- `bun run quality:quick`