### PR TITLE
fix(browser): harden web runtime release boundaries

### DIFF
--- a/.synergy/skill/change-browser-runtime/SKILL.md
+++ b/.synergy/skill/change-browser-runtime/SKILL.md
@@ -24,6 +24,7 @@ description: Add, modify, or review Synergy Browser ownership, persisted page st
 8. Dispose live Browser state on session archive/delete and global shutdown; preserve profile, storage-state, download, annotation, and restored page-ID ownership.
 9. Keep Browser implementations out of the Agent worker runner's static dependency graph. Only serializable Browser tool definitions cross into the worker; callbacks, canonical sessions, Playwright/Chromium state, host signaling, native views, and WebRTC state remain Control Plane/tool-runtime owned.
 10. Attribute resource state by owner and page backend without exposing owner IDs. Retire the remote Host only after the broker reports no active canonical page; Performance aggregation must never close a page or stop the Host.
+11. Keep Browser viewer Origin authorization on explicit server CORS origins. Do not promote auto-detected LAN CORS origins or reverse-proxy forwarding headers into the viewer trust boundary. Origin checks supplement one-shot owner/page/role-bound tickets and never replace them.
 
 ## Verify
 
@@ -39,6 +40,8 @@ description: Add, modify, or review Synergy Browser ownership, persisted page st
 10. For resource-lifecycle changes, prove that an active page cancels idle Host retirement and report headless process coverage as partial when the driver cannot expose RSS.
 11. When Playwright imports or standalone packaging change, build the compiled runtime, copy the whole packaged runtime to a different directory, and run the packaged Playwright loader check there. Verify release validation, the curl installer, and Desktop packaging all retain the filesystem-backed Playwright Core sidecar.
 12. When Linux Browser installation changes, exercise dependency installation in each supported distribution family affected by the change. At minimum, test the oldest supported target image and confirm `browser doctor` names the independent repair command.
+13. When Browser viewer Origin policy changes, cover same-origin, loopback peers, explicitly configured CORS origins, forged forwarding headers, automatic LAN-origin exclusion, Host local-file semantics, and process-global test cleanup.
+14. When Browser Host packaging changes, keep Electron Builder executable names and manifest executable paths on one platform contract, then open each ZIP and prove the declared executable exists before hashing or signing.
 
 ## Handoff
 

