### PR TITLE
fix(channel): deliver tool attachments in replies

### DIFF
--- a/docs/product/connections.md
+++ b/docs/product/connections.md
@@ -52,6 +52,8 @@ assistant it:
 5. records `channelOutboundSent: true` on the assistant after successful
    provider delivery so repeated terminal events do not send it again
 
+The delivered payload includes the terminal assistant text together with completed tool-generated attachments from the same task root. Foreground invocations send those attachments as a separate reply after the streaming response closes. Attachments marked `presentation.hidden` are excluded, repeated URLs are sent once, and only files materialized in Synergy's asset store are eligible for delivery. Assets larger than 25 MiB are skipped before provider upload. Image formats unsupported by Channel providers, such as SVG on Feishu/Lark, are delivered as files.
+
 ### Reply in Thread
 
 The Feishu/Lark provider supports per-account `replyInThread: true` in account

--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -22,6 +22,7 @@ import { ChannelCommand } from "./command"
 import { resolveChannelAccountInvocation } from "./model-selection"
 import { createStatusReactionController } from "./status-reactions"
 import { buildAssistantTranscript, resolveFinalResponseText } from "./response-text"
+import { replyChannelTaskAttachments } from "./outbound-parts"
 import {
   Info as InfoSchema,
   Status as StatusSchema,
@@ -580,6 +581,13 @@ export namespace Channel {
           // degraded fallback so the user still receives tool outputs.
           const fallbackText = hasError ? buildDegradedFallback(toolProgress) : undefined
           await streaming.close(responseText || fallbackText, hasError)
+          await replyChannelTaskAttachments({
+            provider,
+            accountId: ctx.accountId,
+            messageId: ctx.rootId ?? ctx.messageId,
+            sessionID,
+            terminal: result,
+          }).catch((err) => log.warn("channel task attachments delivery failed", { sessionID, error: err }))
 
           await reactionController.setDone()
         } catch (err) {

--- a/packages/synergy/src/channel/outbound-parts.ts
+++ b/packages/synergy/src/channel/outbound-parts.ts
@@ -1,0 +1,168 @@
+import path from "path"
+import { Asset } from "@/asset/asset"
+import { MessageV2 } from "@/session/message-v2"
+import { SessionHistory } from "@/session/history"
+import { Log } from "@/util/log"
+import type { OutboundPart, Provider } from "./types"
+
+const log = Log.create({ service: "channel.outbound-parts" })
+
+type ProjectInput = {
+  messages: MessageV2.WithParts[]
+  rootID: string
+  terminalMessageID: string
+  includeText: boolean
+}
+
+const MAX_CHANNEL_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+const CHANNEL_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/bmp",
+  "image/x-icon",
+  "image/tiff",
+  "image/heic",
+])
+
+export async function projectChannelTaskParts(input: ProjectInput): Promise<OutboundPart[]> {
+  const messages = input.messages.filter(
+    (message) => message.info.role === "assistant" && message.info.rootID === input.rootID,
+  )
+  const result: OutboundPart[] = []
+  const terminal = messages.find((message) => message.info.id === input.terminalMessageID)
+  if (input.includeText && terminal) {
+    const text = MessageV2.extractText(terminal.parts, { includeSynthetic: false })
+    if (text) result.push({ type: "text", text })
+  }
+
+  const seen = new Set<string>()
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (part.type !== "tool" || part.state.status !== "completed") continue
+      for (const attachment of part.state.attachments ?? []) {
+        if (attachment.presentation?.hidden || seen.has(attachment.url)) continue
+        seen.add(attachment.url)
+        const outbound = await projectAttachment(attachment)
+        if (outbound) result.push(outbound)
+      }
+    }
+  }
+  return result
+}
+
+export async function loadChannelTaskMessages(input: {
+  sessionID: string
+  rootID: string
+  terminal: MessageV2.WithParts
+}): Promise<MessageV2.WithParts[]> {
+  const messages = await SessionHistory.messages({ sessionID: input.sessionID })
+  const hydrated = messages.map((message) => (message.info.id === input.terminal.info.id ? input.terminal : message))
+  return MessageV2.deriveSemantics(hydrated)
+}
+
+export async function replyChannelTaskAttachments(input: {
+  provider: Provider
+  accountId: string
+  messageId: string
+  sessionID: string
+  terminal: MessageV2.WithParts
+}): Promise<boolean> {
+  if (input.terminal.info.role !== "assistant") return false
+  const rootID = input.terminal.info.rootID ?? input.terminal.info.parentID
+  const messages = await loadChannelTaskMessages({
+    sessionID: input.sessionID,
+    rootID,
+    terminal: input.terminal,
+  })
+  const parts = await projectChannelTaskParts({
+    messages,
+    rootID,
+    terminalMessageID: input.terminal.info.id,
+    includeText: false,
+  })
+  if (parts.length === 0) return false
+  await input.provider.replyMessage({
+    accountId: input.accountId,
+    messageId: input.messageId,
+    parts,
+  })
+  return true
+}
+
+async function projectAttachment(attachment: MessageV2.AttachmentPart): Promise<OutboundPart | undefined> {
+  const source = await resolveAttachmentSource(attachment)
+  if (!source) return undefined
+  return {
+    type: outboundType(attachment.mime),
+    ...source,
+    filename: attachment.filename ?? inferFilename(attachment),
+    contentType: attachment.mime || undefined,
+  }
+}
+
+async function resolveAttachmentSource(attachment: MessageV2.AttachmentPart): Promise<{ path: string } | undefined> {
+  if (!attachment.url.startsWith("asset://")) {
+    log.warn("channel attachment must use the asset store", {
+      attachmentID: attachment.id,
+      filename: attachment.filename,
+    })
+    return undefined
+  }
+
+  const assetID = assetIDFromUrl(attachment.url)
+  const assetPath = assetID ? Asset.resolvePath(assetID) : undefined
+  if (!assetPath) {
+    log.warn("channel attachment asset is unavailable", {
+      attachmentID: attachment.id,
+      filename: attachment.filename,
+    })
+    return undefined
+  }
+
+  const file = Bun.file(assetPath)
+  if (!(await file.exists())) {
+    log.warn("channel attachment asset is unavailable", {
+      attachmentID: attachment.id,
+      filename: attachment.filename,
+    })
+    return undefined
+  }
+  if (file.size > MAX_CHANNEL_ATTACHMENT_BYTES) {
+    log.warn("channel attachment exceeds the delivery size limit", {
+      attachmentID: attachment.id,
+      filename: attachment.filename,
+      size: file.size,
+      limit: MAX_CHANNEL_ATTACHMENT_BYTES,
+    })
+    return undefined
+  }
+  return { path: assetPath }
+}
+
+function assetIDFromUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.hostname}${parsed.pathname}` || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function outboundType(mime: string): Exclude<OutboundPart["type"], "text"> {
+  if (CHANNEL_IMAGE_MIME_TYPES.has(mime)) return "image"
+  if (mime.startsWith("audio/")) return "audio"
+  if (mime.startsWith("video/")) return "video"
+  return "file"
+}
+
+function inferFilename(attachment: MessageV2.AttachmentPart): string {
+  if (attachment.localPath) return path.basename(attachment.localPath)
+  try {
+    return path.basename(new URL(attachment.url).pathname) || "attachment"
+  } catch {
+    return "attachment"
+  }
+}

--- a/packages/synergy/src/channel/outbound.ts
+++ b/packages/synergy/src/channel/outbound.ts
@@ -6,6 +6,7 @@ import { SessionManager } from "@/session/manager"
 import { SessionProgress } from "@/session/progress"
 import { Session } from "@/session"
 import { Channel } from "."
+import { loadChannelTaskMessages, projectChannelTaskParts } from "./outbound-parts"
 
 const log = Log.create({ service: "channel.outbound" })
 
@@ -65,21 +66,32 @@ export namespace ChannelOutbound {
         return
       }
 
-      const text = MessageV2.extractText(current.parts, { includeSynthetic: false })
-      if (!text) return
-
       try {
+        const rootID = currentAssistant.rootID ?? currentAssistant.parentID
+        const messages = await loadChannelTaskMessages({
+          sessionID: msg.sessionID,
+          rootID,
+          terminal: current,
+        })
+        const parts = await projectChannelTaskParts({
+          messages,
+          rootID,
+          terminalMessageID: currentAssistant.id,
+          includeText: true,
+        })
+        if (parts.length === 0) return
+
         if (replyRequired && replyToMessageId) {
           await provider.replyMessage({
             accountId: channelInfo.accountId,
             messageId: replyToMessageId,
-            parts: [{ type: "text", text }],
+            parts,
           })
         } else {
           await provider.pushMessage({
             accountId: channelInfo.accountId,
             chatId: channelInfo.chatId,
-            parts: [{ type: "text", text }],
+            parts,
           })
         }
 

--- a/packages/synergy/test/channel/feishu-provider.test.ts
+++ b/packages/synergy/test/channel/feishu-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { Asset } from "../../src/asset/asset"
 import {
   FeishuProvider,
   filterInboundMessage,
@@ -354,6 +355,73 @@ describe("Feishu replies", () => {
       expect(requestBody).toMatchObject({
         msg_type: "text",
         reply_in_thread: true,
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("uploads SVG attachments as files instead of unsupported Feishu images", async () => {
+    const originalFetch = globalThis.fetch
+    const requests: Array<{ url: string; body: unknown }> = []
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input)
+      requests.push({ url, body: init?.body })
+      if (url.endsWith("/im/v1/files")) {
+        return new Response(JSON.stringify({ code: 0, data: { file_key: "file_svg" } }), {
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify({ code: 0, data: { message_id: "msg_reply" } }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    }) as typeof fetch
+
+    try {
+      const assetID = await Asset.write(
+        Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="32" height="24"></svg>'),
+        "image/svg+xml",
+        "meme.svg",
+      )
+      const provider = new FeishuProvider()
+      const accounts = (
+        provider as unknown as {
+          accounts: Map<string, unknown>
+        }
+      ).accounts
+      accounts.set("acct_test", {
+        config: accountConfig(),
+        channelConfig: {},
+        apiBase: "https://open.feishu.test/open-apis",
+        tokenCache: { token: "token_test", expiresAt: Date.now() + 120_000 },
+      })
+
+      await provider.replyMessage({
+        accountId: "acct_test",
+        messageId: "msg_topic_root",
+        parts: [
+          {
+            type: "file",
+            path: Asset.resolvePath(assetID),
+            filename: "meme.svg",
+            contentType: "image/svg+xml",
+          },
+        ],
+      })
+
+      expect(requests.map((request) => request.url)).toEqual([
+        "https://open.feishu.test/open-apis/im/v1/files",
+        "https://open.feishu.test/open-apis/im/v1/messages/msg_topic_root/reply",
+      ])
+      expect(requests.some((request) => request.url.endsWith("/im/v1/images"))).toBe(false)
+      const upload = requests[0]?.body
+      expect(upload).toBeInstanceOf(FormData)
+      expect((upload as FormData).get("file_type")).toBe("stream")
+      expect((upload as FormData).get("file_name")).toBe("meme.svg")
+      const reply = JSON.parse(String(requests[1]?.body)) as Record<string, unknown>
+      expect(reply).toMatchObject({
+        msg_type: "file",
+        content: JSON.stringify({ file_key: "file_svg" }),
       })
     } finally {
       globalThis.fetch = originalFetch

--- a/packages/synergy/test/channel/outbound-parts.test.ts
+++ b/packages/synergy/test/channel/outbound-parts.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from "bun:test"
+import { Asset } from "../../src/asset/asset"
+import { projectChannelTaskParts } from "../../src/channel/outbound-parts"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+function message(input: { id: string; rootID: string; parts: MessageV2.Part[]; finish?: string }): MessageV2.WithParts {
+  return {
+    info: {
+      id: input.id,
+      sessionID: "session_test",
+      role: "assistant",
+      parentID: input.rootID,
+      rootID: input.rootID,
+      mode: "synergy",
+      agent: "synergy",
+      path: { cwd: "/tmp", root: "/tmp" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: "test-model",
+      providerID: "test-provider",
+      time: { created: Date.now(), completed: Date.now() },
+      finish: input.finish ?? "stop",
+    },
+    parts: input.parts,
+  }
+}
+
+function attachment(input: {
+  id: string
+  messageID: string
+  url: string
+  mime: string
+  filename: string
+  hidden?: boolean
+  localPath?: string
+}): MessageV2.AttachmentPart {
+  return {
+    id: input.id,
+    sessionID: "session_test",
+    messageID: input.messageID,
+    type: "attachment",
+    url: input.url,
+    mime: input.mime,
+    filename: input.filename,
+    presentation: input.hidden ? { hidden: true } : { renderer: "image" },
+    ...(input.localPath ? { localPath: input.localPath } : {}),
+  }
+}
+
+function completedTool(input: {
+  id: string
+  messageID: string
+  attachments: MessageV2.AttachmentPart[]
+}): MessageV2.ToolPart {
+  return {
+    id: input.id,
+    sessionID: "session_test",
+    messageID: input.messageID,
+    type: "tool",
+    callID: `call_${input.id}`,
+    tool: "generate_meme",
+    state: {
+      status: "completed",
+      input: {},
+      output: "Generated media",
+      title: "Generate media",
+      metadata: {},
+      time: { start: Date.now(), end: Date.now() },
+      attachments: input.attachments,
+    },
+  }
+}
+
+describe("Channel task outbound parts", () => {
+  test("projects terminal text followed by tool attachments from earlier assistant steps", async () => {
+    const svgID = await Asset.write(
+      Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="32" height="24"></svg>'),
+      "image/svg+xml",
+      "meme.svg",
+    )
+    const pngID = await Asset.write(Buffer.from([137, 80, 78, 71]), "image/png", "preview.png")
+    const rootID = "message_root"
+    const toolMessageID = "message_tool"
+    const terminalMessageID = "message_terminal"
+    const svg = attachment({
+      id: "attachment_svg",
+      messageID: toolMessageID,
+      url: `asset://${svgID}`,
+      mime: "image/svg+xml",
+      filename: "meme.svg",
+    })
+    const png = attachment({
+      id: "attachment_png",
+      messageID: toolMessageID,
+      url: `asset://${pngID}`,
+      mime: "image/png",
+      filename: "preview.png",
+    })
+    const external = attachment({
+      id: "attachment_external",
+      messageID: toolMessageID,
+      url: "http://127.0.0.1/internal.png",
+      localPath: Asset.resolvePath(pngID),
+      mime: "image/png",
+      filename: "external.png",
+    })
+    const hidden = attachment({
+      id: "attachment_hidden",
+      messageID: toolMessageID,
+      url: "https://example.test/internal.png",
+      mime: "image/png",
+      filename: "internal.png",
+      hidden: true,
+    })
+    const messages = [
+      message({
+        id: toolMessageID,
+        rootID,
+        finish: "tool-calls",
+        parts: [
+          completedTool({
+            id: "tool_meme",
+            messageID: toolMessageID,
+            attachments: [svg, png, external, hidden, svg],
+          }),
+        ],
+      }),
+      message({
+        id: terminalMessageID,
+        rootID,
+        parts: [
+          {
+            id: "text_terminal",
+            sessionID: "session_test",
+            messageID: terminalMessageID,
+            type: "text",
+            text: "Meme generated",
+          },
+        ],
+      }),
+    ]
+
+    expect(
+      await projectChannelTaskParts({
+        messages,
+        rootID,
+        terminalMessageID,
+        includeText: true,
+      }),
+    ).toEqual([
+      { type: "text", text: "Meme generated" },
+      {
+        type: "file",
+        path: Asset.resolvePath(svgID),
+        filename: "meme.svg",
+        contentType: "image/svg+xml",
+      },
+      {
+        type: "image",
+        path: Asset.resolvePath(pngID),
+        filename: "preview.png",
+        contentType: "image/png",
+      },
+    ])
+  })
+
+  test("projects attachments without requiring terminal text", async () => {
+    const assetID = await Asset.write(Buffer.from([137, 80, 78, 71]), "image/png", "result.png")
+    const rootID = "message_root"
+    const toolMessageID = "message_tool"
+    const messages = [
+      message({
+        id: toolMessageID,
+        rootID,
+        finish: "tool-calls",
+        parts: [
+          completedTool({
+            id: "tool_image",
+            messageID: toolMessageID,
+            attachments: [
+              attachment({
+                id: "attachment_image",
+                messageID: toolMessageID,
+                url: `asset://${assetID}`,
+                mime: "image/png",
+                filename: "result.png",
+              }),
+            ],
+          }),
+        ],
+      }),
+    ]
+
+    expect(
+      await projectChannelTaskParts({
+        messages,
+        rootID,
+        terminalMessageID: "message_terminal",
+        includeText: false,
+      }),
+    ).toEqual([
+      {
+        type: "image",
+        path: Asset.resolvePath(assetID),
+        filename: "result.png",
+        contentType: "image/png",
+      },
+    ])
+  })
+
+  test("skips asset attachments larger than the Channel delivery limit", async () => {
+    const assetID = await Asset.write(Buffer.alloc(25 * 1024 * 1024 + 1), "application/octet-stream", "large.bin")
+    const rootID = "message_root"
+    const toolMessageID = "message_tool"
+
+    expect(
+      await projectChannelTaskParts({
+        messages: [
+          message({
+            id: toolMessageID,
+            rootID,
+            finish: "tool-calls",
+            parts: [
+              completedTool({
+                id: "tool_large_file",
+                messageID: toolMessageID,
+                attachments: [
+                  attachment({
+                    id: "attachment_large_file",
+                    messageID: toolMessageID,
+                    url: `asset://${assetID}`,
+                    mime: "application/octet-stream",
+                    filename: "large.bin",
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        rootID,
+        terminalMessageID: "message_terminal",
+        includeText: false,
+      }),
+    ).toEqual([])
+  })
+})

--- a/packages/synergy/test/channel/outbound.test.ts
+++ b/packages/synergy/test/channel/outbound.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "bun:test"
 import { Bus } from "../../src/bus"
 import { Channel } from "../../src/channel"
 import { ChannelOutbound } from "../../src/channel/outbound"
-import type { Provider } from "../../src/channel/types"
+import { replyChannelTaskAttachments } from "../../src/channel/outbound-parts"
+import type { OutboundPart, Provider } from "../../src/channel/types"
+import { Asset } from "../../src/asset/asset"
 import { Identifier } from "../../src/id/id"
 import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
@@ -18,16 +20,25 @@ async function waitFor(check: () => boolean, timeoutMs = 1_000) {
   }
 }
 
-function provider(type: string, calls: { replies: string[]; pushes: string[] }): Provider {
+type ProviderCalls = {
+  replies: string[]
+  pushes: string[]
+  replyParts?: OutboundPart[][]
+  pushParts?: OutboundPart[][]
+}
+
+function provider(type: string, calls: ProviderCalls): Provider {
   return {
     type,
     async connect() {},
     async replyMessage(input) {
       calls.replies.push(input.messageId)
+      calls.replyParts?.push(input.parts)
       return { messageId: "reply_sent" }
     },
     async pushMessage(input) {
       calls.pushes.push(input.chatId)
+      calls.pushParts?.push(input.parts)
       return { messageId: "push_sent" }
     },
     async addReaction() {},
@@ -52,6 +63,8 @@ async function completedAssistant(
     channelReply: true,
     channelReplyToMessageId: "msg_topic_root",
   },
+  rootID?: string,
+  withText = true,
 ) {
   const created = (await Session.updateMessage({
     id: Identifier.ascending("message"),
@@ -67,19 +80,60 @@ async function completedAssistant(
     time: { created: Date.now() },
     sessionID,
     metadata,
+    ...(rootID ? { rootID } : {}),
   } as MessageV2.Assistant)) as MessageV2.Assistant
-  await Session.updatePart({
-    id: Identifier.ascending("part"),
-    messageID: created.id,
-    sessionID,
-    type: "text",
-    text,
-  })
+  if (withText) {
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: created.id,
+      sessionID,
+      type: "text",
+      text,
+    })
+  }
   return (await Session.updateMessage({
     ...created,
     finish,
     time: { ...created.time, completed: Date.now() },
   })) as MessageV2.Assistant
+}
+
+async function completedToolAttachment(input: {
+  sessionID: string
+  rootID: string
+  assetID: string
+  mime: string
+  filename: string
+}) {
+  const toolAssistant = await completedAssistant(input.sessionID, "", "tool-calls", {}, input.rootID, false)
+  await Session.updatePart({
+    id: Identifier.ascending("part"),
+    messageID: toolAssistant.id,
+    sessionID: input.sessionID,
+    type: "tool",
+    callID: "call_generated_media",
+    tool: "generate_meme",
+    state: {
+      status: "completed",
+      input: {},
+      output: "Generated media",
+      title: "Generate media",
+      metadata: {},
+      time: { start: Date.now(), end: Date.now() },
+      attachments: [
+        {
+          id: Identifier.ascending("part"),
+          messageID: toolAssistant.id,
+          sessionID: input.sessionID,
+          type: "attachment",
+          mime: input.mime,
+          filename: input.filename,
+          url: `asset://${input.assetID}`,
+          presentation: { renderer: "image" },
+        },
+      ],
+    },
+  })
 }
 
 test("replies async channel output to the persisted message anchor exactly once", async () => {
@@ -246,6 +300,115 @@ test("uses the reply anchor carried by each assistant message", async () => {
       } finally {
         dispose()
       }
+    },
+  })
+})
+
+test("delivers tool attachments from earlier assistant steps in the same channel task exactly once", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `outbound-tool-attachment-${crypto.randomUUID()}`
+      const calls: ProviderCalls = { replies: [], pushes: [], replyParts: [], pushParts: [] }
+      Channel.registerProvider(provider(type, calls))
+      const dispose = ChannelOutbound.init()
+      try {
+        const session = await Session.create({
+          endpoint: SessionEndpoint.fromChannel({
+            type,
+            accountId: "acct_test",
+            chatId: "chat_test",
+          }),
+        })
+        const rootID = Identifier.ascending("message")
+        const assetID = await Asset.write(
+          Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="32" height="24"></svg>'),
+          "image/svg+xml",
+          "meme.svg",
+        )
+        await completedToolAttachment({
+          sessionID: session.id,
+          rootID,
+          assetID,
+          mime: "image/svg+xml",
+          filename: "meme.svg",
+        })
+
+        const terminal = await completedAssistant(session.id, "Meme generated", "stop", undefined, rootID)
+        await waitFor(() => (calls.replyParts?.length ?? 0) === 1)
+
+        expect(calls.replyParts).toEqual([
+          [
+            { type: "text", text: "Meme generated" },
+            {
+              type: "file",
+              path: Asset.resolvePath(assetID),
+              filename: "meme.svg",
+              contentType: "image/svg+xml",
+            },
+          ],
+        ])
+
+        await Promise.all([
+          Bus.publish(MessageV2.Event.Updated, { info: terminal }),
+          Bus.publish(MessageV2.Event.Updated, { info: terminal }),
+        ])
+        await Bun.sleep(25)
+        expect(calls.replyParts).toHaveLength(1)
+      } finally {
+        dispose()
+      }
+    },
+  })
+})
+
+test("replies with foreground task attachments as media-only parts on the original message", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const calls: ProviderCalls = { replies: [], pushes: [], replyParts: [], pushParts: [] }
+      const session = await Session.create({
+        endpoint: SessionEndpoint.fromChannel({
+          type: `foreground-tool-attachment-${crypto.randomUUID()}`,
+          accountId: "acct_test",
+          chatId: "chat_test",
+        }),
+      })
+      const rootID = Identifier.ascending("message")
+      const assetID = await Asset.write(Buffer.from([137, 80, 78, 71]), "image/png", "preview.png")
+      await completedToolAttachment({
+        sessionID: session.id,
+        rootID,
+        assetID,
+        mime: "image/png",
+        filename: "preview.png",
+      })
+      const terminalInfo = await completedAssistant(session.id, "Preview generated", "stop", {}, rootID)
+      const terminal = await MessageV2.get({ sessionID: session.id, messageID: terminalInfo.id })
+
+      expect(
+        await replyChannelTaskAttachments({
+          provider: provider("foreground-test", calls),
+          accountId: "acct_test",
+          messageId: "msg_original_root",
+          sessionID: session.id,
+          terminal,
+        }),
+      ).toBe(true)
+      expect(calls.replies).toEqual(["msg_original_root"])
+      expect(calls.pushes).toEqual([])
+      expect(calls.replyParts).toEqual([
+        [
+          {
+            type: "image",
+            path: Asset.resolvePath(assetID),
+            filename: "preview.png",
+            contentType: "image/png",
+          },
+        ],
+      ])
     },
   })
 })


