### PR TITLE
fix(cli): support standalone upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ curl -fsSL https://raw.githubusercontent.com/SII-Holos/synergy/main/install | ba
 
 The CLI installer places the runtime, Web UI, and schema assets under `~/.synergy/`. It does not install the Electron Desktop app. After installation, run `synergy` directly from any directory.
 
+Upgrade an installed CLI runtime with `synergy upgrade`, or run `synergy upgrade <version>` to select a specific release.
+
 Desktop Browser presentation includes Electron's Chromium. For headless Browser tools used directly by the CLI/server, run `synergy browser install` to install verified managed Chromium and `synergy browser doctor` to diagnose discovery and launch readiness. On Linux, installation also ensures the Playwright-pinned system libraries are present; use `--no-deps` to skip that step or `synergy browser install-deps` to rerun it independently. You can instead set `CHROMIUM_PATH` to a separately installed executable.
 
 Configure a model provider, start the background runtime, and open the Web client:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -218,6 +218,8 @@ Local source builds do not have signed release manifests; use an installed relea
 | `synergy uninstall`        | Remove the installed product after confirmation/options                                    |
 | `synergy generate`         | Generate supported artifacts used by development/release workflows                         |
 
+`synergy upgrade` preserves the detected installation channel. Package-manager installations use their owning manager, Desktop installations defer to the Desktop updater, and standalone CLI installations with the binary at `~/.synergy/bin/synergy` rerun the official installer for the requested release. Override detection with `--method <npm|yarn|pnpm|bun|brew|desktop|standalone>`. If the installation method cannot be determined, the command stops with recovery guidance instead of attempting an unknown upgrade method.
+
 `debug` and migration commands are maintainer-oriented. Prefer stable product commands and APIs for application integrations.
 
 ## Plugins

--- a/install
+++ b/install
@@ -90,13 +90,35 @@ has_complete_bundle() {
     has_bundled_assets && has_required_sandbox_asset
 }
 
