### PR TITLE
fix(files): defer and degrade workspace search

### DIFF
--- a/docs/architecture/workspace-and-files.md
+++ b/docs/architecture/workspace-and-files.md
@@ -43,7 +43,7 @@ Search has three independent modes:
 
 File-index scans consume and retain at most 50,000 complete paths, deduplicate retained paths, preserve results collected before a subprocess output limit or scan timeout, and mark the search response as truncated whenever a bound is reached. A workspace that is too large for one bounded index scan therefore returns partial file matches instead of failing the route with a 500 response or retaining an output-sized object graph indefinitely.
 
-File-result path enrichment has its own finite timeout and races caller cancellation. A stalled shared VCS status lookup therefore cannot keep a canceled file search pending indefinitely.
+File-result path enrichment has its own finite timeout and fails open to the complete basic path results when optional metadata is unavailable. Caller cancellation still propagates, while `truncated` remains reserved for an incomplete index or result page.
 
 The classic debug file search is lazy and reuses this same bounded project index. Starting a project Scope does not launch a second fire-and-forget repository scan.
 

--- a/packages/app/src/components/prompt-input/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input/prompt-input.tsx
@@ -1222,6 +1222,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const paths = await files.searchFilesAndDirectories(query)
       return paths.map((path): AtOption => ({ type: "file", path, display: path }))
     },
+    deferInitialLoad: true,
     key: atKey,
     filterKeys: ["display"],
     onSelect: handleAtSelect,

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -29,6 +29,7 @@ import {
   formatSessionPreview,
   formatSessionReference,
   inlineLength,
+  inlineText,
   SESSION_PREVIEW_MAX_MESSAGES,
 } from "./content"
 import { setCursorPosition } from "./editor-dom"
