### PR TITLE
fix(channel): preserve Feishu ingress when sender lookup fails

### DIFF
--- a/packages/synergy/src/channel/provider/feishu/index.ts
+++ b/packages/synergy/src/channel/provider/feishu/index.ts
@@ -731,7 +731,8 @@ export class FeishuProvider implements ChannelTypes.Provider<Config.ChannelFeish
       chatId: msg.chat_id,
       contentPreview: rawContent.slice(0, 800),
     })
-    const senderId = sender?.sender_id?.open_id || "unknown"
+    const senderId =
+      sender?.sender_id?.open_id || sender?.sender_id?.union_id || sender?.sender_id?.user_id || "unknown"
 
     let text = parseMessageContent(rawContent, messageType)
     if (TEXT_MESSAGE_TYPES.has(messageType)) {

--- a/packages/synergy/src/channel/provider/feishu/index.ts
+++ b/packages/synergy/src/channel/provider/feishu/index.ts
@@ -819,7 +819,7 @@ export class FeishuProvider implements ChannelTypes.Provider<Config.ChannelFeish
       chatType: filterResult.isGroup ? "group" : "dm",
       chatName,
       senderId,
-      senderName: senderName ?? sender?.sender_id?.user_id,
+      senderName: senderName ?? senderId,
       text,
       messageId: msg.message_id || "",
       timestamp: Number(msg.create_time) || Date.now(),

--- a/packages/synergy/test/channel/feishu-message.test.ts
+++ b/packages/synergy/test/channel/feishu-message.test.ts
@@ -130,6 +130,30 @@ describe("Feishu sender identity", () => {
 
     expect(context).toMatchObject({ senderId: "ou_sender", senderName: "ou_sender" })
   })
+
+  test("uses alternate stable sender identifiers when open_id is unavailable", async () => {
+    const message = {
+      message_id: "msg_sender",
+      chat_id: "chat_test",
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: "hello" }),
+    }
+
+    const userContext = await buildMessageContext(providerWithAccount(), message, accountConfig(), {
+      sender_id: { user_id: "user_sender" },
+      sender_type: "user",
+    })
+    const unionContext = await buildMessageContext(
+      providerWithAccount(),
+      { ...message, message_id: "msg_union_sender" },
+      accountConfig(),
+      { sender_id: { union_id: "on_sender", user_id: "user_sender" }, sender_type: "user" },
+    )
+
+    expect(userContext).toMatchObject({ senderId: "user_sender", senderName: "user_sender" })
+    expect(unionContext).toMatchObject({ senderId: "on_sender", senderName: "on_sender" })
+  })
 })
 
 describe("Feishu bot identity resolution", () => {

--- a/packages/synergy/test/channel/feishu-message.test.ts
+++ b/packages/synergy/test/channel/feishu-message.test.ts
@@ -66,9 +66,12 @@ async function buildMessageContext(
   provider: FeishuProvider,
   message: Record<string, unknown>,
   config = accountConfig(),
+  sender: Record<string, unknown> = { sender_id: { open_id: "ou_user" }, sender_type: "user" },
 ): Promise<{
   chatType: "dm" | "group"
   text: string
+  senderId: string
+  senderName?: string
   wasMentioned?: boolean
   quotedContent?: string
   attachments?: Array<{ path: string; filename?: string; placeholder?: string }>
@@ -83,6 +86,8 @@ async function buildMessageContext(
       ): Promise<{
         chatType: "dm" | "group"
         text: string
+        senderId: string
+        senderName?: string
         wasMentioned?: boolean
         quotedContent?: string
         attachments?: Array<{ path: string; filename?: string; placeholder?: string }>
@@ -90,13 +95,42 @@ async function buildMessageContext(
     }
   ).buildMessageContext("acct_test", config, channelConfig(), {
     message,
-    sender: { sender_id: { open_id: "ou_user" }, sender_type: "user" },
+    sender,
   })
 }
 
 async function cleanupContextAttachments(context: { attachments?: Array<{ path: string }> }): Promise<void> {
   await Promise.all(context.attachments?.map((attachment) => fs.unlink(attachment.path)) ?? [])
 }
+
+describe("Feishu sender identity", () => {
+  test("falls back to senderId when sender name lookup fails and optional sender fields are null", async () => {
+    globalThis.fetch = (async (input) => {
+      const url = String(input)
+      if (url.includes("/contact/v3/users/ou_sender")) {
+        return new Response(JSON.stringify({ code: 41050, msg: "no user authority error" }), {
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    }) as typeof fetch
+
+    const context = await buildMessageContext(
+      providerWithAccount(),
+      {
+        message_id: "msg_sender",
+        chat_id: "chat_test",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+      accountConfig({ resolveSenderNames: true }),
+      { sender_id: { open_id: "ou_sender", user_id: null }, sender_type: "user" },
+    )
+
+    expect(context).toMatchObject({ senderId: "ou_sender", senderName: "ou_sender" })
+  })
+})
 
 describe("Feishu bot identity resolution", () => {
   test("resolves and caches the bot open_id before filtering required group mentions", async () => {


### PR DESCRIPTION
## Summary

- fall back to the normalized Feishu sender ID when sender-name resolution is unavailable
- prevent nullable optional sender metadata from invalidating otherwise valid inbound Channel messages
- cover the observed contact-permission failure and `null` user ID payload with a regression test

## Verification

- `bun test test/channel/feishu-message.test.ts`
- `bun test test/channel/`
- `bun run typecheck` (from `packages/synergy`)
- `bun run format:check`
- `bun run quality:quick`