### PR TITLE
feat(channel): select workflows with slash commands

### DIFF
--- a/docs/product/connections.md
+++ b/docs/product/connections.md
@@ -28,6 +28,25 @@ Each Feishu/Lark account can set a default model and one of that model's exposed
 
 Channel sessions default to the `autonomous` control profile. An inbound message therefore receives either an allowed result or a clear denial; it never stalls on an approval dialog visible only in another client.
 
+### Slash Commands
+
+Channel sessions recognize slash commands as the first token of an inbound message. Commands are handled before agent invocation and set the conversation workflow mode.
+
+| Command                       | Aliases                               | Workflow       | Description                                                                                                                                |
+| ----------------------------- | ------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/chat [message]`             | —                                     | normal chat    | Exit the current workflow and return to ordinary conversation. Cancels Light Loop; other workflows are exited after confirming the switch. |
+| `/blueprint [request]`        | `/plan`                               | Plan           | Enter canonical Plan to author a Blueprint. If already in Plan mode the command is a no-op.                                                |
+| `/lightloop <task>`           | —                                     | Light Loop     | Keep working until the task passes independent review. Requires a task; reuse while active updates the instructions without restarting.    |
+| `/lattice [goal]`             | —                                     | Lattice (auto) | Decompose and execute a larger goal. Without a goal, Lattice is enabled and the next message provides the goal.                            |
+| `/status`                     | `/状态`                               | —              | Show the current conversation message count, creation time, and last-update time.                                                          |
+| `/model <providerID/modelID>` | —                                     | —              | Override the account-default model for this conversation.                                                                                  |
+| `/new`                        | `/reset`, `/重置`, `/清空`, `/新对话` | —              | Archive the current endpoint session and start a new conversation.                                                                         |
+| `/help`                       | `/commands`                           | —              | Show the command list.                                                                                                                     |
+
+When a workflow command carries a message parameter (`/chat hello`, `/blueprint design a CLI`, `/lightloop fix the build`, `/lattice plan the release`), the workflow is set and the parameter text is forwarded as the next user message in the same invocation.
+
+Only one workflow can be active at a time. Sending a workflow command while a different workflow is active replies with a prompt to `/chat` first rather than silently switching.
+
 ### Outbound Delivery Anchoring
 
 Outbound channel delivery uses a message-scoped reply anchor instead of a

--- a/packages/synergy/src/channel/command.ts
+++ b/packages/synergy/src/channel/command.ts
@@ -5,6 +5,10 @@ import { Log } from "../util/log"
 import { Session } from "../session"
 import { SessionEndpoint } from "../session/endpoint"
 import { Provider } from "../provider/provider"
+import { LatticeError } from "../lattice/error"
+import { BusyError } from "../session/error"
+import { SessionInteraction } from "../session/interaction"
+import { SessionWorkflowService, WorkflowConflictError } from "../session/workflow"
 
 export namespace ChannelCommand {
   const log = Log.create({ service: "channel.command" })
@@ -26,10 +30,12 @@ export namespace ChannelCommand {
     channelType: string
     accountId: string
     chatId: string
+    chatType?: "dm" | "group"
+    chatName?: string
     senderId?: string
+    senderName?: string
     scopeKey?: string
     messageId: string
-    senderName?: string
     mentions?: Array<{ key: string; id?: string; name?: string }>
     wasMentioned?: boolean
     remainder: string
@@ -43,14 +49,77 @@ export namespace ChannelCommand {
     execute: (ctx: Context) => Promise<Result>
   }
 
-  function endpointForContext(ctx: Pick<Context, "channelType" | "accountId" | "chatId" | "senderId" | "scopeKey">) {
+  function endpointForContext(
+    ctx: Pick<
+      Context,
+      "channelType" | "accountId" | "chatId" | "chatType" | "chatName" | "senderId" | "senderName" | "scopeKey"
+    >,
+  ) {
     return SessionEndpoint.fromChannel({
       type: ctx.channelType,
       accountId: ctx.accountId,
       chatId: ctx.chatId,
+      chatType: ctx.chatType,
+      chatName: ctx.chatName,
       senderId: ctx.senderId,
+      senderName: ctx.senderName,
       scopeKey: ctx.scopeKey,
+      createdAt: Date.now(),
     })
+  }
+
+  async function workflowSession(ctx: Context) {
+    return Session.getOrCreateForEndpoint(
+      endpointForContext(ctx),
+      undefined,
+      SessionInteraction.unattended(`channel:${ctx.channelType}`),
+    )
+  }
+
+  function workflowFailure(error: unknown): Result {
+    if (error instanceof BusyError) {
+      return {
+        action: "handled",
+        reply: "⚠️ Wait for the current response to finish before switching workflows.",
+      }
+    }
+    if (error instanceof WorkflowConflictError) {
+      return {
+        action: "handled",
+        reply: `⚠️ ${error.message} Use /chat first to exit the current workflow.`,
+      }
+    }
+    if (error instanceof LatticeError.StateConflict) {
+      return {
+        action: "handled",
+        reply: `⚠️ ${error.data.reason} Use /chat first to exit the current workflow.`,
+      }
+    }
+    throw error
+  }
+
+  async function setWorkflow(
+    ctx: Context,
+    input: SessionWorkflowService.SetInput,
+    confirmation: string,
+  ): Promise<Result> {
+    try {
+      const session = await workflowSession(ctx)
+      const current = session.workflow
+      const planAlreadyActive = input.kind === "plan" && current?.kind === "plan"
+      if (input.kind === "none" && current?.kind === "lightloop") {
+        await SessionWorkflowService.cancelLightloop(session.id)
+      } else if (input.kind === "lightloop" && current?.kind === "lightloop") {
+        await SessionWorkflowService.updateLightloopInstructions(session.id, input.instructions)
+      } else if (!planAlreadyActive) {
+        await SessionWorkflowService.set(session.id, input)
+      }
+    } catch (error) {
+      return workflowFailure(error)
+    }
+
+    if (ctx.remainder) return { action: "continue", text: ctx.remainder }
+    return { action: "handled", reply: confirmation }
   }
 
   const commands: CommandDef[] = [
@@ -69,6 +138,39 @@ export namespace ChannelCommand {
           reply: "✅ Started a new conversation. Send your next message when ready.",
         }
       },
+    },
+    {
+      name: "chat",
+      triggers: ["/chat"],
+      execute: (ctx) => setWorkflow(ctx, { kind: "none" }, "✅ Switched to normal chat."),
+    },
+    {
+      name: "blueprint",
+      triggers: ["/blueprint", "/plan"],
+      execute: (ctx) =>
+        setWorkflow(
+          ctx,
+          { kind: "plan" },
+          "✅ Blueprint planning enabled. Send the request you want turned into a Blueprint.",
+        ),
+    },
+    {
+      name: "lightloop",
+      triggers: ["/lightloop"],
+      async execute(ctx) {
+        if (!ctx.remainder) return { action: "handled", reply: "Usage: /lightloop <task>" }
+        return setWorkflow(ctx, { kind: "lightloop", instructions: ctx.remainder }, "✅ Light Loop enabled.")
+      },
+    },
+    {
+      name: "lattice",
+      triggers: ["/lattice"],
+      execute: (ctx) =>
+        setWorkflow(
+          ctx,
+          { kind: "lattice", mode: "auto" },
+          "✅ Lattice enabled. Send the goal you want decomposed and executed.",
+        ),
     },
     {
       name: "status",
@@ -131,6 +233,10 @@ export namespace ChannelCommand {
           action: "handled",
           reply: [
             "Available commands:",
+            "/chat [message] — use normal chat for this conversation",
+            "/blueprint [request] (/plan) — use Plan to author a Blueprint",
+            "/lightloop <task> — keep working until the task passes independent review",
+            "/lattice [goal] — decompose and execute a larger goal",
             "/model <providerID/modelID> — change the model for this conversation",
             "/new — start a new conversation",
             "/status — show the current conversation status",

--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -421,6 +421,8 @@ export namespace Channel {
           channelType: ctx.channelType,
           accountId: ctx.accountId,
           chatId: ctx.chatId,
+          chatType: ctx.chatType,
+          chatName: ctx.chatName,
           senderId: ctx.senderId,
           senderName: ctx.senderName,
           scopeKey: ctx.scopeKey,

--- a/packages/synergy/test/channel/command.test.ts
+++ b/packages/synergy/test/channel/command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { ChannelCommand } from "../../src/channel/command"
 import { Session } from "../../src/session"
 import { SessionEndpoint } from "../../src/session/endpoint"
+import { SessionManager } from "../../src/session/manager"
 import { ScopeContext } from "../../src/scope/context"
 import { tmpdir } from "../fixture/fixture"
 
@@ -10,8 +11,24 @@ describe("ChannelCommand", () => {
     channelType: "feishu",
     accountId: "acct_test",
     chatId: "chat_test",
+    chatType: "group" as const,
+    chatName: "Synergy Dev",
     senderId: "user_test",
+    senderName: "Maintainer",
     messageId: "msg_test",
+  }
+
+  async function workflowSession() {
+    const session = await Session.findForEndpoint(
+      SessionEndpoint.fromChannel({
+        type: baseContext.channelType,
+        accountId: baseContext.accountId,
+        chatId: baseContext.chatId,
+        senderId: baseContext.senderId,
+      }),
+    )
+    if (!session) throw new Error("expected channel session")
+    return session
   }
 
   test("handles bare /new with explicit confirmation", async () => {
@@ -79,6 +96,194 @@ describe("ChannelCommand", () => {
     })
   })
 
+  test("selects channel workflows and keeps command text as the user request", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const blueprint = await ChannelCommand.execute("/blueprint Design the release", baseContext)
+        expect(blueprint).toEqual({ action: "continue", text: "Design the release" })
+        expect((await workflowSession()).workflow).toEqual({ kind: "plan" })
+
+        const chat = await ChannelCommand.execute("/chat Continue normally", baseContext)
+        expect(chat).toEqual({ action: "continue", text: "Continue normally" })
+        expect((await workflowSession()).workflow).toBeUndefined()
+
+        const lightloop = await ChannelCommand.execute("/lightloop Fix the failing tests", baseContext)
+        expect(lightloop).toEqual({ action: "continue", text: "Fix the failing tests" })
+        expect((await workflowSession()).workflow).toEqual({
+          kind: "lightloop",
+          instructions: "Fix the failing tests",
+        })
+
+        await ChannelCommand.execute("/chat", baseContext)
+        const lattice = await ChannelCommand.execute("/lattice Ship the feature", baseContext)
+        expect(lattice).toEqual({ action: "continue", text: "Ship the feature" })
+        expect((await workflowSession()).workflow).toMatchObject({
+          kind: "lattice",
+          mode: "auto",
+        })
+      },
+    })
+  })
+
+  test("handles mention-prefixed workflow commands", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const result = await ChannelCommand.execute("@Synergy /lightloop 完成并验证修复", {
+          ...baseContext,
+          wasMentioned: true,
+          mentions: [{ key: "@_user_1", name: "Synergy" }],
+        })
+        expect(result).toEqual({ action: "continue", text: "完成并验证修复" })
+        expect((await workflowSession()).workflow).toEqual({
+          kind: "lightloop",
+          instructions: "完成并验证修复",
+        })
+      },
+    })
+  })
+
+  test("preserves channel metadata when a workflow command creates the session", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await ChannelCommand.execute("/blueprint", baseContext)
+        expect((await workflowSession()).endpoint).toMatchObject({
+          kind: "channel",
+          channel: {
+            type: "feishu",
+            accountId: "acct_test",
+            chatId: "chat_test",
+            chatType: "group",
+            chatName: "Synergy Dev",
+            senderId: "user_test",
+            senderName: "Maintainer",
+            createdAt: expect.any(Number),
+          },
+        })
+      },
+    })
+  })
+
+  test("uses Light Loop cancellation when switching to normal chat", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await ChannelCommand.execute("/lightloop Finish the task", baseContext)
+        const session = await workflowSession()
+        const lease = SessionManager.acquire(session.id)
+        expect(lease).toBeDefined()
+
+        try {
+          expect(await ChannelCommand.execute("/chat", baseContext)).toEqual({
+            action: "handled",
+            reply: "✅ Switched to normal chat.",
+          })
+          expect(lease?.signal.aborted).toBe(true)
+          expect((await Session.get(session.id)).workflow).toBeUndefined()
+        } finally {
+          await SessionManager.release(lease!, { requestNextWork: false })
+          SessionManager.unregisterRuntime(session.id)
+        }
+      },
+    })
+  })
+
+  test("updates the active Light Loop task but does not replace a different workflow", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await ChannelCommand.execute("/lightloop Original task", baseContext)
+        expect(await ChannelCommand.execute("/lightloop Revised task", baseContext)).toEqual({
+          action: "continue",
+          text: "Revised task",
+        })
+        expect((await workflowSession()).workflow).toEqual({
+          kind: "lightloop",
+          instructions: "Revised task",
+        })
+
+        await ChannelCommand.execute("/chat", baseContext)
+        await ChannelCommand.execute("/blueprint", baseContext)
+        expect(await ChannelCommand.execute("/lattice New goal", baseContext)).toEqual({
+          action: "handled",
+          reply:
+            "⚠️ Cannot enable Lattice while the plan workflow is active. Use /chat first to exit the current workflow.",
+        })
+        expect((await workflowSession()).workflow).toEqual({ kind: "plan" })
+      },
+    })
+  })
+
+  test("rejects workflow changes while the session is busy", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        await ChannelCommand.execute("/chat", baseContext)
+        const session = await workflowSession()
+        const lease = SessionManager.acquire(session.id)
+        expect(lease).toBeDefined()
+
+        try {
+          expect(await ChannelCommand.execute("/blueprint Design the release", baseContext)).toEqual({
+            action: "handled",
+            reply: "⚠️ Wait for the current response to finish before switching workflows.",
+          })
+          expect((await Session.get(session.id)).workflow).toBeUndefined()
+        } finally {
+          await SessionManager.release(lease!, { requestNextWork: false })
+          SessionManager.unregisterRuntime(session.id)
+        }
+      },
+    })
+  })
+
+  test("requires a task when enabling Light Loop", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        expect(await ChannelCommand.execute("/lightloop", baseContext)).toEqual({
+          action: "handled",
+          reply: "Usage: /lightloop <task>",
+        })
+      },
+    })
+  })
+
+  test("allows selecting a workflow before sending its first request", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        expect(await ChannelCommand.execute("/blueprint", baseContext)).toEqual({
+          action: "handled",
+          reply: "✅ Blueprint planning enabled. Send the request you want turned into a Blueprint.",
+        })
+        expect((await workflowSession()).workflow).toEqual({ kind: "plan" })
+
+        expect(await ChannelCommand.execute("/chat", baseContext)).toEqual({
+          action: "handled",
+          reply: "✅ Switched to normal chat.",
+        })
+        expect((await workflowSession()).workflow).toBeUndefined()
+
+        expect(await ChannelCommand.execute("/lattice", baseContext)).toEqual({
+          action: "handled",
+          reply: "✅ Lattice enabled. Send the goal you want decomposed and executed.",
+        })
+        expect((await workflowSession()).workflow).toMatchObject({ kind: "lattice", mode: "auto" })
+      },
+    })
+  })
+
   test("/help lists available commands", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({
@@ -89,6 +294,10 @@ describe("ChannelCommand", () => {
           action: "handled",
           reply: [
             "Available commands:",
+            "/chat [message] — use normal chat for this conversation",
+            "/blueprint [request] (/plan) — use Plan to author a Blueprint",
+            "/lightloop <task> — keep working until the task passes independent review",
+            "/lattice [goal] — decompose and execute a larger goal",
             "/model <providerID/modelID> — change the model for this conversation",
             "/new — start a new conversation",
             "/status — show the current conversation status",


### PR DESCRIPTION
## Summary

- add Channel slash commands for normal chat, Blueprint planning, Light Loop, and Lattice
- persist workflow selection through the existing session workflow service and reuse the stable Channel endpoint session
- preserve mention-prefixed Feishu commands, forward inline command text as the same user request, and document command behavior

## Commands

| Command                          | Behavior                                             |
| -------------------------------- | ---------------------------------------------------- |
| `/chat [message]`                | Exit the active session workflow and use normal chat |
| `/blueprint [request]` (`/plan`) | Enter Plan to author a Blueprint                     |
| `/lightloop <task>`              | Start or update Light Loop instructions              |
| `/lattice [goal]`                | Start Lattice in auto mode                           |

Workflow conflicts return a Channel reply instead of silently replacing the active workflow. `/chat` uses the dedicated Light Loop cancellation path when applicable.

This PR does not modify Feishu streaming cards, card callbacks, or card actions; those remain in #931's scope.

## Validation

- `bun test test/channel/command.test.ts` — 15 passed
- `bun test:changed` — 2,853 passed, 1 unrelated OOM test skipped, 0 failed
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run skill:check`
- `bun run package-guide:check`
- `bun run test-layout:check`
- `bun run package:check`
- `bun run quality:quick`

Closes #930