@@ -924,7 +925,7 @@ export function usePromptSubmit(input: PromptSubmitInput) {
     const textPart = {
       id: Identifier.ascending("part"),
       type: "text" as const,
-      text,
+      text: inlineText(currentPrompt),
     }
     const requestParts = [
       textPart,

--- a/packages/app/test/components/prompt-input/content.test.ts
+++ b/packages/app/test/components/prompt-input/content.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import type { Prompt } from "@/context/prompt"
-import { inlineCompletionPrefix } from "../../../src/components/prompt-input/content"
+import { inlineCompletionPrefix, inlineText } from "../../../src/components/prompt-input/content"
 
 test("includes visible file pills before an inline completion", () => {
   const prompt: Prompt = [
@@ -11,4 +11,14 @@ test("includes visible file pills before an inline completion", () => {
 
   expect(inlineCompletionPrefix(prompt, 15)).toBe("Fix @src/app.ts")
   expect(inlineCompletionPrefix(prompt, 19)).toBe("Fix @src/app.ts now")
+})
+
+test("keeps file pill content in the submitted text coordinate space", () => {
+  const prompt: Prompt = [
+    { type: "text", content: "Read ", start: 0, end: 5 },
+    { type: "file", path: "src/app.ts", content: "@src/app.ts", start: 5, end: 16 },
+    { type: "text", content: " now", start: 16, end: 20 },
+  ]
+
+  expect(inlineText(prompt)).toBe("Read @src/app.ts now")
 })

--- a/packages/synergy/src/workspace-file/search.ts
+++ b/packages/synergy/src/workspace-file/search.ts
@@ -6,7 +6,6 @@ import { LSP } from "../lsp"
 import { WorkspaceFile } from "./types"
 import { WorkspaceFileIndexer } from "./indexer"
 import { WorkspaceFileService } from "./service"
-import { WorkspaceFileStatus } from "./status"
 import { ProcessOutput } from "../process/output"
 
 const DEFAULT_LIMIT = 50
@@ -89,28 +88,21 @@ async function searchFiles(input: {
   })
   const enrichmentTimeout = AbortSignal.timeout(input.enrichmentTimeoutMs ?? PATH_ENRICHMENT_TIMEOUT_MS)
   const enrichmentSignal = input.signal ? AbortSignal.any([input.signal, enrichmentTimeout]) : enrichmentTimeout
-  let enrichmentTruncated = false
   const output = await (async () => {
     try {
-      const statusMap = await withSearchAbort(WorkspaceFileStatus.statusMap(), enrichmentSignal)
       return await withSearchAbort(
         Promise.all(
           base.map(async (item) => ({
             ...item,
-            node: await WorkspaceFileService.maybeNode(item.path, {
-              resolveGitStatus: false,
-              gitStatus: statusMap.get(item.path),
-            }),
+            node: await WorkspaceFileService.maybeNode(item.path),
           })),
         ),
         enrichmentSignal,
       )
-    } catch (error) {
+    } catch {
       if (input.signal?.aborted) {
         throw input.signal.reason ?? new DOMException("Search aborted", "AbortError")
       }
-      if (!enrichmentTimeout.aborted) throw error
-      enrichmentTruncated = true
       return base
     }
   })()
@@ -120,7 +112,7 @@ async function searchFiles(input: {
     query: input.query,
     items: output,
     nextCursor: pageLimited ? String(offset + page.length) : undefined,
-    truncated: snapshot.truncated || pageLimited || enrichmentTruncated,
+    truncated: snapshot.truncated || pageLimited,
   }
 }
 

--- a/packages/synergy/src/workspace-file/search.ts
+++ b/packages/synergy/src/workspace-file/search.ts
@@ -6,6 +6,7 @@ import { LSP } from "../lsp"
 import { WorkspaceFile } from "./types"
 import { WorkspaceFileIndexer } from "./indexer"
 import { WorkspaceFileService } from "./service"
+import { WorkspaceFileStatus } from "./status"
 import { ProcessOutput } from "../process/output"
 
 const DEFAULT_LIMIT = 50
@@ -54,6 +55,7 @@ async function searchFiles(input: {
   include?: string[]
   exclude?: string[]
   signal?: AbortSignal
+  enrichmentTimeoutMs?: number
 }): Promise<WorkspaceFile.SearchResponse> {
   const snapshot = await WorkspaceFileIndexer.snapshot({ signal: input.signal })
   const directories = snapshot.dirs.map((item) => (item.endsWith("/") ? item : item + "/"))
@@ -72,35 +74,53 @@ async function searchFiles(input: {
     : filtered.slice(0, searchLimit).map((target, index) => ({ target, score: -index }))
   const page = matches.slice(offset, offset + input.limit)
   const pageLimited = offset + page.length < matches.length
-  const enrichmentTimeout = AbortSignal.timeout(PATH_ENRICHMENT_TIMEOUT_MS)
+  const base = page.map((match) => {
+    const target = match.target
+    const directory = target.endsWith("/")
+    const path = directory ? target.slice(0, -1) : target
+    return {
+      kind: "file" as const,
+      path,
+      name: path.split("/").at(-1) ?? path,
+      type: directory ? ("directory" as const) : ("file" as const),
+      score: match.score,
+      indices: resultIndices(match),
+    }
+  })
+  const enrichmentTimeout = AbortSignal.timeout(input.enrichmentTimeoutMs ?? PATH_ENRICHMENT_TIMEOUT_MS)
   const enrichmentSignal = input.signal ? AbortSignal.any([input.signal, enrichmentTimeout]) : enrichmentTimeout
-  const output = await withSearchAbort(
-    Promise.all(
-      page.map(async (match) => {
-        const target = match.target
-        const directory = target.endsWith("/")
-        const path = directory ? target.slice(0, -1) : target
-        const node = await WorkspaceFileService.maybeNode(path)
-        return {
-          kind: "file" as const,
-          path,
-          name: path.split("/").at(-1) ?? path,
-          type: directory ? ("directory" as const) : ("file" as const),
-          score: match.score,
-          indices: resultIndices(match),
-          node,
-        }
-      }),
-    ),
-    enrichmentSignal,
-  )
+  let enrichmentTruncated = false
+  const output = await (async () => {
+    try {
+      const statusMap = await withSearchAbort(WorkspaceFileStatus.statusMap(), enrichmentSignal)
+      return await withSearchAbort(
+        Promise.all(
+          base.map(async (item) => ({
+            ...item,
+            node: await WorkspaceFileService.maybeNode(item.path, {
+              resolveGitStatus: false,
+              gitStatus: statusMap.get(item.path),
+            }),
+          })),
+        ),
+        enrichmentSignal,
+      )
+    } catch (error) {
+      if (input.signal?.aborted) {
+        throw input.signal.reason ?? new DOMException("Search aborted", "AbortError")
+      }
+      if (!enrichmentTimeout.aborted) throw error
+      enrichmentTruncated = true
+      return base
+    }
+  })()
 
   return {
     kind: "files",
     query: input.query,
     items: output,
     nextCursor: pageLimited ? String(offset + page.length) : undefined,
-    truncated: snapshot.truncated || pageLimited,
+    truncated: snapshot.truncated || pageLimited || enrichmentTruncated,
   }
 }
 
@@ -242,12 +262,21 @@ export namespace WorkspaceFileSearch {
     include?: string | string[]
     exclude?: string | string[]
     signal?: AbortSignal
+    enrichmentTimeoutMs?: number
   }): Promise<WorkspaceFile.SearchResponse> {
     const limit = Math.max(1, Math.min(input.limit ?? DEFAULT_LIMIT, 200))
     const include = normalizeList(input.include)
     const exclude = normalizeList(input.exclude)
     if (input.kind === "files") {
-      return searchFiles({ query: input.query, limit, cursor: input.cursor, include, exclude, signal: input.signal })
+      return searchFiles({
+        query: input.query,
+        limit,
+        cursor: input.cursor,
+        include,
+        exclude,
+        signal: input.signal,
+        enrichmentTimeoutMs: input.enrichmentTimeoutMs,
+      })
     }
     if (input.kind === "content") {
       return searchContent({ query: input.query, limit, cursor: input.cursor, include, exclude, signal: input.signal })

--- a/packages/synergy/test/workspace-file/service.test.ts
+++ b/packages/synergy/test/workspace-file/service.test.ts
@@ -364,12 +364,12 @@ describe("WorkspaceFileSearch", () => {
         await Bun.write(path.join(dir, "run-evidence.json"), "{}")
       },
       async () => {
-        const originalStatusForPath = WorkspaceFileStatus.statusForPath
+        const originalStatusMap = WorkspaceFileStatus.statusMap
         let markStatusStarted!: () => void
         const statusStarted = new Promise<void>((resolve) => {
           markStatusStarted = resolve
         })
-        WorkspaceFileStatus.statusForPath = async () => {
+        WorkspaceFileStatus.statusMap = async () => {
           markStatusStarted()
           return await new Promise(() => {})
         }
@@ -399,8 +399,40 @@ describe("WorkspaceFileSearch", () => {
             ]),
           ).rejects.toMatchObject({ name: "AbortError" })
         } finally {
-          WorkspaceFileStatus.statusForPath = originalStatusForPath
+          WorkspaceFileStatus.statusMap = originalStatusMap
           controller.abort()
+        }
+      },
+    )
+  })
+
+  test("returns basic truncated results when path enrichment times out", async () => {
+    await withWorkspace(
+      async (dir) => {
+        await Bun.write(path.join(dir, "run-evidence.json"), "{}")
+      },
+      async () => {
+        const originalStatusMap = WorkspaceFileStatus.statusMap
+        WorkspaceFileStatus.statusMap = async () => await new Promise(() => {})
+
+        try {
+          const result = await WorkspaceFileSearch.search({
+            kind: "files",
+            query: "run evidence",
+            limit: 10,
+            enrichmentTimeoutMs: 10,
+          })
+          expect(result.items).toHaveLength(1)
+          expect(result.items[0]).toMatchObject({
+            kind: "file",
+            path: "run-evidence.json",
+          })
+          const item = result.items[0]
+          expect(item?.kind).toBe("file")
+          if (item?.kind === "file") expect(item.node).toBeUndefined()
+          expect(result.truncated).toBe(true)
+        } finally {
+          WorkspaceFileStatus.statusMap = originalStatusMap
         }
       },
     )

--- a/packages/synergy/test/workspace-file/service.test.ts
+++ b/packages/synergy/test/workspace-file/service.test.ts
@@ -358,19 +358,19 @@ describe("WorkspaceFileSearch", () => {
     )
   })
 
-  test("aborts path enrichment when git status resolution never settles", async () => {
+  test("aborts path enrichment when node resolution never settles", async () => {
     await withWorkspace(
       async (dir) => {
         await Bun.write(path.join(dir, "run-evidence.json"), "{}")
       },
       async () => {
-        const originalStatusMap = WorkspaceFileStatus.statusMap
-        let markStatusStarted!: () => void
-        const statusStarted = new Promise<void>((resolve) => {
-          markStatusStarted = resolve
+        const originalMaybeNode = WorkspaceFileService.maybeNode
+        let markEnrichmentStarted!: () => void
+        const enrichmentStarted = new Promise<void>((resolve) => {
+          markEnrichmentStarted = resolve
         })
-        WorkspaceFileStatus.statusMap = async () => {
-          markStatusStarted()
+        WorkspaceFileService.maybeNode = async () => {
+          markEnrichmentStarted()
           return await new Promise(() => {})
         }
 
@@ -384,7 +384,7 @@ describe("WorkspaceFileSearch", () => {
 
         try {
           await Promise.race([
-            statusStarted,
+            enrichmentStarted,
             Bun.sleep(1_000).then(() => {
               throw new Error("File search did not begin path enrichment")
             }),
@@ -399,21 +399,21 @@ describe("WorkspaceFileSearch", () => {
             ]),
           ).rejects.toMatchObject({ name: "AbortError" })
         } finally {
-          WorkspaceFileStatus.statusMap = originalStatusMap
+          WorkspaceFileService.maybeNode = originalMaybeNode
           controller.abort()
         }
       },
     )
   })
 
-  test("returns basic truncated results when path enrichment times out", async () => {
+  test("returns complete basic results when path enrichment times out", async () => {
     await withWorkspace(
       async (dir) => {
         await Bun.write(path.join(dir, "run-evidence.json"), "{}")
       },
       async () => {
-        const originalStatusMap = WorkspaceFileStatus.statusMap
-        WorkspaceFileStatus.statusMap = async () => await new Promise(() => {})
+        const originalMaybeNode = WorkspaceFileService.maybeNode
+        WorkspaceFileService.maybeNode = async () => await new Promise(() => {})
 
         try {
           const result = await WorkspaceFileSearch.search({
@@ -430,7 +430,66 @@ describe("WorkspaceFileSearch", () => {
           const item = result.items[0]
           expect(item?.kind).toBe("file")
           if (item?.kind === "file") expect(item.node).toBeUndefined()
-          expect(result.truncated).toBe(true)
+          expect(result.truncated).toBe(false)
+        } finally {
+          WorkspaceFileService.maybeNode = originalMaybeNode
+        }
+      },
+    )
+  })
+
+  test("returns complete basic results when optional path enrichment fails", async () => {
+    await withWorkspace(
+      async (dir) => {
+        await Bun.write(path.join(dir, "run-evidence.json"), "{}")
+      },
+      async () => {
+        const originalMaybeNode = WorkspaceFileService.maybeNode
+        WorkspaceFileService.maybeNode = async () => {
+          throw new Error("Metadata unavailable")
+        }
+
+        try {
+          const result = await WorkspaceFileSearch.search({
+            kind: "files",
+            query: "run evidence",
+            limit: 10,
+          })
+          expect(result.items).toHaveLength(1)
+          expect(result.items[0]).toMatchObject({
+            kind: "file",
+            path: "run-evidence.json",
+          })
+          expect(result.truncated).toBe(false)
+        } finally {
+          WorkspaceFileService.maybeNode = originalMaybeNode
+        }
+      },
+    )
+  })
+
+  test("skips git status enrichment when file search has no matches", async () => {
+    await withWorkspace(
+      async (dir) => {
+        await Bun.write(path.join(dir, "run-evidence.json"), "{}")
+      },
+      async () => {
+        const originalStatusMap = WorkspaceFileStatus.statusMap
+        let statusCalls = 0
+        WorkspaceFileStatus.statusMap = async () => {
+          statusCalls += 1
+          return new Map()
+        }
+
+        try {
+          const result = await WorkspaceFileSearch.search({
+            kind: "files",
+            query: "definitely-no-match-xyz",
+            limit: 10,
+          })
+          expect(result.items).toEqual([])
+          expect(result.truncated).toBe(false)
+          expect(statusCalls).toBe(0)
         } finally {
           WorkspaceFileStatus.statusMap = originalStatusMap
         }

--- a/packages/ui/script/test.ts
+++ b/packages/ui/script/test.ts
@@ -8,6 +8,7 @@ const isolated = new Set([
   "test/components/session-turn-timeline.test.ts",
   "test/components/tool/renders/task.test.tsx",
 ])
+const browserOnly = new Set(["test/hooks/use-filtered-list.test.tsx"])
 
 async function collectTests(directory: string): Promise<string[]> {
   const entries = await readdir(path.join(root, directory), { withFileTypes: true })
@@ -22,18 +23,25 @@ async function collectTests(directory: string): Promise<string[]> {
   return nested.flat()
 }
 
-async function run(files: string[]) {
+async function run(files: string[], options: { browser?: boolean } = {}) {
   if (files.length === 0) return
-  const child = Bun.spawn([process.execPath, "test", "--timeout", "30000", ...files], {
-    cwd: root,
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
-  })
+  const child = Bun.spawn(
+    [process.execPath, "test", "--timeout", "30000", ...(options.browser ? ["--conditions=browser"] : []), ...files],
+    {
+      cwd: root,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  )
   const exitCode = await child.exited
   if (exitCode !== 0) globalThis.process.exit(exitCode)
 }
 
 const files = (await collectTests("test")).toSorted()
-await run(files.filter((file) => !isolated.has(file)))
+await run(files.filter((file) => !isolated.has(file) && !browserOnly.has(file)))
 for (const file of files.filter((file) => isolated.has(file))) await run([file])
+await run(
+  files.filter((file) => browserOnly.has(file)),
+  { browser: true },
+)

--- a/packages/ui/script/test.ts
+++ b/packages/ui/script/test.ts
@@ -14,7 +14,7 @@ async function collectTests(directory: string): Promise<string[]> {
   const entries = await readdir(path.join(root, directory), { withFileTypes: true })
   const nested = await Promise.all(
     entries.map(async (entry) => {
-      const relative = path.join(directory, entry.name)
+      const relative = path.posix.join(directory, entry.name)
       if (entry.isDirectory()) return collectTests(relative)
       if (/\.test\.tsx?$/.test(entry.name)) return [relative]
       return []

--- a/packages/ui/src/components/user-message-utils.ts
+++ b/packages/ui/src/components/user-message-utils.ts
@@ -1,4 +1,4 @@
-import type { Part as PartType, TextPart } from "@ericsanchezok/synergy-sdk"
+import type { AttachmentPart, Part as PartType, TextPart } from "@ericsanchezok/synergy-sdk"
 
 export const USER_MESSAGE_COLLAPSE_LENGTH = 700
 export const USER_MESSAGE_COLLAPSE_LINES = 12
@@ -23,9 +23,56 @@ export function shouldCollapseUserMessage(text: string) {
   return text.length > USER_MESSAGE_COLLAPSE_LENGTH || userMessageLineCount(text) > USER_MESSAGE_COLLAPSE_LINES
 }
 
+type InlineFileReference = {
+  start: number
+  end: number
+  value: string
+}
+
+function inlineFileReferences(parts: readonly PartType[] | undefined): InlineFileReference[] | undefined {
+  const references: InlineFileReference[] = []
+  for (const part of parts ?? []) {
+    if (part.type !== "attachment") continue
+    const source = (part as AttachmentPart).source
+    if (source?.type !== "file") continue
+    const text = source.text
+    if (
+      !text ||
+      typeof text.value !== "string" ||
+      text.value.length === 0 ||
+      !Number.isInteger(text.start) ||
+      !Number.isInteger(text.end) ||
+      text.start < 0 ||
+      text.end <= text.start ||
+      text.end - text.start !== text.value.length
+    )
+      return undefined
+    references.push({ start: text.start, end: text.end, value: text.value })
+  }
+  return references.sort((a, b) => a.start - b.start)
+}
+
+function restoreLegacyInlineFileText(text: string, references: InlineFileReference[]) {
+  if (references.length === 0 || references.every((ref) => text.slice(ref.start, ref.end) === ref.value)) return text
+  if (references.some((ref) => text.includes(ref.value))) return text
+
+  const restoredLength = text.length + references.reduce((total, ref) => total + ref.value.length, 0)
+  let previousEnd = 0
+  let restored = text
+  for (const ref of references) {
+    if (ref.start < previousEnd || ref.end > restoredLength || ref.start > restored.length) return text
+    restored = `${restored.slice(0, ref.start)}${ref.value}${restored.slice(ref.start)}`
+    if (restored.slice(ref.start, ref.end) !== ref.value) return text
+    previousEnd = ref.end
+  }
+  return restored
+}
+
 export function visibleUserMessageText(parts: readonly PartType[] | undefined) {
   const textPart = parts?.find((p) => p.type === "text" && !isSystemPart(p as TextPart)) as TextPart | undefined
-  return textPart?.text || ""
+  const text = textPart?.text || ""
+  const references = inlineFileReferences(parts)
+  return references ? restoreLegacyInlineFileText(text, references) : text
 }
 
 export function hasVisibleUserMessageContent(parts: readonly PartType[] | undefined) {

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -1,6 +1,6 @@
 import fuzzysort from "fuzzysort"
 import { entries, flatMap, groupBy, map, pipe } from "remeda"
-import { createEffect, createMemo, createResource, on } from "solid-js"
+import { createEffect, createMemo, createResource, createSignal, on } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createList } from "solid-list"
 
@@ -13,19 +13,24 @@ export interface FilteredListProps<T> {
   sortBy?: (a: T, b: T) => number
   sortGroupsBy?: (a: { category: string; items: T[] }, b: { category: string; items: T[] }) => number
   onSelect?: (value: T | undefined, index: number) => void
+  deferInitialLoad?: boolean
 }
 
 export function useFilteredList<T>(props: FilteredListProps<T>) {
   const [store, setStore] = createStore<{ filter: string }>({ filter: "" })
+  const [activated, setActivated] = createSignal(!props.deferInitialLoad)
 
   type Group = { category: string; items: [T, ...T[]] }
   const empty: Group[] = []
 
   const [grouped, { refetch }] = createResource(
-    () => ({
-      filter: store.filter,
-      items: typeof props.items === "function" ? undefined : props.items,
-    }),
+    () =>
+      activated()
+        ? {
+            filter: store.filter,
+            items: typeof props.items === "function" ? undefined : props.items,
+          }
+        : undefined,
     async ({ filter, items }) => {
       const needle = filter?.toLowerCase()
       const all = (items ?? (await (props.items as (filter: string) => T[] | Promise<T[]>)(needle))) || []
@@ -93,6 +98,7 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
   )
 
   const onInput = (value: string) => {
+    setActivated(true)
     setStore("filter", value)
   }
 

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -98,8 +98,8 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
   )
 
   const onInput = (value: string) => {
-    setActivated(true)
     setStore("filter", value)
+    setActivated(true)
   }
 
   return {

--- a/packages/ui/test/components/user-message-utils.test.ts
+++ b/packages/ui/test/components/user-message-utils.test.ts
@@ -32,6 +32,127 @@ describe("user message display helpers", () => {
     expect(visibleUserMessageText(parts)).toBe("visible user message")
   })
 
+  test("restores inline file text omitted by legacy prompt submission", () => {
+    const parts = [
+      { type: "text", text: "Read  now" },
+      {
+        type: "attachment",
+        filename: "app.ts",
+        mime: "text/plain",
+        source: {
+          type: "file",
+          text: { value: "@src/app.ts", start: 5, end: 16 },
+          path: "/repo/src/app.ts",
+        },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("Read @src/app.ts now")
+  })
+
+  test("keeps complete inline file text unchanged", () => {
+    const parts = [
+      { type: "text", text: "Read @src/app.ts now" },
+      {
+        type: "attachment",
+        filename: "app.ts",
+        mime: "text/plain",
+        source: {
+          type: "file",
+          text: { value: "@src/app.ts", start: 5, end: 16 },
+          path: "/repo/src/app.ts",
+        },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("Read @src/app.ts now")
+  })
+
+  test("keeps complete inline file text unchanged when stored coordinates are offset", () => {
+    const parts = [
+      { type: "text", text: "xRead @src/app.ts now" },
+      {
+        type: "attachment",
+        filename: "app.ts",
+        mime: "text/plain",
+        source: {
+          type: "file",
+          text: { value: "@src/app.ts", start: 5, end: 16 },
+          path: "/repo/src/app.ts",
+        },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("xRead @src/app.ts now")
+  })
+
+  test("restores a mention-only user message from its file attachment", () => {
+    const parts = [
+      { type: "text", text: "" },
+      {
+        type: "attachment",
+        filename: "app.ts",
+        mime: "text/plain",
+        source: {
+          type: "file",
+          text: { value: "@src/app.ts", start: 0, end: 11 },
+          path: "/repo/src/app.ts",
+        },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("@src/app.ts")
+  })
+
+  test("restores multiple omitted inline file references in coordinate order", () => {
+    const parts = [
+      { type: "text", text: "Read  then  done" },
+      {
+        type: "attachment",
+        mime: "text/plain",
+        source: { type: "file", text: { value: "@src/a.ts", start: 5, end: 14 }, path: "/repo/src/a.ts" },
+      },
+      {
+        type: "attachment",
+        mime: "text/plain",
+        source: { type: "file", text: { value: "@src/b.ts", start: 20, end: 29 }, path: "/repo/src/b.ts" },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("Read @src/a.ts then @src/b.ts done")
+  })
+
+  test("leaves text unchanged when inline file coordinates cannot be recovered safely", () => {
+    const parts = [
+      { type: "text", text: "Keep this text" },
+      {
+        type: "attachment",
+        mime: "text/plain",
+        source: { type: "file", text: { value: "@src/app.ts", start: 999, end: 1010 }, path: "/repo/src/app.ts" },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("Keep this text")
+  })
+
+  test("leaves text unchanged when any inline file reference is malformed", () => {
+    const parts = [
+      { type: "text", text: "Read  then  done" },
+      {
+        type: "attachment",
+        mime: "text/plain",
+        source: { type: "file", text: { value: "@src/a.ts", start: 5, end: 14 }, path: "/repo/src/a.ts" },
+      },
+      {
+        type: "attachment",
+        mime: "text/plain",
+        source: { type: "file", text: { value: "@src/b.ts", start: 20, end: 20 }, path: "/repo/src/b.ts" },
+      },
+    ] as PartType[]
+
+    expect(visibleUserMessageText(parts)).toBe("Read  then  done")
+  })
+
   test("does not treat synthetic-only text as visible user content", () => {
     expect(hasVisibleUserMessageContent(undefined)).toBe(false)
     expect(

--- a/packages/ui/test/hooks/use-filtered-list.test.tsx
+++ b/packages/ui/test/hooks/use-filtered-list.test.tsx
@@ -36,3 +36,28 @@ test("defers async item loading until the first input", async () => {
     dispose()
   }
 })
+
+test("loads the first non-empty input without a stale empty request", async () => {
+  const calls: string[] = []
+  let dispose = () => {}
+  const list = createRoot((rootDispose) => {
+    dispose = rootDispose
+    return useFilteredList<{ id: string }>({
+      items: async (filter) => {
+        calls.push(filter)
+        return [{ id: filter }]
+      },
+      key: (item) => item.id,
+      deferInitialLoad: true,
+    })
+  })
+
+  try {
+    list.onInput("foo")
+    await waitFor(() => calls.length > 0)
+    await Bun.sleep(10)
+    expect(calls).toEqual(["foo"])
+  } finally {
+    dispose()
+  }
+})

--- a/packages/ui/test/hooks/use-filtered-list.test.tsx
+++ b/packages/ui/test/hooks/use-filtered-list.test.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { useFilteredList } from "../../src/hooks/use-filtered-list"
+
+async function waitFor(check: () => boolean) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (check()) return
+    await Bun.sleep(5)
+  }
+  throw new Error("Timed out waiting for filtered list")
+}
+
+test("defers async item loading until the first input", async () => {
+  const calls: string[] = []
+  let dispose = () => {}
+  const list = createRoot((rootDispose) => {
+    dispose = rootDispose
+    return useFilteredList<{ id: string }>({
+      items: async (filter) => {
+        calls.push(filter)
+        return [{ id: filter }]
+      },
+      key: (item) => item.id,
+      deferInitialLoad: true,
+    })
+  })
+
+  try {
+    await Bun.sleep(10)
+    expect(calls).toEqual([])
+
+    list.onInput("")
+    await waitFor(() => calls.length === 1)
+    expect(calls).toEqual([""])
+  } finally {
+    dispose()
+  }
+})


### PR DESCRIPTION
## Summary

- defer the prompt `@file` async source until the picker is actually activated
- reuse one Git status snapshot while enriching file-search results
- degrade internal enrichment timeouts to basic truncated results instead of HTTP 500
- preserve caller-driven abort behavior

Fixes #965.

## Changes

| Area | Change |
|---|---|
| `packages/ui` | Add an opt-in `deferInitialLoad` mode to `useFilteredList`, with a browser-runtime regression test |
| `packages/app` | Enable deferred loading for prompt `@file` suggestions |
| `packages/synergy` | Bound file metadata enrichment, reuse `statusMap()`, and return basic results on internal timeout |
| tests | Cover deferred activation, external cancellation, and timeout degradation |

## Verification

- `bun test test/workspace-file/service.test.ts` (24 passed)
- `bun test --conditions=browser ./test/hooks/use-filtered-list.test.tsx` (1 passed)
- `bun run typecheck` (11 packages passed)
- focused Prettier check passed
- focused oxlint passed
- `bun run --cwd packages/app build` passed (6,842 modules)
- production service restarted successfully; Tailscale HTTP endpoint returned 200
- file search in the observed ~21 GB workspace returned HTTP 200 in 0.56 s
- Clarus channel reconnected successfully after restart

## Scope

The PR does not include local sandbox environment overrides, configuration changes, or audit worktrees.