### PR TITLE
fix(app): prevent composer crash during session navigation

### DIFF
--- a/packages/app/src/components/prompt-input/composer-document.ts
+++ b/packages/app/src/components/prompt-input/composer-document.ts
@@ -91,6 +91,7 @@ export class ComposerDocumentController {
   }
 
   completion(): ComposerCompletion | undefined {
+    if (this.#completions.size === 0) return undefined
     const snapshot = this.current()
     return this.#ordered()
       .map((entry) => this.#completions.get(entry.id))

--- a/packages/app/src/context/prompt/index.tsx
+++ b/packages/app/src/context/prompt/index.tsx
@@ -201,11 +201,13 @@ function createPromptSession(dir: string, id: string | undefined) {
     }),
   )
 
+  const current = createMemo(() => sanitizePrompt(store.prompt))
+
   return {
     ready,
-    current: createMemo(() => store.prompt),
+    current,
     cursor: createMemo(() => store.cursor),
-    dirty: createMemo(() => !isPromptEqual(store.prompt, DEFAULT_PROMPT)),
+    dirty: createMemo(() => !isPromptEqual(current(), DEFAULT_PROMPT)),
     context: {
       items: createMemo(() => store.context.items),
       add(item: ContextItem) {

--- a/packages/app/src/context/prompt/sanitize.ts
+++ b/packages/app/src/context/prompt/sanitize.ts
@@ -158,10 +158,10 @@ export function sanitizePromptValue(value: unknown): Record<string, unknown>[] {
 }
 
 export function sanitizePromptStateValue(value: unknown) {
-  if (!isRecord(value)) return value
+  const state = isRecord(value) ? value : {}
   return {
-    ...value,
-    prompt: sanitizePromptValue(value.prompt),
-    context: sanitizePromptContextValue(value.context),
+    ...state,
+    prompt: sanitizePromptValue(state.prompt),
+    context: sanitizePromptContextValue(state.context),
   }
 }

--- a/packages/app/test/components/prompt-input/composer-document.test.ts
+++ b/packages/app/test/components/prompt-input/composer-document.test.ts
@@ -19,6 +19,20 @@ function fixture(options?: { settleMs?: number; submitTimeoutMs?: number }) {
 }
 
 describe("ComposerDocumentController", () => {
+  test("does not read the document when no completion exists", () => {
+    let reads = 0
+    const controller = new ComposerDocumentController({
+      read: () => {
+        reads++
+        throw new Error("Prompt is unavailable during navigation")
+      },
+      applyEdits: () => undefined,
+    })
+
+    expect(controller.completion()).toBeUndefined()
+    expect(reads).toBe(0)
+  })
+
   test("settles the latest revision and aborts stale draft work", async () => {
     const { controller } = fixture()
     const calls: Array<{ revision: number; signal: AbortSignal }> = []

--- a/packages/app/test/context/prompt/sanitize.test.ts
+++ b/packages/app/test/context/prompt/sanitize.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, test } from "bun:test"
-import { sanitizePromptContextValue, sanitizePromptValue } from "../../../src/context/prompt/sanitize"
+import {
+  sanitizePromptContextValue,
+  sanitizePromptStateValue,
+  sanitizePromptValue,
+} from "../../../src/context/prompt/sanitize"
 
 describe("prompt sanitization", () => {
+  test("restores a valid prompt state when persisted data is missing", () => {
+    expect(sanitizePromptStateValue(undefined)).toEqual({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      context: { items: [] },
+    })
+    expect(sanitizePromptStateValue(null)).toEqual({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      context: { items: [] },
+    })
+  })
+
   test("removes legacy image parts and data URL attachments", () => {
     const prompt = sanitizePromptValue([
       { type: "text", content: "hello", start: 0, end: 5 },


### PR DESCRIPTION
## Summary

- avoid reading the composer document after navigation clears all completions
- restore a valid default prompt when persisted root state is missing or malformed
- keep prompt `current` and `dirty` projections on the same sanitized value

## Tests

- `bun test test/components/prompt-input/composer-document.test.ts test/context/prompt/sanitize.test.ts` (packages/app)
- `bun run test` (packages/app)
- `bun run typecheck` (packages/app)
- `bun run build` (packages/app)
- `bun run quality:quick`
- `bunx prettier --check packages/app/src/components/prompt-input/composer-document.ts packages/app/src/context/prompt/index.tsx packages/app/src/context/prompt/sanitize.ts packages/app/test/components/prompt-input/composer-document.test.ts packages/app/test/context/prompt/sanitize.test.ts`