### PR DESCRIPTION
## What does this PR do?

- Projects completed tool-generated attachments across every assistant step in the same Channel root task.
- Sends foreground attachments as a separate media reply after the streaming response closes.
- Sends asynchronous terminal text and attachments through the existing exactly-once Channel outbound bridge.
- Filters hidden attachments, deduplicates repeated URLs, accepts only asset-store sources up to 25 MiB, and sends unsupported Feishu image formats such as SVG as files.

## Why?

Tool attachments are often persisted on an earlier `tool-calls` assistant message while the terminal assistant contains only text. Channel delivery previously inspected only the terminal text, so generated images and files were omitted from both foreground and asynchronous replies.

## How was it tested?

- `bun test test/channel/outbound-parts.test.ts test/channel/outbound.test.ts test/channel/feishu-provider.test.ts test/channel/response-text.test.ts`
- `bun test test/channel (78 tests)`
- `bun run typecheck` from `packages/synergy`
- `bun run quality:quick`
- `git diff --check`

## Checklist

- [x] `bun run quality:quick` passes
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] New or moved tests live under the owning package's `test/` directory (or the root `test/` directory for repository tests)
- [x] `bun run package:check` passes if package exports, build output, release logic, or publishable packages changed
- [ ] `bun run workflow:check` passes if `.github/workflows/**`, GitHub Actions config, or CI helper scripts changed
- [ ] Browser capability or App bootstrap changes pass the browser crypto contract and private HTTP browser smoke
- [ ] `bun run secrets:check passes locally or CI Gitleaks covers the change if auth, provider, channel, config, or credential examples changed (local gitleaks unavailable; CI secret-scan required)`
- [ ] SDK regenerated if server routes or schemas changed (`./script/generate.ts`)
- [x] `bun run localization:check` passes if product copy, accessibility text, locale-sensitive formatting, or shared UI copy changed
- [x] Documentation, AGENTS, and .synergy help updated if developer workflow, quality tooling, commands, or contributor rules changed (canonical Channel behavior documentation updated)
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included