### PR TITLE
fix(config): import ModelsDev from models-schemas not models

### DIFF
--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -12,7 +12,7 @@ import {
   McpToolsConfig,
 } from "@ericsanchezok/synergy-plugin"
 import { DEFAULT_PLUGIN_RUNTIME_LIMITS } from "@ericsanchezok/synergy-util/plugin-policy"
-import { ModelsDev } from "../provider/models"
+import { ModelsDev } from "../provider/models-schemas"
 import { LSPServer } from "../lsp/server"
 import { ModelRole } from "../provider/model-role"
 import { normalizePublicHttpsOrigin } from "../util/public-https-origin"


### PR DESCRIPTION
## Summary
- Fix release workflow crash: `schema.ts` imported `ModelsDev` from the runtime-laden `provider/models` module, causing `ModelsDev.Provider` to be `undefined` during Bun bundle initialization in CI
- Switch to the pure-schema `provider/models-schemas` import — same `Provider` and `Model` Zod schemas, zero side effects

## Root cause
`packages/synergy/src/config/schema.ts` line 15 imported from `../provider/models`, which pulls in `Global` (filesystem I/O), a Bun macro (network fetch at compile time), and `setInterval` (runtime timer). In the CI-built binary, module initialization order could leave the `ModelsDev` namespace partially initialized, making `ModelsDev.Provider` `undefined` when `schema.ts` called `.partial()` on it.

Error in [release run #30602611482](https://github.com/SII-Holos/synergy/actions/runs/30602611482):
```
TypeError: undefined is not an object (evaluating 'ModelsDev2.Provider.partial')
  at <anonymous> (src/config/schema.ts:1078:35)
```

## Change
- `packages/synergy/src/config/schema.ts`: 1 line import change
