### PR TITLE
fix(app): allow selecting file preview text

### DIFF
--- a/packages/app/src/components/file-workbench/styles.css
+++ b/packages/app/src/components/file-workbench/styles.css
@@ -230,6 +230,8 @@
   height: 100%;
   overflow: auto;
   padding: 24px clamp(20px, 5vw, 64px) 80px;
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 .file-markdown-preview > [data-component="markdown"] {

--- a/packages/app/test/components/file-workbench/selection.test.ts
+++ b/packages/app/test/components/file-workbench/selection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { chromium } from "playwright"
+
+const stylesUrl = new URL("../../../src/components/file-workbench/styles.css", import.meta.url)
+
+describe("file workbench preview selection", () => {
+  test("allows mouse selection inside a Markdown preview", async () => {
+    const browser = await chromium.launch({ headless: true })
+    try {
+      const page = await browser.newPage({ viewport: { width: 640, height: 240 } })
+      const styles = await Bun.file(stylesUrl).text()
+      await page.setContent(`
+        <style>
+          ${styles}
+        </style>
+        <div style="-webkit-user-select: none; user-select: none;">
+          <div class="file-markdown-preview">
+            <div data-component="markdown">
+              <p data-preview-text>Select this preview text</p>
+            </div>
+          </div>
+        </div>
+      `)
+
+      await page.locator("[data-preview-text]").click({ clickCount: 3 })
+
+      expect(await page.evaluate(() => window.getSelection()?.toString())).toContain("Select this preview text")
+    } finally {
+      await browser.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Restore selectable text in Files Markdown previews without changing the non-selectable application shell.
- Add Chromium mouse-selection regression coverage.

## Tests

- bun test test/components/file-workbench/selection.test.ts (from packages/app)
- bun run --cwd packages/app test
- bun run --cwd packages/app typecheck
- bun run --cwd packages/ui test
- bun run --cwd packages/app build
- bun run quality