### PR TITLE
fix(session): isolate compaction model variants

### DIFF
--- a/.synergy/skill/integrate-llm/SKILL.md
+++ b/.synergy/skill/integrate-llm/SKILL.md
@@ -38,6 +38,8 @@ A sessionless call does not create session history, Cortex progress, completion 
 
 Use `SessionInvoke` when the caller already owns the target session: direct user/API input, Channel or Agenda execution, workflow continuation, or an in-place loop operation such as compaction.
 
+When an in-place internal operation reuses a root user message only for task identity or attribution while selecting a different model, strip root-owned execution settings that do not belong to the target call. Compaction specifically keeps the persisted root unchanged but clears its `variant` from the ephemeral processor envelope, so the compaction model retains normal provider options without validating or applying another model's variant.
+
 Use `Cortex.launch()` for new child-agent work. Cortex owns:
 
 - child session creation and parent lineage

--- a/docs/architecture/llm-loop.md
+++ b/docs/architecture/llm-loop.md
@@ -244,6 +244,8 @@ The `summary` flag is the context-boundary commit marker, not an in-progress pla
 
 The compaction agent cannot use tools or continue the user's task. Its built-in permission layer denies every tool subject to normal configuration precedence, while the invocation independently passes an empty tool set so no configured permission can equip the compaction model with tools. Its prompt requires observed facts, completed work, current state, next steps, constraints, and relevant files without inventing progress.
 
+The compaction call may reuse root `R` as its ephemeral user envelope for task identity, but it clears `R.variant` before preparing the dedicated compaction model. The persisted root remains unchanged, while the compaction model uses its own normal provider options without validating or applying a variant owned by a different model execution.
+
 If the summarization call itself exceeds context, Synergy writes a deterministic mechanical fallback and commits it through the same boundary. Other compaction-model failures remain explicit failures.
 
 ### Anchor and continuation

--- a/packages/synergy/src/session/compaction.ts
+++ b/packages/synergy/src/session/compaction.ts
@@ -512,7 +512,7 @@ export namespace SessionCompaction {
 
     try {
       await processor.process({
-        user: userMessage,
+        user: { ...userMessage, variant: undefined },
         agent,
         abort: input.abort,
         sessionID: input.sessionID,

--- a/packages/synergy/test/session/invoke-compaction.test.ts
+++ b/packages/synergy/test/session/invoke-compaction.test.ts
@@ -171,9 +171,11 @@ async function filterNewestFirst(messages: MessageV2.WithParts[]) {
 }
 
 async function runCompactionProcessCase(input: {
+  auto?: boolean
   error?: MessageV2.Assistant["error"]
   text?: string
   thrownError?: Error
+  variant?: string
 }) {
   await using tmp = await tmpdir({ git: true })
 
@@ -188,6 +190,7 @@ async function runCompactionProcessCase(input: {
   let initialIncludeInContext: boolean | undefined
   let initialVisible: boolean | undefined
   const attemptStates: Array<unknown> = []
+  let processUserVariant: string | undefined
 
   try {
     ;(Provider.getModel as any) = mock(async () => testModel())
@@ -211,7 +214,8 @@ async function runCompactionProcessCase(input: {
         message: processorInput.assistantMessage,
         partFromToolCall: () => undefined,
         trackExecution: () => {},
-        process: mock(async () => {
+        process: mock(async (processInput: SessionProcessor.ProcessInput) => {
+          processUserVariant = processInput.user.variant
           if (input.thrownError) throw input.thrownError
           if (input.text) {
             const now = Date.now()
@@ -244,6 +248,7 @@ async function runCompactionProcessCase(input: {
           agent: "synergy",
           model: { providerID: "test-provider", modelID: "test-model" },
           time: { created: Date.now() },
+          ...(input.variant ? { variant: input.variant } : {}),
         })
         await Session.updatePart({
           id: Identifier.ascending("part"),
@@ -257,7 +262,7 @@ async function runCompactionProcessCase(input: {
           messageID: user.id,
           sessionID: session.id,
           type: "compaction",
-          auto: false,
+          auto: input.auto ?? false,
         })
 
         const before = await Session.messages({ sessionID: session.id })
@@ -269,7 +274,7 @@ async function runCompactionProcessCase(input: {
             messages: before,
             sessionID: session.id,
             abort: new AbortController().signal,
-            auto: false,
+            auto: input.auto ?? false,
           })
         } catch (error) {
           thrown = error
@@ -283,7 +288,17 @@ async function runCompactionProcessCase(input: {
         const root = after.find((message) => message.info.id === user.id)
         if (!root) throw new Error("compaction root was not persisted")
 
-        return { result, thrown, attempt, root, initialSummary, initialIncludeInContext, initialVisible, attemptStates }
+        return {
+          result,
+          thrown,
+          attempt,
+          root,
+          initialSummary,
+          initialIncludeInContext,
+          initialVisible,
+          processUserVariant,
+          attemptStates,
+        }
       },
     })
   } finally {
@@ -989,6 +1004,17 @@ describe.serial("SessionInvoke preflight compaction", () => {
       sourceMessageID: realUser.info.id,
     })
   })
+  test("isolates auto-compaction from the task root variant", async () => {
+    const observed = await runCompactionProcessCase({
+      auto: true,
+      text: "## Goal\n\nContinue the implementation.",
+      variant: "high",
+    })
+
+    expect(observed.root.info.role === "user" && observed.root.info.variant).toBe("high")
+    expect(observed.processUserVariant).toBeUndefined()
+  })
+
   test("keeps provider failures as uncommitted compaction attempts", async () => {
     const apiKey = ["s", "k-test-secret-12345678"].join("")
     const responseApiKey = ["s", "k-body-secret-12345678"].join("")


### PR DESCRIPTION
## Summary

- clear the task root's persisted `variant` from the ephemeral compaction processor envelope
- preserve the durable root and the compaction model's normal provider options
- add an auto-compaction regression test and document the model-variant ownership boundary

## Verification

- `bun test test/session/invoke-compaction.test.ts`
- `bun test test/session/llm-variant.test.ts test/session/invoke-compaction.test.ts`
- `bunx prettier --check packages/synergy/src/session/compaction.ts packages/synergy/test/session/invoke-compaction.test.ts docs/architecture/llm-loop.md .synergy/skill/integrate-llm/SKILL.md`
- `bun run quality:quick`

## Compatibility

- no API, SDK, schema, config, or persistence migration changes
- non-compaction root execution remains strict for unavailable persisted variants
- compaction continues to use its dedicated model's normal provider options

Closes #948