### PR TITLE
fix(frontend): keep expanded todos scrollable

### DIFF
--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -242,6 +242,21 @@
   padding: 0 6px;
 }
 
+.session-progress-todo {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.session-progress-todo-list {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
 @keyframes session-progress-island-enter {
   from {
     opacity: 0;

--- a/packages/app/src/components/session/session-progress-island.css
+++ b/packages/app/src/components/session/session-progress-island.css
@@ -3,6 +3,7 @@
   --session-progress-island-collapsed-gap: 8px;
   --session-progress-island-collapsed-padding-inline: 12px;
   --session-progress-island-collapsed-max-width: min(620px, calc(100vw - 24px));
+  --session-progress-island-expanded-width: min(900px, calc(100vw - 24px));
   /* Now a normal-flow flex child inside the shared absolute wrapper at
      prompt-dock.tsx:67 (absolute inset-x-0 bottom-full). The wrapper
      guarantees that expanding the island never changes --prompt-height.
@@ -34,8 +35,8 @@
 }
 
 .session-progress-island[data-expanded="true"] .session-progress-island-surface {
-  width: 100%;
-  max-width: min(900px, calc(100vw - 24px));
+  width: var(--session-progress-island-expanded-width);
+  max-width: 100%;
   border-radius: 22px;
   transition:
     width 380ms cubic-bezier(0.16, 1, 0.3, 1),
@@ -175,7 +176,7 @@
   top: 0;
   left: 50%;
   display: flex;
-  width: min(900px, calc(100vw - 24px));
+  width: var(--session-progress-island-expanded-width);
   height: min(52vh, 560px);
   flex-direction: column;
   overflow: hidden;

--- a/packages/app/src/components/session/session-progress-island.tsx
+++ b/packages/app/src/components/session/session-progress-island.tsx
@@ -29,6 +29,7 @@ export function SessionProgressIsland(props: SessionProgressIslandProps) {
   const [measureRef, setMeasureRef] = createSignal<HTMLDivElement | undefined>(undefined)
   const [collapsedWidth, setCollapsedWidth] = createSignal<number | undefined>(undefined)
   const [panelHeight, setPanelHeight] = createSignal<number | undefined>(undefined)
+  const [expandedWidth, setExpandedWidth] = createSignal<number | undefined>(undefined)
 
   const label = createMemo(() => formatProgressLabel(props.snapshot, props.activeLabel, i18n))
   const percentage = createMemo(() => Math.round(props.snapshot.progressRatio * 100))
@@ -47,10 +48,22 @@ export function SessionProgressIsland(props: SessionProgressIslandProps) {
       const width = Math.ceil(measure.getBoundingClientRect().width)
       if (width > 0) setCollapsedWidth(width)
     }
+    const measureExpandedWidth = () => {
+      if (!rootRef) return
+      const style = getComputedStyle(rootRef)
+      const horizontalPadding = Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.paddingRight)
+      const width = Math.min(Math.floor(rootRef.clientWidth - horizontalPadding), 900)
+      if (width > 0) setExpandedWidth(width)
+    }
     const measureElement = measureRef()
-    const measureFrame = requestAnimationFrame(measureCollapsedWidth)
-    const resizeObserver = measureElement ? new ResizeObserver(measureCollapsedWidth) : undefined
-    if (measureElement) resizeObserver?.observe(measureElement)
+    const measureFrame = requestAnimationFrame(() => {
+      measureCollapsedWidth()
+      measureExpandedWidth()
+    })
+    const measureResizeObserver = measureElement ? new ResizeObserver(measureCollapsedWidth) : undefined
+    const rootResizeObserver = rootRef ? new ResizeObserver(measureExpandedWidth) : undefined
+    if (measureElement) measureResizeObserver?.observe(measureElement)
+    if (rootRef) rootResizeObserver?.observe(rootRef)
 
     const keyHandler = (event: KeyboardEvent) => {
       if (event.key === "Escape" && props.expanded) setExpanded(false)
@@ -65,7 +78,8 @@ export function SessionProgressIsland(props: SessionProgressIslandProps) {
     document.addEventListener("click", clickHandler)
     onCleanup(() => {
       cancelAnimationFrame(measureFrame)
-      resizeObserver?.disconnect()
+      measureResizeObserver?.disconnect()
+      rootResizeObserver?.disconnect()
       document.removeEventListener("keydown", keyHandler)
       document.removeEventListener("click", clickHandler)
     })
@@ -121,6 +135,7 @@ export function SessionProgressIsland(props: SessionProgressIslandProps) {
         rootRef = el
       }}
       class={`session-progress-island ${props.class ?? ""}`}
+      style={expandedWidth() == null ? undefined : `--session-progress-island-expanded-width: ${expandedWidth()}px`}
       data-expanded={props.expanded ? "true" : "false"}
       data-collapsed-width={collapsedWidth() == null ? "pending" : "measured"}
       data-status={props.snapshot.status}

--- a/packages/app/src/components/session/session-progress-todo.tsx
+++ b/packages/app/src/components/session/session-progress-todo.tsx
@@ -90,7 +90,7 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
   }
 
   return (
-    <div class={`flex flex-col min-h-0 ${props.class ?? ""}`}>
+    <div class={`session-progress-todo ${props.class ?? ""}`}>
       <Show
         when={summaryParts().length > 0}
         fallback={<div class="text-text-weaker text-xs px-2.5 py-1">{_(S.progressNoActiveTasks)}</div>}
@@ -98,7 +98,7 @@ export function SessionProgressTodo(props: SessionProgressTodoProps) {
         <div class="text-xs text-text-weaker px-2.5 py-1 shrink-0">{summaryParts().join(" · ")}</div>
       </Show>
       <Show when={todos().length > 0}>
-        <div class="flex flex-col divide-y divide-border-weak-base/60 overflow-y-auto min-h-0">
+        <div class="session-progress-todo-list divide-y divide-border-weak-base/60">
           <For each={todos()}>
             {(todo) => {
               const isActive = () => todo.status === "in_progress"

--- a/packages/app/test/components/session/session-progress-island-motion.test.ts
+++ b/packages/app/test/components/session/session-progress-island-motion.test.ts
@@ -112,6 +112,51 @@ describe("session progress island motion", () => {
     }
   })
 
+  test("keeps the expanded panel inside the prompt dock surface", async () => {
+    const page = await browser.newPage({ viewport: { width: 1200, height: 600 } })
+    try {
+      await page.setContent(`
+        <style>
+          *, ::before, ::after { box-sizing: border-box; }
+          ${css}
+          .prompt-dock { width: 54rem; margin: 0 auto; }
+          .session-progress-island-surface { animation: none !important; }
+        </style>
+        <div class="prompt-dock">
+          <div class="session-progress-island" data-expanded="true" data-collapsed-width="measured" style="--session-progress-island-expanded-width: 840px">
+            <div class="session-progress-island-surface" style="--session-progress-island-collapsed-width: 282px">
+              <button class="session-progress-island-header"></button>
+              <div class="session-progress-island-panel-wrap" data-expanded="true">
+                <div class="session-progress-island-panel">
+                  <div class="session-progress-island-panel-topline">Current work</div>
+                  <div class="session-progress-island-body">Todo content</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `)
+      await settleLayout(page)
+
+      const layout = await page.evaluate(() => {
+        const surface = document.querySelector<HTMLElement>(".session-progress-island-surface")!
+        const panel = document.querySelector<HTMLElement>(".session-progress-island-panel")!
+        const surfaceRect = surface.getBoundingClientRect()
+        const panelRect = panel.getBoundingClientRect()
+        return {
+          surfaceLeft: surfaceRect.left,
+          surfaceRight: surfaceRect.right,
+          panelLeft: panelRect.left,
+          panelRight: panelRect.right,
+        }
+      })
+      expect(layout.panelLeft).toBeGreaterThanOrEqual(layout.surfaceLeft)
+      expect(layout.panelRight).toBeLessThanOrEqual(layout.surfaceRight)
+    } finally {
+      await page.close()
+    }
+  })
+
   test("keeps the measured compact shell inside a narrow viewport", async () => {
     const page = await browser.newPage({ viewport: { width: 375, height: 600 } })
     try {

--- a/packages/app/test/components/session/session-progress-todo-layout.test.ts
+++ b/packages/app/test/components/session/session-progress-todo-layout.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { chromium, type Browser } from "playwright"
+
+const css = await readFile(
+  new URL("../../../src/components/session/session-progress-island.css", import.meta.url),
+  "utf8",
+)
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch({ headless: true })
+})
+
+afterAll(async () => {
+  await browser.close()
+})
+
+describe("session progress todo layout", () => {
+  test("keeps expanded todo content scrollable inside the island", async () => {
+    const page = await browser.newPage({ viewport: { width: 760, height: 600 } })
+    try {
+      await page.setContent(`
+        <style>
+          *, ::before, ::after { box-sizing: border-box; }
+          ${css}
+          .session-progress-island-panel {
+            position: static;
+            width: 640px;
+            height: 220px;
+            opacity: 1;
+            pointer-events: auto;
+            transform: none;
+          }
+          .todo-summary { flex: 0 0 24px; }
+          .todo-row { flex: 0 0 36px; }
+          .todo-expanded { flex: 0 0 180px; }
+        </style>
+        <div class="session-progress-island-panel">
+          <div class="session-progress-island-panel-topline">Current work</div>
+          <div class="session-progress-island-body">
+            <div class="session-progress-todo">
+              <div class="todo-summary">1 active · 3 pending</div>
+              <div class="session-progress-todo-list">
+                <div class="todo-row">Inspect the layout owner</div>
+                <div class="todo-row">Expand the long todo</div>
+                <div class="todo-expanded">${"Expanded task details ".repeat(24)}</div>
+                <div class="todo-row" data-last-todo>Verify the final todo remains reachable</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `)
+
+      const beforeScroll = await page.locator(".session-progress-todo-list").evaluate((list) => ({
+        clientHeight: list.clientHeight,
+        scrollHeight: list.scrollHeight,
+      }))
+      expect(beforeScroll.scrollHeight).toBeGreaterThan(beforeScroll.clientHeight)
+
+      const afterScroll = await page.locator(".session-progress-todo-list").evaluate((list) => {
+        list.scrollTop = list.scrollHeight
+        const viewport = list.getBoundingClientRect()
+        const lastTodo = document.querySelector<HTMLElement>("[data-last-todo]")!.getBoundingClientRect()
+        return {
+          scrollTop: list.scrollTop,
+          lastTodoTop: lastTodo.top,
+          lastTodoBottom: lastTodo.bottom,
+          viewportTop: viewport.top,
+          viewportBottom: viewport.bottom,
+        }
+      })
+      expect(afterScroll.scrollTop).toBeGreaterThan(0)
+      expect(afterScroll.lastTodoTop).toBeGreaterThanOrEqual(afterScroll.viewportTop)
+      expect(afterScroll.lastTodoBottom).toBeLessThanOrEqual(afterScroll.viewportBottom + 1)
+    } finally {
+      await page.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- constrain the expanded TodoList to the progress island body
- make the todo rows scroll within the available panel height instead of overflowing into a clipped ancestor
- add a Chromium layout regression test that verifies expanded content can scroll to the final todo

## Testing

- `bun test test/components/session/session-progress-todo-layout.test.ts` (from `packages/app`)
- `bun test test/components/session/session-progress-island-motion.test.ts` (from `packages/app`)
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`

Closes #940