+install_bin_contents() {
+    local bundle_bin="$1"
+    local source name destination staged
+
+    for source in "$bundle_bin"/* "$bundle_bin"/.[!.]* "$bundle_bin"/..?*; do
+        [ -e "$source" ] || [ -L "$source" ] || continue
+        name=$(basename "$source")
+        destination="$INSTALL_DIR/$name"
+
+        if [ -d "$source" ]; then
+            mkdir -p "$destination"
+            cp -R "$source/." "$destination/"
+            continue
+        fi
+
+        staged="$INSTALL_DIR/.${name}.install.$$"
+        rm -f "$staged"
+        cp -P "$source" "$staged"
+        mv -f "$staged" "$destination"
+    done
+}
+
 install_bundle_contents() {
     local bundle_root="$1"
 
     mkdir -p "$ROOT_DIR" "$INSTALL_DIR" "$ROOT_DIR/schema"
 
     if [ -d "$bundle_root/bin" ]; then
-        cp -R "$bundle_root/bin/." "$INSTALL_DIR/"
+        install_bin_contents "$bundle_root/bin"
     fi
 
     if [ -d "$bundle_root/app" ]; then

--- a/packages/synergy/src/cli/cmd/uninstall.ts
+++ b/packages/synergy/src/cli/cmd/uninstall.ts
@@ -154,7 +154,7 @@ async function showRemovalSummary(targets: RemovalTargets, method: Installation.
     return
   }
 
-  if (method !== "unknown") {
+  if (method !== "unknown" && method !== "standalone") {
     const cmds: Record<string, string> = {
       npm: "npm uninstall -g @ericsanchezok/synergy",
       pnpm: "pnpm uninstall -g @ericsanchezok/synergy",
@@ -227,7 +227,7 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
     }
   }
 
-  if (method !== "unknown" && method !== "desktop") {
+  if (method !== "unknown" && method !== "desktop" && method !== "standalone") {
     const cmds: Record<string, string[]> = {
       npm: ["npm", "uninstall", "-g", "@ericsanchezok/synergy"],
       pnpm: ["pnpm", "uninstall", "-g", "@ericsanchezok/synergy"],

--- a/packages/synergy/src/cli/cmd/upgrade.ts
+++ b/packages/synergy/src/cli/cmd/upgrade.ts
@@ -16,7 +16,7 @@ export const UpgradeCommand = {
         alias: "m",
         describe: "installation method to use",
         type: "string",
-        choices: ["npm", "yarn", "pnpm", "bun", "brew", "desktop"],
+        choices: ["npm", "yarn", "pnpm", "bun", "brew", "desktop", "standalone"],
       })
   },
   handler: async (args: { target?: string; method?: string }) => {
@@ -27,19 +27,10 @@ export const UpgradeCommand = {
     const detectedMethod = await Installation.method()
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`synergy is installed to ${process.execPath} and may be managed by a package manager`)
-      const install = await prompts.select({
-        message: "Install anyways?",
-        options: [
-          { label: "Yes", value: true },
-          { label: "No", value: false },
-        ],
-        initialValue: false,
-      })
-      if (!install) {
-        prompts.outro("Done")
-        return
-      }
+      prompts.log.error(`Unable to determine how ${process.execPath} was installed.`)
+      prompts.log.info("Reinstall with the official installer or pass a supported --method option.")
+      prompts.outro("Done")
+      return
     }
     prompts.log.info("Using method: " + method)
     if (method === "desktop") {
@@ -52,7 +43,7 @@ export const UpgradeCommand = {
       prompts.outro("Done")
       return
     }
-    const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest()
+    const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest(method)
 
     if (Installation.VERSION === target) {
       prompts.log.warn(`synergy upgrade skipped: ${target} is already installed`)

--- a/packages/synergy/src/global/installation.ts
+++ b/packages/synergy/src/global/installation.ts
@@ -4,6 +4,7 @@ import z from "zod"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import fs from "fs/promises"
 import { DesktopInstallation } from "./desktop-installation"
+import { StandaloneInstallation } from "./standalone-installation"
 import { Log } from "../util/log"
 import { Flag } from "../flag/flag"
 
@@ -17,7 +18,7 @@ export namespace Installation {
   const log = Log.create({ service: "installation" })
   const NPM_REGISTRY = "https://registry.npmjs.org"
 
-  export type Method = "npm" | "yarn" | "pnpm" | "bun" | "brew" | "desktop" | "unknown"
+  export type Method = "npm" | "yarn" | "pnpm" | "bun" | "brew" | "desktop" | "standalone" | "unknown"
 
   export const Event = {
     Updated: BusEvent.define(
@@ -60,12 +61,23 @@ export namespace Installation {
   }
 
   export const detectDesktopInstall = DesktopInstallation.detectDesktopInstall
+  export const detectStandaloneInstall = StandaloneInstallation.detectStandaloneInstall
 
   export async function method(): Promise<Method> {
     const execPath = process.execPath
     const realExecPath = await fs.realpath(execPath).catch(() => execPath)
     if (DesktopInstallation.isRuntimePath(process.platform, realExecPath)) {
       return "desktop"
+    }
+    if (
+      StandaloneInstallation.detectStandaloneInstall({
+        platform: process.platform,
+        execPath,
+        realExecPath,
+        env: process.env,
+      })
+    ) {
+      return "standalone"
     }
 
     const exec = execPath.toLowerCase()
@@ -130,6 +142,25 @@ export namespace Installation {
   }
 
   export async function upgrade(method: Method, target: string) {
+    if (method === "standalone") {
+      const realExecPath = await fs.realpath(process.execPath).catch(() => process.execPath)
+      const result = await StandaloneInstallation.upgrade({
+        target,
+        context: {
+          platform: process.platform,
+          execPath: process.execPath,
+          realExecPath,
+          env: process.env,
+        },
+      })
+      log.info("upgraded", { method, target, stdout: result.stdout, stderr: result.stderr })
+      if (result.exitCode !== 0) {
+        throw new UpgradeFailedError({ stderr: result.stderr || result.stdout })
+      }
+      await $`${process.execPath} --version`.nothrow().quiet().text()
+      return
+    }
+
     let cmd
     switch (method) {
       case "npm":

--- a/packages/synergy/src/global/standalone-installation.ts
+++ b/packages/synergy/src/global/standalone-installation.ts
@@ -1,0 +1,95 @@
+import path from "path"
+
+export namespace StandaloneInstallation {
+  export interface Context {
+    platform: NodeJS.Platform
+    execPath: string
+    realExecPath: string
+    env?: NodeJS.ProcessEnv
+  }
+
+  export interface InstallerInvocation {
+    command: string[]
+    env: NodeJS.ProcessEnv
+    stdin: string
+  }
+
+  export interface UpgradeResult {
+    exitCode: number
+    stdout: string
+    stderr: string
+  }
+
+  export interface Dependencies {
+    fetch(url: string): Promise<Response>
+    run(invocation: InstallerInvocation): Promise<UpgradeResult>
+  }
+
+  export interface UpgradeOptions {
+    target: string
+    context: Context
+  }
+
+  const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+
+  export function installationHome(context: Context) {
+    const pathModule = context.platform === "win32" ? path.win32 : path.posix
+    const executable = pathModule.basename(context.realExecPath).toLowerCase()
+    const expectedExecutable = context.platform === "win32" ? "synergy.exe" : "synergy"
+    if (executable !== expectedExecutable) return null
+
+    const binDirectory = pathModule.dirname(context.realExecPath)
+    if (pathModule.basename(binDirectory).toLowerCase() !== "bin") return null
+
+    const installationRoot = pathModule.dirname(binDirectory)
+    if (pathModule.basename(installationRoot).toLowerCase() !== ".synergy") return null
+    return pathModule.dirname(installationRoot)
+  }
+
+  export function detectStandaloneInstall(context: Context) {
+    return installationHome(context) !== null
+  }
+
+  export async function upgrade(options: UpgradeOptions, dependencies: Dependencies = defaultDependencies) {
+    if (!VERSION_PATTERN.test(options.target)) {
+      throw new Error(`Invalid Synergy version: ${options.target}`)
+    }
+
+    const home = installationHome(options.context)
+    if (!home) {
+      throw new Error(`Synergy executable is not a standalone installation: ${options.context.realExecPath}`)
+    }
+
+    const url = "https://raw.githubusercontent.com/SII-Holos/synergy/main/install"
+    const response = await dependencies.fetch(url)
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download the Synergy ${options.target} installer: ${response.status} ${response.statusText}`,
+      )
+    }
+
+    return dependencies.run({
+      command: ["bash", "-s", "--", "--version", options.target, "--no-modify-path"],
+      env: { ...options.context.env, HOME: home },
+      stdin: await response.text(),
+    })
+  }
+
+  const defaultDependencies: Dependencies = {
+    fetch: (url) => fetch(url),
+    async run(invocation) {
+      const subprocess = Bun.spawn(invocation.command, {
+        env: invocation.env,
+        stdin: new Blob([invocation.stdin]),
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const [exitCode, stdout, stderr] = await Promise.all([
+        subprocess.exited,
+        new Response(subprocess.stdout).text(),
+        new Response(subprocess.stderr).text(),
+      ])
+      return { exitCode, stdout, stderr }
+    },
+  }
+}

--- a/packages/synergy/test/global/installation.test.ts
+++ b/packages/synergy/test/global/installation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Installation } from "../../src/global/installation"
+import { StandaloneInstallation } from "../../src/global/standalone-installation"
 
 const env = {}
 
@@ -60,5 +61,74 @@ describe("Installation desktop detection", () => {
     const err = await Installation.upgrade("desktop", "999.0.0").catch((error) => error)
     expect(err).toBeInstanceOf(Installation.DesktopManagedUpdateError)
     expect(err.data.message).toContain("Desktop updates are managed from the Synergy app")
+  })
+})
+
+describe("standalone installation", () => {
+  test("detects curl-installed runtime paths", () => {
+    expect(
+      StandaloneInstallation.detectStandaloneInstall({
+        platform: "linux",
+        execPath: "/root/.synergy/bin/synergy",
+        realExecPath: "/root/.synergy/bin/synergy",
+        env,
+      }),
+    ).toBe(true)
+
+    expect(
+      StandaloneInstallation.detectStandaloneInstall({
+        platform: "linux",
+        execPath: "/usr/local/bin/synergy",
+        realExecPath: "/opt/synergy/bin/synergy",
+        env,
+      }),
+    ).toBe(false)
+  })
+
+  test("reports curl-installed executables as standalone", async () => {
+    const originalExecPath = process.execPath
+    Object.defineProperty(process, "execPath", { value: "/root/.synergy/bin/synergy" })
+    try {
+      expect(await Installation.method()).toBe("standalone")
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath })
+    }
+  })
+
+  test("runs the current installer against the requested standalone version and home", async () => {
+    const fetched: string[] = []
+    const invocations: StandaloneInstallation.InstallerInvocation[] = []
+
+    const result = await StandaloneInstallation.upgrade(
+      {
+        target: "3.0.9",
+        context: {
+          platform: "linux",
+          execPath: "/root/.synergy/bin/synergy",
+          realExecPath: "/root/.synergy/bin/synergy",
+          env: { PATH: "/usr/bin" },
+        },
+      },
+      {
+        fetch: async (url) => {
+          fetched.push(String(url))
+          return new Response("#!/usr/bin/env bash\n")
+        },
+        run: async (invocation) => {
+          invocations.push(invocation)
+          return { exitCode: 0, stdout: "installed", stderr: "" }
+        },
+      },
+    )
+
+    expect(fetched).toEqual(["https://raw.githubusercontent.com/SII-Holos/synergy/main/install"])
+    expect(invocations).toEqual([
+      {
+        command: ["bash", "-s", "--", "--version", "3.0.9", "--no-modify-path"],
+        env: { PATH: "/usr/bin", HOME: "/root" },
+        stdin: "#!/usr/bin/env bash\n",
+      },
+    ])
+    expect(result).toEqual({ exitCode: 0, stdout: "installed", stderr: "" })
   })
 })

--- a/packages/synergy/test/server/update-route.test.ts
+++ b/packages/synergy/test/server/update-route.test.ts
@@ -143,28 +143,31 @@ describe("server update route", () => {
     expect(script).toContain("--registry=https://registry.npmjs.org")
   })
 
-  test("does not offer managed daemon updates for unsupported install methods", async () => {
-    process.env.SYNERGY_DAEMON = "1"
-    await writeManifest(["/usr/local/bin/synergy", "server", "--port", "4096"])
-    setServerUpdateWorkerControlsForTest({
-      latestVersion: async () => "999.0.0",
-      installMethod: async () => "unknown",
-      spawn(command) {
-        spawned.push(command)
-      },
-    })
+  test.each(["unknown", "standalone"] as const)(
+    "does not offer managed daemon updates for %s install methods",
+    async (installMethod) => {
+      process.env.SYNERGY_DAEMON = "1"
+      await writeManifest(["/usr/local/bin/synergy", "server", "--port", "4096"])
+      setServerUpdateWorkerControlsForTest({
+        latestVersion: async () => "999.0.0",
+        installMethod: async () => installMethod,
+        spawn(command) {
+          spawned.push(command)
+        },
+      })
 
-    const app = testApp()
-    const response = await app.request("/global/update/check", { method: "POST" })
+      const app = testApp()
+      const response = await app.request("/global/update/check", { method: "POST" })
 
-    expect(response.status).toBe(200)
-    const body = await response.json()
-    expect(body.capability).toBe("managed")
-    expect(body.phase).toBe("error")
-    expect(body.updateAvailable).toBe(true)
-    expect(body.error).toBe("Managed service install method cannot be updated from Web.")
-    expect(spawned).toEqual([])
-  })
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.capability).toBe("managed")
+      expect(body.phase).toBe("error")
+      expect(body.updateAvailable).toBe(true)
+      expect(body.error).toBe("Managed service install method cannot be updated from Web.")
+      expect(spawned).toEqual([])
+    },
+  )
 
   test("reports Desktop-managed updater guidance for desktop install methods", async () => {
     process.env.SYNERGY_DAEMON = "1"
@@ -194,30 +197,33 @@ describe("server update route", () => {
     expect(spawned).toEqual([])
   })
 
-  test("does not start a worker for unsupported managed install methods", async () => {
-    process.env.SYNERGY_DAEMON = "1"
-    await writeManifest(["/usr/local/bin/synergy", "server", "--port", "4096"])
-    setServerUpdateWorkerControlsForTest({
-      latestVersion: async () => "999.0.0",
-      installMethod: async () => "unknown",
-      spawn(command) {
-        spawned.push(command)
-      },
-    })
+  test.each(["unknown", "standalone"] as const)(
+    "does not start a worker for %s managed install methods",
+    async (installMethod) => {
+      process.env.SYNERGY_DAEMON = "1"
+      await writeManifest(["/usr/local/bin/synergy", "server", "--port", "4096"])
+      setServerUpdateWorkerControlsForTest({
+        latestVersion: async () => "999.0.0",
+        installMethod: async () => installMethod,
+        spawn(command) {
+          spawned.push(command)
+        },
+      })
 
-    const app = testApp()
-    const response = await app.request("/global/update/start", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ version: "999.0.0" }),
-    })
+      const app = testApp()
+      const response = await app.request("/global/update/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ version: "999.0.0" }),
+      })
 
-    expect(response.status).toBe(400)
-    const body = await response.json()
-    expect(body.phase).toBe("error")
-    expect(body.error).toBe("Managed service install method cannot be updated from Web.")
-    expect(spawned).toEqual([])
-  })
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.phase).toBe("error")
+      expect(body.error).toBe("Managed service install method cannot be updated from Web.")
+      expect(spawned).toEqual([])
+    },
+  )
 
   test("does not start a worker for Desktop-managed install methods", async () => {
     process.env.SYNERGY_DAEMON = "1"

--- a/test/script/install.test.ts
+++ b/test/script/install.test.ts
@@ -57,6 +57,7 @@ describe("CLI bundle installer", () => {
     ])
     await Promise.all([
       fs.writeFile(path.join(bundle, "bin", "synergy"), "runtime"),
+      fs.writeFile(path.join(bundle, "bin", ".runtime-metadata"), "metadata"),
       fs.writeFile(path.join(bundle, "app", "index.html"), "app"),
       fs.writeFile(path.join(bundle, "schema", "config.schema.json"), "{}"),
       fs.writeFile(path.join(bundle, "sandbox", "synergy-sandbox-linux"), "helper"),
@@ -77,9 +78,42 @@ describe("CLI bundle installer", () => {
 
     expect(result.exitCode).toBe(0)
     expect(await Bun.file(path.join(home, ".synergy", "sandbox", "synergy-sandbox-linux")).text()).toBe("helper")
+    expect(await Bun.file(path.join(home, ".synergy", "bin", ".runtime-metadata")).text()).toBe("metadata")
     expect(
       await Bun.file(path.join(home, ".synergy", "browser-runtime", "playwright-core", "package.json")).text(),
     ).toBe("{}")
+  })
+
+  test.skipIf(process.platform === "win32")("atomically replaces a running Synergy executable", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-install-running-"))
+    temporaryDirectories.push(root)
+    const home = path.join(root, "home")
+    const bundle = path.join(root, "bundle")
+    const installed = path.join(home, ".synergy", "bin", "synergy")
+    await Promise.all([
+      fs.mkdir(path.dirname(installed), { recursive: true }),
+      fs.mkdir(path.join(bundle, "bin"), { recursive: true }),
+    ])
+    await fs.copyFile("/bin/sleep", installed)
+    await fs.chmod(installed, 0o755)
+    const originalInode = (await fs.stat(installed)).ino
+    await fs.writeFile(path.join(bundle, "bin", "synergy"), "updated runtime")
+
+    const running = Bun.spawn([installed, "30"], { stdout: "ignore", stderr: "ignore" })
+    await Bun.sleep(50)
+    try {
+      const result = runInstallFunction('install_bundle_contents "$1"', [bundle], {
+        HOME: home,
+        SYNERGY_INSTALL_PLATFORM: process.platform === "linux" ? "Linux" : "Darwin",
+      })
+
+      expect(result.exitCode).toBe(0)
+      expect(await Bun.file(installed).text()).toBe("updated runtime")
+      expect((await fs.stat(installed)).ino).not.toBe(originalInode)
+    } finally {
+      running.kill()
+      await running.exited
+    }
   })
 
   test("does not treat an existing Linux install without its sandbox helper as complete", async () => {


### PR DESCRIPTION
## Summary

- detect CLI runtimes installed at `~/.synergy/bin/synergy` as standalone installations and upgrade them through the official installer
- fail closed for unknown installation methods while keeping standalone installs out of package-manager, Desktop, and Web-managed update paths
- replace installed binary files atomically, preserve hidden `bin/` assets, and document the supported upgrade flow

## Root cause

The curl-installed runtime was reported as an unknown installation method, so `synergy upgrade` had no valid backend. Replacing the currently running executable through a direct recursive copy could also fail on platforms that prevent overwriting an active binary.

## Testing

- `bun test test/script/install.test.ts`
- `bun test test/global/installation.test.ts test/server/update-route.test.ts`
- `bash -n install`
- `git diff --check`
- `bun run quality:quick`