### PR TITLE
fix(session): isolate lightweight call variants

### DIFF
--- a/.synergy/skill/integrate-llm/SKILL.md
+++ b/.synergy/skill/integrate-llm/SKILL.md
@@ -30,6 +30,7 @@ For every sessionless call:
 6. Bound input and output, treat tagged/untrusted content as data, and redact secrets before policy/classification calls.
 7. Parse and validate structured output with Zod or an equivalent explicit schema. Define whether timeout, unavailable model, malformed output, or provider error fails soft or propagates.
 8. Test model-role fallback, timeout/cancellation, stream disposal, parsing, redaction, and failure semantics without making a live provider call.
+9. Treat any `MessageV2.User.variant` on a reused source or root envelope as durable root-execution metadata. A `small: true` sessionless call must neither validate nor apply it; the call uses `ProviderTransform.smallOptions()` for its target model.
 
 A sessionless call does not create session history, Cortex progress, completion notices, or Experience lineage. Do not imply those properties in UI or events.
 
@@ -83,6 +84,7 @@ Treat streamed tool argument deltas as transport/progress data, not canonical to
 2. Run focused Agent protocol/worker, provider, session, Cortex, and permission tests, then typecheck and `quality:quick`.
 3. Update [LLM loop and compaction](../../../docs/architecture/llm-loop.md) when the shared call pipeline or path-selection contract changes.
 4. Update `add-agent` when a new internal-agent registration pattern or model-role rule emerges.
+5. Assert that `small: true` calls ignore both available and unavailable source-root variants: neither variant options nor `ProviderModelVariantUnavailableError` may reach the target-model call.
 
 ## Handoff
 

--- a/docs/architecture/llm-loop.md
+++ b/docs/architecture/llm-loop.md
@@ -37,6 +37,8 @@ Each outer iteration loads effective, canonicalized session history and finds th
 
 The loop never chooses a Cortex notification, workflow continuation, or other non-root message as the task owner.
 
+A root message's model and variant belong to that durable root execution and remain stable for its continuation and tool loop. Steer and `noReply` messages do not own an execution variant. Each new root independently resolves its model and then its variant; QuickSwitch or `modelOverride` changes apply to the next root. Non-small root execution remains strict for unavailable persisted variants.
+
 ## Inbox Drain Order
 
 For root `R`, each inner iteration follows two inbox gates:
@@ -87,6 +89,8 @@ Model capability metadata from catalogs such as models.dev describes what a mode
 `ProviderTransform.variants()` applies transport-specific rules for third-party services on Anthropic and OpenAI-compatible wiring. Kimi K3 models on direct Anthropic transport expose catalog-declared `low`, `high`, and `max` variants. `low` and `high` map to Anthropic `effort`; `max` omits `effort` because Kimi's service default is already `max` and the locked Anthropic SDK accepts only `low`, `medium`, or `high`. Selecting no variant likewise uses Kimi's server-side `max` default. Kimi K2.x models remain provider-managed and receive no automatic Anthropic thinking variants. MiniMax M2.x models on direct Anthropic transport likewise produce no variants because reasoning is always on. MiniMax M3 on direct Anthropic transport exposes only a `max` variant mapped to `thinking: { type: "adaptive" }`; without it, reasoning defaults to off. MiniMax models on direct OpenAI-compatible Chat transport receive no `reasoningEffort` variants because that endpoint does not support `reasoning_effort`.
 
 When a third-party transport case returns no automatic variants, a configured `role_variant` such as `max` is applied only if the resolved model exposes a same-named variant; otherwise the provider receives no generated option and uses its server-side reasoning default. User-defined model `variants` are merged after automatic defaults and can add or override named variants for individual models.
+
+A sessionless or internal lightweight call may reuse a source root user envelope for context and attribution, but `small: true` never consumes that envelope's durable variant. `SessionRootVariant.options()` returns `{}` before variant validation, so target-model options come from `ProviderTransform.smallOptions()` even when the source and target models match. Non-small root execution continues to validate and apply its persisted variant.
 
 ## Internal LLM Invocation Paths
 