--- a/bun.lock
+++ b/bun.lock
@@ -127,9 +127,11 @@
       },
       "devDependencies": {
         "@types/node": "catalog:",
+        "@types/unzipper": "0.10.11",
         "electron": "42.5.0",
         "electron-builder": "26.11.1",
         "typescript": "catalog:",
+        "unzipper": "^0.12.3",
       },
     },
     "packages/plugin": {
@@ -1569,7 +1571,7 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
-    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
+    "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -2695,7 +2697,7 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -3347,6 +3349,8 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "electron-builder/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "electron-updater/builder-util-runtime": ["builder-util-runtime@9.4.0", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-omkpaKbutPYqC0nwLEeGq540xND1YPhfVzwT6CFyCFzxhNDt/X+fykr17Yo3jxiuwI3zaAnY/1tKFoRN+FeHhg=="],
@@ -3383,9 +3387,15 @@
 
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "knip/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "mammoth/bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
     "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -3481,8 +3491,6 @@
 
     "prosemirror-tables/prosemirror-view": ["prosemirror-view@1.41.7", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w=="],
 
-    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
@@ -3505,8 +3513,6 @@
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
@@ -3514,8 +3520,6 @@
     "tree-sitter-bash/node-addon-api": ["node-addon-api@8.6.0", "", {}, "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "unzipper/bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
     "unzipper/fs-extra": ["fs-extra@11.3.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g=="],
 

--- a/docs/architecture/browser-runtime.md
+++ b/docs/architecture/browser-runtime.md
@@ -67,6 +67,8 @@ Signaling only pairs those peers. Media carries the live page and the WebRTC dat
 
 During page creation, the broker reservation and its one-shot Host ticket form a creation lease. The Host signaling socket may attach under that lease before the new page is committed as canonical session state. Viewer signaling still requires the committed active page, so pending Host construction cannot expose an uncommitted page to a Web client.
 
+Viewer signaling requires an Origin header. HTTP(S) viewers are accepted only when their Origin matches the backend request, both sides are loopback peers, or the Origin appears in the server-authorized viewer allowlist. Explicit server CORS origins populate that allowlist; the startup-snapshotted `SYNERGY_ALLOWED_ORIGINS` environment variable remains a compatibility source. Automatically detected LAN CORS origins and proxy forwarding headers do not authorize Browser viewer sockets. The Origin check supplements, but never replaces, the one-shot owner/page/role-bound viewer ticket.
+
 The Electron Host controller runs from a generated local file, so its WebSocket handshake may carry the exact `file://` Origin. Host signaling permits that local-file Origin or no Origin, rejects HTTP(S) page Origins, and always requires the one-shot owner/page/role-bound ticket.
 
 The registered socket from signaling `onOpen` remains the peer identity for later message and close events; transport adapters may expose a different wrapper object to each callback. Relaying against a callback-local wrapper would incorrectly discard valid viewer offers as stale.

--- a/docs/operations/desktop-release.md
+++ b/docs/operations/desktop-release.md
@@ -59,6 +59,7 @@ The product release also publishes the minimal remote Browser Host for every sup
 - the matching `.manifest.json.sig`
 
 Each manifest is Ed25519-signed and contains the exact Synergy version, Browser protocol version, SHA-256, byte size, release URL, and executable path. The standalone server downloads a Host only when WebRTC presentation is first required, verifies the embedded public key, signature, digest, version, and protocol, and atomically extracts it below `Global.Path.data/browser/host`. Desktop installations use their built-in broker and do not download this artifact for local native presentation.
+Manifest generation opens the completed ZIP before hashing or signing and fails unless the declared executable entry exists. The exact paths are `Synergy Browser Host.app/Contents/MacOS/Synergy Browser Host` on macOS, `Synergy Browser Host.exe` on Windows, and `synergy-browser-host` on Linux. Electron Builder executable names and manifest paths must continue to derive from this shared release contract.
 
 The same release also publishes signed Chromium installation metadata for `darwin-x64`, `darwin-arm64`, `win32-x64`, `linux-x64`, and `linux-arm64`:
 
@@ -150,5 +151,5 @@ Registry read-after-write checks use cache-busted, no-store requests. A successf
 - Confirm Windows does not expose internal runtime helper binaries through PATH
 - Confirm Linux provides both `/usr/bin/synergy-desktop` for the desktop shell and `/usr/bin/synergy` for the runtime CLI
 - Draft GitHub Release contains all expected recommended installer artifacts, portable artifacts, checksum, and updater metadata before finalize
-- Draft GitHub Release contains six Browser Host zips, six exact-version manifests, and six signatures; tampered zip/signature tests pass before finalize
+- Draft GitHub Release contains six Browser Host zips, six exact-version manifests, and six signatures; every manifest executable exists at its exact platform path inside the matching zip, and tampered zip/signature tests pass before finalize
 - Draft GitHub Release contains five exact-version Chromium manifests and five signatures for the supported standalone install targets; signature, target-substitution, and archive-tampering tests pass before finalize.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,6 +38,7 @@ synergy stop
 `start` runs the first-time configuration wizard in an interactive terminal when no config exists. `--non-interactive` skips first-run and Holos prompts. Existing services report config drift; stop and start again to install changed network settings into the service definition.
 
 The managed service defaults to `127.0.0.1:4096`. `--hostname`, `--port`, `--mdns`, and repeatable `--cors` override the corresponding `server` config for the installed service invocation.
+Each explicit `--cors` value authorizes both cross-origin HTTP requests and Browser viewer WebSocket handshakes from that exact HTTP(S) origin. Automatically detected LAN CORS origins and reverse-proxy forwarding headers do not authorize Browser viewer sockets, so pass the public Browser viewer Origin explicitly.
 
 `status --verbose` adds runtime-lock, health, process, listening-port, trace, and local process-registry information. `stop` manages only the installed background service; do not use it as a generic process killer for an unrelated foreground server.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -216,9 +216,13 @@ A Feishu/Lark account may also set `projectDir` to bind the account's sessions t
 
 ## Server Settings
 
-The `server` object supports `hostname`, `port`, `mdns`, and additional CORS origins. Explicit CLI network flags override configured values. The managed background service snapshots these values into its service definition, so restart the service after changing them.
+The `server` object supports `hostname`, `port`, `mdns`, and additional allowed origins through `cors`. Explicit CLI network flags override configured values. The managed background service snapshots these values into its service definition, so restart the service after changing them.
 
-Binding a server beyond loopback exposes it to other hosts. Configure CORS and the surrounding network boundary deliberately.
+Each explicit `server.cors` entry authorizes both ordinary cross-origin HTTP requests and Browser viewer WebSocket handshakes from that exact HTTP(S) origin. Automatically detected LAN CORS origins and reverse-proxy forwarding headers do not authorize Browser viewer sockets; configure the public Browser viewer Origin explicitly.
+
+`SYNERGY_ALLOWED_ORIGINS` is a comma-separated compatibility source for additional Browser viewer Origins. Its value is snapshotted when the server process starts, is read again after a restart, and does not add HTTP CORS response headers.
+
+Binding a server beyond loopback exposes it to other hosts. Configure allowed origins and the surrounding network boundary deliberately.
 
 ## Code Checks
 

--- a/packages/desktop/electron-builder.browser-host.json
+++ b/packages/desktop/electron-builder.browser-host.json
@@ -14,10 +14,12 @@
     "entitlementsInherit": "build/entitlements.mac.plist"
   },
   "win": {
+    "executableName": "Synergy Browser Host",
     "artifactName": "synergy-browser-host-win32-${arch}-${version}.zip",
     "target": [{ "target": "zip", "arch": ["x64", "arm64"] }]
   },
   "linux": {
+    "executableName": "synergy-browser-host",
     "artifactName": "synergy-browser-host-linux-${arch}-${version}.zip",
     "target": [{ "target": "zip", "arch": ["x64", "arm64"] }]
   }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -34,8 +34,10 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/unzipper": "0.10.11",
     "electron": "42.5.0",
     "electron-builder": "26.11.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "unzipper": "^0.12.3"
   }
 }

--- a/packages/desktop/script/browser-host-archive.ts
+++ b/packages/desktop/script/browser-host-archive.ts
@@ -1,0 +1,10 @@
+import unzipper from "unzipper"
+
+export async function assertBrowserHostArchive(data: Buffer, executable: string): Promise<void> {
+  const archive = await unzipper.Open.buffer(data)
+  const expected = executable.replace(/\\/g, "/")
+  const entries = new Set(archive.files.map((entry) => entry.path.replace(/\\/g, "/")))
+  if (!entries.has(expected)) {
+    throw new Error(`Browser Host archive does not contain its manifest executable: ${executable}`)
+  }
+}

--- a/packages/desktop/script/browser-host-manifest.ts
+++ b/packages/desktop/script/browser-host-manifest.ts
@@ -3,8 +3,10 @@ import { createHash, createPrivateKey, sign } from "node:crypto"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { BROWSER_PROTOCOL_VERSION } from "@ericsanchezok/synergy-browser"
+import { assertBrowserHostArchive } from "./browser-host-archive.js"
 import {
   browserHostArtifactName,
+  browserHostExecutablePath,
   browserHostManifestName,
   browserHostManifestSignatureName,
   type DesktopReleaseArch,
@@ -26,12 +28,8 @@ for (const arch of ["x64", "arm64"] satisfies DesktopReleaseArch[]) {
   const name = browserHostArtifactName(version, platform, arch)
   const filepath = path.join(releaseDir, name)
   const data = await fs.readFile(filepath)
-  const executable =
-    platform === "darwin"
-      ? "Synergy Browser Host.app/Contents/MacOS/Synergy Browser Host"
-      : platform === "win32"
-        ? "Synergy Browser Host.exe"
-        : "synergy-browser-host"
+  const executable = browserHostExecutablePath(platform)
+  await assertBrowserHostArchive(data, executable)
   const manifest = {
     version,
     protocolVersion: BROWSER_PROTOCOL_VERSION,

--- a/packages/desktop/src/release-assets.ts
+++ b/packages/desktop/src/release-assets.ts
@@ -60,6 +60,12 @@ export function browserHostArtifactName(
   return `synergy-browser-host-${platform}-${arch}-${version}.zip`
 }
 
+export function browserHostExecutablePath(platform: DesktopReleasePlatform): string {
+  if (platform === "darwin") return "Synergy Browser Host.app/Contents/MacOS/Synergy Browser Host"
+  if (platform === "win32") return "Synergy Browser Host.exe"
+  return "synergy-browser-host"
+}
+
 export function browserHostManifestName(
   version: string,
   platform: DesktopReleasePlatform,

--- a/packages/desktop/test/browser-host-archive.test.ts
+++ b/packages/desktop/test/browser-host-archive.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { assertBrowserHostArchive } from "../script/browser-host-archive.js"
+
+const archive = Buffer.from(
+  "UEsDBBQAAAAIAFCz+1z9EyfPBgAAAAQAAAAUAAAAc3luZXJneS1icm93c2VyLWhvc3TLyC8uAQBQSwECFAMUAAAACABQs/tc/RMnzwYAAAAEAAAAFAAAAAAAAAAAAAAAgAEAAAAAc3luZXJneS1icm93c2VyLWhvc3RQSwUGAAAAAAEAAQBCAAAAOAAAAAAA",
+  "base64",
+)
+
+describe("Browser Host release archive", () => {
+  test("contains the executable declared by its signed manifest", async () => {
+    await expect(assertBrowserHostArchive(archive, "synergy-browser-host")).resolves.toBeUndefined()
+  })
+
+  test("rejects a manifest executable absent from the archive", async () => {
+    await expect(assertBrowserHostArchive(archive, "wrong-browser-host")).rejects.toThrow(
+      "Browser Host archive does not contain its manifest executable",
+    )
+  })
+})

--- a/packages/desktop/test/packaging.test.ts
+++ b/packages/desktop/test/packaging.test.ts
@@ -34,6 +34,11 @@ interface ElectronBuilderConfig {
   }>
 }
 
+interface BrowserHostBuilderConfig {
+  win?: { executableName?: string }
+  linux?: { executableName?: string }
+}
+
 const temporaryDirectories: string[] = []
 
 afterEach(async () => {
@@ -104,6 +109,15 @@ describe("desktop packaging", () => {
     expect(config.nsis?.shortcutName).toBe("Synergy")
     expect(config.linux?.desktop?.entry?.Name).toBe("Synergy")
     expect(config.linux?.desktop?.entry?.StartupWMClass).toBe("synergy")
+  })
+
+  test("pins Browser Host executable names to the signed manifest contract", async () => {
+    const config = (await Bun.file(
+      new URL("../electron-builder.browser-host.json", import.meta.url),
+    ).json()) as BrowserHostBuilderConfig
+
+    expect(config.win?.executableName).toBe("Synergy Browser Host")
+    expect(config.linux?.executableName).toBe("synergy-browser-host")
   })
 
   test("configures installer hooks that expose the embedded runtime as synergy", async () => {

--- a/packages/desktop/test/release-assets.test.ts
+++ b/packages/desktop/test/release-assets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   browserHostArtifactName,
+  browserHostExecutablePath,
   browserHostManifestName,
   browserHostManifestSignatureName,
   chromiumManifestName,
@@ -54,6 +55,12 @@ describe("desktop release asset names", () => {
       "synergy-browser-host-linux-arm64-1.2.3.manifest.json.sig",
     )
     expect(expectedBrowserHostArtifacts("1.2.3")).toHaveLength(18)
+  })
+
+  test("keeps Browser Host executable paths aligned with packaged platform names", () => {
+    expect(browserHostExecutablePath("darwin")).toBe("Synergy Browser Host.app/Contents/MacOS/Synergy Browser Host")
+    expect(browserHostExecutablePath("win32")).toBe("Synergy Browser Host.exe")
+    expect(browserHostExecutablePath("linux")).toBe("synergy-browser-host")
   })
   test("names all supported signed Chromium manifests", () => {
     expect(chromiumManifestName("1.2.3", "darwin", "arm64")).toBe("synergy-chromium-darwin-arm64-1.2.3.manifest.json")

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2050,7 +2050,7 @@ export type ServerConfig = {
    */
   mdns?: boolean
   /**
-   * Additional domains to allow for CORS
+   * Additional origins allowed for CORS and Browser viewer WebSockets
    */
   cors?: Array<string>
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -26089,7 +26089,7 @@
             "type": "boolean"
           },
           "cors": {
-            "description": "Additional domains to allow for CORS",
+            "description": "Additional origins allowed for CORS and Browser viewer WebSockets",
             "type": "array",
             "items": {
               "type": "string"

--- a/packages/synergy/schema/config.schema.json
+++ b/packages/synergy/schema/config.schema.json
@@ -42,7 +42,7 @@
           "type": "boolean"
         },
         "cors": {
-          "description": "Additional domains to allow for CORS",
+          "description": "Additional origins allowed for CORS and Browser viewer WebSockets",
           "type": "array",
           "items": {
             "type": "string"

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -693,7 +693,7 @@ export const Server = z
     port: z.number().int().positive().optional().describe("Port to listen on"),
     hostname: z.string().optional().describe("Hostname to listen on"),
     mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
-    cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
+    cors: z.array(z.string()).optional().describe("Additional origins allowed for CORS and Browser viewer WebSockets"),
   })
   .strict()
   .meta({

--- a/packages/synergy/src/server/browser-route.ts
+++ b/packages/synergy/src/server/browser-route.ts
@@ -42,6 +42,8 @@ const MAX_BROKER_BYTES = 80 * 1024 * 1024
 const MAX_TICKET_BYTES = 16 * 1024
 const MAX_ANNOTATION_BYTES = 256 * 1024
 const MAX_DIAGNOSTICS_BYTES = 64 * 1024
+
+let browserViewerOrigins = new Set<string>()
 const payloadTooLargeResponse = {
   description: "Browser request payload is too large",
   content: { "application/json": { schema: resolver(BrowserAPIErrorSchema) } },
@@ -605,18 +607,37 @@ function assertWebSocketRequest(c: any, role: "viewer" | "host"): void {
     return
   }
   if (!origin) throw new Error("Browser viewer connections require an Origin header.")
-  if (origin === "file://") return
-  const requestURL = new URL(c.req.url)
-  if (origin === requestURL.origin) return
-  const parsed = new URL(origin)
-  if (isLoopback(parsed.hostname) && isLoopback(requestURL.hostname)) return
-  const allowed = new Set(
-    (process.env.SYNERGY_ALLOWED_ORIGINS ?? "")
-      .split(",")
-      .map((value) => value.trim())
-      .filter(Boolean),
-  )
-  if (!allowed.has(origin)) throw new Error(`Browser viewer Origin is not allowed: ${origin}`)
+  if (!browserViewerOriginAllowed({ origin, requestURL: c.req.url })) {
+    throw new Error(`Browser viewer Origin is not allowed: ${origin}`)
+  }
+}
+
+export function configureBrowserViewerOrigins(origins: Iterable<string>): void {
+  const compatibilityOrigins = (process.env.SYNERGY_ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+  browserViewerOrigins = new Set([...origins, ...compatibilityOrigins].map((origin) => origin.trim()).filter(Boolean))
+}
+
+export function browserViewerOriginAllowed(input: { origin: string; requestURL: string }): boolean {
+  if (input.origin === "file://") return true
+  const origin = httpOrigin(input.origin)
+  const request = httpOrigin(input.requestURL)
+  if (!origin || !request) return false
+  if (origin.origin === request.origin) return true
+  if (isLoopback(origin.hostname) && isLoopback(request.hostname)) return true
+  return browserViewerOrigins.has(origin.origin)
+}
+
+function httpOrigin(value: string): URL | undefined {
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return
+    return parsed
+  } catch {
+    return
+  }
 }
 
 export function browserHostOriginAllowed(origin: string | undefined): boolean {

--- a/packages/synergy/src/server/server.ts
+++ b/packages/synergy/src/server/server.ts
@@ -70,7 +70,7 @@ import { GlobalNavRoute } from "./global-nav"
 import { GitHubConfiguredRoute } from "./github-configured"
 import { ControlProfileRoute } from "./control-profile-route"
 import { SandboxReadinessRoute } from "./sandbox-readiness-route"
-import { BrowserRoute } from "./browser-route"
+import { BrowserRoute, configureBrowserViewerOrigins } from "./browser-route"
 import { BlueprintRoute } from "./blueprint"
 import { LatticeRoute } from "./lattice"
 import { WorkflowRoute } from "./workflow"
@@ -1601,6 +1601,7 @@ export namespace Server {
   export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
     const isExternalHost = opts.hostname !== "127.0.0.1" && opts.hostname !== "localhost" && opts.hostname !== "::1"
     _corsWhitelist = new Set([...(opts.cors ?? []), ...(isExternalHost ? lanOrigins() : [])])
+    configureBrowserViewerOrigins(opts.cors ?? [])
 
     const args = {
       hostname: opts.hostname,

--- a/packages/synergy/test/server/browser-route.test.ts
+++ b/packages/synergy/test/server/browser-route.test.ts
@@ -6,6 +6,8 @@ import {
   browserHostOriginAllowed,
   browserSignalingEventSocket,
   browserSignalingPageAvailable,
+  browserViewerOriginAllowed,
+  configureBrowserViewerOrigins,
 } from "../../src/server/browser-route"
 import { Server } from "../../src/server/server"
 import { Scope } from "../../src/scope"
@@ -16,6 +18,7 @@ afterEach(() => {
   restoreRuntime?.()
   restoreRuntime = undefined
   BrowserCommandService.clear()
+  configureBrowserViewerOrigins([])
 })
 
 function suspended(owner: BrowserOwner.Info): BrowserSession {
@@ -129,6 +132,28 @@ describe("BrowserRoute protocol v2", () => {
     expect(browserHostOriginAllowed("file://")).toBe(true)
     expect(browserHostOriginAllowed("http://127.0.0.1:3000")).toBe(false)
     expect(browserHostOriginAllowed("https://example.com")).toBe(false)
+  })
+
+  test("requires explicit authorization for non-matching viewer origins", () => {
+    configureBrowserViewerOrigins([])
+
+    expect(
+      browserViewerOriginAllowed({
+        origin: "https://attacker.example.com",
+        requestURL: "http://127.0.0.1:4096/home/browser/events",
+      }),
+    ).toBe(false)
+  })
+
+  test("uses configured server CORS origins for Browser viewer sockets", () => {
+    configureBrowserViewerOrigins(["https://browser.example.com"])
+
+    expect(
+      browserViewerOriginAllowed({
+        origin: "https://browser.example.com",
+        requestURL: "http://127.0.0.1:4096/home/browser/events",
+      }),
+    ).toBe(true)
   })
 
   test("keeps the registered socket identity across websocket event wrappers", () => {


### PR DESCRIPTION
## Summary

- authorize Browser viewer WebSocket Origins through same-origin, loopback peers, or explicit viewer allowlists while excluding auto-detected LAN Origins and proxy forwarding headers
- align Browser Host executable names and signed manifest paths across platforms
- reject Browser Host release archives whose declared executable is missing before hashing or signing
- document the Browser Origin and release archive contracts and add durable regression guidance

## Verification

- `bun test test/server/browser-route.test.ts` (from `packages/synergy`)
- `bun test test/browser-host-archive.test.ts test/packaging.test.ts test/release-assets.test.ts` (from `packages/desktop`)
- `bun run desktop:test` (from `packages/desktop`)
- `bun run release:test`
- `bun run typecheck` in `packages/synergy`, `packages/desktop`, and `packages/app`
- `bun test --cwd packages/app test/testing/browser-crypto-contract.test.ts`
- `bun run --cwd packages/app build && bun packages/app/script/private-http-smoke.ts`
- `bun run browser-host:build` (from `packages/desktop`)
- `bun run quality:quick`

## Review

- security review confirmed no remaining High or Medium findings after removing forwarded-header trust and automatic LAN Origin reuse
- compatibility, maintainability, and documentation reviews found no delivery blockers

## Notes

- full current-platform Browser Host distribution reached the platform signing step but was stopped after signing stalled; archive structure is covered by focused ZIP validation tests and the Browser Host build passed