### PR TITLE
fix: defer provider catalog runtime schema load

### DIFF
--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -7,12 +7,22 @@ import z from "zod"
 import { Auth } from "./api-key"
 import { registerBuiltinProviderProfiles } from "./builtin"
 import { CodexProvider } from "./codex"
-import { ModelsDev } from "./models"
+import { ModelsDev } from "./models-schemas"
 import { ProviderProfile } from "./profile"
 import { normalizeImageMediaTypes } from "./image-capability"
 
 export namespace ProviderCatalog {
   const log = Log.create({ service: "provider.catalog" })
+
+  type ModelsDevRuntime = (typeof import("./models"))["ModelsDev"]
+  let modelsDevRuntime: Promise<ModelsDevRuntime> | undefined
+
+  function loadModelsDevRuntime() {
+    if (!modelsDevRuntime) {
+      modelsDevRuntime = import("./models").then((module) => module.ModelsDev)
+    }
+    return modelsDevRuntime
+  }
 
   export const DEFAULT_REGISTRY_URL =
     "https://raw.githubusercontent.com/SII-Holos/synergy-provider-registry/main/catalog.v1.json"
@@ -730,7 +740,8 @@ export namespace ProviderCatalog {
     generation: number,
   ): Promise<Record<string, ModelsDev.Provider>> {
     const config = Config.parse((input?.config as any)?.providerCatalog ?? {})
-    const modelsDev = withBuiltinSourceSurfaces(await ModelsDev.get())
+    const runtimeModelsDev = await loadModelsDevRuntime()
+    const modelsDev = withBuiltinSourceSurfaces(await runtimeModelsDev.get())
     const result: Record<string, ModelsDev.Provider> = { ...modelsDev }
 
     for (const [providerID, provider] of Object.entries(bundledSnapshot(modelsDev))) {
@@ -850,11 +861,17 @@ export namespace ProviderCatalog {
     snapshots = undefined
   }
 
-  ModelsDev.onRefresh(async () => {
-    invalidateModelsDevProjection()
-    const { RuntimeReload } = await import("@/runtime/reload")
-    await RuntimeReload.reloadGlobal({ targets: ["provider"], reason: "models.dev catalog refreshed" })
-  })
+  void loadModelsDevRuntime()
+    .then((modelsDevRuntime) =>
+      modelsDevRuntime.onRefresh(async () => {
+        invalidateModelsDevProjection()
+        const { RuntimeReload } = await import("@/runtime/reload")
+        await RuntimeReload.reloadGlobal({ targets: ["provider"], reason: "models.dev catalog refreshed" })
+      }),
+    )
+    .catch((error) => {
+      log.warn("failed to register models.dev refresh listener", { error })
+    })
 
   export function modelCatalogState(providerID: string) {
     return catalogStates.get(providerID)

--- a/packages/synergy/test/provider/catalog-resilient-load.test.ts
+++ b/packages/synergy/test/provider/catalog-resilient-load.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, expect, mock, test } from "bun:test"
+import path from "path"
+import { pathToFileURL } from "url"
+
+const catalogModule = pathToFileURL(path.resolve(import.meta.dir, "../../src/provider/catalog.ts")).href
+const modelsModule = pathToFileURL(path.resolve(import.meta.dir, "../../src/provider/models")).href
+const modelsModuleWithExtension = pathToFileURL(path.resolve(import.meta.dir, "../../src/provider/models.ts")).href
+
+afterEach(() => {
+  mock.restore()
+})
+
+test("ProviderCatalog module import does not crash when ModelsDev module export is missing", async () => {
+  mock.module(modelsModuleWithExtension, () => {
+    return {}
+  })
+  mock.module(modelsModule, () => {
+    return {}
+  })
+
+  const catalog = await import(catalogModule)
+  expect(catalog.ProviderCatalog).toBeDefined()
+})

--- a/packages/synergy/test/provider/catalog-resilient-load.test.ts
+++ b/packages/synergy/test/provider/catalog-resilient-load.test.ts
@@ -1,23 +1,18 @@
-import { afterEach, expect, mock, test } from "bun:test"
+import { expect, test } from "bun:test"
 import path from "path"
-import { pathToFileURL } from "url"
 
-const catalogModule = pathToFileURL(path.resolve(import.meta.dir, "../../src/provider/catalog.ts")).href
-const modelsModule = pathToFileURL(path.resolve(import.meta.dir, "../../src/provider/models")).href
-const modelsModuleWithExtension = pathToFileURL(path.resolve(import.meta.dir, "../../src/provider/models.ts")).href
-
-afterEach(() => {
-  mock.restore()
-})
+const fixture = path.join(import.meta.dir, "fixtures", "catalog-resilient-load.ts")
 
 test("ProviderCatalog module import does not crash when ModelsDev module export is missing", async () => {
-  mock.module(modelsModuleWithExtension, () => {
-    return {}
+  const child = Bun.spawn([process.execPath, "run", fixture], {
+    stdout: "pipe",
+    stderr: "pipe",
   })
-  mock.module(modelsModule, () => {
-    return {}
-  })
-
-  const catalog = await import(catalogModule)
-  expect(catalog.ProviderCatalog).toBeDefined()
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ])
+  if (exitCode !== 0) throw new Error(`catalog resilient load fixture failed (${exitCode}): ${stderr}`)
+  expect(stdout.trim()).toBe("OK")
 })

--- a/packages/synergy/test/provider/fixtures/catalog-resilient-load.ts
+++ b/packages/synergy/test/provider/fixtures/catalog-resilient-load.ts
@@ -1,0 +1,18 @@
+import { mock } from "bun:test"
+import path from "path"
+import { pathToFileURL } from "url"
+
+const catalogModule = pathToFileURL(path.resolve(import.meta.dir, "../../../src/provider/catalog.ts")).href
+const modelsModule = pathToFileURL(path.resolve(import.meta.dir, "../../../src/provider/models")).href
+const modelsModuleWithExtension = pathToFileURL(path.resolve(import.meta.dir, "../../../src/provider/models.ts")).href
+
+mock.module(modelsModuleWithExtension, () => ({}))
+mock.module(modelsModule, () => ({}))
+
+const catalog = await import(catalogModule)
+if (!catalog.ProviderCatalog) {
+  process.stderr.write("ProviderCatalog was not defined\n")
+  process.exit(1)
+}
+
+process.stdout.write("OK\n")


### PR DESCRIPTION
## Why
- Prevent provider catalog process startup crash when `./models` has runtime schema/import issues during module load.
- Keep `./models-schemas` as the compile-time dependency while moving `./models` loading to runtime.

## What changed
- Lazy-load `ModelsDev` from `./models` in `packages/synergy/src/provider/catalog.ts`.
- Guard models.dev refresh listener registration with error handling around the lazy import.
- Add regression test `packages/synergy/test/provider/catalog-resilient-load.test.ts` to ensure `ProviderCatalog` module import still succeeds when the `models` module export is missing.

## Tests
- `bun test test/provider/catalog-resilient-load.test.ts`