--- a/packages/synergy/src/session/root-variant.ts
+++ b/packages/synergy/src/session/root-variant.ts
@@ -69,9 +69,10 @@ export namespace SessionRootVariant {
     small?: boolean
   }): Record<string, unknown> {
     if (!input.variant) return {}
+    // Lightweight internal calls use target-model small options, never durable root variants.
+    if (input.small) return {}
     const availableVariants = Object.keys(input.model.variants ?? {})
     assertAvailable({ variant: input.variant, model: input.model, availableVariants })
-    if (input.small) return {}
     return input.model.variants![input.variant]
   }
 

--- a/packages/synergy/test/session/input.test.ts
+++ b/packages/synergy/test/session/input.test.ts
@@ -186,6 +186,69 @@ describe("session root variants", () => {
       },
     })
   })
+  test("resolves variant independently against the model override after a model switch", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        model: "test-provider/model-a",
+        provider: {
+          "test-provider": {
+            name: "Test Provider",
+            npm: "@ai-sdk/openai-compatible",
+            env: [],
+            models: {
+              "model-a": {
+                name: "Model A",
+                tool_call: true,
+                limit: { context: 128_000, output: 4_096 },
+                variants: { high: { from: "model-a" } },
+              },
+              "model-b": {
+                name: "Model B",
+                tool_call: true,
+                limit: { context: 128_000, output: 4_096 },
+                variants: { high: { from: "model-b" } },
+              },
+            },
+            options: { apiKey: "test-key" },
+          },
+        },
+        agent: {
+          switch_agent: {
+            model: "test-provider/model-a",
+            mode: "primary",
+            defaultVariant: "high",
+          },
+        },
+      } as any,
+    })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const session = await Session.create({})
+        const firstRoot = await createUserMessage({
+          sessionID: session.id,
+          agent: "switch_agent",
+          model: { providerID: "test-provider", modelID: "model-a" },
+          parts: [{ type: "text", text: "first request" }],
+        })
+        expect(firstRoot.info.variant).toBe("high")
+
+        await Session.update(session.id, (draft) => {
+          draft.modelOverride = { providerID: "test-provider", modelID: "model-b" }
+        })
+
+        const secondRoot = await createUserMessage({
+          sessionID: session.id,
+          agent: "switch_agent",
+          parts: [{ type: "text", text: "request after model switch" }],
+        })
+        expect(secondRoot.info.model).toEqual({ providerID: "test-provider", modelID: "model-b" })
+        expect(secondRoot.info.variant).toBe("high")
+        expect(secondRoot.info.agent).toBe("switch_agent")
+      },
+    })
+  })
 })
 
 describe("session input attachment extraction", () => {

--- a/packages/synergy/test/session/llm-variant.test.ts
+++ b/packages/synergy/test/session/llm-variant.test.ts
@@ -94,15 +94,35 @@ describe("LLM root variant consumption", () => {
     })
   })
 
-  test("validates unavailable persisted variants before bypassing options for small calls", async () => {
+  test("bypasses variant validation and options for small calls even when the persisted variant is unavailable", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
       scope: await tmp.scope(),
       fn: async () => {
-        await expect(LLM.prepare(input("missing", true))).rejects.toMatchObject({
-          name: "ProviderModelVariantUnavailableError",
-          data: { variant: "missing" },
-        })
+        const prepared = await LLM.prepare(input("missing", true))
+        expect(prepared.params.options.rootVariantMarker).toBeUndefined()
+      },
+    })
+  })
+
+  test("bypasses variant options for small calls when the persisted variant is valid", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const prepared = await LLM.prepare(input("high", true))
+        expect(prepared.params.options.rootVariantMarker).toBeUndefined()
+      },
+    })
+  })
+
+  test("applies variant options for a valid persisted variant on a non-small root", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const prepared = await LLM.prepare(input("high"))
+        expect(prepared.params.options.rootVariantMarker).toBe("high")
       },
     })
   })


### PR DESCRIPTION
## Summary

- keep persisted model variants scoped to durable root execution
- make `small: true` title, summary, and sessionless calls ignore source-root variants and use target-model small options
- cover unavailable/available small-call variants, strict non-small roots, model switching, and existing steer behavior
- document the ownership rule in the LLM architecture and internal-call workflow

## Verification

- `bun test test/session/llm-variant.test.ts test/session/input.test.ts test/session/inbox.test.ts`
- `bun run quality:quick`

## Compatibility

- no API, SDK, schema, config, or persistence migration changes
- non-small root execution continues to validate unavailable persisted variants strictly