### PR TITLE
feat(provider): resolve account runtime profiles

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -224,7 +224,6 @@ A local provider connection can reuse a canonical Models.dev catalog while keepi
 {
   "provider": {
     "deepseek-team": {
-      "profile": "deepseek",
       "modelsDevProviderID": "deepseek",
       "name": "DeepSeek Team",
       "env": ["DEEPSEEK_TEAM_API_KEY"],

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -224,6 +224,7 @@ A local provider connection can reuse a canonical Models.dev catalog while keepi
 {
   "provider": {
     "deepseek-team": {
+      "profile": "deepseek",
       "modelsDevProviderID": "deepseek",
       "name": "DeepSeek Team",
       "env": ["DEEPSEEK_TEAM_API_KEY"],
@@ -234,7 +235,9 @@ A local provider connection can reuse a canonical Models.dev catalog while keepi
 
 Inherited models are projected onto the connection ID, so model references such as `deepseek-team/deepseek-chat` select that account. Connection-level `api`, `npm`, `options`, allowlist/blacklist, and explicit model entries override inherited catalog metadata without mutating the canonical provider.
 
-`modelsDevProviderID` shares model metadata only. Provider-specific runtime behavior, authentication strategy, usage reporting, and credential-aware live discovery are not inherited by this field.
+`modelsDevProviderID` shares model metadata only. Set `profile` separately when the connection should also use the canonical provider's runtime hooks, model factory, auth recovery, usage reporting, and credential-aware live discovery. Credentials, health, live catalog snapshots, and model references remain keyed by the connection ID.
+
+Keeping these fields separate is intentional: an OpenAI-compatible gateway can inherit a catalog without inheriting the canonical provider's OAuth or request behavior.
 
 ### Model variants and role variants
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1593,6 +1593,7 @@ export type Model = {
 
 export type Provider = {
   id: string
+  profileID?: string
   name: string
   source: "env" | "config" | "custom" | "api"
   env: Array<string>
@@ -2459,10 +2460,6 @@ export type ProviderConfig = {
   env?: Array<string>
   id?: string
   npm?: string
-  /**
-   * Models.dev provider id to use as this provider connection's model catalog source
-   */
-  modelsDevProviderID?: string
   models?: {
     [key: string]: {
       id?: string
@@ -2529,6 +2526,14 @@ export type ProviderConfig = {
       }
     }
   }
+  /**
+   * Canonical provider profile whose runtime behavior this account connection uses
+   */
+  profile?: string
+  /**
+   * Models.dev provider id to use as this provider connection's model catalog source
+   */
+  modelsDevProviderID?: string
   whitelist?: Array<string>
   blacklist?: Array<string>
   options?: {
@@ -7841,6 +7846,14 @@ export type EventProviderAuthUpdated = {
   }
 }
 
+export type EventConfigUpdated = {
+  type: "config.updated"
+  properties: {
+    scope: "global" | "project"
+    changedFields: Array<string>
+  }
+}
+
 export type EventInstallationUpdated = {
   type: "installation.updated"
   properties: {
@@ -7852,14 +7865,6 @@ export type EventInstallationUpdateAvailable = {
   type: "installation.update-available"
   properties: {
     version: string
-  }
-}
-
-export type EventConfigUpdated = {
-  type: "config.updated"
-  properties: {
-    scope: "global" | "project"
-    changedFields: Array<string>
   }
 }
 
@@ -8449,9 +8454,9 @@ export type Event =
   | EventScopeRemoved
   | EventScopeRuntimeDisposed
   | EventProviderAuthUpdated
+  | EventConfigUpdated
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
-  | EventConfigUpdated
   | EventMcpToolsChanged
   | EventMcpPromptsChanged
   | EventMcpResourcesChanged

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -25640,6 +25640,9 @@
           "id": {
             "type": "string"
           },
+          "profileID": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -27294,11 +27297,6 @@
           "npm": {
             "type": "string"
           },
-          "modelsDevProviderID": {
-            "description": "Models.dev provider id to use as this provider connection's model catalog source",
-            "type": "string",
-            "minLength": 1
-          },
           "models": {
             "type": "object",
             "propertyNames": {
@@ -27342,6 +27340,7 @@
                   }
                 },
                 "temperature": {
+                  "default": false,
                   "type": "boolean"
                 },
                 "tool_call": {
@@ -27452,6 +27451,7 @@
                   "enum": ["active", "retained"]
                 },
                 "options": {
+                  "default": {},
                   "type": "object",
                   "propertyNames": {
                     "type": "string"
@@ -27473,8 +27473,7 @@
                     "npm": {
                       "type": "string"
                     }
-                  },
-                  "required": ["npm"]
+                  }
                 },
                 "variants": {
                   "description": "Variant-specific configuration",
@@ -27495,6 +27494,16 @@
                 }
               }
             }
+          },
+          "profile": {
+            "description": "Canonical provider profile whose runtime behavior this account connection uses",
+            "type": "string",
+            "minLength": 1
+          },
+          "modelsDevProviderID": {
+            "description": "Models.dev provider id to use as this provider connection's model catalog source",
+            "type": "string",
+            "minLength": 1
           },
           "whitelist": {
             "type": "array",
@@ -41598,6 +41607,32 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.config.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "config.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "type": "string",
+                "enum": ["global", "project"]
+              },
+              "changedFields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["scope", "changedFields"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "Event.installation.updated": {
         "type": "object",
         "properties": {
@@ -41632,32 +41667,6 @@
               }
             },
             "required": ["version"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
-      "Event.config.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "config.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "scope": {
-                "type": "string",
-                "enum": ["global", "project"]
-              },
-              "changedFields": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": ["scope", "changedFields"]
           }
         },
         "required": ["type", "properties"]
@@ -43317,13 +43326,13 @@
             "$ref": "#/components/schemas/Event.provider.auth.updated"
           },
           {
+            "$ref": "#/components/schemas/Event.config.updated"
+          },
+          {
             "$ref": "#/components/schemas/Event.installation.updated"
           },
           {
             "$ref": "#/components/schemas/Event.installation.update-available"
-          },
-          {
-            "$ref": "#/components/schemas/Event.config.updated"
           },
           {
             "$ref": "#/components/schemas/Event.mcp.tools.changed"

--- a/packages/synergy/schema/config.schema.json
+++ b/packages/synergy/schema/config.schema.json
@@ -1301,6 +1301,11 @@
               "additionalProperties": false
             }
           },
+          "profile": {
+            "description": "Canonical provider profile whose runtime behavior this account connection uses",
+            "type": "string",
+            "minLength": 1
+          },
           "modelsDevProviderID": {
             "description": "Models.dev provider id to use as this provider connection's model catalog source",
             "type": "string",

--- a/packages/synergy/src/cli/cmd/auth.ts
+++ b/packages/synergy/src/cli/cmd/auth.ts
@@ -22,6 +22,7 @@ import { MiniMaxProvider } from "@/provider/minimax"
 import { GitHubProvider } from "@/provider/github"
 import type { AuthOuathResult } from "@ericsanchezok/synergy-plugin/auth"
 import { ProviderUsage } from "@/provider/usage-service"
+import { ProviderAuth } from "@/provider/auth"
 
 type PluginAuth = AuthHook
 
@@ -605,6 +606,15 @@ export const AuthLoginCommand = cmd({
         })
 
         if (prompts.isCancel(provider)) throw new UI.CancelledError()
+
+        const configuredProfile = config.provider?.[provider]?.profile
+        if (configuredProfile) {
+          const auth = await ProviderAuth.hook(provider)
+          if (auth) {
+            const handled = await handlePluginAuth({ auth }, provider)
+            if (handled) return
+          }
+        }
 
         if (provider === CodexProvider.PROVIDER_ID) {
           const handled = await handleCodexAuth()

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -1077,6 +1077,11 @@ export type LibraryConfig = z.infer<typeof LibraryConfig>
 
 export const Provider = ModelsDev.Provider.partial()
   .extend({
+    profile: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Canonical provider profile whose runtime behavior this account connection uses"),
     modelsDevProviderID: z
       .string()
       .min(1)

--- a/packages/synergy/src/config/setup.ts
+++ b/packages/synergy/src/config/setup.ts
@@ -1,5 +1,6 @@
 import { Auth } from "../provider/api-key"
 import { ModelsDev } from "../provider/models"
+import { ProviderCatalog } from "../provider/catalog"
 import { Provider } from "../provider/provider"
 import { ProviderTransform } from "../provider/transform"
 import { Config } from "./config"
@@ -753,12 +754,12 @@ export namespace ConfigSetup {
     ref: string,
   ): Promise<ImportedProviderModelTarget> {
     const { providerID, modelID } = Provider.parseModel(ref)
-    const database = await ModelsDev.get()
+    const database = await ProviderCatalog.resolve({ config, includeLive: false })
     const imported = config.provider?.[providerID]
     const sourceProviderID = imported?.modelsDevProviderID ?? providerID
-    const source = database[sourceProviderID]
+    const source = database[providerID] ?? database[sourceProviderID]
     const base =
-      source && sourceProviderID !== providerID
+      source && source.id !== providerID
         ? {
             ...source,
             id: providerID,

--- a/packages/synergy/src/config/setup.ts
+++ b/packages/synergy/src/config/setup.ts
@@ -754,7 +754,18 @@ export namespace ConfigSetup {
     const { providerID, modelID } = Provider.parseModel(ref)
     const database = await ModelsDev.get()
     const imported = config.provider?.[providerID]
-    const base = database[providerID]
+    const sourceProviderID = imported?.modelsDevProviderID ?? providerID
+    const source = database[sourceProviderID]
+    const base =
+      source && sourceProviderID !== providerID
+        ? {
+            ...source,
+            id: providerID,
+            env: [],
+            api: imported?.api ?? source.api,
+            npm: imported?.npm ?? source.npm,
+          }
+        : source
 
     if (!imported && !base) {
       throw new Error(`Provider \"${providerID}\" was not found in the imported config or known provider catalog`)
@@ -806,6 +817,7 @@ export namespace ConfigSetup {
 
     const provider: Provider.Info = {
       id: providerID,
+      profileID: imported?.profile,
       name: imported?.name ?? existing?.name ?? providerID,
       source: "config",
       env: imported?.env ?? existing?.env ?? [],

--- a/packages/synergy/src/config/setup.ts
+++ b/packages/synergy/src/config/setup.ts
@@ -973,6 +973,7 @@ export namespace ConfigSetup {
     }
 
     const sdk = Provider.createSDKFromSpec(target.model, {
+      profileID: target.provider.profileID,
       options: { ...providerOptions, ...modelOptions, apiKey },
       key: apiKey,
     })

--- a/packages/synergy/src/config/setup.ts
+++ b/packages/synergy/src/config/setup.ts
@@ -193,6 +193,7 @@ export namespace ConfigSetup {
 
   interface LanguageProbeTarget {
     ref: string
+    provider?: Provider.Info
     model: Provider.Model
     runtimeModel: Awaited<ReturnType<typeof Provider.getLanguage>>
   }
@@ -858,6 +859,7 @@ export namespace ConfigSetup {
 
     return {
       ref: value,
+      provider,
       model,
       runtimeModel: await Provider.getLanguage(model),
     }
@@ -1010,7 +1012,10 @@ export namespace ConfigSetup {
         "runtimeModel" in target
           ? target.runtimeModel
           : await createImportedLanguageRuntime(target, options?.importContext?.auth)
-      const providerOptions = ProviderTransform.providerOptions(model, ProviderTransform.smallOptions(model))
+      const providerOptions = ProviderTransform.providerOptions(
+        model,
+        ProviderTransform.smallOptions(model, target.provider?.profileID),
+      )
 
       const messages: ModelMessage[] = options?.requireImageInput
         ? [

--- a/packages/synergy/src/config/setup.ts
+++ b/packages/synergy/src/config/setup.ts
@@ -199,6 +199,7 @@ export namespace ConfigSetup {
   interface ImportedProviderModelTarget {
     provider: Provider.Info
     model: Provider.Model
+    catalogProvider?: ModelsDev.Provider
   }
 
   export async function init() {
@@ -822,14 +823,17 @@ export namespace ConfigSetup {
       source: "config",
       env: imported?.env ?? existing?.env ?? [],
       key: undefined,
-      options: mergeDeep(existing?.options ?? {}, imported?.options ?? {}),
+      options: mergeDeep(
+        existing?.options ?? {},
+        mergeDeep(imported?.api ? { baseURL: imported.api } : {}, imported?.options ?? {}),
+      ),
       models: {
         ...(existing?.models ?? {}),
         [modelID]: model,
       },
     }
 
-    return { provider, model }
+    return { provider, model, catalogProvider: base }
   }
 
   async function resolveImportedProviderModel(config: Config.Info, ref: string): Promise<ImportedProviderModelTarget> {
@@ -972,8 +976,6 @@ export namespace ConfigSetup {
     target: ImportedProviderModelTarget,
     authChanges?: Record<string, StagedAuthChange>,
   ) {
-    const modelOptions = (target.model.options ?? {}) as Record<string, unknown>
-    const providerOptions = (target.provider.options ?? {}) as Record<string, unknown>
     const apiKey = await resolveProviderAPIKey(target.provider, target.model, authChanges)
 
     if (!apiKey) {
@@ -984,13 +986,13 @@ export namespace ConfigSetup {
       )
     }
 
-    const sdk = Provider.createSDKFromSpec(target.model, {
+    return Provider.createLanguageFromSpec(target.model, {
       profileID: target.provider.profileID,
-      options: { ...providerOptions, ...modelOptions, apiKey },
+      options: target.provider.options,
       key: apiKey,
+      auth: { type: "api", key: apiKey },
+      catalogProvider: target.catalogProvider,
     })
-
-    return sdk.languageModel(target.model.api.id)
   }
 
   async function probeLanguageModel(

--- a/packages/synergy/src/provider/anthropic-oauth.ts
+++ b/packages/synergy/src/provider/anthropic-oauth.ts
@@ -190,10 +190,12 @@ export namespace AnthropicOAuthProvider {
       })
     }
     if (auth.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return auth.access
+    let refreshCredentialID = selected.credentialID
     try {
       return await Auth.withLock(`${providerID}:oauth-refresh`, async () => {
         const latestSelected = await Auth.select(providerID)
         const latest = latestSelected?.auth
+        refreshCredentialID = latestSelected?.credentialID ?? refreshCredentialID
         if (latest?.type === "oauth" && latest.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return latest.access
         const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch, providerID)
         await Auth.replaceSelectedCredential(
@@ -210,7 +212,7 @@ export namespace AnthropicOAuthProvider {
       })
     } catch (error) {
       if (AuthError.isInstance(error) && error.data.reloginRequired) {
-        await Auth.markDead(providerID, error.data.code).catch(() => {})
+        await Auth.markDead(providerID, error.data.code, { credentialID: refreshCredentialID }).catch(() => {})
         if (options?.allowMissing) return undefined
       }
       throw error

--- a/packages/synergy/src/provider/anthropic-oauth.ts
+++ b/packages/synergy/src/provider/anthropic-oauth.ts
@@ -23,7 +23,7 @@ export namespace AnthropicOAuthProvider {
   export const AuthError = NamedError.create(
     "AnthropicOAuthError",
     z.object({
-      providerID: z.literal(PROVIDER_ID),
+      providerID: z.string(),
       code: z.string(),
       message: z.string(),
       reloginRequired: z.boolean(),
@@ -68,7 +68,7 @@ export namespace AnthropicOAuthProvider {
     }
   }
 
-  async function postToken(body: Record<string, string>, fetchFn: FetchLike) {
+  async function postToken(body: Record<string, string>, fetchFn: FetchLike, providerID = PROVIDER_ID) {
     let lastPayload: Record<string, any> = {}
     let lastStatus = 0
     for (const endpoint of OAUTH_TOKEN_URLS) {
@@ -89,7 +89,7 @@ export namespace AnthropicOAuthProvider {
     }
     const code = String(lastPayload.error ?? lastPayload.type ?? "anthropic_oauth_failed")
     throw new AuthError({
-      providerID: PROVIDER_ID,
+      providerID,
       code,
       message: String(
         lastPayload.error_description ?? lastPayload.message ?? `Anthropic OAuth failed with status ${lastStatus}.`,
@@ -147,7 +147,11 @@ export namespace AnthropicOAuthProvider {
     }
   }
 
-  export async function refreshOAuth(auth: z.infer<typeof Auth.Oauth>, fetchFn: FetchLike = fetch) {
+  export async function refreshOAuth(
+    auth: z.infer<typeof Auth.Oauth>,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ) {
     const payload = await postToken(
       {
         grant_type: "refresh_token",
@@ -155,10 +159,11 @@ export namespace AnthropicOAuthProvider {
         refresh_token: auth.refresh,
       },
       fetchFn,
+      providerID,
     )
     if (typeof payload.access_token !== "string") {
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "missing_access_token",
         message: "Anthropic OAuth refresh response was missing access_token.",
         reloginRequired: true,
@@ -171,13 +176,14 @@ export namespace AnthropicOAuthProvider {
     }
   }
 
-  export async function resolveToken(options?: { allowMissing?: boolean; fetch?: FetchLike }) {
-    const selected = await Auth.select(PROVIDER_ID)
+  export async function resolveToken(options?: { providerID?: string; allowMissing?: boolean; fetch?: FetchLike }) {
+    const providerID = options?.providerID ?? PROVIDER_ID
+    const selected = await Auth.select(providerID)
     const auth = selected?.auth
     if (!selected || !auth || auth.type !== "oauth") {
       if (options?.allowMissing) return undefined
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "anthropic_oauth_missing",
         message: "No Anthropic OAuth credentials stored.",
         reloginRequired: true,
@@ -185,13 +191,13 @@ export namespace AnthropicOAuthProvider {
     }
     if (auth.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return auth.access
     try {
-      return await Auth.withLock(`${PROVIDER_ID}:oauth-refresh`, async () => {
-        const latestSelected = await Auth.select(PROVIDER_ID)
+      return await Auth.withLock(`${providerID}:oauth-refresh`, async () => {
+        const latestSelected = await Auth.select(providerID)
         const latest = latestSelected?.auth
         if (latest?.type === "oauth" && latest.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return latest.access
-        const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch)
+        const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch, providerID)
         await Auth.replaceSelectedCredential(
-          PROVIDER_ID,
+          providerID,
           {
             type: "oauth",
             access: refreshed.access,
@@ -204,7 +210,7 @@ export namespace AnthropicOAuthProvider {
       })
     } catch (error) {
       if (AuthError.isInstance(error) && error.data.reloginRequired) {
-        await Auth.markDead(PROVIDER_ID, error.data.code).catch(() => {})
+        await Auth.markDead(providerID, error.data.code).catch(() => {})
         if (options?.allowMissing) return undefined
       }
       throw error
@@ -221,55 +227,61 @@ export namespace AnthropicOAuthProvider {
     }
   }
 
-  export async function anthropicFetch(input: RequestInfo | URL, init?: RequestInit) {
-    return ProviderAuthRecovery.execute({
-      providerID: PROVIDER_ID,
-      request: async () => {
-        const token = await resolveToken()
-        const headers = new Headers(init?.headers)
-        headers.delete("x-api-key")
-        headers.delete("X-Api-Key")
-        for (const [key, value] of Object.entries(requestHeaders(token!))) headers.set(key, value)
-        return fetch(input, { ...init, headers })
-      },
-      refresh: refreshAuth,
-      classify: classifyError,
-    })
+  export function anthropicFetchFor(providerID = PROVIDER_ID) {
+    return async (input: RequestInfo | URL, init?: RequestInit) =>
+      ProviderAuthRecovery.execute({
+        providerID,
+        request: async () => {
+          const token = await resolveToken({ providerID })
+          const headers = new Headers(init?.headers)
+          headers.delete("x-api-key")
+          headers.delete("X-Api-Key")
+          for (const [key, value] of Object.entries(requestHeaders(token!))) headers.set(key, value)
+          return fetch(input, { ...init, headers })
+        },
+        refresh: (auth) => refreshAuth(auth, fetch, providerID),
+        classify: classifyError,
+      })
   }
 
-  export async function fetchUsage(fetchFn: FetchLike = fetch): Promise<AccountUsage.Snapshot> {
-    const token = await resolveToken({ allowMissing: true, fetch: fetchFn })
+  export const anthropicFetch = anthropicFetchFor(PROVIDER_ID)
+
+  export async function fetchUsage(
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<AccountUsage.Snapshot> {
+    const token = await resolveToken({ providerID, allowMissing: true, fetch: fetchFn })
     if (!token) {
       return AccountUsage.unavailable(
-        PROVIDER_ID,
+        providerID,
         "Anthropic account limits are only available for OAuth-backed Claude accounts.",
       )
     }
     const response = await ProviderAuthRecovery.execute({
-      providerID: PROVIDER_ID,
+      providerID,
       request: async () => {
-        const current = await resolveToken({ allowMissing: true, fetch: fetchFn })
+        const current = await resolveToken({ providerID, allowMissing: true, fetch: fetchFn })
         if (!current) return new Response(null, { status: 401 })
         return fetchFn("https://api.anthropic.com/api/oauth/usage", {
           headers: requestHeaders(current),
           signal: AbortSignal.timeout(15_000),
         })
       },
-      refresh: (auth) => refreshAuth(auth, fetchFn),
+      refresh: (auth) => refreshAuth(auth, fetchFn, providerID),
       classify: classifyError,
       throwOnActionRequired: false,
     })
     if (!response.ok) {
       const failure = classifyError({ status: response.status, body: await safeJson(response.clone()) })
       if (failure?.reloginRequired) {
-        return AccountUsage.error(PROVIDER_ID, "Anthropic rejected these credentials. Reconnect to restore usage.", {
+        return AccountUsage.error(providerID, "Anthropic rejected these credentials. Reconnect to restore usage.", {
           reloginRequired: true,
         })
       }
       if (failure?.exhausted) {
-        return AccountUsage.unavailable(PROVIDER_ID, "Anthropic usage is temporarily rate limited.")
+        return AccountUsage.unavailable(providerID, "Anthropic usage is temporarily rate limited.")
       }
-      return AccountUsage.error(PROVIDER_ID, "Anthropic usage is temporarily unavailable.")
+      return AccountUsage.error(providerID, "Anthropic usage is temporarily unavailable.")
     }
     const payload = await safeJson(response)
     const windows = [
@@ -292,7 +304,7 @@ export namespace AnthropicOAuthProvider {
       )
     }
     return {
-      providerID: PROVIDER_ID,
+      providerID,
       status: "available",
       source: "oauth_usage_api",
       fetchedAt: new Date().toISOString(),
@@ -301,9 +313,13 @@ export namespace AnthropicOAuthProvider {
     }
   }
 
-  export async function refreshAuth(auth: Auth.Info, fetchFn: FetchLike = fetch): Promise<Auth.Info | undefined> {
+  export async function refreshAuth(
+    auth: Auth.Info,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<Auth.Info | undefined> {
     if (auth.type !== "oauth") return undefined
-    const refreshed = await refreshOAuth(auth, fetchFn)
+    const refreshed = await refreshOAuth(auth, fetchFn, providerID)
     return {
       type: "oauth",
       access: refreshed.access,

--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -9,6 +9,7 @@ export namespace ProviderAuthRecovery {
 
   export interface ExecuteInput {
     providerID: string
+    profileID?: string
     request: () => Promise<Response>
     refresh?: (auth: Auth.Info) => Promise<Auth.Info | undefined>
     recoverWithoutCredential?: () => Promise<boolean>
@@ -73,7 +74,7 @@ export namespace ProviderAuthRecovery {
 
   async function classify(input: ExecuteInput, response: Response) {
     const body = await responseBody(response)
-    const profile = ProviderProfile.get(input.providerID)
+    const profile = ProviderProfile.resolve(input.providerID, input.profileID)
     const classified =
       input.classify?.({ providerID: input.providerID, status: response.status, body }) ??
       profile?.classifyError?.({ providerID: input.providerID, status: response.status, body })
@@ -119,8 +120,8 @@ export namespace ProviderAuthRecovery {
     await RuntimeReload.reload({ targets: ["provider"], reason })
   }
 
-  function runtimeCredential(providerID: string) {
-    const profile = ProviderProfile.get(providerID)
+  function runtimeCredential(providerID: string, profileID?: string) {
+    const profile = ProviderProfile.resolve(providerID, profileID)
     const usesEnvironment = profile?.env?.some((name) => !!process.env[name]?.trim()) === true
     return {
       source: usesEnvironment ? "env" : profile?.origin === "plugin" ? "plugin" : "runtime",
@@ -129,14 +130,14 @@ export namespace ProviderAuthRecovery {
     }
   }
 
-  async function markSuccess(providerID: string, removalRevision: number) {
+  async function markSuccess(providerID: string, removalRevision: number, profileID?: string) {
     const entry = (await Auth.entries())[providerID]
     if (Auth.removalRevision(providerID) !== removalRevision) return
     if (entry) {
       await ProviderAuthHealth.clearObservation(providerID, entry)
       return
     }
-    const runtime = runtimeCredential(providerID)
+    const runtime = runtimeCredential(providerID, profileID)
     await ProviderAuthHealth.observe({
       providerID,
       status: "connected",
@@ -152,7 +153,7 @@ export namespace ProviderAuthRecovery {
     removalRevision: number,
   ) {
     if (Auth.removalRevision(input.providerID) !== removalRevision) return
-    const runtime = runtimeCredential(input.providerID)
+    const runtime = runtimeCredential(input.providerID, input.profileID)
     if (failure.exhausted) {
       if (selected) {
         await Auth.markExhausted(input.providerID, {
@@ -192,7 +193,7 @@ export namespace ProviderAuthRecovery {
   }
 
   async function refresh(input: ExecuteInput, selected: NonNullable<Awaited<ReturnType<typeof Auth.select>>>) {
-    const profile = ProviderProfile.get(input.providerID)
+    const profile = ProviderProfile.resolve(input.providerID, input.profileID)
     const refresh =
       input.refresh ??
       (profile?.refreshAuth
@@ -256,7 +257,7 @@ export namespace ProviderAuthRecovery {
     try {
       const response = await input.request()
       if (response.ok) {
-        await markSuccess(input.providerID, removalRevision)
+        await markSuccess(input.providerID, removalRevision, input.profileID)
         return response
       }
       const failure = await classify(input, response)
@@ -306,7 +307,7 @@ export namespace ProviderAuthRecovery {
       throw error
     }
     if (first.ok) {
-      await markSuccess(input.providerID, removalRevision)
+      await markSuccess(input.providerID, removalRevision, input.profileID)
       return first
     }
 
@@ -358,12 +359,13 @@ export namespace ProviderAuthRecovery {
     return retryOnce(input, removalRevision)
   }
 
-  export function wrapFetch(providerID: string, fetchFn: FetchLike = fetch): FetchLike {
+  export function wrapFetch(providerID: string, fetchFn: FetchLike = fetch, profileID?: string): FetchLike {
     if (handledFetches.has(fetchFn)) return fetchFn
     const wrapped: FetchLike = (input, init) => {
       const template = new Request(input, init)
       return execute({
         providerID,
+        profileID,
         request: async () => {
           const selected = await Auth.select(providerID)
           const request = template.clone()

--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -374,19 +374,29 @@ export namespace ProviderAuthRecovery {
     return retryOnce(input, removalRevision)
   }
 
-  export function wrapFetch(providerID: string, fetchFn: FetchLike = fetch, profileID?: string): FetchLike {
+  export function wrapFetch(
+    providerID: string,
+    fetchFn: FetchLike = fetch,
+    profileID?: string,
+    options?: { effectiveAPIKey?: string },
+  ): FetchLike {
     if (handledFetches.has(fetchFn)) return fetchFn
-    const wrapped: FetchLike = (input, init) => {
+    const wrapped: FetchLike = async (input, init) => {
       const template = new Request(input, init)
+      const selected = await Auth.select(providerID)
+      const manageStoredCredential =
+        options?.effectiveAPIKey === undefined ||
+        (selected?.auth.type === "api" && selected.auth.key === options.effectiveAPIKey)
       return execute({
         providerID,
         profileID,
+        manageStoredCredential,
         request: async () => {
-          const selected = await Auth.select(providerID)
           const request = template.clone()
           const headers = new Headers(request.headers)
-          if (selected?.auth.type === "api") {
-            const key = selected.auth.key
+          const current = manageStoredCredential ? await Auth.select(providerID) : undefined
+          if (current?.auth.type === "api") {
+            const key = current.auth.key
             if (headers.has("authorization")) headers.set("authorization", `Bearer ${key}`)
             if (headers.has("x-api-key")) headers.set("x-api-key", key)
             if (headers.has("api-key")) headers.set("api-key", key)

--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -19,6 +19,7 @@ export namespace ProviderAuthRecovery {
       error?: unknown
       body?: unknown
     }) => ProviderProfile.ClassifiedError | undefined
+    manageStoredCredential?: boolean
     reloadOnTransition?: boolean
     throwOnActionRequired?: boolean
   }
@@ -130,7 +131,18 @@ export namespace ProviderAuthRecovery {
     }
   }
 
-  async function markSuccess(providerID: string, removalRevision: number, profileID?: string) {
+  async function selectCredential(input: ExecuteInput) {
+    if (input.manageStoredCredential === false) return undefined
+    return Auth.select(input.providerID)
+  }
+
+  async function markSuccess(
+    providerID: string,
+    removalRevision: number,
+    profileID?: string,
+    manageStoredCredential = true,
+  ) {
+    if (!manageStoredCredential) return
     const entry = (await Auth.entries())[providerID]
     if (Auth.removalRevision(providerID) !== removalRevision) return
     if (entry) {
@@ -152,6 +164,7 @@ export namespace ProviderAuthRecovery {
     failure: ProviderProfile.ClassifiedError,
     removalRevision: number,
   ) {
+    if (input.manageStoredCredential === false) return
     if (Auth.removalRevision(input.providerID) !== removalRevision) return
     const runtime = runtimeCredential(input.providerID, input.profileID)
     if (failure.exhausted) {
@@ -254,20 +267,20 @@ export namespace ProviderAuthRecovery {
   }
 
   async function retryOnce(input: ExecuteInput, removalRevision: number) {
-    const selectedBeforeRequest = await Auth.select(input.providerID)
+    const selectedBeforeRequest = await selectCredential(input)
     try {
       const response = await input.request()
       if (response.ok) {
-        await markSuccess(input.providerID, removalRevision, input.profileID)
+        await markSuccess(input.providerID, removalRevision, input.profileID, input.manageStoredCredential !== false)
         return response
       }
       const failure = await classify(input, response)
-      if (failure) await markFailure(input, await Auth.select(input.providerID), failure, removalRevision)
+      if (failure) await markFailure(input, await selectCredential(input), failure, removalRevision)
       return failure ? finishFailure(input, response, failure) : response
     } catch (error) {
       const failure = classifiedThrownError(error)
       if (!failure) throw error
-      const selected = selectedBeforeRequest ?? (await Auth.select(input.providerID))
+      const selected = selectedBeforeRequest ?? (await selectCredential(input))
       const entry = (await Auth.entries())[input.providerID]
       if (isMissingCredentialError(error) && !entry) throw error
       await markFailure(input, selected, failure, removalRevision)
@@ -283,25 +296,25 @@ export namespace ProviderAuthRecovery {
     failure: ProviderProfile.ClassifiedError,
     removalRevision: number,
   ) {
-    const backup = await Auth.select(input.providerID)
+    const backup = await selectCredential(input)
     if (!backup || backup.credentialID === rejectedCredentialID) return finishFailure(input, original, failure)
     return retryOnce(input, removalRevision)
   }
 
   export async function execute(input: ExecuteInput) {
     const removalRevision = Auth.removalRevision(input.providerID)
-    const selectedBeforeRequest = await Auth.select(input.providerID)
+    const selectedBeforeRequest = await selectCredential(input)
     let first: Response
     try {
       first = await input.request()
     } catch (error) {
       const failure = classifiedThrownError(error)
       if (!failure) throw error
-      const selected = selectedBeforeRequest ?? (await Auth.select(input.providerID))
+      const selected = selectedBeforeRequest ?? (await selectCredential(input))
       const entry = (await Auth.entries())[input.providerID]
       if (isMissingCredentialError(error) && !entry) throw error
       await markFailure(input, selected, failure, removalRevision)
-      const backup = await Auth.select(input.providerID)
+      const backup = await selectCredential(input)
       if (selected && backup && backup.credentialID !== selected.credentialID) {
         return retryOnce(input, removalRevision)
       }
@@ -309,19 +322,19 @@ export namespace ProviderAuthRecovery {
       throw error
     }
     if (first.ok) {
-      await markSuccess(input.providerID, removalRevision, input.profileID)
+      await markSuccess(input.providerID, removalRevision, input.profileID, input.manageStoredCredential !== false)
       return first
     }
 
     const firstFailure = await classify(input, first)
     if (!firstFailure) return first
     if (firstFailure.exhausted) {
-      await markFailure(input, await Auth.select(input.providerID), firstFailure, removalRevision)
+      await markFailure(input, await selectCredential(input), firstFailure, removalRevision)
       return first
     }
     if (!firstFailure.reloginRequired) return first
 
-    const selected = await Auth.select(input.providerID)
+    const selected = await selectCredential(input)
     if (!selected) {
       if (input.recoverWithoutCredential) {
         try {

--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -3,6 +3,7 @@ import { ProviderAuthRecoveryError } from "./auth-recovery-error"
 import { Auth } from "./api-key"
 import { ProviderAuthHealth } from "./auth-health"
 import { ProviderProfile } from "./profile"
+import { Env } from "@/util/env"
 
 export namespace ProviderAuthRecovery {
   type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -20,6 +21,7 @@ export namespace ProviderAuthRecovery {
       body?: unknown
     }) => ProviderProfile.ClassifiedError | undefined
     manageStoredCredential?: boolean
+    environment?: string[]
     reloadOnTransition?: boolean
     throwOnActionRequired?: boolean
   }
@@ -121,9 +123,10 @@ export namespace ProviderAuthRecovery {
     await RuntimeReload.reload({ targets: ["provider"], reason })
   }
 
-  function runtimeCredential(providerID: string, profileID?: string) {
+  function runtimeCredential(providerID: string, profileID?: string, environment?: string[]) {
     const profile = ProviderProfile.resolve(providerID, profileID)
-    const usesEnvironment = profile?.env?.some((name) => !!process.env[name]?.trim()) === true
+    const environmentValues = ScopeContext.tryScope() ? Env.all() : process.env
+    const usesEnvironment = (environment ?? profile?.env ?? []).some((name) => !!environmentValues[name]?.trim())
     return {
       source: usesEnvironment ? "env" : profile?.origin === "plugin" ? "plugin" : "runtime",
       recovery: usesEnvironment ? ("update_environment" as const) : ("reconnect" as const),
@@ -141,6 +144,7 @@ export namespace ProviderAuthRecovery {
     removalRevision: number,
     profileID?: string,
     manageStoredCredential = true,
+    environment?: string[],
   ) {
     if (!manageStoredCredential) return
     const entry = (await Auth.entries())[providerID]
@@ -149,7 +153,7 @@ export namespace ProviderAuthRecovery {
       await ProviderAuthHealth.clearObservation(providerID, entry)
       return
     }
-    const runtime = runtimeCredential(providerID, profileID)
+    const runtime = runtimeCredential(providerID, profileID, environment)
     await ProviderAuthHealth.observe({
       providerID,
       status: "connected",
@@ -166,7 +170,7 @@ export namespace ProviderAuthRecovery {
   ) {
     if (input.manageStoredCredential === false) return
     if (Auth.removalRevision(input.providerID) !== removalRevision) return
-    const runtime = runtimeCredential(input.providerID, input.profileID)
+    const runtime = runtimeCredential(input.providerID, input.profileID, input.environment)
     if (failure.exhausted) {
       if (selected) {
         await Auth.markExhausted(input.providerID, {
@@ -271,7 +275,13 @@ export namespace ProviderAuthRecovery {
     try {
       const response = await input.request()
       if (response.ok) {
-        await markSuccess(input.providerID, removalRevision, input.profileID, input.manageStoredCredential !== false)
+        await markSuccess(
+          input.providerID,
+          removalRevision,
+          input.profileID,
+          input.manageStoredCredential !== false,
+          input.environment,
+        )
         return response
       }
       const failure = await classify(input, response)
@@ -322,7 +332,13 @@ export namespace ProviderAuthRecovery {
       throw error
     }
     if (first.ok) {
-      await markSuccess(input.providerID, removalRevision, input.profileID, input.manageStoredCredential !== false)
+      await markSuccess(
+        input.providerID,
+        removalRevision,
+        input.profileID,
+        input.manageStoredCredential !== false,
+        input.environment,
+      )
       return first
     }
 
@@ -378,19 +394,25 @@ export namespace ProviderAuthRecovery {
     providerID: string,
     fetchFn: FetchLike = fetch,
     profileID?: string,
-    options?: { effectiveAPIKey?: string },
+    options?: { effectiveAPIKey?: string; environment?: string[] },
   ): FetchLike {
     if (handledFetches.has(fetchFn)) return fetchFn
     const wrapped: FetchLike = async (input, init) => {
       const template = new Request(input, init)
       const selected = await Auth.select(providerID)
+      const environmentValues = ScopeContext.tryScope() ? Env.all() : process.env
+      const environmentKey = options?.environment
+        ?.map((name) => environmentValues[name]?.trim())
+        .find((value): value is string => !!value)
       const manageStoredCredential =
         options?.effectiveAPIKey === undefined ||
+        environmentKey === options.effectiveAPIKey ||
         (selected?.auth.type === "api" && selected.auth.key === options.effectiveAPIKey)
       return execute({
         providerID,
         profileID,
         manageStoredCredential,
+        environment: options?.environment,
         request: async () => {
           const request = template.clone()
           const headers = new Headers(request.headers)

--- a/packages/synergy/src/provider/auth-recovery.ts
+++ b/packages/synergy/src/provider/auth-recovery.ts
@@ -254,6 +254,7 @@ export namespace ProviderAuthRecovery {
   }
 
   async function retryOnce(input: ExecuteInput, removalRevision: number) {
+    const selectedBeforeRequest = await Auth.select(input.providerID)
     try {
       const response = await input.request()
       if (response.ok) {
@@ -266,7 +267,7 @@ export namespace ProviderAuthRecovery {
     } catch (error) {
       const failure = classifiedThrownError(error)
       if (!failure) throw error
-      const selected = await Auth.select(input.providerID)
+      const selected = selectedBeforeRequest ?? (await Auth.select(input.providerID))
       const entry = (await Auth.entries())[input.providerID]
       if (isMissingCredentialError(error) && !entry) throw error
       await markFailure(input, selected, failure, removalRevision)
@@ -289,13 +290,14 @@ export namespace ProviderAuthRecovery {
 
   export async function execute(input: ExecuteInput) {
     const removalRevision = Auth.removalRevision(input.providerID)
+    const selectedBeforeRequest = await Auth.select(input.providerID)
     let first: Response
     try {
       first = await input.request()
     } catch (error) {
       const failure = classifiedThrownError(error)
       if (!failure) throw error
-      const selected = await Auth.select(input.providerID)
+      const selected = selectedBeforeRequest ?? (await Auth.select(input.providerID))
       const entry = (await Auth.entries())[input.providerID]
       if (isMissingCredentialError(error) && !entry) throw error
       await markFailure(input, selected, failure, removalRevision)

--- a/packages/synergy/src/provider/auth.ts
+++ b/packages/synergy/src/provider/auth.ts
@@ -47,7 +47,12 @@ export namespace ProviderAuth {
     }
   }
 
-  function retargetHook(hook: AuthHook, providerID: string, profileID: string): AuthHook {
+  function retargetHook(
+    hook: AuthHook,
+    providerID: string,
+    profileID: string,
+    options?: { enterpriseUrl?: string },
+  ): AuthHook {
     return {
       ...hook,
       provider: providerID,
@@ -60,6 +65,7 @@ export namespace ProviderAuth {
                 profileID === CopilotProvider.PROVIDER_ID || profileID === CopilotProvider.ENTERPRISE_PROVIDER_ID
                   ? await CopilotProvider.authorizeDeviceCode(providerID, fetch, {
                       enterprise: profileID === CopilotProvider.ENTERPRISE_PROVIDER_ID,
+                      enterpriseUrl: options?.enterpriseUrl,
                     })
                   : await method.authorize(inputs)
               return retargetOauth(result, providerID)
@@ -206,7 +212,9 @@ export namespace ProviderAuth {
       const profileID = profile?.id ?? provider.profile
       const source = methods[profileID]
       if (!source) continue
-      methods[providerID] = retargetHook(source, providerID, profileID)
+      methods[providerID] = retargetHook(source, providerID, profileID, {
+        enterpriseUrl: provider.options?.enterpriseUrl,
+      })
     }
     return { methods, pending: {} as Record<string, PendingOauthResult> }
   })

--- a/packages/synergy/src/provider/auth.ts
+++ b/packages/synergy/src/provider/auth.ts
@@ -17,6 +17,8 @@ import { Provider } from "./provider"
 import { RuntimeReload } from "@/runtime/reload"
 import { authHook } from "@/plugin/auth-provider"
 import { ProviderAuthHealth } from "./auth-health"
+import { Config } from "@/config/config"
+import { ProviderProfile } from "./profile"
 
 type AutoOauthResult = Extract<AuthOuathResult, { method: "auto" }>
 type PendingOauthResult =
@@ -26,6 +28,59 @@ type PendingOauthResult =
     })
 
 export namespace ProviderAuth {
+  function retargetResult<T extends AuthImportResult>(result: T, providerID: string): T {
+    if (result.type !== "success") return result
+    return { ...result, provider: providerID }
+  }
+
+  function retargetOauth(result: AuthOuathResult, providerID: string): AuthOuathResult {
+    if (result.method === "code") {
+      return {
+        ...result,
+        callback: async (code) => retargetResult(await result.callback(code), providerID),
+      }
+    }
+    return {
+      ...result,
+      callback: async () => retargetResult(await result.callback(), providerID),
+    }
+  }
+
+  function retargetHook(hook: AuthHook, providerID: string, profileID: string): AuthHook {
+    return {
+      ...hook,
+      provider: providerID,
+      methods: hook.methods.map((method) => {
+        if (method.type === "oauth") {
+          return {
+            ...method,
+            authorize: async (inputs?: Record<string, string>) => {
+              const result =
+                profileID === CopilotProvider.PROVIDER_ID || profileID === CopilotProvider.ENTERPRISE_PROVIDER_ID
+                  ? await CopilotProvider.authorizeDeviceCode(providerID)
+                  : await method.authorize(inputs)
+              return retargetOauth(result, providerID)
+            },
+          }
+        }
+        if (method.type === "api" && method.authorize) {
+          return {
+            ...method,
+            authorize: async (inputs?: Record<string, string>) =>
+              retargetResult(await method.authorize!(inputs), providerID),
+          }
+        }
+        if (method.type === "import") {
+          return {
+            ...method,
+            import: async (inputs?: Record<string, string>) => retargetResult(await method.import(inputs), providerID),
+          }
+        }
+        return method
+      }),
+    }
+  }
+
   async function reloadProvider(reason: string) {
     if (ScopeContext.tryScope()) {
       await RuntimeReload.reload({ targets: ["provider"], reason })
@@ -141,6 +196,15 @@ export namespace ProviderAuth {
       },
     }
     const methods: Record<string, AuthHook> = { ...builtinMethods, ...pluginMethods }
+    const config = await Config.current()
+    for (const [providerID, provider] of Object.entries(config.provider ?? {})) {
+      if (!provider.profile) continue
+      const profile = ProviderProfile.get(provider.profile)
+      if (!profile) continue
+      const source = methods[profile.id]
+      if (!source) continue
+      methods[providerID] = retargetHook(source, providerID, profile.id)
+    }
     return { methods, pending: {} as Record<string, PendingOauthResult> }
   })
 
@@ -164,6 +228,14 @@ export namespace ProviderAuth {
         }),
       ),
     )
+  }
+
+  export async function hook(providerID: string) {
+    return state().then((x) => x.methods[providerID])
+  }
+
+  export async function reload() {
+    await state.resetAll()
   }
 
   export const Authorization = z

--- a/packages/synergy/src/provider/auth.ts
+++ b/packages/synergy/src/provider/auth.ts
@@ -203,10 +203,10 @@ export namespace ProviderAuth {
     for (const [providerID, provider] of Object.entries(config.provider ?? {})) {
       if (!provider.profile) continue
       const profile = ProviderProfile.get(provider.profile)
-      if (!profile) continue
-      const source = methods[profile.id]
+      const profileID = profile?.id ?? provider.profile
+      const source = methods[profileID]
       if (!source) continue
-      methods[providerID] = retargetHook(source, providerID, profile.id)
+      methods[providerID] = retargetHook(source, providerID, profileID)
     }
     return { methods, pending: {} as Record<string, PendingOauthResult> }
   })

--- a/packages/synergy/src/provider/auth.ts
+++ b/packages/synergy/src/provider/auth.ts
@@ -40,9 +40,10 @@ export namespace ProviderAuth {
         callback: async (code) => retargetResult(await result.callback(code), providerID),
       }
     }
+    const callback = result.callback as (signal?: AbortSignal) => ReturnType<AutoOauthResult["callback"]>
     return {
       ...result,
-      callback: async () => retargetResult(await result.callback(), providerID),
+      callback: async (signal?: AbortSignal) => retargetResult(await callback(signal), providerID),
     }
   }
 
@@ -57,7 +58,9 @@ export namespace ProviderAuth {
             authorize: async (inputs?: Record<string, string>) => {
               const result =
                 profileID === CopilotProvider.PROVIDER_ID || profileID === CopilotProvider.ENTERPRISE_PROVIDER_ID
-                  ? await CopilotProvider.authorizeDeviceCode(providerID)
+                  ? await CopilotProvider.authorizeDeviceCode(providerID, fetch, {
+                      enterprise: profileID === CopilotProvider.ENTERPRISE_PROVIDER_ID,
+                    })
                   : await method.authorize(inputs)
               return retargetOauth(result, providerID)
             },

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -209,7 +209,7 @@ export function registerBuiltinProviderProfiles() {
         return createAnthropic({
           name: "github-copilot",
           apiKey: "synergy-copilot",
-          baseURL: CopilotProvider.BASE_URL,
+          baseURL: (options?.baseURL as string | undefined) ?? CopilotProvider.BASE_URL,
           fetch: options?.fetch as typeof fetch,
         }).languageModel(modelID)
       }
@@ -243,7 +243,7 @@ export function registerBuiltinProviderProfiles() {
         return createAnthropic({
           name: "github-copilot-enterprise",
           apiKey: "synergy-copilot-enterprise",
-          baseURL: CopilotProvider.BASE_URL,
+          baseURL: (options?.baseURL as string | undefined) ?? CopilotProvider.BASE_URL,
           fetch: options?.fetch as typeof fetch,
         }).languageModel(modelID)
       }

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -98,7 +98,7 @@ export function registerBuiltinProviderProfiles() {
       if (!access) return []
       return CodexProvider.fetchModelCatalog(access, input.fetch)
     },
-    fetchUsage: (input) => CodexProvider.fetchUsage(input?.fetch),
+    fetchUsage: (input) => CodexProvider.fetchUsage(input.fetch),
     refreshAuth: (input) => (input.auth ? CodexProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
     classifyError: CodexProvider.classifyError,
   })
@@ -139,7 +139,7 @@ export function registerBuiltinProviderProfiles() {
         },
       }
     },
-    fetchUsage: (input) => AnthropicOAuthProvider.fetchUsage(input?.fetch),
+    fetchUsage: (input) => AnthropicOAuthProvider.fetchUsage(input.fetch),
     refreshAuth: (input) => (input.auth ? AnthropicOAuthProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
     classifyError: AnthropicOAuthProvider.classifyError,
   })
@@ -582,6 +582,6 @@ export function registerBuiltinProviderProfiles() {
         "X-OpenRouter-Categories": "cli-agent,personal-agent",
       },
     }),
-    fetchUsage: () => AccountUsage.openrouter("openrouter"),
+    fetchUsage: (input) => AccountUsage.openrouter(input.providerID, input.fetch),
   })
 }

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -455,12 +455,14 @@ export function registerBuiltinProviderProfiles() {
     modelFactory: "languageModel",
     modelsDevProviderID: "cloudflare-ai-gateway",
     autoload: async () => Boolean(Env.get("CLOUDFLARE_ACCOUNT_ID") && Env.get("CLOUDFLARE_GATEWAY_ID")),
-    runtimeOptions: async ({ providerID }) => {
+    runtimeOptions: async (input) => {
       const accountId = Env.get("CLOUDFLARE_ACCOUNT_ID")
       const gateway = Env.get("CLOUDFLARE_GATEWAY_ID")
       if (!accountId || !gateway) return {}
-      const auth = await Auth.get(providerID)
-      const apiToken = Env.get("CLOUDFLARE_API_TOKEN") ?? (auth?.type === "api" ? auth.key : undefined)
+      const auth = input.auth ?? (await Auth.get(input.providerID))
+      const authKey = auth?.type === "api" ? auth.key : undefined
+      const apiToken =
+        input.providerID === "cloudflare-ai-gateway" ? (authKey ?? Env.get("CLOUDFLARE_API_TOKEN")) : authKey
       return {
         baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gateway}/compat`,
         headers: {

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -78,28 +78,40 @@ export function registerBuiltinProviderProfiles() {
       if (!accountID) return undefined
       return `${CodexProvider.runtimeBaseURL()}:${accountID}`
     },
-    runtimeOptions: async () => {
-      const access = await CodexProvider.resolveToken({ allowMissing: true }).catch(() => undefined)
+    runtimeOptions: async (input) => {
+      const access = await CodexProvider.resolveToken({
+        providerID: input.providerID,
+        allowMissing: true,
+      }).catch(() => undefined)
       if (!access) return {}
       return {
         apiKey: "synergy-codex-oauth",
         baseURL: CodexProvider.runtimeBaseURL(),
-        fetch: ProviderAuthRecovery.handled(CodexProvider.codexFetch),
+        fetch: ProviderAuthRecovery.handled(CodexProvider.codexFetchFor(input.providerID)),
         setCacheKey: true,
       }
     },
     fetchModels: async (input) => {
-      const access = await CodexProvider.resolveToken({ allowMissing: true, fetch: input.fetch }).catch(() => undefined)
+      const access = await CodexProvider.resolveToken({
+        providerID: input.providerID,
+        allowMissing: true,
+        fetch: input.fetch,
+      }).catch(() => undefined)
       if (!access) return []
-      return CodexProvider.fetchModelIDs(access, input.fetch)
+      return CodexProvider.fetchModelIDs(access, input.fetch, input.providerID)
     },
     fetchModelCatalog: async (input) => {
-      const access = await CodexProvider.resolveToken({ allowMissing: true, fetch: input.fetch }).catch(() => undefined)
+      const access = await CodexProvider.resolveToken({
+        providerID: input.providerID,
+        allowMissing: true,
+        fetch: input.fetch,
+      }).catch(() => undefined)
       if (!access) return []
-      return CodexProvider.fetchModelCatalog(access, input.fetch)
+      return CodexProvider.fetchModelCatalog(access, input.fetch, input.providerID)
     },
-    fetchUsage: (input) => CodexProvider.fetchUsage(input.fetch),
-    refreshAuth: (input) => (input.auth ? CodexProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
+    fetchUsage: (input) => CodexProvider.fetchUsage(input.fetch, input.providerID),
+    refreshAuth: (input) =>
+      input.auth ? CodexProvider.refreshAuth(input.auth, fetch, input.providerID) : Promise.resolve(undefined),
     classifyError: CodexProvider.classifyError,
   })
 
@@ -132,15 +144,16 @@ export function registerBuiltinProviderProfiles() {
       }
       return {
         apiKey: "synergy-anthropic-oauth",
-        fetch: ProviderAuthRecovery.handled(AnthropicOAuthProvider.anthropicFetch),
+        fetch: ProviderAuthRecovery.handled(AnthropicOAuthProvider.anthropicFetchFor(input.providerID)),
         headers: {
           "anthropic-beta":
             "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
         },
       }
     },
-    fetchUsage: (input) => AnthropicOAuthProvider.fetchUsage(input.fetch),
-    refreshAuth: (input) => (input.auth ? AnthropicOAuthProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
+    fetchUsage: (input) => AnthropicOAuthProvider.fetchUsage(input.fetch, input.providerID),
+    refreshAuth: (input) =>
+      input.auth ? AnthropicOAuthProvider.refreshAuth(input.auth, fetch, input.providerID) : Promise.resolve(undefined),
     classifyError: AnthropicOAuthProvider.classifyError,
   })
 
@@ -186,26 +199,26 @@ export function registerBuiltinProviderProfiles() {
       "gemini-3-pro-preview",
     ],
     liveModelDiscovery: "copilot",
-    runtimeOptions: async () => ({
+    runtimeOptions: async (input) => ({
       apiKey: "synergy-copilot",
       baseURL: CopilotProvider.BASE_URL,
-      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor("github-copilot")),
+      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor(input.providerID)),
     }),
-    getModel: async ({ sdk, modelID }) => {
+    getModel: async ({ sdk, modelID, options }) => {
       if (modelID.toLowerCase().includes("claude")) {
         return createAnthropic({
           name: "github-copilot",
           apiKey: "synergy-copilot",
           baseURL: CopilotProvider.BASE_URL,
-          fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor("github-copilot")) as typeof fetch,
+          fetch: options?.fetch as typeof fetch,
         }).languageModel(modelID)
       }
       if (modelID.includes("codex") || modelID.startsWith("gpt-5")) return sdk.responses(modelID)
       return sdk.chat(modelID)
     },
-    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog("github-copilot", input.fetch),
+    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog(input.providerID, input.fetch),
     refreshAuth: (input) =>
-      input.auth ? CopilotProvider.refreshAuth("github-copilot", input.auth) : Promise.resolve(undefined),
+      input.auth ? CopilotProvider.refreshAuth(input.providerID, input.auth) : Promise.resolve(undefined),
     classifyError: CopilotProvider.classifyError,
   })
 
@@ -220,28 +233,26 @@ export function registerBuiltinProviderProfiles() {
     modelFactory: "copilotAuto",
     modelsDevProviderID: "github-copilot",
     fallbackModels: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "claude-sonnet-4.6"],
-    runtimeOptions: async () => ({
+    runtimeOptions: async (input) => ({
       apiKey: "synergy-copilot-enterprise",
       baseURL: CopilotProvider.BASE_URL,
-      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor("github-copilot-enterprise")),
+      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor(input.providerID)),
     }),
-    getModel: async ({ sdk, modelID }) => {
+    getModel: async ({ sdk, modelID, options }) => {
       if (modelID.toLowerCase().includes("claude")) {
         return createAnthropic({
           name: "github-copilot-enterprise",
           apiKey: "synergy-copilot-enterprise",
           baseURL: CopilotProvider.BASE_URL,
-          fetch: ProviderAuthRecovery.handled(
-            CopilotProvider.copilotFetchFor("github-copilot-enterprise"),
-          ) as typeof fetch,
+          fetch: options?.fetch as typeof fetch,
         }).languageModel(modelID)
       }
       if (modelID.includes("codex") || modelID.startsWith("gpt-5")) return sdk.responses(modelID)
       return sdk.chat(modelID)
     },
-    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog("github-copilot-enterprise", input.fetch),
+    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog(input.providerID, input.fetch),
     refreshAuth: (input) =>
-      input.auth ? CopilotProvider.refreshAuth("github-copilot-enterprise", input.auth) : Promise.resolve(undefined),
+      input.auth ? CopilotProvider.refreshAuth(input.providerID, input.auth) : Promise.resolve(undefined),
     classifyError: CopilotProvider.classifyError,
   })
 
@@ -515,12 +526,13 @@ export function registerBuiltinProviderProfiles() {
     modelFactory: "languageModel",
     modelsDevProviderID: "minimax",
     fallbackModels: ["MiniMax-M2.7", "MiniMax-M3"],
-    runtimeOptions: async () => ({
+    runtimeOptions: async (input) => ({
       apiKey: "synergy-minimax-oauth",
       baseURL: MiniMaxProvider.GLOBAL_INFERENCE,
-      fetch: ProviderAuthRecovery.handled(MiniMaxProvider.minimaxFetch),
+      fetch: ProviderAuthRecovery.handled(MiniMaxProvider.minimaxFetchFor(input.providerID)),
     }),
-    refreshAuth: (input) => (input.auth ? MiniMaxProvider.refreshAuth(input.auth) : Promise.resolve(undefined)),
+    refreshAuth: (input) =>
+      input.auth ? MiniMaxProvider.refreshAuth(input.auth, fetch, input.providerID) : Promise.resolve(undefined),
     classifyError: MiniMaxProvider.classifyError,
   })
 

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -604,6 +604,10 @@ export function registerBuiltinProviderProfiles() {
         "X-OpenRouter-Categories": "cli-agent,personal-agent",
       },
     }),
-    fetchUsage: (input) => AccountUsage.openrouter(input.providerID, input.fetch),
+    fetchUsage: (input) =>
+      AccountUsage.openrouter(input.providerID, input.fetch, {
+        auth: input.auth,
+        manageStoredCredential: input.manageStoredCredential,
+      }),
   })
 }

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -202,7 +202,7 @@ export function registerBuiltinProviderProfiles() {
     runtimeOptions: async (input) => ({
       apiKey: "synergy-copilot",
       baseURL: CopilotProvider.BASE_URL,
-      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor(input.providerID)),
+      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor(input.providerID, input.auth)),
     }),
     getModel: async ({ sdk, modelID, options }) => {
       if (modelID.toLowerCase().includes("claude")) {
@@ -216,7 +216,7 @@ export function registerBuiltinProviderProfiles() {
       if (modelID.includes("codex") || modelID.startsWith("gpt-5")) return sdk.responses(modelID)
       return sdk.chat(modelID)
     },
-    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog(input.providerID, input.fetch),
+    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog(input.providerID, input.fetch, input.auth),
     refreshAuth: (input) =>
       input.auth ? CopilotProvider.refreshAuth(input.providerID, input.auth) : Promise.resolve(undefined),
     classifyError: CopilotProvider.classifyError,
@@ -236,7 +236,7 @@ export function registerBuiltinProviderProfiles() {
     runtimeOptions: async (input) => ({
       apiKey: "synergy-copilot-enterprise",
       baseURL: CopilotProvider.BASE_URL,
-      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor(input.providerID)),
+      fetch: ProviderAuthRecovery.handled(CopilotProvider.copilotFetchFor(input.providerID, input.auth)),
     }),
     getModel: async ({ sdk, modelID, options }) => {
       if (modelID.toLowerCase().includes("claude")) {
@@ -250,7 +250,7 @@ export function registerBuiltinProviderProfiles() {
       if (modelID.includes("codex") || modelID.startsWith("gpt-5")) return sdk.responses(modelID)
       return sdk.chat(modelID)
     },
-    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog(input.providerID, input.fetch),
+    fetchModelCatalog: (input) => CopilotProvider.fetchModelCatalog(input.providerID, input.fetch, input.auth),
     refreshAuth: (input) =>
       input.auth ? CopilotProvider.refreshAuth(input.providerID, input.auth) : Promise.resolve(undefined),
     classifyError: CopilotProvider.classifyError,
@@ -287,38 +287,43 @@ export function registerBuiltinProviderProfiles() {
     aiSdkPackage: "@ai-sdk/amazon-bedrock",
     modelFactory: "languageModel",
     modelsDevProviderID: "amazon-bedrock",
-    autoload: async () => {
+    autoload: async (input) => {
       const { Config } = await import("@/config/config")
       const config = await Config.current()
-      const providerConfig = config.provider?.["amazon-bedrock"]
+      const providerConfig = config.provider?.[input.providerID]
       const profile = providerConfig?.options?.profile ?? Env.get("AWS_PROFILE")
       const awsAccessKeyId = Env.get("AWS_ACCESS_KEY_ID")
-      const auth = await Auth.get("amazon-bedrock")
-      const awsBearerToken = Env.get("AWS_BEARER_TOKEN_BEDROCK") ?? (auth?.type === "api" ? auth.key : undefined)
+      const stored = input.auth ?? (await Auth.get(input.providerID))
+      const authKey = stored?.type === "api" ? stored.key : undefined
+      const awsBearerToken =
+        input.providerID === "amazon-bedrock"
+          ? (Env.get("AWS_BEARER_TOKEN_BEDROCK") ?? authKey)
+          : (authKey ?? Env.get("AWS_BEARER_TOKEN_BEDROCK"))
       return Boolean(profile || awsAccessKeyId || awsBearerToken)
     },
-    runtimeOptions: async () => {
+    runtimeOptions: async (input) => {
       const { Config } = await import("@/config/config")
       const config = await Config.current()
-      const providerConfig = config.provider?.["amazon-bedrock"]
-      const auth = await Auth.get("amazon-bedrock")
+      const providerConfig = config.provider?.[input.providerID]
+      const stored = input.auth ?? (await Auth.get(input.providerID))
+      const authKey = stored?.type === "api" ? stored.key : undefined
       const defaultRegion = providerConfig?.options?.region ?? Env.get("AWS_REGION") ?? "us-east-1"
       const profile = providerConfig?.options?.profile ?? Env.get("AWS_PROFILE")
-      const awsBearerToken = iife(() => {
-        const envToken = Env.get("AWS_BEARER_TOKEN_BEDROCK")
-        if (envToken) return envToken
-        if (auth?.type === "api") {
-          Env.set("AWS_BEARER_TOKEN_BEDROCK", auth.key)
-          return auth.key
-        }
-        return undefined
-      })
+      const awsBearerToken =
+        input.providerID === "amazon-bedrock"
+          ? (Env.get("AWS_BEARER_TOKEN_BEDROCK") ?? authKey)
+          : (authKey ?? Env.get("AWS_BEARER_TOKEN_BEDROCK"))
       if (!profile && !Env.get("AWS_ACCESS_KEY_ID") && !awsBearerToken) return {}
 
-      const { fromNodeProviderChain } = await import((await BunProc.install("@aws-sdk/credential-providers")).entryPath)
       const providerOptions: AmazonBedrockProviderSettings = {
         region: defaultRegion,
-        credentialProvider: fromNodeProviderChain(profile ? { profile } : {}),
+      }
+      if (awsBearerToken) providerOptions.apiKey = awsBearerToken
+      else {
+        const { fromNodeProviderChain } = await import(
+          (await BunProc.install("@aws-sdk/credential-providers")).entryPath
+        )
+        providerOptions.credentialProvider = fromNodeProviderChain(profile ? { profile } : {})
       }
       const endpoint = providerConfig?.options?.endpoint ?? providerConfig?.options?.baseURL
       if (endpoint) providerOptions.baseURL = endpoint
@@ -420,18 +425,23 @@ export function registerBuiltinProviderProfiles() {
     aiSdkPackage: "@ai-sdk/openai-compatible",
     modelFactory: "call",
     modelsDevProviderID: "sap-ai-core",
-    autoload: async () => {
-      const auth = await Auth.get("sap-ai-core")
-      return Boolean(Env.get("AICORE_SERVICE_KEY") ?? (auth?.type === "api" ? auth.key : undefined))
+    autoload: async (input) => {
+      const auth = input.auth ?? (await Auth.get(input.providerID))
+      const authKey = auth?.type === "api" ? auth.key : undefined
+      return Boolean(input.providerID === "sap-ai-core" ? (Env.get("AICORE_SERVICE_KEY") ?? authKey) : authKey)
     },
-    runtimeOptions: async () => {
-      const auth = await Auth.get("sap-ai-core")
-      const envServiceKey = Env.get("AICORE_SERVICE_KEY") ?? (auth?.type === "api" ? auth.key : undefined)
-      if (envServiceKey) Env.set("AICORE_SERVICE_KEY", envServiceKey)
-      return envServiceKey
+    runtimeOptions: async (input) => {
+      const { Config } = await import("@/config/config")
+      const config = await Config.current()
+      const providerConfig = config.provider?.[input.providerID]
+      const auth = input.auth ?? (await Auth.get(input.providerID))
+      const authKey = auth?.type === "api" ? auth.key : undefined
+      const serviceKey = input.providerID === "sap-ai-core" ? (Env.get("AICORE_SERVICE_KEY") ?? authKey) : authKey
+      return serviceKey
         ? {
-            deploymentId: Env.get("AICORE_DEPLOYMENT_ID"),
-            resourceGroup: Env.get("AICORE_RESOURCE_GROUP"),
+            apiKey: serviceKey,
+            deploymentId: providerConfig?.options?.deploymentId ?? Env.get("AICORE_DEPLOYMENT_ID"),
+            resourceGroup: providerConfig?.options?.resourceGroup ?? Env.get("AICORE_RESOURCE_GROUP"),
           }
         : {}
     },

--- a/packages/synergy/src/provider/builtin.ts
+++ b/packages/synergy/src/provider/builtin.ts
@@ -98,7 +98,7 @@ export function registerBuiltinProviderProfiles() {
         fetch: input.fetch,
       }).catch(() => undefined)
       if (!access) return []
-      return CodexProvider.fetchModelIDs(access, input.fetch, input.providerID)
+      return CodexProvider.fetchModelIDs(access, input.fetch, input.providerID, input.baseURL)
     },
     fetchModelCatalog: async (input) => {
       const access = await CodexProvider.resolveToken({
@@ -107,7 +107,7 @@ export function registerBuiltinProviderProfiles() {
         fetch: input.fetch,
       }).catch(() => undefined)
       if (!access) return []
-      return CodexProvider.fetchModelCatalog(access, input.fetch, input.providerID)
+      return CodexProvider.fetchModelCatalog(access, input.fetch, input.providerID, input.baseURL)
     },
     fetchUsage: (input) => CodexProvider.fetchUsage(input.fetch, input.providerID),
     refreshAuth: (input) =>

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -117,6 +117,7 @@ export namespace ProviderCatalog {
     profile: ProviderProfile.Profile
     context: LiveDiscoveryContext
     baseURL?: string
+    configured?: ConfiguredProvider
   }
 
   type ConfiguredProvider = {
@@ -578,6 +579,7 @@ export namespace ProviderCatalog {
         profile,
         context: await resolveLiveDiscoveryContext(profile, providerID, baseURL, configured),
         baseURL,
+        configured,
       })
     }
     return targets
@@ -622,6 +624,7 @@ export namespace ProviderCatalog {
     providerID: string,
     profileID: string,
     baseURL: string | undefined,
+    configured: ConfiguredProvider | undefined,
     failure: Failure,
     error?: unknown,
   ) {
@@ -630,7 +633,7 @@ export namespace ProviderCatalog {
     const timer = setTimeout(
       () => {
         retryTimers.delete(providerID)
-        void refreshAndReload(providerID, profileID, baseURL)
+        void refreshAndReload(providerID, profileID, baseURL, configured)
       },
       retryDelay({ failure, retryAfterMs: retryAfterMs(error) }),
     )
@@ -664,15 +667,20 @@ export namespace ProviderCatalog {
     }
   }
 
-  export async function refresh(providerID: string, profileID?: string, baseURL?: string): Promise<ModelCatalogState> {
+  export async function refresh(
+    providerID: string,
+    profileID?: string,
+    baseURL?: string,
+    configuredInput?: ConfiguredProvider,
+  ): Promise<ModelCatalogState> {
     registerBuiltinProviderProfiles()
     await registerPluginProfiles()
     let profile = ProviderProfile.resolve(providerID, profileID)
-    let configured: ConfiguredProvider | undefined
-    if (!profile || ((profileID === undefined || baseURL === undefined) && ScopeContext.tryScope())) {
+    let configured = configuredInput
+    if (ScopeContext.tryScope() && (!configured || profileID === undefined || baseURL === undefined)) {
       const { Config } = await import("@/config/config")
       const config = await Config.current()
-      configured = config.provider?.[providerID]
+      configured ??= config.provider?.[providerID]
       if (profileID === undefined && configured?.profile) profile = ProviderProfile.get(configured.profile)
       else if (!profile) profile = ProviderProfile.get(configured?.profile ?? "")
     }
@@ -739,7 +747,7 @@ export namespace ProviderCatalog {
           failure,
         }
         catalogStates.set(providerID, state)
-        scheduleRetry(providerID, profile.id, resolvedBaseURL, failure, error)
+        scheduleRetry(providerID, profile.id, resolvedBaseURL, configured, failure, error)
         log.warn("failed to refresh provider model catalog", { providerID, profileID: profile.id, failure, error })
         return state
       }
@@ -768,9 +776,14 @@ export namespace ProviderCatalog {
     return request
   }
 
-  async function refreshAndReload(providerID: string, profileID?: string, baseURL?: string) {
+  async function refreshAndReload(
+    providerID: string,
+    profileID?: string,
+    baseURL?: string,
+    configured?: ConfiguredProvider,
+  ) {
     try {
-      await refresh(providerID, profileID, baseURL)
+      await refresh(providerID, profileID, baseURL, configured)
       const { RuntimeReload } = await import("@/runtime/reload")
       await RuntimeReload.reload({ targets: ["provider"], reason: "provider model catalog refreshed" })
     } catch (error) {
@@ -783,6 +796,7 @@ export namespace ProviderCatalog {
     profile: ProviderProfile.Profile,
     context: LiveDiscoveryContext,
     baseURL: string | undefined,
+    configured: ConfiguredProvider | undefined,
     snapshot: Snapshot | undefined,
   ) {
     if (!context.auth && profile.authKind !== "none") return
@@ -794,7 +808,7 @@ export namespace ProviderCatalog {
     if (refreshInFlight.has(key) || scheduledRefreshes.has(key)) return
     scheduledRefreshes.add(key)
     queueMicrotask(() => {
-      void refreshAndReload(providerID, profile.id, baseURL).finally(() => scheduledRefreshes.delete(key))
+      void refreshAndReload(providerID, profile.id, baseURL, configured).finally(() => scheduledRefreshes.delete(key))
     })
   }
 
@@ -935,7 +949,7 @@ export namespace ProviderCatalog {
         result[providerID] = await applyCachedDiscovery(provider, target.profile, modelsDev, target.context, providerID)
         if (target.profile.fetchModelCatalog || target.profile.fetchModels) {
           const snapshot = (await readSnapshots()).get(snapshotKey(providerID, target.context.identityHash))
-          scheduleRefresh(providerID, target.profile, target.context, target.baseURL, snapshot)
+          scheduleRefresh(providerID, target.profile, target.context, target.baseURL, target.configured, snapshot)
         }
       }
     }

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -588,7 +588,8 @@ export namespace ProviderCatalog {
   ): Promise<LiveDiscoveryContext> {
     const selected = await Auth.select(providerID)
     const environmentValues = ScopeContext.tryScope() ? Env.all() : process.env
-    const environment = (configured?.env ?? profile.env ?? [])
+    const environmentNames = configured?.env ?? (providerID === profile.id ? (profile.env ?? []) : [])
+    const environment = environmentNames
       .map((name) => ({ name, value: environmentValues[name]?.trim() }))
       .find((entry) => entry.value)
     const environmentAuth = environment?.value

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -1,5 +1,6 @@
 import { Global } from "@/global"
 import { Installation } from "@/global/installation"
+import { ScopeContext } from "@/scope/context"
 import { Log } from "@/util/log"
 import fs from "fs/promises"
 import { mergeDeep } from "remeda"
@@ -114,11 +115,17 @@ export namespace ProviderCatalog {
   type LiveDiscoveryTarget = {
     profile: ProviderProfile.Profile
     context: LiveDiscoveryContext
+    baseURL?: string
   }
 
-  type ConfiguredProvider = Partial<ModelsDev.Provider> & {
+  type ConfiguredProvider = {
     profile?: string
     modelsDevProviderID?: string
+    name?: string
+    api?: string
+    npm?: string
+    env?: string[]
+    options?: Record<string, unknown>
   }
 
   type CacheEntry = {
@@ -142,8 +149,8 @@ export namespace ProviderCatalog {
     return `${providerID}:${identityHash}`
   }
 
-  async function hashIdentity(providerID: string, identity: string) {
-    const bytes = new TextEncoder().encode(`${providerID}\u0000${identity}`)
+  async function hashIdentity(providerID: string, profileID: string, identity: string) {
+    const bytes = new TextEncoder().encode(`${providerID}\u0000${profileID}\u0000${identity}`)
     const digest = await crypto.subtle.digest("SHA-256", bytes)
     return Buffer.from(digest).toString("hex")
   }
@@ -506,7 +513,7 @@ export namespace ProviderCatalog {
         : profile.authKind === "none"
           ? "anonymous"
           : "unauthenticated")
-    return { auth: selected?.auth, identityHash: await hashIdentity(providerID, identity) }
+    return { auth: selected?.auth, identityHash: await hashIdentity(providerID, profile.id, identity) }
   }
 
   function configuredProviders(config: unknown): Record<string, ConfiguredProvider> {
@@ -536,9 +543,14 @@ export namespace ProviderCatalog {
     for (const [providerID, profile] of configuredProfiles(config)) profiles.set(providerID, profile)
     for (const [providerID, profile] of profiles) {
       if (!profile.fetchModelCatalog && !profile.fetchModels) continue
+      const configured = configuredProviders(config)[providerID]
       targets.set(providerID, {
         profile,
         context: await resolveLiveDiscoveryContext(profile, providerID),
+        baseURL:
+          (typeof configured?.options?.baseURL === "string" ? configured.options.baseURL : undefined) ??
+          configured?.api ??
+          profile.baseURL,
       })
     }
     return targets
@@ -579,13 +591,19 @@ export namespace ProviderCatalog {
     return undefined
   }
 
-  function scheduleRetry(providerID: string, profileID: string, failure: Failure, error?: unknown) {
+  function scheduleRetry(
+    providerID: string,
+    profileID: string,
+    baseURL: string | undefined,
+    failure: Failure,
+    error?: unknown,
+  ) {
     const current = retryTimers.get(providerID)
     if (current) clearTimeout(current)
     const timer = setTimeout(
       () => {
         retryTimers.delete(providerID)
-        void refreshAndReload(providerID, profileID)
+        void refreshAndReload(providerID, profileID, baseURL)
       },
       retryDelay({ failure, retryAfterMs: retryAfterMs(error) }),
     )
@@ -619,18 +637,25 @@ export namespace ProviderCatalog {
     }
   }
 
-  export async function refresh(providerID: string, profileID?: string): Promise<ModelCatalogState> {
+  export async function refresh(providerID: string, profileID?: string, baseURL?: string): Promise<ModelCatalogState> {
     registerBuiltinProviderProfiles()
     await registerPluginProfiles()
     let profile = ProviderProfile.resolve(providerID, profileID)
-    if (!profile) {
+    let configured: ConfiguredProvider | undefined
+    if (!profile || (baseURL === undefined && ScopeContext.tryScope())) {
       const { Config } = await import("@/config/config")
       const config = await Config.current()
-      profile = ProviderProfile.get(config.provider?.[providerID]?.profile ?? "")
+      configured = config.provider?.[providerID]
+      if (!profile) profile = ProviderProfile.get(configured?.profile ?? "")
     }
     if (!profile?.fetchModelCatalog && !profile?.fetchModels) {
       return { source: "bundled", refreshing: false, modelCount: 0 }
     }
+    const resolvedBaseURL =
+      baseURL ??
+      (typeof configured?.options?.baseURL === "string" ? configured.options.baseURL : undefined) ??
+      configured?.api ??
+      profile.baseURL
     const context = await resolveLiveDiscoveryContext(profile, providerID)
     const key = snapshotKey(providerID, context.identityHash)
     const pending = refreshInFlight.get(key)
@@ -652,8 +677,8 @@ export namespace ProviderCatalog {
       let entries: ProviderProfile.ModelCatalogEntry[]
       try {
         entries = profile.fetchModelCatalog
-          ? await profile.fetchModelCatalog({ providerID, auth: context.auth, fetch, baseURL: profile.baseURL })
-          : (await profile.fetchModels!({ providerID, auth: context.auth, fetch, baseURL: profile.baseURL })).map(
+          ? await profile.fetchModelCatalog({ providerID, auth: context.auth, fetch, baseURL: resolvedBaseURL })
+          : (await profile.fetchModels!({ providerID, auth: context.auth, fetch, baseURL: resolvedBaseURL })).map(
               (id) => ({ id }),
             )
         if (entries.length === 0)
@@ -686,7 +711,7 @@ export namespace ProviderCatalog {
           failure,
         }
         catalogStates.set(providerID, state)
-        scheduleRetry(providerID, profile.id, failure, error)
+        scheduleRetry(providerID, profile.id, resolvedBaseURL, failure, error)
         log.warn("failed to refresh provider model catalog", { providerID, profileID: profile.id, failure, error })
         return state
       }
@@ -715,9 +740,9 @@ export namespace ProviderCatalog {
     return request
   }
 
-  async function refreshAndReload(providerID: string, profileID?: string) {
+  async function refreshAndReload(providerID: string, profileID?: string, baseURL?: string) {
     try {
-      await refresh(providerID, profileID)
+      await refresh(providerID, profileID, baseURL)
       const { RuntimeReload } = await import("@/runtime/reload")
       await RuntimeReload.reload({ targets: ["provider"], reason: "provider model catalog refreshed" })
     } catch (error) {
@@ -729,6 +754,7 @@ export namespace ProviderCatalog {
     providerID: string,
     profile: ProviderProfile.Profile,
     context: LiveDiscoveryContext,
+    baseURL: string | undefined,
     snapshot: Snapshot | undefined,
   ) {
     if (!context.auth && profile.authKind !== "none") return
@@ -740,7 +766,7 @@ export namespace ProviderCatalog {
     if (refreshInFlight.has(key) || scheduledRefreshes.has(key)) return
     scheduledRefreshes.add(key)
     queueMicrotask(() => {
-      void refreshAndReload(providerID, profile.id).finally(() => scheduledRefreshes.delete(key))
+      void refreshAndReload(providerID, profile.id, baseURL).finally(() => scheduledRefreshes.delete(key))
     })
   }
 
@@ -881,7 +907,7 @@ export namespace ProviderCatalog {
         result[providerID] = await applyCachedDiscovery(provider, target.profile, modelsDev, target.context, providerID)
         if (target.profile.fetchModelCatalog || target.profile.fetchModels) {
           const snapshot = (await readSnapshots()).get(snapshotKey(providerID, target.context.identityHash))
-          scheduleRefresh(providerID, target.profile, target.context, snapshot)
+          scheduleRefresh(providerID, target.profile, target.context, target.baseURL, snapshot)
         }
       }
     }

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -817,7 +817,7 @@ export namespace ProviderCatalog {
     const providerCatalog = (input?.config as { providerCatalog?: unknown } | undefined)?.providerCatalog ?? {}
     const connections = Object.fromEntries(
       Object.entries(configuredProviders(input?.config)).flatMap(([providerID, provider]) =>
-        provider.profile
+        provider.profile || provider.modelsDevProviderID
           ? [
               [
                 providerID,

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -161,12 +161,20 @@ export namespace ProviderCatalog {
   function isSensitiveConfiguredKey(key: string) {
     const normalized = key.replace(/[-_.]/g, "").toLowerCase()
     return (
+      normalized === "auth" ||
+      normalized === "cookie" ||
+      normalized === "setcookie" ||
       normalized.endsWith("apikey") ||
+      normalized.endsWith("apitoken") ||
+      normalized.endsWith("sessiontoken") ||
+      normalized.endsWith("accesskey") ||
+      normalized.endsWith("accesskeyid") ||
+      normalized.endsWith("privatekey") ||
       normalized.endsWith("password") ||
-      normalized.endsWith("secret") ||
-      normalized.endsWith("secretkey") ||
+      normalized.includes("secret") ||
       normalized === "token" ||
-      ["authtoken", "accesstoken", "refreshtoken", "bearertoken"].some((suffix) => normalized.endsWith(suffix)) ||
+      normalized.endsWith("token") ||
+      normalized.endsWith("credential") ||
       normalized.endsWith("authorization")
     )
   }
@@ -196,7 +204,10 @@ export namespace ProviderCatalog {
       const model = publicConfiguredValue(raw) as Record<string, any>
       const sourceID = typeof model.id === "string" ? model.id : modelID
       const source = result.models[sourceID] ?? result.models[modelID] ?? fallbackModel(result, sourceID)
-      result.models[modelID] = mergeDeep(source, model) as ModelsDev.Model
+      result.models[modelID] = {
+        ...(mergeDeep(source, model) as ModelsDev.Model),
+        id: modelID,
+      }
     }
     for (const modelID of Object.keys(result.models)) {
       if (configured.whitelist && !configured.whitelist.includes(modelID)) delete result.models[modelID]
@@ -578,8 +589,15 @@ export namespace ProviderCatalog {
     const environmentAuth = environment?.value
       ? ({ type: "api", key: environment.value } satisfies Auth.Info)
       : undefined
-    const auth = selected?.auth ?? environmentAuth
-    const credentialID = selected?.credentialID ?? (environment ? `env:${environment.name}` : undefined)
+    const inlineKey =
+      typeof configured?.options?.apiKey === "string" && configured.options.apiKey
+        ? configured.options.apiKey
+        : undefined
+    const inlineAuth = inlineKey ? ({ type: "api", key: inlineKey } satisfies Auth.Info) : undefined
+    const auth = selected?.auth ?? environmentAuth ?? inlineAuth
+    const credentialID =
+      selected?.credentialID ??
+      (environment ? `env:${environment.name}` : inlineAuth ? "config:options.apiKey" : undefined)
     const authUpdatedAt = selected?.poolEntry?.updatedAt ?? selected?.entry.updatedAt
     const customIdentity = await profile.modelCatalogIdentity?.({
       providerID,

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -128,6 +128,9 @@ export namespace ProviderCatalog {
     npm?: string
     env?: string[]
     options?: Record<string, unknown>
+    models?: Record<string, Record<string, any>>
+    whitelist?: string[]
+    blacklist?: string[]
   }
 
   type CacheEntry = {
@@ -149,6 +152,57 @@ export namespace ProviderCatalog {
 
   function snapshotKey(providerID: string, identityHash: string) {
     return `${providerID}:${identityHash}`
+  }
+
+  function catalogStateKey(providerID: string) {
+    return `${ScopeContext.tryScope()?.id ?? "global"}:${providerID}`
+  }
+
+  function isSensitiveConfiguredKey(key: string) {
+    const normalized = key.replace(/[-_.]/g, "").toLowerCase()
+    return (
+      normalized.endsWith("apikey") ||
+      normalized.endsWith("password") ||
+      normalized.endsWith("secret") ||
+      normalized.endsWith("secretkey") ||
+      normalized === "token" ||
+      ["authtoken", "accesstoken", "refreshtoken", "bearertoken"].some((suffix) => normalized.endsWith(suffix)) ||
+      normalized.endsWith("authorization")
+    )
+  }
+
+  function publicConfiguredValue(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(publicConfiguredValue)
+    if (!value || typeof value !== "object") return value
+    return Object.fromEntries(
+      Object.entries(value).flatMap(([key, entry]) =>
+        isSensitiveConfiguredKey(key) ? [] : [[key, publicConfiguredValue(entry)] as const],
+      ),
+    )
+  }
+
+  function modelRulesIdentity(provider: ConfiguredProvider) {
+    const rules = {
+      whitelist: provider.whitelist,
+      blacklist: provider.blacklist,
+      models: publicConfiguredValue(provider.models),
+    }
+    return new Bun.CryptoHasher("sha256").update(JSON.stringify(rules)).digest("hex")
+  }
+
+  function applyConfiguredModelRules(provider: ModelsDev.Provider, configured: ConfiguredProvider) {
+    const result = structuredClone(provider)
+    for (const [modelID, raw] of Object.entries(configured.models ?? {})) {
+      const model = publicConfiguredValue(raw) as Record<string, any>
+      const sourceID = typeof model.id === "string" ? model.id : modelID
+      const source = result.models[sourceID] ?? result.models[modelID] ?? fallbackModel(result, sourceID)
+      result.models[modelID] = mergeDeep(source, model) as ModelsDev.Model
+    }
+    for (const modelID of Object.keys(result.models)) {
+      if (configured.whitelist && !configured.whitelist.includes(modelID)) delete result.models[modelID]
+      if (configured.blacklist?.includes(modelID)) delete result.models[modelID]
+    }
+    return result
   }
 
   function normalizeDiscoveryEndpoint(baseURL: string | undefined) {
@@ -595,13 +649,13 @@ export namespace ProviderCatalog {
     if (!profile.fetchModelCatalog && !profile.fetchModels) return provider
     const auth = context?.auth
     if (!auth && profile.authKind !== "none") {
-      catalogStates.delete(providerID)
+      catalogStates.delete(catalogStateKey(providerID))
       return provider
     }
     const key = context ? snapshotKey(providerID, context.identityHash) : undefined
     const snapshot = key ? (await readSnapshots()).get(key) : undefined
     const modelCount = snapshot?.activeModels.length ?? Object.keys(provider.models).length
-    catalogStates.set(providerID, {
+    catalogStates.set(catalogStateKey(providerID), {
       source: snapshot && key && freshlyVerified.has(key) ? "live" : snapshot ? "cached" : "bundled",
       refreshing: key ? refreshInFlight.has(key) || scheduledRefreshes.has(key) : false,
       modelCount,
@@ -702,7 +756,7 @@ export namespace ProviderCatalog {
       const store = await readSnapshots()
       const previous = store.get(key)
       const now = Date.now()
-      catalogStates.set(providerID, {
+      catalogStates.set(catalogStateKey(providerID), {
         source: previous ? (freshlyVerified.has(key) ? "live" : "cached") : "bundled",
         refreshing: true,
         modelCount: previous?.activeModels.length ?? 0,
@@ -746,7 +800,7 @@ export namespace ProviderCatalog {
           lastVerifiedAt: failed.lastVerifiedAt,
           failure,
         }
-        catalogStates.set(providerID, state)
+        catalogStates.set(catalogStateKey(providerID), state)
         scheduleRetry(providerID, profile.id, resolvedBaseURL, configured, failure, error)
         log.warn("failed to refresh provider model catalog", { providerID, profileID: profile.id, failure, error })
         return state
@@ -766,7 +820,7 @@ export namespace ProviderCatalog {
         modelCount: next.activeModels.length,
         lastVerifiedAt: next.lastVerifiedAt,
       }
-      catalogStates.set(providerID, state)
+      catalogStates.set(catalogStateKey(providerID), state)
       return state
     })().finally(() => {
       if (refreshInFlight.get(key) === request) refreshInFlight.delete(key)
@@ -854,6 +908,7 @@ export namespace ProviderCatalog {
                   api: provider.api,
                   npm: provider.npm,
                   env: provider.env,
+                  modelRules: modelRulesIdentity(provider),
                 },
               ],
             ]
@@ -933,13 +988,16 @@ export namespace ProviderCatalog {
         })
         continue
       }
-      result[providerID] = mergeProvider(structuredClone(source), {
-        id: providerID,
-        name: provider.name ?? source.name,
-        api: provider.api ?? source.api,
-        npm: provider.npm ?? source.npm,
-        env: provider.env ?? [],
-      })
+      result[providerID] = applyConfiguredModelRules(
+        mergeProvider(structuredClone(source), {
+          id: providerID,
+          name: provider.name ?? source.name,
+          api: provider.api ?? source.api,
+          npm: provider.npm ?? source.npm,
+          env: provider.env ?? [],
+        }),
+        provider,
+      )
     }
 
     if (input?.includeLive) {
@@ -1029,6 +1087,6 @@ export namespace ProviderCatalog {
     })
 
   export function modelCatalogState(providerID: string) {
-    return catalogStates.get(providerID)
+    return catalogStates.get(catalogStateKey(providerID))
   }
 }

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -149,8 +149,22 @@ export namespace ProviderCatalog {
     return `${providerID}:${identityHash}`
   }
 
-  async function hashIdentity(providerID: string, profileID: string, identity: string) {
-    const bytes = new TextEncoder().encode(`${providerID}\u0000${profileID}\u0000${identity}`)
+  function normalizeDiscoveryEndpoint(baseURL: string | undefined) {
+    const value = baseURL?.trim()
+    if (!value) return ""
+    try {
+      const url = new URL(value)
+      url.hash = ""
+      url.pathname = url.pathname.replace(/\/+$/, "") || "/"
+      return url.toString().replace(/\/$/, "")
+    } catch {
+      return value.replace(/\/+$/, "")
+    }
+  }
+
+  async function hashIdentity(providerID: string, profileID: string, baseURL: string | undefined, identity: string) {
+    const endpoint = normalizeDiscoveryEndpoint(baseURL)
+    const bytes = new TextEncoder().encode(`${providerID}\u0000${profileID}\u0000${endpoint}\u0000${identity}`)
     const digest = await crypto.subtle.digest("SHA-256", bytes)
     return Buffer.from(digest).toString("hex")
   }
@@ -175,7 +189,7 @@ export namespace ProviderCatalog {
     const protectedKeys = new Set([currentKey])
     for (const profile of ProviderProfile.all()) {
       if (!profile.fetchModelCatalog && !profile.fetchModels) continue
-      const context = await resolveLiveDiscoveryContext(profile).catch(() => undefined)
+      const context = await resolveLiveDiscoveryContext(profile, profile.id, profile.baseURL).catch(() => undefined)
       if (context?.auth) protectedKeys.add(snapshotKey(profile.id, context.identityHash))
     }
     if (store.size > MAX_SNAPSHOT_ENTRIES) {
@@ -497,6 +511,7 @@ export namespace ProviderCatalog {
   async function resolveLiveDiscoveryContext(
     profile: ProviderProfile.Profile,
     providerID = profile.id,
+    baseURL = profile.baseURL,
   ): Promise<LiveDiscoveryContext> {
     const selected = await Auth.select(providerID)
     const authUpdatedAt = selected?.poolEntry?.updatedAt ?? selected?.entry.updatedAt
@@ -513,7 +528,7 @@ export namespace ProviderCatalog {
         : profile.authKind === "none"
           ? "anonymous"
           : "unauthenticated")
-    return { auth: selected?.auth, identityHash: await hashIdentity(providerID, profile.id, identity) }
+    return { auth: selected?.auth, identityHash: await hashIdentity(providerID, profile.id, baseURL, identity) }
   }
 
   function configuredProviders(config: unknown): Record<string, ConfiguredProvider> {
@@ -544,13 +559,14 @@ export namespace ProviderCatalog {
     for (const [providerID, profile] of profiles) {
       if (!profile.fetchModelCatalog && !profile.fetchModels) continue
       const configured = configuredProviders(config)[providerID]
+      const baseURL =
+        (typeof configured?.options?.baseURL === "string" ? configured.options.baseURL : undefined) ??
+        configured?.api ??
+        profile.baseURL
       targets.set(providerID, {
         profile,
-        context: await resolveLiveDiscoveryContext(profile, providerID),
-        baseURL:
-          (typeof configured?.options?.baseURL === "string" ? configured.options.baseURL : undefined) ??
-          configured?.api ??
-          profile.baseURL,
+        context: await resolveLiveDiscoveryContext(profile, providerID, baseURL),
+        baseURL,
       })
     }
     return targets
@@ -656,7 +672,7 @@ export namespace ProviderCatalog {
       (typeof configured?.options?.baseURL === "string" ? configured.options.baseURL : undefined) ??
       configured?.api ??
       profile.baseURL
-    const context = await resolveLiveDiscoveryContext(profile, providerID)
+    const context = await resolveLiveDiscoveryContext(profile, providerID, resolvedBaseURL)
     const key = snapshotKey(providerID, context.identityHash)
     const pending = refreshInFlight.get(key)
     if (pending) return pending

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -658,11 +658,12 @@ export namespace ProviderCatalog {
     await registerPluginProfiles()
     let profile = ProviderProfile.resolve(providerID, profileID)
     let configured: ConfiguredProvider | undefined
-    if (!profile || (baseURL === undefined && ScopeContext.tryScope())) {
+    if (!profile || ((profileID === undefined || baseURL === undefined) && ScopeContext.tryScope())) {
       const { Config } = await import("@/config/config")
       const config = await Config.current()
       configured = config.provider?.[providerID]
-      if (!profile) profile = ProviderProfile.get(configured?.profile ?? "")
+      if (profileID === undefined && configured?.profile) profile = ProviderProfile.get(configured.profile)
+      else if (!profile) profile = ProviderProfile.get(configured?.profile ?? "")
     }
     if (!profile?.fetchModelCatalog && !profile?.fetchModels) {
       return { source: "bundled", refreshing: false, modelCount: 0 }

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -164,6 +164,10 @@ export namespace ProviderCatalog {
       normalized === "auth" ||
       normalized === "cookie" ||
       normalized === "setcookie" ||
+      normalized === "key" ||
+      normalized === "keys" ||
+      normalized === "credential" ||
+      normalized === "credentials" ||
       normalized.endsWith("apikey") ||
       normalized.endsWith("apitoken") ||
       normalized.endsWith("sessiontoken") ||
@@ -175,6 +179,7 @@ export namespace ProviderCatalog {
       normalized === "token" ||
       normalized.endsWith("token") ||
       normalized.endsWith("credential") ||
+      normalized.endsWith("credentials") ||
       normalized.endsWith("authorization")
     )
   }

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -599,11 +599,28 @@ export namespace ProviderCatalog {
         ? configured.options.apiKey
         : undefined
     const inlineAuth = inlineKey ? ({ type: "api", key: inlineKey } satisfies Auth.Info) : undefined
-    const auth = selected?.auth ?? environmentAuth ?? inlineAuth
-    const credentialID =
-      selected?.credentialID ??
-      (environment ? `env:${environment.name}` : inlineAuth ? "config:options.apiKey" : undefined)
-    const authUpdatedAt = selected?.poolEntry?.updatedAt ?? selected?.entry.updatedAt
+    const resolvedCredential = inlineAuth
+      ? {
+          auth: inlineAuth,
+          credentialID: "config:options.apiKey",
+          authUpdatedAt: undefined,
+        }
+      : selected
+        ? {
+            auth: selected.auth,
+            credentialID: selected.credentialID,
+            authUpdatedAt: selected.poolEntry?.updatedAt ?? selected.entry.updatedAt,
+          }
+        : environmentAuth
+          ? {
+              auth: environmentAuth,
+              credentialID: `env:${environment?.name}`,
+              authUpdatedAt: undefined,
+            }
+          : undefined
+    const auth = resolvedCredential?.auth
+    const credentialID = resolvedCredential?.credentialID
+    const authUpdatedAt = resolvedCredential?.authUpdatedAt
     const customIdentity = await profile.modelCatalogIdentity?.({
       providerID,
       auth,

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -894,15 +894,15 @@ export namespace ProviderCatalog {
     }
 
     for (const [providerID, provider] of Object.entries(configuredProviders(input?.config))) {
-      if (!provider.profile) continue
-      const profile = ProviderProfile.get(provider.profile)
-      if (!profile) continue
-      const sourceID = provider.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
+      const profile = provider.profile ? ProviderProfile.get(provider.profile) : undefined
+      if (provider.profile && !profile) continue
+      const sourceID = provider.modelsDevProviderID ?? profile?.modelsDevProviderID ?? profile?.id
+      if (!sourceID) continue
       const source = result[sourceID]
       if (!source) {
-        log.warn("configured provider profile catalog source not found", {
+        log.warn("configured provider catalog source not found", {
           providerID,
-          profileID: profile.id,
+          profileID: profile?.id,
           modelsDevProviderID: sourceID,
         })
         continue

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -111,6 +111,16 @@ export namespace ProviderCatalog {
     identityHash: string
   }
 
+  type LiveDiscoveryTarget = {
+    profile: ProviderProfile.Profile
+    context: LiveDiscoveryContext
+  }
+
+  type ConfiguredProvider = Partial<ModelsDev.Provider> & {
+    profile?: string
+    modelsDevProviderID?: string
+  }
+
   type CacheEntry = {
     value: Record<string, ModelsDev.Provider>
     createdAt: number
@@ -352,8 +362,8 @@ export namespace ProviderCatalog {
     recommendation?: ProviderProfile.Recommendation
   }
 
-  export function providerMetadata(provider: ProviderMetadataSource): ProviderProfile.Metadata {
-    const profile = ProviderProfile.get(provider.id)
+  export function providerMetadata(provider: ProviderMetadataSource, profileID?: string): ProviderProfile.Metadata {
+    const profile = ProviderProfile.resolve(provider.id, profileID)
     return {
       id: provider.id,
       name: profile?.name ?? provider.name,
@@ -477,10 +487,14 @@ export namespace ProviderCatalog {
     return JSON.stringify({ credentialID, credential })
   }
 
-  async function resolveLiveDiscoveryContext(profile: ProviderProfile.Profile): Promise<LiveDiscoveryContext> {
-    const selected = await Auth.select(profile.id)
+  async function resolveLiveDiscoveryContext(
+    profile: ProviderProfile.Profile,
+    providerID = profile.id,
+  ): Promise<LiveDiscoveryContext> {
+    const selected = await Auth.select(providerID)
     const authUpdatedAt = selected?.poolEntry?.updatedAt ?? selected?.entry.updatedAt
     const customIdentity = await profile.modelCatalogIdentity?.({
+      providerID,
       auth: selected?.auth,
       credentialID: selected?.credentialID,
       authUpdatedAt,
@@ -492,19 +506,42 @@ export namespace ProviderCatalog {
         : profile.authKind === "none"
           ? "anonymous"
           : "unauthenticated")
-    return { auth: selected?.auth, identityHash: await hashIdentity(profile.id, identity) }
+    return { auth: selected?.auth, identityHash: await hashIdentity(providerID, identity) }
   }
 
-  async function resolveLiveDiscoveryContexts(includeLive: boolean | undefined) {
-    const contexts = new Map<string, LiveDiscoveryContext>()
-    if (!includeLive) return contexts
+  function configuredProviders(config: unknown): Record<string, ConfiguredProvider> {
+    return config && typeof config === "object" && "provider" in config
+      ? ((config.provider as Record<string, ConfiguredProvider> | undefined) ?? {})
+      : {}
+  }
+
+  function configuredProfiles(config: unknown) {
+    return Object.entries(configuredProviders(config)).flatMap(([providerID, provider]) => {
+      if (!provider?.profile) return []
+      const profile = ProviderProfile.get(provider.profile)
+      if (!profile) {
+        log.warn("configured provider profile not found", { providerID, profileID: provider.profile })
+        return []
+      }
+      return [[providerID, profile] as const]
+    })
+  }
+
+  async function resolveLiveDiscoveryContexts(includeLive: boolean | undefined, config: unknown) {
+    const targets = new Map<string, LiveDiscoveryTarget>()
+    if (!includeLive) return targets
 
     registerBuiltinProviderProfiles()
-    for (const profile of ProviderProfile.all()) {
+    const profiles = new Map(ProviderProfile.all().map((profile) => [profile.id, profile]))
+    for (const [providerID, profile] of configuredProfiles(config)) profiles.set(providerID, profile)
+    for (const [providerID, profile] of profiles) {
       if (!profile.fetchModelCatalog && !profile.fetchModels) continue
-      contexts.set(profile.id, await resolveLiveDiscoveryContext(profile))
+      targets.set(providerID, {
+        profile,
+        context: await resolveLiveDiscoveryContext(profile, providerID),
+      })
     }
-    return contexts
+    return targets
   }
 
   async function applyCachedDiscovery(
@@ -512,17 +549,18 @@ export namespace ProviderCatalog {
     profile: ProviderProfile.Profile,
     modelsDev: Record<string, ModelsDev.Provider>,
     context: LiveDiscoveryContext | undefined,
+    providerID = profile.id,
   ): Promise<ModelsDev.Provider> {
     if (!profile.fetchModelCatalog && !profile.fetchModels) return provider
     const auth = context?.auth
     if (!auth && profile.authKind !== "none") {
-      catalogStates.delete(profile.id)
+      catalogStates.delete(providerID)
       return provider
     }
-    const key = context ? snapshotKey(profile.id, context.identityHash) : undefined
+    const key = context ? snapshotKey(providerID, context.identityHash) : undefined
     const snapshot = key ? (await readSnapshots()).get(key) : undefined
     const modelCount = snapshot?.activeModels.length ?? Object.keys(provider.models).length
-    catalogStates.set(profile.id, {
+    catalogStates.set(providerID, {
       source: snapshot && key && freshlyVerified.has(key) ? "live" : snapshot ? "cached" : "bundled",
       refreshing: key ? refreshInFlight.has(key) || scheduledRefreshes.has(key) : false,
       modelCount,
@@ -541,13 +579,13 @@ export namespace ProviderCatalog {
     return undefined
   }
 
-  function scheduleRetry(providerID: string, failure: Failure, error?: unknown) {
+  function scheduleRetry(providerID: string, profileID: string, failure: Failure, error?: unknown) {
     const current = retryTimers.get(providerID)
     if (current) clearTimeout(current)
     const timer = setTimeout(
       () => {
         retryTimers.delete(providerID)
-        void refreshAndReload(providerID)
+        void refreshAndReload(providerID, profileID)
       },
       retryDelay({ failure, retryAfterMs: retryAfterMs(error) }),
     )
@@ -581,15 +619,20 @@ export namespace ProviderCatalog {
     }
   }
 
-  export async function refresh(providerID: string): Promise<ModelCatalogState> {
+  export async function refresh(providerID: string, profileID?: string): Promise<ModelCatalogState> {
     registerBuiltinProviderProfiles()
     await registerPluginProfiles()
-    const profile = ProviderProfile.get(providerID)
+    let profile = ProviderProfile.resolve(providerID, profileID)
+    if (!profile) {
+      const { Config } = await import("@/config/config")
+      const config = await Config.current()
+      profile = ProviderProfile.get(config.provider?.[providerID]?.profile ?? "")
+    }
     if (!profile?.fetchModelCatalog && !profile?.fetchModels) {
       return { source: "bundled", refreshing: false, modelCount: 0 }
     }
-    const context = await resolveLiveDiscoveryContext(profile)
-    const key = snapshotKey(profile.id, context.identityHash)
+    const context = await resolveLiveDiscoveryContext(profile, providerID)
+    const key = snapshotKey(providerID, context.identityHash)
     const pending = refreshInFlight.get(key)
     if (pending) return pending
 
@@ -598,7 +641,7 @@ export namespace ProviderCatalog {
       const store = await readSnapshots()
       const previous = store.get(key)
       const now = Date.now()
-      catalogStates.set(profile.id, {
+      catalogStates.set(providerID, {
         source: previous ? (freshlyVerified.has(key) ? "live" : "cached") : "bundled",
         refreshing: true,
         modelCount: previous?.activeModels.length ?? 0,
@@ -609,8 +652,10 @@ export namespace ProviderCatalog {
       let entries: ProviderProfile.ModelCatalogEntry[]
       try {
         entries = profile.fetchModelCatalog
-          ? await profile.fetchModelCatalog({ auth: context.auth, fetch, baseURL: profile.baseURL })
-          : (await profile.fetchModels!({ auth: context.auth, fetch, baseURL: profile.baseURL })).map((id) => ({ id }))
+          ? await profile.fetchModelCatalog({ providerID, auth: context.auth, fetch, baseURL: profile.baseURL })
+          : (await profile.fetchModels!({ providerID, auth: context.auth, fetch, baseURL: profile.baseURL })).map(
+              (id) => ({ id }),
+            )
         if (entries.length === 0)
           throw Object.assign(new Error("provider returned an empty model catalog"), {
             catalogFailure: "invalid_response",
@@ -622,7 +667,7 @@ export namespace ProviderCatalog {
             : classifyFailure(error)
         const failed: Snapshot = {
           version: 1,
-          providerID: profile.id,
+          providerID,
           identityHash: context.identityHash,
           activeModels: previous?.activeModels ?? [],
           retainedModels: previous?.retainedModels ?? [],
@@ -640,27 +685,27 @@ export namespace ProviderCatalog {
           lastVerifiedAt: failed.lastVerifiedAt,
           failure,
         }
-        catalogStates.set(profile.id, state)
-        scheduleRetry(profile.id, failure, error)
-        log.warn("failed to refresh provider model catalog", { providerID: profile.id, failure, error })
+        catalogStates.set(providerID, state)
+        scheduleRetry(providerID, profile.id, failure, error)
+        log.warn("failed to refresh provider model catalog", { providerID, profileID: profile.id, failure, error })
         return state
       }
 
-      const next = mergeRefresh(previous, entries, { providerID: profile.id, identityHash: context.identityHash, now })
+      const next = mergeRefresh(previous, entries, { providerID, identityHash: context.identityHash, now })
       store.set(key, next)
       await persistSnapshots(key)
       memoryCache.clear()
       freshlyVerified.add(key)
-      const retry = retryTimers.get(profile.id)
+      const retry = retryTimers.get(providerID)
       if (retry) clearTimeout(retry)
-      retryTimers.delete(profile.id)
+      retryTimers.delete(providerID)
       const state: ModelCatalogState = {
         source: "live",
         refreshing: false,
         modelCount: next.activeModels.length,
         lastVerifiedAt: next.lastVerifiedAt,
       }
-      catalogStates.set(profile.id, state)
+      catalogStates.set(providerID, state)
       return state
     })().finally(() => {
       if (refreshInFlight.get(key) === request) refreshInFlight.delete(key)
@@ -670,9 +715,9 @@ export namespace ProviderCatalog {
     return request
   }
 
-  async function refreshAndReload(providerID: string) {
+  async function refreshAndReload(providerID: string, profileID?: string) {
     try {
-      await refresh(providerID)
+      await refresh(providerID, profileID)
       const { RuntimeReload } = await import("@/runtime/reload")
       await RuntimeReload.reload({ targets: ["provider"], reason: "provider model catalog refreshed" })
     } catch (error) {
@@ -681,6 +726,7 @@ export namespace ProviderCatalog {
   }
 
   function scheduleRefresh(
+    providerID: string,
     profile: ProviderProfile.Profile,
     context: LiveDiscoveryContext,
     snapshot: Snapshot | undefined,
@@ -690,11 +736,11 @@ export namespace ProviderCatalog {
     const verifiedRecently = snapshot?.lastVerifiedAt && now - snapshot.lastVerifiedAt < DEFAULT_CACHE_TTL_MS
     const failedRecently = snapshot?.failure && now - snapshot.lastAttemptAt < RETRY_DELAY_MS
     if (verifiedRecently || failedRecently) return
-    const key = snapshotKey(profile.id, context.identityHash)
+    const key = snapshotKey(providerID, context.identityHash)
     if (refreshInFlight.has(key) || scheduledRefreshes.has(key)) return
     scheduledRefreshes.add(key)
     queueMicrotask(() => {
-      void refreshAndReload(profile.id).finally(() => scheduledRefreshes.delete(key))
+      void refreshAndReload(providerID, profile.id).finally(() => scheduledRefreshes.delete(key))
     })
   }
 
@@ -705,7 +751,7 @@ export namespace ProviderCatalog {
   }): Promise<Record<string, ModelsDev.Provider>> {
     registerBuiltinProviderProfiles()
     await registerPluginProfiles()
-    const liveContexts = await resolveLiveDiscoveryContexts(input?.includeLive)
+    const liveContexts = await resolveLiveDiscoveryContexts(input?.includeLive, input?.config)
     const key = cacheKey(input, liveContexts)
     const cached = memoryCache.get(key)
     if (!input?.forceRefresh && cached && Date.now() - cached.createdAt < cached.ttlMs) {
@@ -724,18 +770,37 @@ export namespace ProviderCatalog {
 
   function cacheKey(
     input: { config?: unknown; includeLive?: boolean } | undefined,
-    liveContexts: Map<string, LiveDiscoveryContext>,
+    liveContexts: Map<string, LiveDiscoveryTarget>,
   ) {
     const providerCatalog = (input?.config as { providerCatalog?: unknown } | undefined)?.providerCatalog ?? {}
-    const liveIdentities = Object.fromEntries(
-      [...liveContexts.entries()].map(([providerID, context]) => [providerID, context.identityHash]),
+    const connections = Object.fromEntries(
+      Object.entries(configuredProviders(input?.config)).flatMap(([providerID, provider]) =>
+        provider.profile
+          ? [
+              [
+                providerID,
+                {
+                  profile: provider.profile,
+                  modelsDevProviderID: provider.modelsDevProviderID,
+                  name: provider.name,
+                  api: provider.api,
+                  npm: provider.npm,
+                  env: provider.env,
+                },
+              ],
+            ]
+          : [],
+      ),
     )
-    return JSON.stringify({ includeLive: input?.includeLive === true, providerCatalog, liveIdentities })
+    const liveIdentities = Object.fromEntries(
+      [...liveContexts.entries()].map(([providerID, target]) => [providerID, target.context.identityHash]),
+    )
+    return JSON.stringify({ includeLive: input?.includeLive === true, providerCatalog, connections, liveIdentities })
   }
 
   async function doResolve(
     input: { config?: unknown; includeLive?: boolean } | undefined,
-    liveContexts: Map<string, LiveDiscoveryContext>,
+    liveContexts: Map<string, LiveDiscoveryTarget>,
     key: string,
     generation: number,
   ): Promise<Record<string, ModelsDev.Provider>> {
@@ -786,15 +851,37 @@ export namespace ProviderCatalog {
       }
     }
 
+    for (const [providerID, provider] of Object.entries(configuredProviders(input?.config))) {
+      if (!provider.profile) continue
+      const profile = ProviderProfile.get(provider.profile)
+      if (!profile) continue
+      const sourceID = provider.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
+      const source = result[sourceID]
+      if (!source) {
+        log.warn("configured provider profile catalog source not found", {
+          providerID,
+          profileID: profile.id,
+          modelsDevProviderID: sourceID,
+        })
+        continue
+      }
+      result[providerID] = mergeProvider(structuredClone(source), {
+        id: providerID,
+        name: provider.name ?? source.name,
+        api: provider.api ?? source.api,
+        npm: provider.npm ?? source.npm,
+        env: provider.env ?? [],
+      })
+    }
+
     if (input?.includeLive) {
-      for (const profile of ProviderProfile.all()) {
-        const provider = result[profile.id]
+      for (const [providerID, target] of liveContexts) {
+        const provider = result[providerID]
         if (!provider) continue
-        const context = liveContexts.get(profile.id)
-        result[profile.id] = await applyCachedDiscovery(provider, profile, modelsDev, context)
-        if (context && (profile.fetchModelCatalog || profile.fetchModels)) {
-          const snapshot = (await readSnapshots()).get(snapshotKey(profile.id, context.identityHash))
-          scheduleRefresh(profile, context, snapshot)
+        result[providerID] = await applyCachedDiscovery(provider, target.profile, modelsDev, target.context, providerID)
+        if (target.profile.fetchModelCatalog || target.profile.fetchModels) {
+          const snapshot = (await readSnapshots()).get(snapshotKey(providerID, target.context.identityHash))
+          scheduleRefresh(providerID, target.profile, target.context, snapshot)
         }
       }
     }

--- a/packages/synergy/src/provider/catalog.ts
+++ b/packages/synergy/src/provider/catalog.ts
@@ -11,6 +11,7 @@ import { CodexProvider } from "./codex"
 import { ModelsDev } from "./models-schemas"
 import { ProviderProfile } from "./profile"
 import { normalizeImageMediaTypes } from "./image-capability"
+import { Env } from "@/util/env"
 
 export namespace ProviderCatalog {
   const log = Log.create({ service: "provider.catalog" })
@@ -512,23 +513,33 @@ export namespace ProviderCatalog {
     profile: ProviderProfile.Profile,
     providerID = profile.id,
     baseURL = profile.baseURL,
+    configured?: ConfiguredProvider,
   ): Promise<LiveDiscoveryContext> {
     const selected = await Auth.select(providerID)
+    const environmentValues = ScopeContext.tryScope() ? Env.all() : process.env
+    const environment = (configured?.env ?? profile.env ?? [])
+      .map((name) => ({ name, value: environmentValues[name]?.trim() }))
+      .find((entry) => entry.value)
+    const environmentAuth = environment?.value
+      ? ({ type: "api", key: environment.value } satisfies Auth.Info)
+      : undefined
+    const auth = selected?.auth ?? environmentAuth
+    const credentialID = selected?.credentialID ?? (environment ? `env:${environment.name}` : undefined)
     const authUpdatedAt = selected?.poolEntry?.updatedAt ?? selected?.entry.updatedAt
     const customIdentity = await profile.modelCatalogIdentity?.({
       providerID,
-      auth: selected?.auth,
-      credentialID: selected?.credentialID,
+      auth,
+      credentialID,
       authUpdatedAt,
     })
     const identity =
       customIdentity ??
-      (selected
-        ? defaultCredentialIdentity(selected.credentialID, selected.auth)
+      (auth && credentialID
+        ? defaultCredentialIdentity(credentialID, auth)
         : profile.authKind === "none"
           ? "anonymous"
           : "unauthenticated")
-    return { auth: selected?.auth, identityHash: await hashIdentity(providerID, profile.id, baseURL, identity) }
+    return { auth, identityHash: await hashIdentity(providerID, profile.id, baseURL, identity) }
   }
 
   function configuredProviders(config: unknown): Record<string, ConfiguredProvider> {
@@ -565,7 +576,7 @@ export namespace ProviderCatalog {
         profile.baseURL
       targets.set(providerID, {
         profile,
-        context: await resolveLiveDiscoveryContext(profile, providerID, baseURL),
+        context: await resolveLiveDiscoveryContext(profile, providerID, baseURL, configured),
         baseURL,
       })
     }
@@ -673,7 +684,7 @@ export namespace ProviderCatalog {
       (typeof configured?.options?.baseURL === "string" ? configured.options.baseURL : undefined) ??
       configured?.api ??
       profile.baseURL
-    const context = await resolveLiveDiscoveryContext(profile, providerID, resolvedBaseURL)
+    const context = await resolveLiveDiscoveryContext(profile, providerID, resolvedBaseURL, configured)
     const key = snapshotKey(providerID, context.identityHash)
     const pending = refreshInFlight.get(key)
     if (pending) return pending

--- a/packages/synergy/src/provider/codex.ts
+++ b/packages/synergy/src/provider/codex.ts
@@ -618,13 +618,18 @@ export namespace CodexProvider {
     }
   }
 
-  async function fetchModelPayload(accessToken: string, fetchFn: FetchLike = fetch, providerID = PROVIDER_ID) {
+  async function fetchModelPayload(
+    accessToken: string,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+    discoveryBaseURL = baseURL(),
+  ) {
     const response = await ProviderAuthRecovery.execute({
       providerID,
       request: async () => {
         const current =
           (await resolveToken({ providerID, allowMissing: true, fetch: fetchFn }).catch(() => undefined)) ?? accessToken
-        return fetchFn(`${baseURL()}/models?client_version=1.0.0`, {
+        return fetchFn(`${discoveryBaseURL.trim().replace(/\/+$/, "")}/models?client_version=1.0.0`, {
           headers: {
             Authorization: `Bearer ${current}`,
             Accept: "application/json",
@@ -647,8 +652,9 @@ export namespace CodexProvider {
     accessToken: string,
     fetchFn: FetchLike = fetch,
     providerID = PROVIDER_ID,
+    discoveryBaseURL = baseURL(),
   ): Promise<ProviderProfile.ModelCatalogEntry[]> {
-    const entries = await fetchModelPayload(accessToken, fetchFn, providerID)
+    const entries = await fetchModelPayload(accessToken, fetchFn, providerID, discoveryBaseURL)
     const models: Array<ProviderProfile.ModelCatalogEntry & { rank: number }> = []
     for (const entry of entries) {
       if (!entry || typeof entry !== "object") continue
@@ -672,8 +678,9 @@ export namespace CodexProvider {
     accessToken: string,
     fetchFn: FetchLike = fetch,
     providerID = PROVIDER_ID,
+    discoveryBaseURL = baseURL(),
   ): Promise<string[]> {
-    const payload = await fetchModelCatalog(accessToken, fetchFn, providerID)
+    const payload = await fetchModelCatalog(accessToken, fetchFn, providerID, discoveryBaseURL)
     return payload.map((item) => item.id)
   }
 

--- a/packages/synergy/src/provider/codex.ts
+++ b/packages/synergy/src/provider/codex.ts
@@ -451,10 +451,12 @@ export namespace CodexProvider {
 
     if (!shouldRefresh) return auth.access
 
+    let refreshCredentialID = selected.credentialID
     try {
       return await Auth.withLock(`${providerID}:oauth-refresh`, async () => {
         const latestSelected = await Auth.select(providerID)
         const latest = latestSelected?.auth
+        refreshCredentialID = latestSelected?.credentialID ?? refreshCredentialID
         if (latest?.type === "oauth" && !options?.forceRefresh) {
           const latestExpires = accessTokenExpiresAt(latest.access) ?? latest.expires
           const latestShouldRefresh =
@@ -482,11 +484,12 @@ export namespace CodexProvider {
         await Auth.markExhausted(providerID, {
           failureCode: error.data.code,
           cooldownUntil: error.data.retryAfterSeconds ? nowSeconds() + error.data.retryAfterSeconds : undefined,
+          credentialID: refreshCredentialID,
         }).catch(() => {})
         if (auth.access) return auth.access
       }
       if (AuthError.isInstance(error) && error.data.reloginRequired) {
-        await Auth.markDead(providerID, error.data.code).catch(() => {})
+        await Auth.markDead(providerID, error.data.code, { credentialID: refreshCredentialID }).catch(() => {})
       }
       if (options?.allowMissing && AuthError.isInstance(error) && error.data.reloginRequired) return undefined
       throw error

--- a/packages/synergy/src/provider/codex.ts
+++ b/packages/synergy/src/provider/codex.ts
@@ -38,7 +38,7 @@ export namespace CodexProvider {
   export const AuthError = NamedError.create(
     "CodexAuthError",
     z.object({
-      providerID: z.literal(PROVIDER_ID),
+      providerID: z.string(),
       code: z.string(),
       message: z.string(),
       reloginRequired: z.boolean(),
@@ -48,7 +48,7 @@ export namespace CodexProvider {
   export const RateLimitError = NamedError.create(
     "CodexRateLimitError",
     z.object({
-      providerID: z.literal(PROVIDER_ID),
+      providerID: z.string(),
       code: z.literal("rate_limited"),
       message: z.string(),
       retryAfterSeconds: z.number().optional(),
@@ -369,10 +369,14 @@ export namespace CodexProvider {
     }
   }
 
-  export async function refreshOAuth(auth: OAuthAuth, fetchFn: FetchLike = fetch): Promise<TokenPayload> {
+  export async function refreshOAuth(
+    auth: OAuthAuth,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<TokenPayload> {
     if (!auth.refresh) {
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "missing_refresh_token",
         message: "Codex credentials are missing a refresh token. Sign in again with ChatGPT.",
         reloginRequired: true,
@@ -394,7 +398,7 @@ export namespace CodexProvider {
     if (response.status === 429) {
       const retryAfterSeconds = parseRetryAfterSeconds(response.headers)
       throw new RateLimitError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "rate_limited",
         message: retryAfterSeconds
           ? `Codex provider quota exhausted or rate-limited. Retry after ${retryAfterSeconds}s. Credentials are still valid.`
@@ -410,7 +414,7 @@ export namespace CodexProvider {
         response.status === 401 ||
         response.status === 403
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code,
         message: errorMessage(payload, `Codex token refresh failed with status ${response.status}.`),
         reloginRequired,
@@ -420,17 +424,19 @@ export namespace CodexProvider {
   }
 
   export async function resolveToken(options?: {
+    providerID?: string
     forceRefresh?: boolean
     refreshIfExpiring?: boolean
     allowMissing?: boolean
     fetch?: FetchLike
   }): Promise<string | undefined> {
-    const selected = await Auth.select(PROVIDER_ID)
+    const providerID = options?.providerID ?? PROVIDER_ID
+    const selected = await Auth.select(providerID)
     const auth = selected?.auth
     if (!selected || !auth || auth.type !== "oauth") {
       if (options?.allowMissing) return undefined
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "codex_auth_missing",
         message: "No Codex credentials stored. Run `synergy auth login` and choose OpenAI Codex.",
         reloginRequired: true,
@@ -446,8 +452,8 @@ export namespace CodexProvider {
     if (!shouldRefresh) return auth.access
 
     try {
-      return await Auth.withLock(`${PROVIDER_ID}:oauth-refresh`, async () => {
-        const latestSelected = await Auth.select(PROVIDER_ID)
+      return await Auth.withLock(`${providerID}:oauth-refresh`, async () => {
+        const latestSelected = await Auth.select(providerID)
         const latest = latestSelected?.auth
         if (latest?.type === "oauth" && !options?.forceRefresh) {
           const latestExpires = accessTokenExpiresAt(latest.access) ?? latest.expires
@@ -458,9 +464,9 @@ export namespace CodexProvider {
         }
 
         const refreshSource = latest?.type === "oauth" ? latest : auth
-        const refreshed = await refreshOAuth(refreshSource, options?.fetch)
+        const refreshed = await refreshOAuth(refreshSource, options?.fetch, providerID)
         await Auth.replaceSelectedCredential(
-          PROVIDER_ID,
+          providerID,
           {
             type: "oauth",
             access: refreshed.access,
@@ -473,14 +479,14 @@ export namespace CodexProvider {
       })
     } catch (error) {
       if (RateLimitError.isInstance(error)) {
-        await Auth.markExhausted(PROVIDER_ID, {
+        await Auth.markExhausted(providerID, {
           failureCode: error.data.code,
           cooldownUntil: error.data.retryAfterSeconds ? nowSeconds() + error.data.retryAfterSeconds : undefined,
         }).catch(() => {})
         if (auth.access) return auth.access
       }
       if (AuthError.isInstance(error) && error.data.reloginRequired) {
-        await Auth.markDead(PROVIDER_ID, error.data.code).catch(() => {})
+        await Auth.markDead(providerID, error.data.code).catch(() => {})
       }
       if (options?.allowMissing && AuthError.isInstance(error) && error.data.reloginRequired) return undefined
       throw error
@@ -612,12 +618,12 @@ export namespace CodexProvider {
     }
   }
 
-  async function fetchModelPayload(accessToken: string, fetchFn: FetchLike = fetch) {
+  async function fetchModelPayload(accessToken: string, fetchFn: FetchLike = fetch, providerID = PROVIDER_ID) {
     const response = await ProviderAuthRecovery.execute({
-      providerID: PROVIDER_ID,
+      providerID,
       request: async () => {
         const current =
-          (await resolveToken({ allowMissing: true, fetch: fetchFn }).catch(() => undefined)) ?? accessToken
+          (await resolveToken({ providerID, allowMissing: true, fetch: fetchFn }).catch(() => undefined)) ?? accessToken
         return fetchFn(`${baseURL()}/models?client_version=1.0.0`, {
           headers: {
             Authorization: `Bearer ${current}`,
@@ -627,7 +633,7 @@ export namespace CodexProvider {
           signal: AbortSignal.timeout(10_000),
         })
       },
-      refresh: (auth) => refreshAuth(auth, fetchFn),
+      refresh: (auth) => refreshAuth(auth, fetchFn, providerID),
       classify: classifyError,
       reloadOnTransition: false,
       throwOnActionRequired: false,
@@ -640,8 +646,9 @@ export namespace CodexProvider {
   export async function fetchModelCatalog(
     accessToken: string,
     fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
   ): Promise<ProviderProfile.ModelCatalogEntry[]> {
-    const entries = await fetchModelPayload(accessToken, fetchFn)
+    const entries = await fetchModelPayload(accessToken, fetchFn, providerID)
     const models: Array<ProviderProfile.ModelCatalogEntry & { rank: number }> = []
     for (const entry of entries) {
       if (!entry || typeof entry !== "object") continue
@@ -661,8 +668,12 @@ export namespace CodexProvider {
     return models.sort((a, b) => a.rank - b.rank || a.id.localeCompare(b.id))
   }
 
-  export async function fetchModelIDs(accessToken: string, fetchFn: FetchLike = fetch): Promise<string[]> {
-    const payload = await fetchModelCatalog(accessToken, fetchFn)
+  export async function fetchModelIDs(
+    accessToken: string,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<string[]> {
+    const payload = await fetchModelCatalog(accessToken, fetchFn, providerID)
     return payload.map((item) => item.id)
   }
 
@@ -706,48 +717,51 @@ export namespace CodexProvider {
     return input.clone().text()
   }
 
-  export async function codexFetch(input: RequestInfo | URL, init?: RequestInit) {
-    return ProviderAuthRecovery.execute({
-      providerID: PROVIDER_ID,
-      request: async () => {
-        const access = await resolveToken({ refreshIfExpiring: true })
-        if (!access) {
-          throw new AuthError({
-            providerID: PROVIDER_ID,
-            code: "codex_auth_missing",
-            message: "No Codex credentials stored. Run `synergy auth login` and choose OpenAI Codex.",
-            reloginRequired: true,
-          })
-        }
+  export function codexFetchFor(providerID = PROVIDER_ID) {
+    return async (input: RequestInfo | URL, init?: RequestInit) =>
+      ProviderAuthRecovery.execute({
+        providerID,
+        request: async () => {
+          const access = await resolveToken({ providerID, refreshIfExpiring: true })
+          if (!access) {
+            throw new AuthError({
+              providerID,
+              code: "codex_auth_missing",
+              message: "No Codex credentials stored. Run `synergy auth login` and choose OpenAI Codex.",
+              reloginRequired: true,
+            })
+          }
 
-        const headers = new Headers(input instanceof Request ? input.headers : init?.headers)
-        if (input instanceof Request && init?.headers) {
-          for (const [key, value] of new Headers(init.headers)) headers.set(key, value)
-        }
-        headers.set("Authorization", `Bearer ${access}`)
-        for (const [key, value] of Object.entries(codexHeaders(access))) {
-          headers.set(key, value)
-        }
+          const headers = new Headers(input instanceof Request ? input.headers : init?.headers)
+          if (input instanceof Request && init?.headers) {
+            for (const [key, value] of new Headers(init.headers)) headers.set(key, value)
+          }
+          headers.set("Authorization", `Bearer ${access}`)
+          for (const [key, value] of Object.entries(codexHeaders(access))) {
+            headers.set(key, value)
+          }
 
-        const rewritten = rewriteCodexBody(await codexRequestBody(input, init))
-        if (rewritten.promptCacheKey) {
-          headers.set("session_id", rewritten.promptCacheKey)
-          headers.set("x-client-request-id", rewritten.promptCacheKey)
-        }
+          const rewritten = rewriteCodexBody(await codexRequestBody(input, init))
+          if (rewritten.promptCacheKey) {
+            headers.set("session_id", rewritten.promptCacheKey)
+            headers.set("x-client-request-id", rewritten.promptCacheKey)
+          }
 
-        const requestInit: RequestInit = {
-          ...init,
-          headers,
-        }
-        if (rewritten.body !== undefined) requestInit.body = rewritten.body
-        return fetch(input, requestInit)
-      },
-      refresh: async (auth) => {
-        return refreshAuth(auth)
-      },
-      classify: classifyError,
-    })
+          const requestInit: RequestInit = {
+            ...init,
+            headers,
+          }
+          if (rewritten.body !== undefined) requestInit.body = rewritten.body
+          return fetch(input, requestInit)
+        },
+        refresh: async (auth) => {
+          return refreshAuth(auth, fetch, providerID)
+        },
+        classify: classifyError,
+      })
   }
+
+  export const codexFetch = codexFetchFor(PROVIDER_ID)
 
   export function classifyError(input: {
     status?: number
@@ -765,9 +779,13 @@ export namespace CodexProvider {
     return undefined
   }
 
-  export async function refreshAuth(auth: Auth.Info, fetchFn: FetchLike = fetch): Promise<Auth.Info | undefined> {
+  export async function refreshAuth(
+    auth: Auth.Info,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<Auth.Info | undefined> {
     if (auth.type !== "oauth") return undefined
-    const refreshed = await refreshOAuth(auth, fetchFn)
+    const refreshed = await refreshOAuth(auth, fetchFn, providerID)
     return {
       type: "oauth",
       access: refreshed.access,
@@ -800,18 +818,21 @@ export namespace CodexProvider {
     return `${normalized}/api/codex/usage`
   }
 
-  export async function fetchUsage(fetchFn: FetchLike = fetch): Promise<AccountUsage.Snapshot> {
-    const access = await resolveToken({ refreshIfExpiring: true, allowMissing: true, fetch: fetchFn })
+  export async function fetchUsage(
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<AccountUsage.Snapshot> {
+    const access = await resolveToken({ providerID, refreshIfExpiring: true, allowMissing: true, fetch: fetchFn })
     if (!access) {
-      return AccountUsage.unavailable(PROVIDER_ID, "OpenAI Codex is not connected.", { reloginRequired: true })
+      return AccountUsage.unavailable(providerID, "OpenAI Codex is not connected.", { reloginRequired: true })
     }
     let response: Response
     try {
       response = await ProviderAuthRecovery.execute({
-        providerID: PROVIDER_ID,
+        providerID,
         request: async () => {
           const current =
-            (await resolveToken({ refreshIfExpiring: true, allowMissing: true, fetch: fetchFn })) ?? access
+            (await resolveToken({ providerID, refreshIfExpiring: true, allowMissing: true, fetch: fetchFn })) ?? access
           return fetchFn(usageURL(), {
             headers: {
               Authorization: `Bearer ${current}`,
@@ -822,24 +843,24 @@ export namespace CodexProvider {
             signal: AbortSignal.timeout(15_000),
           })
         },
-        refresh: (auth) => refreshAuth(auth, fetchFn),
+        refresh: (auth) => refreshAuth(auth, fetchFn, providerID),
         classify: classifyError,
         throwOnActionRequired: false,
       })
     } catch {
-      return AccountUsage.error(PROVIDER_ID, "OpenAI Codex usage request failed.")
+      return AccountUsage.error(providerID, "OpenAI Codex usage request failed.")
     }
     if (!response.ok) {
       const failure = await classifyError({ status: response.status, body: await safeJson(response.clone()) })
       if (failure?.reloginRequired) {
-        return AccountUsage.error(PROVIDER_ID, "OpenAI rejected these credentials. Reconnect to restore usage.", {
+        return AccountUsage.error(providerID, "OpenAI rejected these credentials. Reconnect to restore usage.", {
           reloginRequired: true,
         })
       }
       if (failure?.exhausted) {
-        return AccountUsage.unavailable(PROVIDER_ID, "OpenAI Codex usage is temporarily rate limited.")
+        return AccountUsage.unavailable(providerID, "OpenAI Codex usage is temporarily rate limited.")
       }
-      return AccountUsage.error(PROVIDER_ID, "OpenAI Codex usage is temporarily unavailable.")
+      return AccountUsage.error(providerID, "OpenAI Codex usage is temporarily unavailable.")
     }
     const payload = await safeJson(response)
     const rateLimit = payload.rate_limit ?? {}
@@ -869,7 +890,7 @@ export namespace CodexProvider {
     if (credits?.unlimited) details.push("Credits balance: unlimited")
     if (typeof credits?.balance === "number") details.push(`Credits balance: $${credits.balance.toFixed(2)}`)
     return {
-      providerID: PROVIDER_ID,
+      providerID,
       status: "available",
       source: "usage_api",
       fetchedAt: new Date().toISOString(),

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -43,16 +43,16 @@ export namespace CopilotProvider {
     }
   }
 
-  function githubBase(providerID: string) {
-    const enterprise = providerID === ENTERPRISE_PROVIDER_ID
+  function githubBase(enterprise: boolean) {
     return enterprise ? process.env.COPILOT_GITHUB_ENTERPRISE_URL || "https://github.com" : "https://github.com"
   }
 
   export async function authorizeDeviceCode(
     providerID = PROVIDER_ID,
     fetchFn: FetchLike = fetch,
+    options: { enterprise?: boolean } = {},
   ): Promise<AuthOuathResult> {
-    const base = githubBase(providerID).replace(/\/+$/, "")
+    const base = githubBase(options.enterprise ?? providerID === ENTERPRISE_PROVIDER_ID).replace(/\/+$/, "")
     const response = await fetchFn(`${base}/login/device/code`, {
       method: "POST",
       headers: {

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -43,16 +43,21 @@ export namespace CopilotProvider {
     }
   }
 
-  function githubBase(enterprise: boolean) {
-    return enterprise ? process.env.COPILOT_GITHUB_ENTERPRISE_URL || "https://github.com" : "https://github.com"
+  function githubBase(enterprise: boolean, enterpriseUrl?: string) {
+    return enterprise
+      ? enterpriseUrl || process.env.COPILOT_GITHUB_ENTERPRISE_URL || "https://github.com"
+      : "https://github.com"
   }
 
   export async function authorizeDeviceCode(
     providerID = PROVIDER_ID,
     fetchFn: FetchLike = fetch,
-    options: { enterprise?: boolean } = {},
+    options: { enterprise?: boolean; enterpriseUrl?: string } = {},
   ): Promise<AuthOuathResult> {
-    const base = githubBase(options.enterprise ?? providerID === ENTERPRISE_PROVIDER_ID).replace(/\/+$/, "")
+    const base = githubBase(options.enterprise ?? providerID === ENTERPRISE_PROVIDER_ID, options.enterpriseUrl).replace(
+      /\/+$/,
+      "",
+    )
     const response = await fetchFn(`${base}/login/device/code`, {
       method: "POST",
       headers: {

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -131,13 +131,18 @@ export namespace CopilotProvider {
     return true
   }
 
-  export async function resolveGitHubToken(providerID = PROVIDER_ID): Promise<string | undefined> {
+  export async function resolveGitHubToken(
+    providerID = PROVIDER_ID,
+    preferredAuth?: Auth.Info,
+  ): Promise<string | undefined> {
+    const stored = preferredAuth ?? (await Auth.get(providerID))
+    const mapped = providerID !== PROVIDER_ID && providerID !== ENTERPRISE_PROVIDER_ID
+    if (mapped && stored?.type === "api" && validateGitHubToken(stored.key)) return stored.key
     for (const env of ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]) {
       const value = process.env[env]
       if (value && validateGitHubToken(value)) return value
     }
-    const auth = await Auth.get(providerID)
-    if (auth?.type === "api" && validateGitHubToken(auth.key)) return auth.key
+    if (stored?.type === "api" && validateGitHubToken(stored.key)) return stored.key
     return undefined
   }
 
@@ -145,7 +150,12 @@ export namespace CopilotProvider {
     runtimeTokens.delete(providerID)
   }
 
-  export async function exchangeToken(providerID = PROVIDER_ID, fetchFn: FetchLike = fetch, force = false) {
+  export async function exchangeToken(
+    providerID = PROVIDER_ID,
+    fetchFn: FetchLike = fetch,
+    force = false,
+    preferredAuth?: Auth.Info,
+  ) {
     const selected = await Auth.select(providerID)
     const auth = selected?.auth
     const metadata = auth?.metadata ?? {}
@@ -158,7 +168,7 @@ export namespace CopilotProvider {
     ) {
       return metadata.copilotApiToken
     }
-    const githubToken = await resolveGitHubToken(providerID)
+    const githubToken = await resolveGitHubToken(providerID, preferredAuth)
     if (!githubToken) {
       throw new AuthError({
         providerID,
@@ -245,12 +255,12 @@ export namespace CopilotProvider {
     })
   }
 
-  export function copilotFetchFor(providerID = PROVIDER_ID) {
+  export function copilotFetchFor(providerID = PROVIDER_ID, auth?: Auth.Info) {
     return async (input: RequestInfo | URL, init?: RequestInit) => {
       return ProviderAuthRecovery.execute({
         providerID,
         request: async () => {
-          const token = await exchangeToken(providerID)
+          const token = await exchangeToken(providerID, fetch, false, auth)
           const headers = new Headers(init?.headers)
           headers.set("Authorization", `Bearer ${token}`)
           headers.set("User-Agent", USER_AGENT)
@@ -261,7 +271,7 @@ export namespace CopilotProvider {
         refresh: (auth) => refreshAuth(providerID, auth),
         recoverWithoutCredential: async () => {
           clearApiToken(providerID)
-          await exchangeToken(providerID, fetch, true)
+          await exchangeToken(providerID, fetch, true, auth)
           return true
         },
         classify: classifyError,
@@ -271,11 +281,11 @@ export namespace CopilotProvider {
 
   export const copilotFetch = copilotFetchFor(PROVIDER_ID)
 
-  async function fetchModelPayload(providerID: string, fetchFn: FetchLike) {
+  async function fetchModelPayload(providerID: string, fetchFn: FetchLike, auth?: Auth.Info) {
     const response = await ProviderAuthRecovery.execute({
       providerID,
       request: async () => {
-        const token = await exchangeToken(providerID, fetchFn)
+        const token = await exchangeToken(providerID, fetchFn, false, auth)
         return fetchFn(`${BASE_URL}/models`, {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -289,7 +299,7 @@ export namespace CopilotProvider {
       refresh: (auth) => refreshAuth(providerID, auth, fetchFn),
       recoverWithoutCredential: async () => {
         clearApiToken(providerID)
-        await exchangeToken(providerID, fetchFn, true)
+        await exchangeToken(providerID, fetchFn, true, auth)
         return true
       },
       classify: classifyError,
@@ -304,8 +314,9 @@ export namespace CopilotProvider {
   export async function fetchModelCatalog(
     providerID = PROVIDER_ID,
     fetchFn: FetchLike = fetch,
+    auth?: Auth.Info,
   ): Promise<ProviderProfile.ModelCatalogEntry[]> {
-    const entries = await fetchModelPayload(providerID, fetchFn)
+    const entries = await fetchModelPayload(providerID, fetchFn, auth)
     const result: ProviderProfile.ModelCatalogEntry[] = []
     for (const entry of entries) {
       if (!entry || typeof entry !== "object" || typeof entry.id !== "string" || !entry.id.trim()) continue
@@ -327,8 +338,12 @@ export namespace CopilotProvider {
     return result
   }
 
-  export async function fetchModelIDs(providerID = PROVIDER_ID, fetchFn: FetchLike = fetch): Promise<string[]> {
-    return (await fetchModelCatalog(providerID, fetchFn)).map((entry) => entry.id)
+  export async function fetchModelIDs(
+    providerID = PROVIDER_ID,
+    fetchFn: FetchLike = fetch,
+    auth?: Auth.Info,
+  ): Promise<string[]> {
+    return (await fetchModelCatalog(providerID, fetchFn, auth)).map((entry) => entry.id)
   }
 
   export async function refreshAuth(
@@ -338,7 +353,7 @@ export namespace CopilotProvider {
   ): Promise<Auth.Info | undefined> {
     if (auth.type !== "api") return undefined
     clearApiToken(providerID)
-    await exchangeToken(providerID, fetchFn, true)
+    await exchangeToken(providerID, fetchFn, true, auth)
     return (await Auth.select(providerID))?.auth ?? auth
   }
 

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -157,7 +157,7 @@ export namespace CopilotProvider {
     preferredAuth?: Auth.Info,
   ) {
     const selected = await Auth.select(providerID)
-    const auth = selected?.auth
+    const auth = selected?.auth ?? preferredAuth
     const metadata = auth?.metadata ?? {}
     if (
       !force &&
@@ -168,7 +168,7 @@ export namespace CopilotProvider {
     ) {
       return metadata.copilotApiToken
     }
-    const githubToken = await resolveGitHubToken(providerID, preferredAuth)
+    const githubToken = await resolveGitHubToken(providerID, auth)
     if (!githubToken) {
       throw new AuthError({
         providerID,
@@ -187,7 +187,7 @@ export namespace CopilotProvider {
     }
     return Auth.withLock(`${providerID}:copilot-token`, async () => {
       const latestSelected = await Auth.select(providerID)
-      const latest = latestSelected?.auth
+      const latest = latestSelected?.auth ?? preferredAuth
       const latestMetadata = latest?.metadata ?? {}
       if (
         !force &&
@@ -198,17 +198,26 @@ export namespace CopilotProvider {
       ) {
         return latestMetadata.copilotApiToken
       }
+      const latestGitHubToken = await resolveGitHubToken(providerID, latest)
+      if (!latestGitHubToken) {
+        throw new AuthError({
+          providerID,
+          code: "github_token_missing",
+          message: "No GitHub token available for GitHub Copilot.",
+          reloginRequired: true,
+        })
+      }
       const latestRuntime = runtimeTokens.get(providerID)
       if (
         !force &&
-        latestRuntime?.githubToken === githubToken &&
+        latestRuntime?.githubToken === latestGitHubToken &&
         latestRuntime.expiresAt > nowSeconds() + API_TOKEN_REFRESH_MARGIN_SECONDS
       ) {
         return latestRuntime.token
       }
       const response = await fetchFn(TOKEN_EXCHANGE_URL, {
         headers: {
-          Authorization: `token ${githubToken}`,
+          Authorization: `token ${latestGitHubToken}`,
           "User-Agent": USER_AGENT,
           Accept: "application/json",
           "Editor-Version": EDITOR_VERSION,
@@ -239,7 +248,7 @@ export namespace CopilotProvider {
           providerID,
           {
             type: "api",
-            key: githubToken,
+            key: latestGitHubToken,
             metadata: {
               ...(latest.metadata ?? auth?.metadata ?? {}),
               copilotApiToken: payload.token,
@@ -249,7 +258,7 @@ export namespace CopilotProvider {
           { credentialID: latestSelected.credentialID, source: latestSelected.poolEntry?.source ?? "api" },
         )
       } else {
-        runtimeTokens.set(providerID, { githubToken, token: payload.token, expiresAt })
+        runtimeTokens.set(providerID, { githubToken: latestGitHubToken, token: payload.token, expiresAt })
       }
       return payload.token
     })

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -155,6 +155,12 @@ export namespace CopilotProvider {
     runtimeTokens.delete(providerID)
   }
 
+  async function shouldPreferProvidedAuth(providerID: string, auth?: Auth.Info) {
+    if (!auth) return false
+    const selected = await Auth.select(providerID)
+    return !(auth.type === "api" && selected?.auth.type === "api" && auth.key === selected.auth.key)
+  }
+
   export async function exchangeToken(
     providerID = PROVIDER_ID,
     fetchFn: FetchLike = fetch,
@@ -276,9 +282,7 @@ export namespace CopilotProvider {
     let externalPreferredAuth: Promise<boolean> | undefined
     const usesExternalPreferredAuth = () => {
       if (!auth) return Promise.resolve(false)
-      externalPreferredAuth ??= Auth.select(providerID).then(
-        (selected) => !(auth.type === "api" && selected?.auth.type === "api" && auth.key === selected.auth.key),
-      )
+      externalPreferredAuth ??= shouldPreferProvidedAuth(providerID, auth)
       return externalPreferredAuth
     }
     return async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -309,10 +313,11 @@ export namespace CopilotProvider {
   export const copilotFetch = copilotFetchFor(PROVIDER_ID)
 
   async function fetchModelPayload(providerID: string, fetchFn: FetchLike, auth?: Auth.Info) {
+    const preferProvidedAuth = await shouldPreferProvidedAuth(providerID, auth)
     const response = await ProviderAuthRecovery.execute({
       providerID,
       request: async () => {
-        const token = await exchangeToken(providerID, fetchFn, false, auth)
+        const token = await exchangeToken(providerID, fetchFn, false, auth, preferProvidedAuth)
         return fetchFn(`${BASE_URL}/models`, {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -326,10 +331,11 @@ export namespace CopilotProvider {
       refresh: (auth) => refreshAuth(providerID, auth, fetchFn),
       recoverWithoutCredential: async () => {
         clearApiToken(providerID)
-        await exchangeToken(providerID, fetchFn, true, auth)
+        await exchangeToken(providerID, fetchFn, true, auth, preferProvidedAuth)
         return true
       },
       classify: classifyError,
+      manageStoredCredential: !preferProvidedAuth,
       reloadOnTransition: false,
       throwOnActionRequired: false,
     })

--- a/packages/synergy/src/provider/copilot.ts
+++ b/packages/synergy/src/provider/copilot.ts
@@ -155,9 +155,10 @@ export namespace CopilotProvider {
     fetchFn: FetchLike = fetch,
     force = false,
     preferredAuth?: Auth.Info,
+    preferProvidedAuth = false,
   ) {
     const selected = await Auth.select(providerID)
-    const auth = selected?.auth ?? preferredAuth
+    const auth = preferProvidedAuth ? (preferredAuth ?? selected?.auth) : (selected?.auth ?? preferredAuth)
     const metadata = auth?.metadata ?? {}
     if (
       !force &&
@@ -187,7 +188,9 @@ export namespace CopilotProvider {
     }
     return Auth.withLock(`${providerID}:copilot-token`, async () => {
       const latestSelected = await Auth.select(providerID)
-      const latest = latestSelected?.auth ?? preferredAuth
+      const latest = preferProvidedAuth
+        ? (preferredAuth ?? latestSelected?.auth)
+        : (latestSelected?.auth ?? preferredAuth)
       const latestMetadata = latest?.metadata ?? {}
       if (
         !force &&
@@ -243,7 +246,7 @@ export namespace CopilotProvider {
       }
       const expires = Number(payload.expires_at)
       const expiresAt = Number.isFinite(expires) && expires > 0 ? expires : nowSeconds() + 25 * 60
-      if (latestSelected && latest?.type === "api") {
+      if (!preferProvidedAuth && latestSelected && latest?.type === "api") {
         await Auth.replaceSelectedCredential(
           providerID,
           {
@@ -265,11 +268,20 @@ export namespace CopilotProvider {
   }
 
   export function copilotFetchFor(providerID = PROVIDER_ID, auth?: Auth.Info) {
+    let externalPreferredAuth: Promise<boolean> | undefined
+    const usesExternalPreferredAuth = () => {
+      if (!auth) return Promise.resolve(false)
+      externalPreferredAuth ??= Auth.select(providerID).then(
+        (selected) => !(auth.type === "api" && selected?.auth.type === "api" && auth.key === selected.auth.key),
+      )
+      return externalPreferredAuth
+    }
     return async (input: RequestInfo | URL, init?: RequestInit) => {
+      const preferProvidedAuth = await usesExternalPreferredAuth()
       return ProviderAuthRecovery.execute({
         providerID,
         request: async () => {
-          const token = await exchangeToken(providerID, fetch, false, auth)
+          const token = await exchangeToken(providerID, fetch, false, auth, preferProvidedAuth)
           const headers = new Headers(init?.headers)
           headers.set("Authorization", `Bearer ${token}`)
           headers.set("User-Agent", USER_AGENT)
@@ -280,10 +292,11 @@ export namespace CopilotProvider {
         refresh: (auth) => refreshAuth(providerID, auth),
         recoverWithoutCredential: async () => {
           clearApiToken(providerID)
-          await exchangeToken(providerID, fetch, true, auth)
+          await exchangeToken(providerID, fetch, true, auth, preferProvidedAuth)
           return true
         },
         classify: classifyError,
+        manageStoredCredential: !preferProvidedAuth,
       })
     }
   }

--- a/packages/synergy/src/provider/minimax.ts
+++ b/packages/synergy/src/provider/minimax.ts
@@ -19,7 +19,7 @@ export namespace MiniMaxProvider {
   export const AuthError = NamedError.create(
     "MiniMaxOAuthError",
     z.object({
-      providerID: z.literal(PROVIDER_ID),
+      providerID: z.string(),
       code: z.string(),
       message: z.string(),
       reloginRequired: z.boolean(),
@@ -140,7 +140,11 @@ export namespace MiniMaxProvider {
     }
   }
 
-  export async function refreshOAuth(auth: z.infer<typeof Auth.Oauth>, fetchFn: FetchLike = fetch) {
+  export async function refreshOAuth(
+    auth: z.infer<typeof Auth.Oauth>,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ) {
     const response = await fetchFn(`${GLOBAL_BASE}/oauth/token`, {
       method: "POST",
       headers: {
@@ -156,7 +160,7 @@ export namespace MiniMaxProvider {
     })
     if (!response.ok) {
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "refresh_failed",
         message: `MiniMax OAuth refresh failed with status ${response.status}.`,
         reloginRequired: response.status === 401 || response.status === 403,
@@ -165,7 +169,7 @@ export namespace MiniMaxProvider {
     const payload = await safeJson(response)
     if (typeof payload.access_token !== "string") {
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "missing_access_token",
         message: "MiniMax OAuth refresh response was missing access_token.",
         reloginRequired: true,
@@ -178,13 +182,14 @@ export namespace MiniMaxProvider {
     }
   }
 
-  export async function resolveToken(options?: { allowMissing?: boolean; fetch?: FetchLike }) {
-    const selected = await Auth.select(PROVIDER_ID)
+  export async function resolveToken(options?: { providerID?: string; allowMissing?: boolean; fetch?: FetchLike }) {
+    const providerID = options?.providerID ?? PROVIDER_ID
+    const selected = await Auth.select(providerID)
     const auth = selected?.auth
     if (!selected || !auth || auth.type !== "oauth") {
       if (options?.allowMissing) return undefined
       throw new AuthError({
-        providerID: PROVIDER_ID,
+        providerID,
         code: "minimax_oauth_missing",
         message: "No MiniMax OAuth credentials stored.",
         reloginRequired: true,
@@ -192,13 +197,13 @@ export namespace MiniMaxProvider {
     }
     if (auth.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return auth.access
     try {
-      return await Auth.withLock(`${PROVIDER_ID}:oauth-refresh`, async () => {
-        const latestSelected = await Auth.select(PROVIDER_ID)
+      return await Auth.withLock(`${providerID}:oauth-refresh`, async () => {
+        const latestSelected = await Auth.select(providerID)
         const latest = latestSelected?.auth
         if (latest?.type === "oauth" && latest.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return latest.access
-        const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch)
+        const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch, providerID)
         await Auth.replaceSelectedCredential(
-          PROVIDER_ID,
+          providerID,
           {
             type: "oauth",
             access: refreshed.access,
@@ -211,30 +216,37 @@ export namespace MiniMaxProvider {
       })
     } catch (error) {
       if (AuthError.isInstance(error) && error.data.reloginRequired) {
-        await Auth.markDead(PROVIDER_ID, error.data.code).catch(() => {})
+        await Auth.markDead(providerID, error.data.code).catch(() => {})
         if (options?.allowMissing) return undefined
       }
       throw error
     }
   }
 
-  export async function minimaxFetch(input: RequestInfo | URL, init?: RequestInit) {
-    return ProviderAuthRecovery.execute({
-      providerID: PROVIDER_ID,
-      request: async () => {
-        const token = await resolveToken()
-        const headers = new Headers(init?.headers)
-        headers.set("Authorization", `Bearer ${token}`)
-        return fetch(input, { ...init, headers })
-      },
-      refresh: refreshAuth,
-      classify: classifyError,
-    })
+  export function minimaxFetchFor(providerID = PROVIDER_ID) {
+    return async (input: RequestInfo | URL, init?: RequestInit) =>
+      ProviderAuthRecovery.execute({
+        providerID,
+        request: async () => {
+          const token = await resolveToken({ providerID })
+          const headers = new Headers(init?.headers)
+          headers.set("Authorization", `Bearer ${token}`)
+          return fetch(input, { ...init, headers })
+        },
+        refresh: (auth) => refreshAuth(auth, fetch, providerID),
+        classify: classifyError,
+      })
   }
 
-  export async function refreshAuth(auth: Auth.Info, fetchFn: FetchLike = fetch): Promise<Auth.Info | undefined> {
+  export const minimaxFetch = minimaxFetchFor(PROVIDER_ID)
+
+  export async function refreshAuth(
+    auth: Auth.Info,
+    fetchFn: FetchLike = fetch,
+    providerID = PROVIDER_ID,
+  ): Promise<Auth.Info | undefined> {
     if (auth.type !== "oauth") return undefined
-    const refreshed = await refreshOAuth(auth, fetchFn)
+    const refreshed = await refreshOAuth(auth, fetchFn, providerID)
     return {
       type: "oauth",
       access: refreshed.access,

--- a/packages/synergy/src/provider/minimax.ts
+++ b/packages/synergy/src/provider/minimax.ts
@@ -196,10 +196,12 @@ export namespace MiniMaxProvider {
       })
     }
     if (auth.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return auth.access
+    let refreshCredentialID = selected.credentialID
     try {
       return await Auth.withLock(`${providerID}:oauth-refresh`, async () => {
         const latestSelected = await Auth.select(providerID)
         const latest = latestSelected?.auth
+        refreshCredentialID = latestSelected?.credentialID ?? refreshCredentialID
         if (latest?.type === "oauth" && latest.expires > nowSeconds() + AUTH_REFRESH_SKEW_SECONDS) return latest.access
         const refreshed = await refreshOAuth(latest?.type === "oauth" ? latest : auth, options?.fetch, providerID)
         await Auth.replaceSelectedCredential(
@@ -216,7 +218,7 @@ export namespace MiniMaxProvider {
       })
     } catch (error) {
       if (AuthError.isInstance(error) && error.data.reloginRequired) {
-        await Auth.markDead(providerID, error.data.code).catch(() => {})
+        await Auth.markDead(providerID, error.data.code, { credentialID: refreshCredentialID }).catch(() => {})
         if (options?.allowMissing) return undefined
       }
       throw error

--- a/packages/synergy/src/provider/profile.ts
+++ b/packages/synergy/src/provider/profile.ts
@@ -134,14 +134,25 @@ export namespace ProviderProfile {
     }): ClassifiedError | undefined
     runtimeOptions?(input: RuntimeOptionsInput): Promise<Record<string, any>>
     getModel?(input: ModelFactoryInput): Promise<any>
-    fetchModelCatalog?(input: { auth?: Auth.Info; fetch?: FetchLike; baseURL?: string }): Promise<ModelCatalogEntry[]>
-    fetchModels?(input: { auth?: Auth.Info; fetch?: FetchLike; baseURL?: string }): Promise<string[]>
+    fetchModelCatalog?(input: {
+      providerID: string
+      auth?: Auth.Info
+      fetch?: FetchLike
+      baseURL?: string
+    }): Promise<ModelCatalogEntry[]>
+    fetchModels?(input: {
+      providerID: string
+      auth?: Auth.Info
+      fetch?: FetchLike
+      baseURL?: string
+    }): Promise<string[]>
     modelCatalogIdentity?(input: {
+      providerID: string
       auth?: Auth.Info
       credentialID?: string
       authUpdatedAt?: number
     }): Promise<string | undefined> | string | undefined
-    fetchUsage?(input?: { fetch?: FetchLike }): Promise<AccountUsage.Snapshot>
+    fetchUsage?(input: { providerID: string; fetch?: FetchLike }): Promise<AccountUsage.Snapshot>
   }
 
   const profiles = new Map<string, Profile>()
@@ -156,6 +167,10 @@ export namespace ProviderProfile {
 
   export function get(providerID: string): Profile | undefined {
     return profiles.get(aliases.get(providerID) ?? providerID)
+  }
+
+  export function resolve(providerID: string, profileID?: string): Profile | undefined {
+    return get(profileID ?? providerID)
   }
 
   export function all(): Profile[] {

--- a/packages/synergy/src/provider/profile.ts
+++ b/packages/synergy/src/provider/profile.ts
@@ -152,7 +152,12 @@ export namespace ProviderProfile {
       credentialID?: string
       authUpdatedAt?: number
     }): Promise<string | undefined> | string | undefined
-    fetchUsage?(input: { providerID: string; fetch?: FetchLike }): Promise<AccountUsage.Snapshot>
+    fetchUsage?(input: {
+      providerID: string
+      auth?: Auth.Info
+      manageStoredCredential?: boolean
+      fetch?: FetchLike
+    }): Promise<AccountUsage.Snapshot>
   }
 
   const profiles = new Map<string, Profile>()

--- a/packages/synergy/src/provider/prompt-cache-policy.ts
+++ b/packages/synergy/src/provider/prompt-cache-policy.ts
@@ -22,9 +22,13 @@ export namespace PromptCachePolicy {
     return LATE_USER_CONTEXT_PROVIDER_IDS.has(model.providerID) || LATE_USER_CONTEXT_SDK_PACKAGES.has(model.api.npm)
   }
 
-  export function usesSessionPromptCacheKey(model: Provider.Model, providerOptions?: Record<string, unknown>): boolean {
+  export function usesSessionPromptCacheKey(
+    model: Provider.Model,
+    providerOptions?: Record<string, unknown>,
+    profileID?: string,
+  ): boolean {
     return (
-      SESSION_CACHE_KEY_PROVIDER_IDS.has(model.providerID) ||
+      SESSION_CACHE_KEY_PROVIDER_IDS.has(profileID ?? model.providerID) ||
       SESSION_CACHE_KEY_SDK_PACKAGES.has(model.api.npm) ||
       providerOptions?.setCacheKey === true
     )

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -445,14 +445,15 @@ export namespace Provider {
     registerBuiltinProviderProfiles()
     const profile = ProviderProfile.resolve(model.providerID, plan.profileID)
     const storedAuth = await Auth.get(model.providerID)
+    const auth = storedAuth ?? (plan.key ? ({ type: "api", key: plan.key } satisfies Auth.Info) : undefined)
     const profileInput = {
       providerID: model.providerID,
-      auth: storedAuth,
+      auth,
       provider: undefined,
     }
-    const auth = (await profile?.resolveAuth?.(profileInput)) ?? storedAuth
-    const modelOptions = (await profile?.modelOptions?.({ ...profileInput, auth })) ?? {}
-    const runtimeOptions = (await profile?.runtimeOptions?.({ ...profileInput, auth })) ?? {}
+    const resolvedAuth = (await profile?.resolveAuth?.(profileInput)) ?? auth
+    const modelOptions = (await profile?.modelOptions?.({ ...profileInput, auth: resolvedAuth })) ?? {}
+    const runtimeOptions = (await profile?.runtimeOptions?.({ ...profileInput, auth: resolvedAuth })) ?? {}
     const options = mergeDeep(mergeDeep(modelOptions, runtimeOptions), plan.options)
     workerState.providers[model.providerID] = {
       id: model.providerID,
@@ -710,14 +711,17 @@ export namespace Provider {
       const base = database[providerID]
       if (!base) continue
       const storedAuth = await Auth.get(providerID)
+      const providerKey = providers[providerID]?.key
+      const connectionAuth =
+        storedAuth ?? (providerKey ? ({ type: "api", key: providerKey } satisfies Auth.Info) : undefined)
       const configProvider = config.provider?.[providerID]
       const sourceProviderID = configProvider?.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
       const profileInput = {
         providerID,
-        auth: storedAuth,
+        auth: connectionAuth,
         provider: modelsDev[providerID] ?? inheritedModelsDev?.[sourceProviderID],
       }
-      const auth = (await profile.resolveAuth?.(profileInput)) ?? storedAuth
+      const auth = (await profile.resolveAuth?.(profileInput)) ?? connectionAuth
       const autoload = (await profile.autoload?.({ ...profileInput, auth })) ?? false
       const shouldMerge = !!auth || !!providers[providerID] || autoload
       if (!shouldMerge) continue

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -453,7 +453,7 @@ export namespace Provider {
     const auth = (await profile?.resolveAuth?.(profileInput)) ?? storedAuth
     const modelOptions = (await profile?.modelOptions?.({ ...profileInput, auth })) ?? {}
     const runtimeOptions = (await profile?.runtimeOptions?.({ ...profileInput, auth })) ?? {}
-    const options = mergeDeep(mergeDeep(plan.options, modelOptions), runtimeOptions)
+    const options = mergeDeep(mergeDeep(modelOptions, runtimeOptions), plan.options)
     workerState.providers[model.providerID] = {
       id: model.providerID,
       profileID: plan.profileID,

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -756,7 +756,9 @@ export namespace Provider {
       const partial: Partial<Info> = { source: "config" }
       if (provider.env) partial.env = provider.env
       if (provider.name) partial.name = provider.name
-      if (provider.options) partial.options = provider.options
+      if (provider.api || provider.options) {
+        partial.options = mergeDeep(provider.api ? { baseURL: provider.api } : {}, provider.options ?? {})
+      }
       mergeProvider(providerID, partial)
     }
 

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -452,7 +452,7 @@ export namespace Provider {
     const profile = ProviderProfile.resolve(model.providerID, plan.profileID)
     const storedAuth = await Auth.get(model.providerID)
     const inlineModelKey =
-      typeof model.options.apiKey === "string" && model.options.apiKey ? model.options.apiKey : undefined
+      typeof model.options?.apiKey === "string" && model.options.apiKey ? model.options.apiKey : undefined
     const inlineProviderKey =
       typeof plan.options.apiKey === "string" && plan.options.apiKey ? plan.options.apiKey : undefined
     const connectionKey = plan.key ?? inlineProviderKey
@@ -853,8 +853,8 @@ export namespace Provider {
     runtimeProfile: RuntimeProfileState | undefined,
   ): Promise<Record<string, any>> {
     const inlineModelKey =
-      typeof model.options.apiKey === "string" && model.options.apiKey ? model.options.apiKey : undefined
-    if (!inlineModelKey || !runtimeProfile) return { ...provider.options, ...model.options }
+      typeof model.options?.apiKey === "string" && model.options.apiKey ? model.options.apiKey : undefined
+    if (!inlineModelKey || !runtimeProfile) return { ...provider.options, ...(model.options ?? {}) }
 
     const profileInput = {
       providerID: model.providerID,
@@ -867,7 +867,7 @@ export namespace Provider {
     const dynamicOptions = mergeDeep(modelOptions, runtimeOptions)
     const withRuntime = mergeDeep(provider.options, dynamicOptions)
     const withExplicitConnection = mergeDeep(withRuntime, runtimeProfile.explicitOptions)
-    return { ...withExplicitConnection, ...model.options }
+    return { ...withExplicitConnection, ...(model.options ?? {}) }
   }
 
   export async function reload() {

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -458,8 +458,8 @@ export namespace Provider {
     const connectionKey = plan.key ?? inlineProviderKey
     const auth =
       (inlineModelKey ? ({ type: "api", key: inlineModelKey } satisfies Auth.Info) : undefined) ??
-      storedAuth ??
-      (connectionKey ? ({ type: "api", key: connectionKey } satisfies Auth.Info) : undefined)
+      (connectionKey ? ({ type: "api", key: connectionKey } satisfies Auth.Info) : undefined) ??
+      storedAuth
     const profileInput = {
       providerID: model.providerID,
       auth,
@@ -750,12 +750,13 @@ export namespace Provider {
         typeof configProvider?.options?.apiKey === "string" && configProvider.options.apiKey
           ? configProvider.options.apiKey
           : undefined
-      const connectionKey = providerKey ?? inlineProviderKey
       const hasInlineModelKey = Object.values(configProvider?.models ?? {}).some(
         (model) => typeof model.options?.apiKey === "string" && model.options.apiKey.length > 0,
       )
       const connectionAuth =
-        storedAuth ?? (connectionKey ? ({ type: "api", key: connectionKey } satisfies Auth.Info) : undefined)
+        (inlineProviderKey ? ({ type: "api", key: inlineProviderKey } satisfies Auth.Info) : undefined) ??
+        storedAuth ??
+        (providerKey ? ({ type: "api", key: providerKey } satisfies Auth.Info) : undefined)
       const sourceProviderID = configProvider?.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
       const profileInput = {
         providerID,
@@ -795,6 +796,9 @@ export namespace Provider {
       const partial: Partial<Info> = { source: "config" }
       if (provider.env) partial.env = provider.env
       if (provider.name) partial.name = provider.name
+      if (typeof provider.options?.apiKey === "string" && provider.options.apiKey) {
+        partial.key = provider.options.apiKey
+      }
       if (provider.api || provider.options) {
         partial.options = mergeDeep(provider.api ? { baseURL: provider.api } : {}, provider.options ?? {})
       }

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -884,7 +884,13 @@ export namespace Provider {
           ...model.headers,
         }
 
-      const key = Bun.hash.xxHash32(JSON.stringify({ npm: model.api.npm, options }))
+      const key = Bun.hash.xxHash32(
+        JSON.stringify({
+          providerID: model.providerID,
+          npm: model.api.npm,
+          options,
+        }),
+      )
       const SDK_CACHE_TTL_MS = 4 * 60 * 60 * 1000 // 4 hours — prevent stale HTTP client state in long-running processes
       const existing = s.sdk.get(key)
       if (existing) {

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -309,6 +309,7 @@ export namespace Provider {
   export const Info = z
     .object({
       id: z.string(),
+      profileID: z.string().optional(),
       name: z.string(),
       source: z.enum(["env", "config", "custom", "api"]),
       env: z.string().array(),
@@ -322,6 +323,7 @@ export namespace Provider {
   export type Info = z.infer<typeof Info>
 
   export interface WorkerPlan {
+    profileID?: string
     key?: string
     options: Record<string, unknown>
     timeouts: {
@@ -333,6 +335,7 @@ export namespace Provider {
 
   export function workerPlan(provider: Info | undefined, timeouts: WorkerPlan["timeouts"]): WorkerPlan {
     return {
+      ...(provider?.profileID ? { profileID: provider.profileID } : {}),
       key: provider?.key,
       options: serializableProviderOptions(provider?.options ?? {}),
       timeouts,
@@ -440,7 +443,7 @@ export namespace Provider {
     }
     const { registerBuiltinProviderProfiles } = await import("./builtin")
     registerBuiltinProviderProfiles()
-    const profile = ProviderProfile.get(model.providerID)
+    const profile = ProviderProfile.resolve(model.providerID, plan.profileID)
     const storedAuth = await Auth.get(model.providerID)
     const profileInput = {
       providerID: model.providerID,
@@ -453,6 +456,7 @@ export namespace Provider {
     const options = mergeDeep(mergeDeep(plan.options, modelOptions), runtimeOptions)
     workerState.providers[model.providerID] = {
       id: model.providerID,
+      profileID: plan.profileID,
       name: model.providerID,
       source: plan.key ? "api" : "custom",
       env: [],
@@ -523,9 +527,11 @@ export namespace Provider {
     // extend database from config
     for (const [providerID, provider] of configProviders) {
       const sourceProviderID = provider.modelsDevProviderID ?? providerID
-      const sourceCatalog = provider.modelsDevProviderID
-        ? inheritedModelsDev?.[sourceProviderID]
-        : modelsDev[sourceProviderID]
+      const sourceCatalog = provider.profile
+        ? modelsDev[providerID]
+        : provider.modelsDevProviderID
+          ? inheritedModelsDev?.[sourceProviderID]
+          : modelsDev[sourceProviderID]
       if (provider.modelsDevProviderID && !sourceCatalog) {
         log.warn("configured provider model catalog source not found", {
           providerID,
@@ -554,6 +560,7 @@ export namespace Provider {
       }
       const parsed: Info = {
         id: providerID,
+        profileID: provider.profile,
         name: provider.name ?? existing?.name ?? providerID,
         env: provider.env ?? existing?.env ?? [],
         options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
@@ -687,16 +694,28 @@ export namespace Provider {
       }
     }
 
-    for (const profile of ProviderProfile.all()) {
-      const providerID = profile.id
+    const runtimeProfiles = new Map(ProviderProfile.all().map((profile) => [profile.id, profile]))
+    for (const [providerID, provider] of configProviders) {
+      if (!provider.profile) continue
+      const profile = ProviderProfile.get(provider.profile)
+      if (!profile) {
+        log.warn("configured provider profile not found", { providerID, profileID: provider.profile })
+        continue
+      }
+      runtimeProfiles.set(providerID, profile)
+    }
+
+    for (const [providerID, profile] of runtimeProfiles) {
       if (disabled.has(providerID)) continue
       const base = database[providerID]
       if (!base) continue
       const storedAuth = await Auth.get(providerID)
+      const configProvider = config.provider?.[providerID]
+      const sourceProviderID = configProvider?.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
       const profileInput = {
         providerID,
         auth: storedAuth,
-        provider: modelsDev[providerID],
+        provider: modelsDev[providerID] ?? inheritedModelsDev?.[sourceProviderID],
       }
       const auth = (await profile.resolveAuth?.(profileInput)) ?? storedAuth
       const autoload = (await profile.autoload?.({ ...profileInput, auth })) ?? false
@@ -712,6 +731,7 @@ export namespace Provider {
         }
       }
       mergeProvider(providerID, {
+        profileID: profile.id,
         source: "custom",
         options,
       })
@@ -787,7 +807,10 @@ export namespace Provider {
    * Used by both the normal `getSDK` (which wraps this with caching) and
    * the import probe path (which has no scope context).
    */
-  export function createSDKFromSpec(model: Model, provider: { options?: Record<string, unknown>; key?: string }): SDK {
+  export function createSDKFromSpec(
+    model: Model,
+    provider: { profileID?: string; options?: Record<string, unknown>; key?: string },
+  ): SDK {
     const options: Record<string, any> = { ...provider.options, ...model.options }
 
     if (model.api.npm.includes("@ai-sdk/openai-compatible") && options["includeUsage"] !== false) {
@@ -815,7 +838,7 @@ export namespace Provider {
     delete options["proxy"]
     delete options["noProxy"]
 
-    const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch)
+    const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID)
     const proxyFetch =
       proxyUrl || noProxy
         ? (input: any, init?: any) => fetchWithProxyOptions(authFetch, input, init, proxyUrl, noProxy)
@@ -871,7 +894,7 @@ export namespace Provider {
       }
 
       const customFetch = options["fetch"]
-      const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch)
+      const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID)
       const proxyUrl = options["proxy"] as string | undefined
       const noProxy = options["noProxy"] === true
       delete options["proxy"]

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -648,9 +648,11 @@ export namespace Provider {
       import("@/plugin/loader"),
       import("@/plugin/auth-provider"),
     ])
+    const authProviderPlugins = new Map<string, ReturnType<typeof authHook>>()
     for (const entry of await getAuthProviderEntries()) {
       const plugin = authHook(entry.plugin, entry.contribution)
       const providerID = plugin.provider
+      authProviderPlugins.set(providerID, plugin)
       if (disabled.has(providerID)) continue
 
       // For github-copilot plugin, check if auth exists for either github-copilot or github-copilot-enterprise
@@ -711,6 +713,14 @@ export namespace Provider {
       const base = database[providerID]
       if (!base) continue
       const storedAuth = await Auth.get(providerID)
+      const sourcePlugin = providerID === profile.id ? undefined : authProviderPlugins.get(profile.id)
+      if (storedAuth && sourcePlugin?.loader) {
+        const options = await sourcePlugin.loader(() => Auth.get(providerID) as any, base)
+        mergeProvider(providerID, {
+          source: "custom",
+          options,
+        })
+      }
       const providerKey = providers[providerID]?.key
       const connectionAuth =
         storedAuth ?? (providerKey ? ({ type: "api", key: providerKey } satisfies Auth.Info) : undefined)

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -332,6 +332,8 @@ export namespace Provider {
     profileID?: string
     key?: string
     options: Record<string, unknown>
+    baseOptions?: Record<string, unknown>
+    explicitOptions?: Record<string, unknown>
     timeouts: {
       ttfbMs: number
       idleMs: number | false
@@ -339,11 +341,18 @@ export namespace Provider {
     }
   }
 
-  export function workerPlan(provider: Info | undefined, timeouts: WorkerPlan["timeouts"]): WorkerPlan {
+  export async function workerPlan(provider: Info | undefined, timeouts: WorkerPlan["timeouts"]): Promise<WorkerPlan> {
+    const runtimeProfile = provider?.id ? (await state()).runtimeProfileStates[provider.id] : undefined
     return {
       ...(provider?.profileID ? { profileID: provider.profileID } : {}),
       key: provider?.key,
       options: serializableProviderOptions(provider?.options ?? {}),
+      ...(runtimeProfile
+        ? {
+            baseOptions: serializableProviderOptions(runtimeProfile.baseOptions),
+            explicitOptions: serializableProviderOptions(runtimeProfile.explicitOptions),
+          }
+        : {}),
       timeouts,
     }
   }
@@ -469,12 +478,16 @@ export namespace Provider {
     const resolvedAuth = (await profile?.resolveAuth?.(profileInput)) ?? auth
     const modelOptions = (await profile?.modelOptions?.({ ...profileInput, auth: resolvedAuth })) ?? {}
     const runtimeOptions = (await profile?.runtimeOptions?.({ ...profileInput, auth: resolvedAuth })) ?? {}
-    const options = mergeDeep(mergeDeep(modelOptions, runtimeOptions), plan.options)
+    const dynamicOptions = mergeDeep(modelOptions, runtimeOptions)
+    const options =
+      profile && plan.baseOptions && plan.explicitOptions
+        ? mergeDeep(mergeDeep(plan.baseOptions, dynamicOptions), plan.explicitOptions)
+        : mergeDeep(dynamicOptions, plan.options)
     if (profile) {
       workerState.runtimeProfileStates[model.providerID] = {
         profile,
-        baseOptions: {},
-        explicitOptions: plan.options,
+        baseOptions: plan.baseOptions ?? {},
+        explicitOptions: plan.explicitOptions ?? plan.options,
       }
     } else {
       delete workerState.runtimeProfileStates[model.providerID]

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -182,6 +182,11 @@ export namespace Provider {
   }
 
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
+  type RuntimeProfileState = {
+    profile: ProviderProfile.Profile
+    provider?: ModelsDev.Provider
+    explicitOptions: Record<string, any>
+  }
   export const Model = z
     .object({
       id: z.string(),
@@ -429,6 +434,7 @@ export namespace Provider {
     providers: {} as Record<string, Info>,
     sdk: new Map<number, { instance: SDK; createdAt: number }>(),
     modelLoaders: {} as Record<string, CustomModelLoader>,
+    runtimeProfileStates: {} as Record<string, RuntimeProfileState>,
     timeouts: {} as Record<string, WorkerPlan["timeouts"]>,
   }
 
@@ -445,7 +451,15 @@ export namespace Provider {
     registerBuiltinProviderProfiles()
     const profile = ProviderProfile.resolve(model.providerID, plan.profileID)
     const storedAuth = await Auth.get(model.providerID)
-    const auth = storedAuth ?? (plan.key ? ({ type: "api", key: plan.key } satisfies Auth.Info) : undefined)
+    const inlineModelKey =
+      typeof model.options.apiKey === "string" && model.options.apiKey ? model.options.apiKey : undefined
+    const inlineProviderKey =
+      typeof plan.options.apiKey === "string" && plan.options.apiKey ? plan.options.apiKey : undefined
+    const connectionKey = plan.key ?? inlineProviderKey
+    const auth =
+      (inlineModelKey ? ({ type: "api", key: inlineModelKey } satisfies Auth.Info) : undefined) ??
+      storedAuth ??
+      (connectionKey ? ({ type: "api", key: connectionKey } satisfies Auth.Info) : undefined)
     const profileInput = {
       providerID: model.providerID,
       auth,
@@ -455,6 +469,14 @@ export namespace Provider {
     const modelOptions = (await profile?.modelOptions?.({ ...profileInput, auth: resolvedAuth })) ?? {}
     const runtimeOptions = (await profile?.runtimeOptions?.({ ...profileInput, auth: resolvedAuth })) ?? {}
     const options = mergeDeep(mergeDeep(modelOptions, runtimeOptions), plan.options)
+    if (profile) {
+      workerState.runtimeProfileStates[model.providerID] = {
+        profile,
+        explicitOptions: plan.options,
+      }
+    } else {
+      delete workerState.runtimeProfileStates[model.providerID]
+    }
     workerState.providers[model.providerID] = {
       id: model.providerID,
       profileID: plan.profileID,
@@ -508,6 +530,7 @@ export namespace Provider {
     const modelLoaders: {
       [providerID: string]: CustomModelLoader
     } = {}
+    const runtimeProfileStates: Record<string, RuntimeProfileState> = {}
     const sdk = new Map<number, { instance: SDK; createdAt: number }>()
 
     log.info("init")
@@ -743,6 +766,14 @@ export namespace Provider {
       const autoload = (await profile.autoload?.({ ...profileInput, auth })) ?? false
       const shouldMerge = !!auth || !!providers[providerID] || hasInlineModelKey || autoload
       if (!shouldMerge) continue
+      runtimeProfileStates[providerID] = {
+        profile,
+        provider: profileInput.provider,
+        explicitOptions: mergeDeep(
+          configProvider?.api ? { baseURL: configProvider.api } : {},
+          configProvider?.options ?? {},
+        ),
+      }
       const modelOptions = (await profile.modelOptions?.({ ...profileInput, auth })) ?? {}
       const runtimeOptions = (await profile.runtimeOptions?.({ ...profileInput, auth })) ?? {}
       const options = mergeDeep(modelOptions, runtimeOptions)
@@ -812,8 +843,32 @@ export namespace Provider {
       providers,
       sdk,
       modelLoaders,
+      runtimeProfileStates,
     }
   })
+
+  async function resolveModelOptions(
+    model: Model,
+    provider: Info,
+    runtimeProfile: RuntimeProfileState | undefined,
+  ): Promise<Record<string, any>> {
+    const inlineModelKey =
+      typeof model.options.apiKey === "string" && model.options.apiKey ? model.options.apiKey : undefined
+    if (!inlineModelKey || !runtimeProfile) return { ...provider.options, ...model.options }
+
+    const profileInput = {
+      providerID: model.providerID,
+      auth: { type: "api", key: inlineModelKey } satisfies Auth.Info,
+      provider: runtimeProfile.provider,
+    }
+    const auth = (await runtimeProfile.profile.resolveAuth?.(profileInput)) ?? profileInput.auth
+    const modelOptions = (await runtimeProfile.profile.modelOptions?.({ ...profileInput, auth })) ?? {}
+    const runtimeOptions = (await runtimeProfile.profile.runtimeOptions?.({ ...profileInput, auth })) ?? {}
+    const dynamicOptions = mergeDeep(modelOptions, runtimeOptions)
+    const withRuntime = mergeDeep(provider.options, dynamicOptions)
+    const withExplicitConnection = mergeDeep(withRuntime, runtimeProfile.explicitOptions)
+    return { ...withExplicitConnection, ...model.options }
+  }
 
   export async function reload() {
     log.info("reloading provider state")
@@ -887,14 +942,16 @@ export namespace Provider {
     return builtSDK
   }
 
-  export async function getSDK(model: Model) {
+  export async function getSDK(model: Model, resolvedOptions?: Record<string, any>) {
     try {
       using _ = log.time("getSDK", {
         providerID: model.providerID,
       })
       const s = await state()
       const provider = s.providers[model.providerID]
-      const options: Record<string, any> = { ...provider.options, ...model.options }
+      const options: Record<string, any> = {
+        ...(resolvedOptions ?? (await resolveModelOptions(model, provider, s.runtimeProfileStates[model.providerID]))),
+      }
 
       if (model.api.npm.includes("@ai-sdk/openai-compatible") && options["includeUsage"] !== false) {
         options["includeUsage"] = true
@@ -1138,7 +1195,7 @@ export namespace Provider {
   export async function getLanguage(model: Model): Promise<LanguageModelV2> {
     const s = await state()
     const provider = s.providers[model.providerID]
-    const options = { ...provider.options, ...model.options }
+    const options = await resolveModelOptions(model, provider, s.runtimeProfileStates[model.providerID])
     const key = Bun.hash
       .xxHash32(
         JSON.stringify({
@@ -1158,7 +1215,7 @@ export namespace Provider {
       log.info("model cache entry expired, recreating", { key })
     }
 
-    const sdk = await getSDK(model)
+    const sdk = await getSDK(model, options)
 
     try {
       const language = s.modelLoaders[model.providerID]

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -185,6 +185,7 @@ export namespace Provider {
   type RuntimeProfileState = {
     profile: ProviderProfile.Profile
     provider?: ModelsDev.Provider
+    baseOptions: Record<string, any>
     explicitOptions: Record<string, any>
   }
   export const Model = z
@@ -472,6 +473,7 @@ export namespace Provider {
     if (profile) {
       workerState.runtimeProfileStates[model.providerID] = {
         profile,
+        baseOptions: {},
         explicitOptions: plan.options,
       }
     } else {
@@ -770,6 +772,7 @@ export namespace Provider {
       runtimeProfileStates[providerID] = {
         profile,
         provider: profileInput.provider,
+        baseOptions: base.options,
         explicitOptions: mergeDeep(
           configProvider?.api ? { baseURL: configProvider.api } : {},
           configProvider?.options ?? {},
@@ -869,7 +872,7 @@ export namespace Provider {
     const modelOptions = (await runtimeProfile.profile.modelOptions?.({ ...profileInput, auth })) ?? {}
     const runtimeOptions = (await runtimeProfile.profile.runtimeOptions?.({ ...profileInput, auth })) ?? {}
     const dynamicOptions = mergeDeep(modelOptions, runtimeOptions)
-    const withRuntime = mergeDeep(provider.options, dynamicOptions)
+    const withRuntime = mergeDeep(runtimeProfile.baseOptions, dynamicOptions)
     const withExplicitConnection = mergeDeep(withRuntime, runtimeProfile.explicitOptions)
     return { ...withExplicitConnection, ...(model.options ?? {}) }
   }
@@ -921,7 +924,9 @@ export namespace Provider {
     delete options["proxy"]
     delete options["noProxy"]
 
-    const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID)
+    const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID, {
+      effectiveAPIKey: typeof options["apiKey"] === "string" ? options["apiKey"] : undefined,
+    })
     const proxyFetch =
       proxyUrl || noProxy
         ? (input: any, init?: any) => fetchWithProxyOptions(authFetch, input, init, proxyUrl, noProxy)
@@ -985,7 +990,9 @@ export namespace Provider {
       }
 
       const customFetch = options["fetch"]
-      const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID)
+      const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID, {
+        effectiveAPIKey: typeof options["apiKey"] === "string" ? options["apiKey"] : undefined,
+      })
       const proxyUrl = options["proxy"] as string | undefined
       const noProxy = options["noProxy"] === true
       delete options["proxy"]

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -722,9 +722,17 @@ export namespace Provider {
         })
       }
       const providerKey = providers[providerID]?.key
-      const connectionAuth =
-        storedAuth ?? (providerKey ? ({ type: "api", key: providerKey } satisfies Auth.Info) : undefined)
       const configProvider = config.provider?.[providerID]
+      const inlineProviderKey =
+        typeof configProvider?.options?.apiKey === "string" && configProvider.options.apiKey
+          ? configProvider.options.apiKey
+          : undefined
+      const connectionKey = providerKey ?? inlineProviderKey
+      const hasInlineModelKey = Object.values(configProvider?.models ?? {}).some(
+        (model) => typeof model.options?.apiKey === "string" && model.options.apiKey.length > 0,
+      )
+      const connectionAuth =
+        storedAuth ?? (connectionKey ? ({ type: "api", key: connectionKey } satisfies Auth.Info) : undefined)
       const sourceProviderID = configProvider?.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
       const profileInput = {
         providerID,
@@ -733,7 +741,7 @@ export namespace Provider {
       }
       const auth = (await profile.resolveAuth?.(profileInput)) ?? connectionAuth
       const autoload = (await profile.autoload?.({ ...profileInput, auth })) ?? false
-      const shouldMerge = !!auth || !!providers[providerID] || autoload
+      const shouldMerge = !!auth || !!providers[providerID] || hasInlineModelKey || autoload
       if (!shouldMerge) continue
       const modelOptions = (await profile.modelOptions?.({ ...profileInput, auth })) ?? {}
       const runtimeOptions = (await profile.runtimeOptions?.({ ...profileInput, auth })) ?? {}
@@ -1154,7 +1162,7 @@ export namespace Provider {
 
     try {
       const language = s.modelLoaders[model.providerID]
-        ? await s.modelLoaders[model.providerID](sdk, model.api.id, provider.options)
+        ? await s.modelLoaders[model.providerID](sdk, model.api.id, options)
         : model.api.npm === "@ai-sdk/openai"
           ? (sdk as any).responses(model.api.id)
           : sdk.languageModel(model.api.id)

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -331,6 +331,7 @@ export namespace Provider {
   export interface WorkerPlan {
     profileID?: string
     key?: string
+    env?: string[]
     options: Record<string, unknown>
     baseOptions?: Record<string, unknown>
     explicitOptions?: Record<string, unknown>
@@ -346,6 +347,7 @@ export namespace Provider {
     return {
       ...(provider?.profileID ? { profileID: provider.profileID } : {}),
       key: provider?.key,
+      ...(provider?.env ? { env: provider.env } : {}),
       options: serializableProviderOptions(provider?.options ?? {}),
       ...(runtimeProfile
         ? {
@@ -497,7 +499,7 @@ export namespace Provider {
       profileID: plan.profileID,
       name: model.providerID,
       source: plan.key ? "api" : "custom",
-      env: [],
+      env: plan.env ?? [],
       key: plan.key,
       options,
       models: { [model.id]: model },
@@ -761,6 +763,9 @@ export namespace Provider {
       }
       const providerKey = providers[providerID]?.key
       const configProvider = config.provider?.[providerID]
+      const environmentProviderKey = providers[providerID]?.env
+        .map((name) => env[name]?.trim())
+        .find((value): value is string => !!value)
       const inlineProviderKey =
         typeof configProvider?.options?.apiKey === "string" && configProvider.options.apiKey
           ? configProvider.options.apiKey
@@ -771,6 +776,7 @@ export namespace Provider {
       const connectionAuth =
         (inlineProviderKey ? ({ type: "api", key: inlineProviderKey } satisfies Auth.Info) : undefined) ??
         storedAuth ??
+        (environmentProviderKey ? ({ type: "api", key: environmentProviderKey } satisfies Auth.Info) : undefined) ??
         (providerKey ? ({ type: "api", key: providerKey } satisfies Auth.Info) : undefined)
       const sourceProviderID = configProvider?.modelsDevProviderID ?? profile.modelsDevProviderID ?? profile.id
       const profileInput = {
@@ -803,6 +809,7 @@ export namespace Provider {
       mergeProvider(providerID, {
         profileID: profile.id,
         source: "custom",
+        key: auth?.type === "api" ? auth.key : undefined,
         options,
       })
     }
@@ -908,7 +915,7 @@ export namespace Provider {
    */
   export function createSDKFromSpec(
     model: Model,
-    provider: { profileID?: string; options?: Record<string, unknown>; key?: string },
+    provider: { profileID?: string; options?: Record<string, unknown>; key?: string; env?: string[] },
   ): SDK {
     const options: Record<string, any> = { ...provider.options, ...model.options }
 
@@ -939,6 +946,7 @@ export namespace Provider {
 
     const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID, {
       effectiveAPIKey: typeof options["apiKey"] === "string" ? options["apiKey"] : undefined,
+      environment: provider.env,
     })
     const proxyFetch =
       proxyUrl || noProxy
@@ -1054,6 +1062,7 @@ export namespace Provider {
       const customFetch = options["fetch"]
       const authFetch = ProviderAuthRecovery.wrapFetch(model.providerID, customFetch ?? fetch, provider.profileID, {
         effectiveAPIKey: typeof options["apiKey"] === "string" ? options["apiKey"] : undefined,
+        environment: provider.env,
       })
       const proxyUrl = options["proxy"] as string | undefined
       const noProxy = options["noProxy"] === true

--- a/packages/synergy/src/provider/provider.ts
+++ b/packages/synergy/src/provider/provider.ts
@@ -964,6 +964,55 @@ export namespace Provider {
     return builtSDK
   }
 
+  /**
+   * Create a language model from an explicit provider spec without using scoped
+   * provider state. Import probes use this path before a config is installed.
+   */
+  export async function createLanguageFromSpec(
+    model: Model,
+    provider: {
+      profileID?: string
+      options?: Record<string, unknown>
+      key?: string
+      auth?: Auth.Info
+      catalogProvider?: ModelsDev.Provider
+    },
+  ): Promise<LanguageModelV2> {
+    const { registerBuiltinProviderProfiles } = await import("./builtin")
+    registerBuiltinProviderProfiles()
+
+    const profile = ProviderProfile.resolve(model.providerID, provider.profileID)
+    const connectionAuth =
+      provider.auth ?? (provider.key ? ({ type: "api", key: provider.key } satisfies Auth.Info) : undefined)
+    const profileInput = {
+      providerID: model.providerID,
+      auth: connectionAuth,
+      provider: provider.catalogProvider,
+    }
+    const auth = (await profile?.resolveAuth?.(profileInput)) ?? connectionAuth
+    const modelOptions = (await profile?.modelOptions?.({ ...profileInput, auth })) ?? {}
+    const runtimeOptions = (await profile?.runtimeOptions?.({ ...profileInput, auth })) ?? {}
+    const dynamicOptions = mergeDeep(modelOptions, runtimeOptions)
+    const options = mergeDeep(dynamicOptions, provider.options ?? {})
+    const key = auth?.type === "api" ? auth.key : provider.key
+    const sdk = createSDKFromSpec(model, {
+      profileID: profile?.id ?? provider.profileID,
+      options,
+      key,
+    })
+
+    if (profile?.getModel) return profile.getModel({ sdk, modelID: model.api.id, options })
+    if (profile?.modelFactory) {
+      return ProviderProfile.defaultModelFactory(profile.modelFactory, {
+        sdk,
+        modelID: model.api.id,
+        options,
+      }) as LanguageModelV2
+    }
+    if (model.api.npm === "@ai-sdk/openai") return (sdk as any).responses(model.api.id)
+    return sdk.languageModel(model.api.id) as LanguageModelV2
+  }
+
   export async function getSDK(model: Model, resolvedOptions?: Record<string, any>) {
     try {
       using _ = log.time("getSDK", {

--- a/packages/synergy/src/provider/transform.ts
+++ b/packages/synergy/src/provider/transform.ts
@@ -618,8 +618,10 @@ export namespace ProviderTransform {
     model: Provider.Model,
     sessionID: string,
     providerOptions?: Record<string, any>,
+    profileID?: string,
   ): Record<string, any> {
     const result: Record<string, any> = {}
+    const providerID = profileID ?? model.providerID
 
     if (model.api.npm === "@openrouter/ai-sdk-provider") {
       result["usage"] = {
@@ -630,17 +632,17 @@ export namespace ProviderTransform {
       }
     }
 
-    if (model.providerID === "baseten") {
+    if (providerID === "baseten") {
       result["chat_template_args"] = { enable_thinking: true }
     }
 
-    if (PromptCachePolicy.usesSessionPromptCacheKey(model, providerOptions)) {
+    if (PromptCachePolicy.usesSessionPromptCacheKey(model, providerOptions, profileID)) {
       result["promptCacheKey"] = sessionID
     }
 
     // openai and providers using openai package should set store to false by default
     // to avoid item_reference lookups that fail on proxies/non-OpenAI backends
-    if (model.providerID === "openai" || model.providerID === "openai-codex" || model.api.npm === "@ai-sdk/openai") {
+    if (providerID === "openai" || providerID === "openai-codex" || model.api.npm === "@ai-sdk/openai") {
       result["store"] = false
     }
 
@@ -665,7 +667,7 @@ export namespace ProviderTransform {
         // @ai-sdk/openai-compatible proxies (e.g. LiteLLM) do not support reasoningEffort + tools
         // on /v1/chat/completions and will return a 400 error.
         if (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") {
-          if (model.providerID !== "openai-codex") {
+          if (providerID !== "openai-codex") {
             result["reasoningEffort"] = "medium"
             result["reasoningSummary"] = "auto"
           }
@@ -678,8 +680,8 @@ export namespace ProviderTransform {
         model.api.id.includes("gpt-5.") &&
         !model.api.id.includes("codex") &&
         !model.api.id.includes("-chat") &&
-        model.providerID !== "azure" &&
-        model.providerID !== "openai-codex" &&
+        providerID !== "azure" &&
+        providerID !== "openai-codex" &&
         model.api.npm === "@ai-sdk/openai"
       ) {
         result["textVerbosity"] = "low"
@@ -688,11 +690,12 @@ export namespace ProviderTransform {
     return result
   }
 
-  export function smallOptions(model: Provider.Model) {
-    if (model.providerID === "openai-codex") {
+  export function smallOptions(model: Provider.Model, profileID?: string) {
+    const providerID = profileID ?? model.providerID
+    if (providerID === "openai-codex") {
       return { store: false }
     }
-    if (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai") {
+    if (providerID === "openai" || model.api.npm === "@ai-sdk/openai") {
       if (model.api.id.includes("gpt-5")) {
         if (model.api.id.includes("5.") || model.api.id.includes("5-mini")) {
           return { store: false, reasoningEffort: "low" }
@@ -701,14 +704,14 @@ export namespace ProviderTransform {
       }
       return { store: false }
     }
-    if (model.providerID === "google") {
+    if (providerID === "google") {
       // gemini-3 uses thinkingLevel, gemini-2.5 uses thinkingBudget
       if (model.api.id.includes("gemini-3")) {
         return { thinkingConfig: { thinkingLevel: "minimal" } }
       }
       return { thinkingConfig: { thinkingBudget: 0 } }
     }
-    if (model.providerID === "openrouter") {
+    if (providerID === "openrouter") {
       if (model.api.id.includes("google")) {
         return { reasoning: { enabled: false } }
       }

--- a/packages/synergy/src/provider/usage-service.ts
+++ b/packages/synergy/src/provider/usage-service.ts
@@ -10,11 +10,15 @@ export namespace ProviderUsage {
 
   export async function get(providerID: string): Promise<AccountUsage.Snapshot> {
     registerBuiltinProviderProfiles()
-    const profile = ProviderProfile.get(providerID)
+    const provider = (await Provider.list())[providerID]
+    const profile = ProviderProfile.resolve(providerID, provider?.profileID)
     if (!profile?.fetchUsage) {
       return AccountUsage.unavailable(providerID, "This provider does not expose account usage through Synergy.")
     }
-    return profile.fetchUsage()
+    return {
+      ...(await profile.fetchUsage({ providerID })),
+      providerID,
+    }
   }
 
   export async function all(): Promise<Record<string, AccountUsage.Snapshot>> {
@@ -26,7 +30,7 @@ export namespace ProviderUsage {
     for (const providerID of Object.keys(providers)) {
       if (disabled.has(providerID)) continue
       if (enabled && !enabled.has(providerID)) continue
-      const profile = ProviderProfile.get(providerID)
+      const profile = ProviderProfile.resolve(providerID, providers[providerID]?.profileID)
       if (!profile?.fetchUsage) continue
       try {
         result[providerID] = await get(providerID)

--- a/packages/synergy/src/provider/usage-service.ts
+++ b/packages/synergy/src/provider/usage-service.ts
@@ -1,22 +1,40 @@
 import { Config } from "@/config/config"
 import { Log } from "@/util/log"
 import { AccountUsage } from "./usage"
+import { Auth } from "./api-key"
 import { registerBuiltinProviderProfiles } from "./builtin"
 import { Provider } from "./provider"
 import { ProviderProfile } from "./profile"
+import { Env } from "@/util/env"
 
 export namespace ProviderUsage {
   const log = Log.create({ service: "provider.usage" })
 
   export async function get(providerID: string, profileID?: string): Promise<AccountUsage.Snapshot> {
     registerBuiltinProviderProfiles()
-    const resolvedProfileID = profileID ?? (await Config.current()).provider?.[providerID]?.profile
+    const config = await Config.current()
+    const configured = config.provider?.[providerID]
+    const resolvedProfileID = profileID ?? configured?.profile
     const profile = ProviderProfile.resolve(providerID, resolvedProfileID)
     if (!profile?.fetchUsage) {
       return AccountUsage.unavailable(providerID, "This provider does not expose account usage through Synergy.")
     }
+    const inlineKey =
+      typeof configured?.options?.apiKey === "string" && configured.options.apiKey
+        ? configured.options.apiKey
+        : undefined
+    const storedAuth = await Auth.get(providerID)
+    const environment = (configured?.env ?? profile.env ?? [])
+      .map((name) => Env.get(name)?.trim())
+      .find((value) => value)
+    const configuredKey = inlineKey ?? (storedAuth ? undefined : environment)
+    const configuredAuth = configuredKey ? ({ type: "api", key: configuredKey } satisfies Auth.Info) : undefined
     return {
-      ...(await profile.fetchUsage({ providerID })),
+      ...(await profile.fetchUsage({
+        providerID,
+        auth: configuredAuth,
+        manageStoredCredential: configuredAuth ? false : undefined,
+      })),
       providerID,
     }
   }

--- a/packages/synergy/src/provider/usage-service.ts
+++ b/packages/synergy/src/provider/usage-service.ts
@@ -8,10 +8,10 @@ import { ProviderProfile } from "./profile"
 export namespace ProviderUsage {
   const log = Log.create({ service: "provider.usage" })
 
-  export async function get(providerID: string): Promise<AccountUsage.Snapshot> {
+  export async function get(providerID: string, profileID?: string): Promise<AccountUsage.Snapshot> {
     registerBuiltinProviderProfiles()
-    const provider = (await Provider.list())[providerID]
-    const profile = ProviderProfile.resolve(providerID, provider?.profileID)
+    const resolvedProfileID = profileID ?? (await Config.current()).provider?.[providerID]?.profile
+    const profile = ProviderProfile.resolve(providerID, resolvedProfileID)
     if (!profile?.fetchUsage) {
       return AccountUsage.unavailable(providerID, "This provider does not expose account usage through Synergy.")
     }
@@ -33,7 +33,7 @@ export namespace ProviderUsage {
       const profile = ProviderProfile.resolve(providerID, providers[providerID]?.profileID)
       if (!profile?.fetchUsage) continue
       try {
-        result[providerID] = await get(providerID)
+        result[providerID] = await get(providerID, providers[providerID]?.profileID)
       } catch (error) {
         result[providerID] = AccountUsage.error(providerID, "Failed to load usage data.")
         log.error("provider usage fetch failed", { providerID, error })

--- a/packages/synergy/src/provider/usage.ts
+++ b/packages/synergy/src/provider/usage.ts
@@ -99,16 +99,22 @@ export namespace AccountUsage {
   export async function openrouter(
     providerID = "openrouter",
     fetchFn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> = fetch,
+    options?: {
+      auth?: Auth.Info
+      manageStoredCredential?: boolean
+    },
   ): Promise<Snapshot> {
-    const auth = await Auth.get(providerID)
+    const auth = options?.auth ?? (await Auth.get(providerID))
     if (!auth || auth.type !== "api") {
       return unavailable(providerID, "OpenRouter credits are only available for API-key credentials.")
     }
+    const manageStoredCredential = options?.manageStoredCredential !== false
     const request = (url: string) =>
       ProviderAuthRecovery.execute({
         providerID,
+        manageStoredCredential,
         request: async () => {
-          const current = await Auth.get(providerID)
+          const current = manageStoredCredential ? await Auth.get(providerID) : auth
           if (current?.type !== "api") return new Response(null, { status: 401 })
           return fetchFn(url, {
             headers: {

--- a/packages/synergy/src/provider/usage.ts
+++ b/packages/synergy/src/provider/usage.ts
@@ -96,7 +96,10 @@ export namespace AccountUsage {
     }
   }
 
-  export async function openrouter(providerID = "openrouter", fetchFn: typeof fetch = fetch): Promise<Snapshot> {
+  export async function openrouter(
+    providerID = "openrouter",
+    fetchFn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> = fetch,
+  ): Promise<Snapshot> {
     const auth = await Auth.get(providerID)
     if (!auth || auth.type !== "api") {
       return unavailable(providerID, "OpenRouter credits are only available for API-key credentials.")

--- a/packages/synergy/src/runtime/reload.ts
+++ b/packages/synergy/src/runtime/reload.ts
@@ -349,6 +349,10 @@ export namespace RuntimeReload {
           const { TimeoutConfig } = await import("@/util/timeout-config")
           TimeoutConfig.invalidate()
         }
+        if (changedFields.includes("provider")) {
+          const { ProviderAuth } = await import("../provider/auth")
+          await ProviderAuth.reload()
+        }
         const { Plugin } = await import("../plugin")
         await Plugin.notifyConfigHooks({ source: "reload", config: result.config, changedFields })
         return inferConfigCascades(changedFields)

--- a/packages/synergy/src/server/provider-view.ts
+++ b/packages/synergy/src/server/provider-view.ts
@@ -56,7 +56,7 @@ export async function listProvidersForClient(): Promise<z.infer<typeof ProviderL
   const profiles = Object.fromEntries(
     Object.entries(providers).map(([providerID, provider]) => [
       providerID,
-      ProviderCatalog.providerMetadata(filteredProviders[providerID] ?? provider),
+      ProviderCatalog.providerMetadata(filteredProviders[providerID] ?? provider, provider.profileID),
     ]),
   )
   const entries = await Auth.entries()
@@ -66,7 +66,7 @@ export async function listProvidersForClient(): Promise<z.infer<typeof ProviderL
       const health = ProviderAuthHealth.fromEntry(providerID, entries[providerID])
       if (health.status !== "not_configured") return [providerID, health]
       const provider = providers[providerID]
-      const profile = ProviderProfile.get(providerID)
+      const profile = ProviderProfile.resolve(providerID, provider?.profileID)
       const githubEnvironment =
         providerID === GitHubProvider.PROVIDER_ID &&
         !!(process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim())
@@ -99,7 +99,7 @@ export async function listProvidersForClient(): Promise<z.infer<typeof ProviderL
       !credentialExhausted &&
       Object.prototype.hasOwnProperty.call(connected, provider.id) &&
       modelCount > 0
-    const profile = ProviderProfile.get(provider.id)
+    const profile = ProviderProfile.resolve(provider.id, provider.profileID)
     return {
       providerID: provider.id,
       available,
@@ -140,7 +140,7 @@ export async function listProvidersForClient(): Promise<z.infer<typeof ProviderL
     runtimeAvailability,
     modelCatalog: Object.fromEntries(
       Object.entries(providers).flatMap(([providerID, provider]) => {
-        const profile = ProviderProfile.get(providerID)
+        const profile = ProviderProfile.resolve(providerID, provider.profileID)
         if (!profile?.fetchModelCatalog && !profile?.fetchModels) return []
         return [
           [

--- a/packages/synergy/src/session/llm.ts
+++ b/packages/synergy/src/session/llm.ts
@@ -348,8 +348,8 @@ export namespace LLM {
       small: input.small,
     })
     const base = input.small
-      ? ProviderTransform.smallOptions(input.model)
-      : ProviderTransform.options(input.model, input.sessionID, provider?.options)
+      ? ProviderTransform.smallOptions(input.model, provider?.profileID)
+      : ProviderTransform.options(input.model, input.sessionID, provider?.options, provider?.profileID)
     const options: Record<string, unknown> = pipe(
       base,
       mergeDeep(input.model.options),

--- a/packages/synergy/src/session/llm.ts
+++ b/packages/synergy/src/session/llm.ts
@@ -390,7 +390,7 @@ export namespace LLM {
     return {
       system,
       baseSystemLength,
-      provider: Provider.workerPlan(provider, {
+      provider: await Provider.workerPlan(provider, {
         ttfbMs: timeout.providerTtfbMs,
         idleMs: timeout.providerIdleMs,
         wallMs: timeout.providerWallMs,

--- a/packages/synergy/src/skill/builtin/synergy-config/references/providers.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/references/providers.txt
@@ -114,6 +114,7 @@ When the user wants a second, independently selectable account for a provider th
 {
   "provider": {
     "deepseek-team": {
+      "profile": "deepseek",
       "modelsDevProviderID": "deepseek",
       "name": "DeepSeek Team",
       "env": ["DEEPSEEK_TEAM_API_KEY"]
@@ -122,7 +123,9 @@ When the user wants a second, independently selectable account for a provider th
 }
 ```
 
-This inherits model catalog metadata only. The connection keeps its own provider ID, credentials, endpoint/SDK overrides, allowlist/blacklist, and explicit model overrides. It does not inherit provider-specific runtime, auth, usage, or live-discovery behavior.
+`modelsDevProviderID` inherits model catalog metadata. `profile` separately enables the canonical provider's runtime, auth recovery, usage, model factory, and credential-aware live-discovery behavior. The connection keeps its own provider ID, credentials, health state, live catalog snapshot, endpoint/SDK overrides, allowlist/blacklist, and explicit model overrides.
+
+Omit `profile` when the connection is only an OpenAI-compatible gateway that should share model metadata without canonical OAuth or request behavior.
 
 **Overriding baseURL for a built-in provider:**
 ```jsonc

--- a/packages/synergy/src/skill/builtin/synergy-config/references/providers.txt
+++ b/packages/synergy/src/skill/builtin/synergy-config/references/providers.txt
@@ -114,7 +114,6 @@ When the user wants a second, independently selectable account for a provider th
 {
   "provider": {
     "deepseek-team": {
-      "profile": "deepseek",
       "modelsDevProviderID": "deepseek",
       "name": "DeepSeek Team",
       "env": ["DEEPSEEK_TEAM_API_KEY"]
@@ -123,7 +122,7 @@ When the user wants a second, independently selectable account for a provider th
 }
 ```
 
-`modelsDevProviderID` inherits model catalog metadata. `profile` separately enables the canonical provider's runtime, auth recovery, usage, model factory, and credential-aware live-discovery behavior. The connection keeps its own provider ID, credentials, health state, live catalog snapshot, endpoint/SDK overrides, allowlist/blacklist, and explicit model overrides.
+`modelsDevProviderID` inherits model catalog metadata. A registered `profile` can separately enable the canonical provider's runtime, auth recovery, usage, model factory, and credential-aware live-discovery behavior. The connection keeps its own provider ID, credentials, health state, live catalog snapshot, endpoint/SDK overrides, allowlist/blacklist, and explicit model overrides.
 
 Omit `profile` when the connection is only an OpenAI-compatible gateway that should share model metadata without canonical OAuth or request behavior.
 

--- a/packages/synergy/test/config/setup.test.ts
+++ b/packages/synergy/test/config/setup.test.ts
@@ -63,6 +63,31 @@ test("mapped provider models validate through their configured catalog source", 
   })
 })
 
+test("mapped provider models validate through synthetic profile catalogs", async () => {
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      const result = await ConfigSetup.validateRequiredCore({
+        model: "codex-secondary/gpt-5.4-mini",
+        provider: {
+          "codex-secondary": {
+            profile: "openai-codex",
+            modelsDevProviderID: "openai-codex",
+            options: { apiKey: "test-api-key" },
+          },
+        },
+      })
+
+      expect(result.fields.model).toMatchObject({
+        valid: true,
+        mode: "static",
+        message: "Default model verified",
+      })
+    },
+  })
+})
+
 test("mapped provider live probes run profile auth, options, and model hooks", async () => {
   const profileID = `setup-probe-profile-${Math.random().toString(36).slice(2)}`
   const providerID = `${profileID}-secondary`

--- a/packages/synergy/test/config/setup.test.ts
+++ b/packages/synergy/test/config/setup.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { ConfigSetup } from "../../src/config/setup"
+import { ProviderProfile } from "../../src/provider/profile"
 import { ScopeContext } from "../../src/scope/context"
 import { tmpdir } from "../fixture/fixture"
 
@@ -57,6 +58,84 @@ test("mapped provider models validate through their configured catalog source", 
         valid: true,
         mode: "static",
         message: "Default model verified",
+      })
+    },
+  })
+})
+
+test("mapped provider live probes run profile auth, options, and model hooks", async () => {
+  const profileID = `setup-probe-profile-${Math.random().toString(36).slice(2)}`
+  const providerID = `${profileID}-secondary`
+  const calls: string[] = []
+  let receivedOptions: Record<string, any> | undefined
+
+  ProviderProfile.register({
+    id: profileID,
+    name: "Setup probe profile",
+    modelsDevProviderID: "openai",
+    resolveAuth: async ({ providerID: resolvedProviderID, auth, provider }) => {
+      expect(resolvedProviderID).toBe(providerID)
+      expect(auth).toEqual({ type: "api", key: "setup-probe-key" })
+      expect(provider?.id).toBe(providerID)
+      calls.push("resolveAuth")
+      return auth
+    },
+    modelOptions: async () => {
+      calls.push("modelOptions")
+      return { modelHook: true }
+    },
+    runtimeOptions: async () => {
+      calls.push("runtimeOptions")
+      return { runtimeHook: true, baseURL: "https://profile.invalid/v1" }
+    },
+    getModel: async ({ modelID, options }) => {
+      calls.push("getModel")
+      receivedOptions = options
+      return {
+        specificationVersion: "v2",
+        provider: profileID,
+        modelId: modelID,
+        supportedUrls: {},
+        async doGenerate() {
+          return {
+            content: [{ type: "text", text: "OK" }],
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            warnings: [],
+          }
+        },
+      } as any
+    },
+  })
+
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      const result = await ConfigSetup.probeImportedCore({
+        model: `${providerID}/gpt-4o`,
+        provider: {
+          [providerID]: {
+            profile: profileID,
+            modelsDevProviderID: "openai",
+            api: "https://connection.invalid/v1",
+            options: { apiKey: "setup-probe-key", connectionHook: true },
+          },
+        },
+      })
+
+      expect(result.fields.model).toMatchObject({
+        valid: true,
+        mode: "live",
+        message: "Default model passed a live probe",
+      })
+      expect(calls).toEqual(["resolveAuth", "modelOptions", "runtimeOptions", "getModel"])
+      expect(receivedOptions).toMatchObject({
+        apiKey: "setup-probe-key",
+        baseURL: "https://connection.invalid/v1",
+        modelHook: true,
+        runtimeHook: true,
+        connectionHook: true,
       })
     },
   })

--- a/packages/synergy/test/config/setup.test.ts
+++ b/packages/synergy/test/config/setup.test.ts
@@ -36,3 +36,28 @@ test("vision_model requires image input rather than another non-text modality", 
     },
   })
 })
+
+test("mapped provider models validate through their configured catalog source", async () => {
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      const result = await ConfigSetup.validateRequiredCore({
+        model: "openai-secondary/gpt-4o",
+        provider: {
+          "openai-secondary": {
+            profile: "openai",
+            modelsDevProviderID: "openai",
+            options: { apiKey: "test-api-key" },
+          },
+        },
+      })
+
+      expect(result.fields.model).toMatchObject({
+        valid: true,
+        mode: "static",
+        message: "Default model verified",
+      })
+    },
+  })
+})

--- a/packages/synergy/test/provider/auth-recovery.test.ts
+++ b/packages/synergy/test/provider/auth-recovery.test.ts
@@ -16,6 +16,7 @@ const PROVIDERS = [
   "test-status",
   "test-exhausted",
   "test-env",
+  "test-env-mapped",
   "test-missing",
   "test-plugin-with-hooks",
   "test-plugin-without-classifier",
@@ -290,6 +291,43 @@ test("environment credential rejection is process-local and requests an environm
     expect((await Auth.entries())["test-env"]).toBeUndefined()
   } finally {
     delete process.env.SYNERGY_TEST_ENV_TOKEN
+  }
+})
+
+test("mapped multi-name environment credentials retain environment recovery", async () => {
+  ProviderProfile.register({
+    id: "test-env",
+    name: "Test environment provider",
+    origin: "plugin",
+    env: ["SYNERGY_TEST_ENV_TOKEN"],
+    classifyError: ({ status }) =>
+      status === 401 ? { code: "test_env_rejected", retryable: false, reloginRequired: true } : undefined,
+  })
+  process.env.SYNERGY_TEST_MAPPED_ENV_TOKEN = "invalid"
+  try {
+    const transport = ProviderAuthRecovery.wrapFetch(
+      "test-env-mapped",
+      async () => new Response(null, { status: 401 }),
+      "test-env",
+      {
+        effectiveAPIKey: "invalid",
+        environment: ["SYNERGY_TEST_MISSING_ENV_TOKEN", "SYNERGY_TEST_MAPPED_ENV_TOKEN"],
+      },
+    )
+
+    await expect(
+      transport("https://provider.test/v1/messages", {
+        headers: { Authorization: "Bearer invalid" },
+      }),
+    ).rejects.toMatchObject({ name: "ProviderAuthenticationRequiredError" })
+
+    expect(ProviderAuthHealth.fromEntry("test-env-mapped", undefined)).toMatchObject({
+      status: "action_required",
+      recovery: "update_environment",
+      source: "env",
+    })
+  } finally {
+    delete process.env.SYNERGY_TEST_MAPPED_ENV_TOKEN
   }
 })
 

--- a/packages/synergy/test/provider/auth-recovery.test.ts
+++ b/packages/synergy/test/provider/auth-recovery.test.ts
@@ -18,6 +18,7 @@ const PROVIDERS = [
   "test-missing",
   "test-plugin-with-hooks",
   "test-plugin-without-classifier",
+  "test-thrown-backup",
 ]
 
 async function reset() {
@@ -76,6 +77,32 @@ test("a rejected primary API key switches to a backup within the single retry bu
   expect(keys).toEqual(["primary", "backup"])
   expect((await Auth.select("test-backup"))?.credentialID).toBe("backup")
   expect(ProviderAuthHealth.fromEntry("test-backup", (await Auth.entries())["test-backup"]).status).toBe("connected")
+})
+
+test("a request-local rejection cannot mark the newly selected backup dead", async () => {
+  await Auth.set("test-thrown-backup", { type: "api", key: "primary" })
+  await Auth.addToPool("test-thrown-backup", "backup", { type: "api", key: "backup" })
+  const seen: string[] = []
+
+  const response = await ProviderAuthRecovery.execute({
+    providerID: "test-thrown-backup",
+    request: async () => {
+      const selected = await Auth.select("test-thrown-backup")
+      const key = selected?.auth.type === "api" ? selected.auth.key : ""
+      seen.push(key)
+      if (selected?.credentialID === "test-thrown-backup") {
+        await Auth.markDead("test-thrown-backup", "refresh_rejected", {
+          credentialID: selected.credentialID,
+        })
+        throw { data: { code: "refresh_rejected", reloginRequired: true } }
+      }
+      return new Response(null, { status: 200 })
+    },
+  })
+
+  expect(response.status).toBe(200)
+  expect(seen).toEqual(["primary", "backup"])
+  expect((await Auth.select("test-thrown-backup"))?.credentialID).toBe("backup")
 })
 
 test("a lone API key is invalidated only after a confirmed rejection", async () => {

--- a/packages/synergy/test/provider/auth-recovery.test.ts
+++ b/packages/synergy/test/provider/auth-recovery.test.ts
@@ -346,6 +346,46 @@ test("plugin classifier and refresh hooks run, while an unclassified plugin 401 
   expect(await Auth.get("test-plugin-without-classifier")).toMatchObject({ type: "api", key: "plugin-key" })
 })
 
+test("canonical profile recovery hooks operate on the concrete account connection", async () => {
+  const profileID = `test-profile-${Math.random().toString(36).slice(2)}`
+  const connectionID = `${profileID}-secondary`
+  let refreshedProviderID: string | undefined
+  ProviderProfile.register({
+    id: profileID,
+    name: "Test account profile",
+    origin: "plugin",
+    classifyError: ({ status }) =>
+      status === 401 ? { code: "profile_token_rejected", retryable: false, reloginRequired: true } : undefined,
+    refreshAuth: async ({ providerID, auth }) => {
+      refreshedProviderID = providerID
+      return auth?.type === "oauth" ? { ...auth, access: "secondary-new" } : undefined
+    },
+  })
+  await Auth.set(connectionID, {
+    type: "oauth",
+    access: "secondary-old",
+    refresh: "secondary-refresh",
+    expires: 9999999999,
+  })
+
+  try {
+    const recovered = await ProviderAuthRecovery.execute({
+      providerID: connectionID,
+      profileID,
+      request: async () => {
+        const auth = await Auth.get(connectionID)
+        return new Response(null, { status: auth?.type === "oauth" && auth.access === "secondary-new" ? 200 : 401 })
+      },
+    })
+    expect(recovered.status).toBe(200)
+    expect(refreshedProviderID).toBe(connectionID)
+    expect(await Auth.get(profileID)).toBeUndefined()
+    expect(await Auth.get(connectionID)).toMatchObject({ type: "oauth", access: "secondary-new" })
+  } finally {
+    await Auth.remove(connectionID)
+  }
+})
+
 test("health events contain only public state and ignore connected token rotation", async () => {
   await using tmp = await tmpdir({ git: true })
   await ScopeContext.provide({

--- a/packages/synergy/test/provider/auth-recovery.test.ts
+++ b/packages/synergy/test/provider/auth-recovery.test.ts
@@ -12,6 +12,7 @@ const PROVIDERS = [
   "test-backup",
   "test-api-confirm",
   "test-wrapped-api",
+  "test-inline-api",
   "test-status",
   "test-exhausted",
   "test-env",
@@ -180,6 +181,28 @@ test("generic SDK transport rewrites common API-key headers when selecting a bac
   })
   expect(response.status).toBe(200)
   expect(seen).toEqual(["Bearer primary", "Bearer backup"])
+})
+
+test("generic SDK transport preserves an effective inline API key", async () => {
+  await Auth.set("test-inline-api", { type: "api", key: "stored" })
+  const seen: string[] = []
+  const transport = ProviderAuthRecovery.wrapFetch(
+    "test-inline-api",
+    async (_input, init) => {
+      seen.push(new Headers(init?.headers).get("authorization") ?? "")
+      return new Response(null, { status: 401 })
+    },
+    undefined,
+    { effectiveAPIKey: "inline" },
+  )
+
+  const response = await transport("https://provider.test/v1/messages", {
+    headers: { Authorization: "Bearer inline" },
+  })
+
+  expect(response.status).toBe(401)
+  expect(seen).toEqual(["Bearer inline"])
+  expect(await Auth.get("test-inline-api")).toMatchObject({ type: "api", key: "stored" })
 })
 
 test("403, server failures, and network exceptions do not invalidate credentials without classification", async () => {

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -233,6 +233,35 @@ test("configured account endpoint is passed to live model discovery", async () =
   expect(configuredBaseURL).toBe("https://account.invalid/v1")
 })
 
+test("catalog-only account projections are isolated by configuration", async () => {
+  const first = await ProviderCatalog.resolve({
+    config: {
+      providerCatalog: { enabled: false, offlineCache: false },
+      provider: {
+        "catalog-account-a": {
+          modelsDevProviderID: "openai",
+          name: "Catalog Account A",
+        },
+      },
+    },
+  })
+  expect(first["catalog-account-a"]?.name).toBe("Catalog Account A")
+
+  const second = await ProviderCatalog.resolve({
+    config: {
+      providerCatalog: { enabled: false, offlineCache: false },
+      provider: {
+        "catalog-account-b": {
+          modelsDevProviderID: "anthropic",
+          name: "Catalog Account B",
+        },
+      },
+    },
+  })
+  expect(second["catalog-account-b"]?.name).toBe("Catalog Account B")
+  expect(second["catalog-account-a"]).toBeUndefined()
+})
+
 test("reconnecting a provider does not reuse the previous credential's catalog", async () => {
   const originalNow = Date.now
   Date.now = () => 1_000

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -21,6 +21,8 @@ const environmentProviderID = `catalog-environment-provider-${Math.random().toSt
 const environmentName = "SYNERGY_TEST_CATALOG_ACCOUNT_KEY"
 let alternateFetchCalls = 0
 let environmentDiscoveryAuth: string | undefined
+let environmentDiscovery: Promise<void>
+let resolveEnvironmentDiscovery: (() => void) | undefined
 
 ProviderProfile.register({
   id: providerID,
@@ -50,9 +52,11 @@ ProviderProfile.register({
   name: "Catalog Environment Profile Test",
   authKind: "api_key",
   modelsDevProviderID: "openai",
+  baseURL: "https://environment-catalog.invalid/v1",
   fallbackModels: ["gpt-5.5"],
   fetchModelCatalog: async ({ auth }) => {
     environmentDiscoveryAuth = auth?.type === "api" ? auth.key : undefined
+    resolveEnvironmentDiscovery?.()
     return [{ id: "environment-model" }]
   },
 })
@@ -91,6 +95,9 @@ async function reset() {
   fetchCatalog = async () => []
   alternateFetchCalls = 0
   environmentDiscoveryAuth = undefined
+  environmentDiscovery = new Promise<void>((resolve) => {
+    resolveEnvironmentDiscovery = resolve
+  })
   configuredBaseURL = undefined
   configuredDiscovery = new Promise<void>((resolve) => {
     resolveConfiguredDiscovery = resolve
@@ -303,15 +310,28 @@ test("configured environment credentials participate in live discovery", async (
     },
   })
 
-  const result = await ScopeContext.provide({
+  await ScopeContext.provide({
     scope: await tmp.scope(),
     fn: async () => {
       Env.set(environmentName, "environment-account-key")
-      return ProviderCatalog.refresh(environmentProviderID)
+      await ProviderCatalog.resolve({
+        config: {
+          providerCatalog: { enabled: false, offlineCache: false },
+          provider: {
+            [environmentProviderID]: {
+              profile: environmentProfileID,
+              modelsDevProviderID: "openai",
+              env: [environmentName],
+            },
+          },
+        },
+        includeLive: true,
+        forceRefresh: true,
+      })
+      await environmentDiscovery
     },
   })
 
-  expect(result.modelCount).toBe(1)
   expect(environmentDiscoveryAuth).toBe("environment-account-key")
 })
 

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -10,6 +10,9 @@ const providerID = `catalog-stability-${Math.random().toString(36).slice(2)}`
 let identity = "account-a"
 let fetchCatalog: () => Promise<ProviderProfile.ModelCatalogEntry[]>
 const credentialProviderID = `catalog-credentials-${Math.random().toString(36).slice(2)}`
+const alternateProfileID = `catalog-alternate-profile-${Math.random().toString(36).slice(2)}`
+const configuredProfileID = `catalog-configured-profile-${Math.random().toString(36).slice(2)}`
+const configuredProviderID = `catalog-configured-provider-${Math.random().toString(36).slice(2)}`
 
 ProviderProfile.register({
   id: providerID,
@@ -19,6 +22,34 @@ ProviderProfile.register({
   fallbackModels: ["gpt-5.5"],
   modelCatalogIdentity: () => identity,
   fetchModelCatalog: () => fetchCatalog(),
+})
+
+ProviderProfile.register({
+  id: alternateProfileID,
+  name: "Catalog Alternate Profile Test",
+  authKind: "none",
+  modelsDevProviderID: "openai",
+  fallbackModels: ["gpt-5.5"],
+  modelCatalogIdentity: () => identity,
+  fetchModelCatalog: async () => [{ id: "alternate-model" }],
+})
+
+let configuredBaseURL: string | undefined
+let configuredDiscovery: Promise<void> | undefined
+let resolveConfiguredDiscovery: (() => void) | undefined
+ProviderProfile.register({
+  id: configuredProfileID,
+  name: "Catalog Configured Endpoint Test",
+  authKind: "none",
+  modelsDevProviderID: "openai",
+  fallbackModels: ["gpt-5.5"],
+  fetchModelCatalog: async ({ providerID, baseURL }) => {
+    if (providerID === configuredProviderID) {
+      configuredBaseURL = baseURL
+      resolveConfiguredDiscovery?.()
+    }
+    return [{ id: "configured-model" }]
+  },
 })
 
 ProviderProfile.register({
@@ -35,6 +66,10 @@ ProviderProfile.register({
 async function reset() {
   identity = "account-a"
   fetchCatalog = async () => []
+  configuredBaseURL = undefined
+  configuredDiscovery = new Promise<void>((resolve) => {
+    resolveConfiguredDiscovery = resolve
+  })
   await Auth.remove(credentialProviderID).catch(() => {})
   ProviderCatalog.reset()
   await fs.rm(Global.Path.providerModelCatalogCache, { force: true })
@@ -153,6 +188,36 @@ test("catalog snapshots are isolated by opaque identity hashes", async () => {
   const accountA = await ProviderCatalog.resolve({ config, includeLive: true })
   expect(accountA[providerID].models["model-a"].catalog_state).toBe("active")
   expect(accountA[providerID].models["model-b"]).toBeUndefined()
+})
+
+test("catalog snapshots include the runtime profile identity", async () => {
+  fetchCatalog = async () => [{ id: "primary-model" }]
+  await ProviderCatalog.refresh(providerID)
+  await ProviderCatalog.refresh(providerID, alternateProfileID)
+
+  const persisted = JSON.parse(await Bun.file(Global.Path.providerModelCatalogCache).text())
+  const matching = persisted.snapshots.filter((snapshot: { providerID: string }) => snapshot.providerID === providerID)
+  expect(matching).toHaveLength(2)
+  expect(new Set(matching.map((snapshot: { identityHash: string }) => snapshot.identityHash)).size).toBe(2)
+})
+
+test("configured account endpoint is passed to live model discovery", async () => {
+  await ProviderCatalog.resolve({
+    config: {
+      providerCatalog: { enabled: false, offlineCache: false },
+      provider: {
+        [configuredProviderID]: {
+          profile: configuredProfileID,
+          options: { baseURL: "https://account.invalid/v1" },
+        },
+      },
+    },
+    includeLive: true,
+    forceRefresh: true,
+  })
+  await configuredDiscovery
+
+  expect(configuredBaseURL).toBe("https://account.invalid/v1")
 })
 
 test("reconnecting a provider does not reuse the previous credential's catalog", async () => {

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -18,6 +18,7 @@ const configuredProfileID = `catalog-configured-profile-${Math.random().toString
 const configuredProviderID = `catalog-configured-provider-${Math.random().toString(36).slice(2)}`
 const environmentProfileID = `catalog-environment-profile-${Math.random().toString(36).slice(2)}`
 const environmentProviderID = `catalog-environment-provider-${Math.random().toString(36).slice(2)}`
+const inlineProviderID = `catalog-inline-credentials-${Math.random().toString(36).slice(2)}`
 const environmentName = "SYNERGY_TEST_CATALOG_ACCOUNT_KEY"
 let alternateFetchCalls = 0
 let environmentDiscoveryAuth: string | undefined
@@ -103,6 +104,7 @@ async function reset() {
     resolveConfiguredDiscovery = resolve
   })
   await Auth.remove(credentialProviderID).catch(() => {})
+  await Auth.remove(inlineProviderID).catch(() => {})
   ProviderCatalog.reset()
   await fs.rm(Global.Path.providerModelCatalogCache, { force: true })
 }
@@ -336,7 +338,6 @@ test("configured environment credentials participate in live discovery", async (
 })
 
 test("configured inline credentials participate in live discovery", async () => {
-  const providerID = "catalog-inline-credentials"
   const configured = {
     profile: environmentProfileID,
     modelsDevProviderID: "openai",
@@ -345,6 +346,10 @@ test("configured inline credentials participate in live discovery", async () => 
     },
   }
   await using tmp = await tmpdir()
+  await Auth.set(inlineProviderID, {
+    type: "api",
+    key: "stored-catalog-key",
+  })
 
   await ScopeContext.provide({
     scope: await tmp.scope(),
@@ -353,14 +358,14 @@ test("configured inline credentials participate in live discovery", async () => 
         config: {
           providerCatalog: { enabled: false, offlineCache: false },
           provider: {
-            [providerID]: configured,
+            [inlineProviderID]: configured,
           },
         },
         includeLive: true,
         forceRefresh: true,
       })
       await environmentDiscovery
-      await ProviderCatalog.refresh(providerID, environmentProfileID, undefined, configured)
+      await ProviderCatalog.refresh(inlineProviderID, environmentProfileID, undefined, configured)
     },
   })
 

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -335,6 +335,39 @@ test("configured environment credentials participate in live discovery", async (
   expect(environmentDiscoveryAuth).toBe("environment-account-key")
 })
 
+test("configured inline credentials participate in live discovery", async () => {
+  const providerID = "catalog-inline-credentials"
+  const configured = {
+    profile: environmentProfileID,
+    modelsDevProviderID: "openai",
+    options: {
+      apiKey: "inline-catalog-key",
+    },
+  }
+  await using tmp = await tmpdir()
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      await ProviderCatalog.resolve({
+        config: {
+          providerCatalog: { enabled: false, offlineCache: false },
+          provider: {
+            [providerID]: configured,
+          },
+        },
+        includeLive: true,
+        forceRefresh: true,
+      })
+      await environmentDiscovery
+      await ProviderCatalog.refresh(providerID, environmentProfileID, undefined, configured)
+    },
+  })
+
+  expect(environmentDiscoveryAuth).toBe("inline-catalog-key")
+  expect(await Bun.file(Global.Path.providerModelCatalogCache).text()).not.toContain("inline-catalog-key")
+})
+
 test("catalog-only account projections are isolated by configuration", async () => {
   const first = await ProviderCatalog.resolve({
     config: {
@@ -384,6 +417,10 @@ test("catalog-only projections apply model rules without exposing inline credent
                   Authorization: "must-not-be-projected",
                   "X-API-Key": "must-not-be-projected",
                 },
+                apiToken: "must-not-be-projected",
+                sessionToken: "must-not-be-projected",
+                accessKeyId: "must-not-be-projected",
+                secretAccessKey: "must-not-be-projected",
                 maxTokens: 16_384,
                 reasoningEffort: "high",
               },
@@ -396,6 +433,7 @@ test("catalog-only projections apply model rules without exposing inline credent
 
   expect(Object.keys(first[accountID].models)).toEqual(["account-alias"])
   expect(first[accountID].models["account-alias"].name).toBe("Account Alias")
+  expect(first[accountID].models["account-alias"].id).toBe("account-alias")
   expect(first[accountID].models["account-alias"].options).toEqual({
     headers: {},
     maxTokens: 16_384,

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -421,6 +421,8 @@ test("catalog-only projections apply model rules without exposing inline credent
                 sessionToken: "must-not-be-projected",
                 accessKeyId: "must-not-be-projected",
                 secretAccessKey: "must-not-be-projected",
+                key: "must-not-be-projected",
+                credentials: "must-not-be-projected",
                 maxTokens: 16_384,
                 reasoningEffort: "high",
               },

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -201,6 +201,19 @@ test("catalog snapshots include the runtime profile identity", async () => {
   expect(new Set(matching.map((snapshot: { identityHash: string }) => snapshot.identityHash)).size).toBe(2)
 })
 
+test("catalog snapshots include the normalized discovery endpoint", async () => {
+  fetchCatalog = async () => [{ id: "endpoint-model" }]
+  await ProviderCatalog.refresh(providerID, undefined, "https://first.invalid/v1/")
+  await ProviderCatalog.refresh(providerID, undefined, "https://second.invalid/v1")
+
+  const persisted = JSON.parse(await Bun.file(Global.Path.providerModelCatalogCache).text())
+  const matching = persisted.snapshots.filter((snapshot: { providerID: string }) => snapshot.providerID === providerID)
+  expect(matching).toHaveLength(2)
+  expect(new Set(matching.map((snapshot: { identityHash: string }) => snapshot.identityHash)).size).toBe(2)
+  expect(JSON.stringify(matching)).not.toContain("first.invalid")
+  expect(JSON.stringify(matching)).not.toContain("second.invalid")
+})
+
 test("configured account endpoint is passed to live model discovery", async () => {
   await ProviderCatalog.resolve({
     config: {

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -364,6 +364,94 @@ test("catalog-only account projections are isolated by configuration", async () 
   expect(second["catalog-account-a"]).toBeUndefined()
 })
 
+test("catalog-only projections apply model rules without exposing inline credentials", async () => {
+  const accountID = "catalog-account-rules"
+  const first = await ProviderCatalog.resolve({
+    config: {
+      providerCatalog: { enabled: false, offlineCache: false },
+      provider: {
+        [accountID]: {
+          modelsDevProviderID: "openai",
+          whitelist: ["gpt-5.5", "account-alias"],
+          blacklist: ["gpt-5.5"],
+          models: {
+            "account-alias": {
+              id: "gpt-5.5",
+              name: "Account Alias",
+              options: {
+                apiKey: "must-not-be-projected",
+                headers: {
+                  Authorization: "must-not-be-projected",
+                  "X-API-Key": "must-not-be-projected",
+                },
+                maxTokens: 16_384,
+                reasoningEffort: "high",
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  expect(Object.keys(first[accountID].models)).toEqual(["account-alias"])
+  expect(first[accountID].models["account-alias"].name).toBe("Account Alias")
+  expect(first[accountID].models["account-alias"].options).toEqual({
+    headers: {},
+    maxTokens: 16_384,
+    reasoningEffort: "high",
+  })
+  expect(JSON.stringify(first[accountID])).not.toContain("must-not-be-projected")
+
+  const second = await ProviderCatalog.resolve({
+    config: {
+      providerCatalog: { enabled: false, offlineCache: false },
+      provider: {
+        [accountID]: {
+          modelsDevProviderID: "openai",
+          whitelist: ["gpt-5.4"],
+        },
+      },
+    },
+  })
+  expect(second[accountID].models["gpt-5.4"]).toBeDefined()
+  expect(second[accountID].models["account-alias"]).toBeUndefined()
+})
+
+test("catalog state is isolated between scopes that reuse a provider ID", async () => {
+  await using first = await tmpdir()
+  await using second = await tmpdir()
+  const firstScope = await first.scope()
+  const secondScope = await second.scope()
+
+  identity = "scope-a"
+  fetchCatalog = async () => [{ id: "scope-a-model" }]
+  await ScopeContext.provide({
+    scope: firstScope,
+    fn: () => ProviderCatalog.refresh(providerID),
+  })
+
+  identity = "scope-b"
+  fetchCatalog = async () => [{ id: "scope-b-model" }, { id: "scope-b-model-2" }]
+  await ScopeContext.provide({
+    scope: secondScope,
+    fn: () => ProviderCatalog.refresh(providerID),
+  })
+
+  expect(
+    await ScopeContext.provide({
+      scope: firstScope,
+      fn: () => ProviderCatalog.modelCatalogState(providerID)?.modelCount,
+    }),
+  ).toBe(1)
+  expect(
+    await ScopeContext.provide({
+      scope: secondScope,
+      fn: () => ProviderCatalog.modelCatalogState(providerID)?.modelCount,
+    }),
+  ).toBe(2)
+})
+
 test("reconnecting a provider does not reuse the previous credential's catalog", async () => {
   const originalNow = Date.now
   Date.now = () => 1_000

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -20,10 +20,10 @@ const environmentProfileID = `catalog-environment-profile-${Math.random().toStri
 const environmentProviderID = `catalog-environment-provider-${Math.random().toString(36).slice(2)}`
 const inlineProviderID = `catalog-inline-credentials-${Math.random().toString(36).slice(2)}`
 const environmentName = "SYNERGY_TEST_CATALOG_ACCOUNT_KEY"
+const mappedEnvironmentName = "SYNERGY_TEST_MAPPED_CATALOG_ACCOUNT_KEY"
 let alternateFetchCalls = 0
 let environmentDiscoveryAuth: string | undefined
-let environmentDiscovery: Promise<void>
-let resolveEnvironmentDiscovery: (() => void) | undefined
+const environmentDiscoveryByProvider = new Map<string, string | undefined>()
 
 ProviderProfile.register({
   id: providerID,
@@ -54,10 +54,11 @@ ProviderProfile.register({
   authKind: "api_key",
   modelsDevProviderID: "openai",
   baseURL: "https://environment-catalog.invalid/v1",
+  env: [environmentName],
   fallbackModels: ["gpt-5.5"],
-  fetchModelCatalog: async ({ auth }) => {
+  fetchModelCatalog: async ({ providerID, auth }) => {
     environmentDiscoveryAuth = auth?.type === "api" ? auth.key : undefined
-    resolveEnvironmentDiscovery?.()
+    environmentDiscoveryByProvider.set(providerID, environmentDiscoveryAuth)
     return [{ id: "environment-model" }]
   },
 })
@@ -96,9 +97,7 @@ async function reset() {
   fetchCatalog = async () => []
   alternateFetchCalls = 0
   environmentDiscoveryAuth = undefined
-  environmentDiscovery = new Promise<void>((resolve) => {
-    resolveEnvironmentDiscovery = resolve
-  })
+  environmentDiscoveryByProvider.clear()
   configuredBaseURL = undefined
   configuredDiscovery = new Promise<void>((resolve) => {
     resolveConfiguredDiscovery = resolve
@@ -107,6 +106,14 @@ async function reset() {
   await Auth.remove(inlineProviderID).catch(() => {})
   ProviderCatalog.reset()
   await fs.rm(Global.Path.providerModelCatalogCache, { force: true })
+}
+
+async function waitForEnvironmentDiscovery(providerID: string) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (environmentDiscoveryByProvider.has(providerID)) return
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for catalog discovery for ${providerID}`)
 }
 
 beforeEach(reset)
@@ -304,7 +311,7 @@ test("configured environment credentials participate in live discovery", async (
             [environmentProviderID]: {
               profile: environmentProfileID,
               modelsDevProviderID: "openai",
-              env: [environmentName],
+              env: [mappedEnvironmentName],
             },
           },
         }),
@@ -315,7 +322,8 @@ test("configured environment credentials participate in live discovery", async (
   await ScopeContext.provide({
     scope: await tmp.scope(),
     fn: async () => {
-      Env.set(environmentName, "environment-account-key")
+      Env.set(environmentName, "canonical-environment-key")
+      Env.set(mappedEnvironmentName, "environment-account-key")
       await ProviderCatalog.resolve({
         config: {
           providerCatalog: { enabled: false, offlineCache: false },
@@ -323,18 +331,66 @@ test("configured environment credentials participate in live discovery", async (
             [environmentProviderID]: {
               profile: environmentProfileID,
               modelsDevProviderID: "openai",
-              env: [environmentName],
+              env: [mappedEnvironmentName],
             },
           },
         },
         includeLive: true,
         forceRefresh: true,
       })
-      await environmentDiscovery
+      await waitForEnvironmentDiscovery(environmentProviderID)
     },
   })
 
-  expect(environmentDiscoveryAuth).toBe("environment-account-key")
+  expect(environmentDiscoveryByProvider.get(environmentProviderID)).toBe("environment-account-key")
+})
+
+test("canonical profile environment credentials participate in live discovery", async () => {
+  await using tmp = await tmpdir()
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      Env.set(environmentName, "canonical-environment-key")
+      await ProviderCatalog.resolve({
+        config,
+        includeLive: true,
+        forceRefresh: true,
+      })
+      await waitForEnvironmentDiscovery(environmentProfileID)
+    },
+  })
+
+  expect(environmentDiscoveryByProvider.get(environmentProfileID)).toBe("canonical-environment-key")
+})
+
+test("mapped connections do not inherit canonical profile environment credentials", async () => {
+  const mappedProviderID = `catalog-unbound-environment-${Math.random().toString(36).slice(2)}`
+  await using tmp = await tmpdir()
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      Env.set(environmentName, "canonical-environment-key")
+      await ProviderCatalog.resolve({
+        config: {
+          providerCatalog: { enabled: false, offlineCache: false },
+          provider: {
+            [mappedProviderID]: {
+              profile: environmentProfileID,
+              modelsDevProviderID: "openai",
+            },
+          },
+        },
+        includeLive: true,
+        forceRefresh: true,
+      })
+      await waitForEnvironmentDiscovery(environmentProfileID)
+      await Bun.sleep(20)
+    },
+  })
+
+  expect(environmentDiscoveryByProvider.has(mappedProviderID)).toBe(false)
 })
 
 test("configured inline credentials participate in live discovery", async () => {
@@ -364,7 +420,7 @@ test("configured inline credentials participate in live discovery", async () => 
         includeLive: true,
         forceRefresh: true,
       })
-      await environmentDiscovery
+      await waitForEnvironmentDiscovery(inlineProviderID)
       await ProviderCatalog.refresh(inlineProviderID, environmentProfileID, undefined, configured)
     },
   })

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -6,6 +6,7 @@ import { ProviderProfile } from "../../src/provider/profile"
 import { Auth } from "../../src/provider/api-key"
 import { ScopeContext } from "../../src/scope/context"
 import { tmpdir } from "../fixture/fixture"
+import { Env } from "../../src/util/env"
 
 const config = { providerCatalog: { enabled: false, offlineCache: false } }
 const providerID = `catalog-stability-${Math.random().toString(36).slice(2)}`
@@ -15,7 +16,11 @@ const credentialProviderID = `catalog-credentials-${Math.random().toString(36).s
 const alternateProfileID = `catalog-alternate-profile-${Math.random().toString(36).slice(2)}`
 const configuredProfileID = `catalog-configured-profile-${Math.random().toString(36).slice(2)}`
 const configuredProviderID = `catalog-configured-provider-${Math.random().toString(36).slice(2)}`
+const environmentProfileID = `catalog-environment-profile-${Math.random().toString(36).slice(2)}`
+const environmentProviderID = `catalog-environment-provider-${Math.random().toString(36).slice(2)}`
+const environmentName = "SYNERGY_TEST_CATALOG_ACCOUNT_KEY"
 let alternateFetchCalls = 0
+let environmentDiscoveryAuth: string | undefined
 
 ProviderProfile.register({
   id: providerID,
@@ -37,6 +42,18 @@ ProviderProfile.register({
   fetchModelCatalog: async () => {
     alternateFetchCalls++
     return [{ id: "alternate-model" }]
+  },
+})
+
+ProviderProfile.register({
+  id: environmentProfileID,
+  name: "Catalog Environment Profile Test",
+  authKind: "api_key",
+  modelsDevProviderID: "openai",
+  fallbackModels: ["gpt-5.5"],
+  fetchModelCatalog: async ({ auth }) => {
+    environmentDiscoveryAuth = auth?.type === "api" ? auth.key : undefined
+    return [{ id: "environment-model" }]
   },
 })
 
@@ -73,6 +90,7 @@ async function reset() {
   identity = "account-a"
   fetchCatalog = async () => []
   alternateFetchCalls = 0
+  environmentDiscoveryAuth = undefined
   configuredBaseURL = undefined
   configuredDiscovery = new Promise<void>((resolve) => {
     resolveConfiguredDiscovery = resolve
@@ -265,6 +283,36 @@ test("explicit refresh honors a configured profile for a registered provider ID"
 
   expect(alternateFetchCalls).toBe(1)
   expect(result.modelCount).toBe(1)
+})
+
+test("configured environment credentials participate in live discovery", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/synergy.json`,
+        JSON.stringify({
+          provider: {
+            [environmentProviderID]: {
+              profile: environmentProfileID,
+              modelsDevProviderID: "openai",
+              env: [environmentName],
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  const result = await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      Env.set(environmentName, "environment-account-key")
+      return ProviderCatalog.refresh(environmentProviderID)
+    },
+  })
+
+  expect(result.modelCount).toBe(1)
+  expect(environmentDiscoveryAuth).toBe("environment-account-key")
 })
 
 test("catalog-only account projections are isolated by configuration", async () => {

--- a/packages/synergy/test/provider/catalog-stability.test.ts
+++ b/packages/synergy/test/provider/catalog-stability.test.ts
@@ -4,6 +4,8 @@ import { Global } from "../../src/global"
 import { ProviderCatalog } from "../../src/provider/catalog"
 import { ProviderProfile } from "../../src/provider/profile"
 import { Auth } from "../../src/provider/api-key"
+import { ScopeContext } from "../../src/scope/context"
+import { tmpdir } from "../fixture/fixture"
 
 const config = { providerCatalog: { enabled: false, offlineCache: false } }
 const providerID = `catalog-stability-${Math.random().toString(36).slice(2)}`
@@ -13,6 +15,7 @@ const credentialProviderID = `catalog-credentials-${Math.random().toString(36).s
 const alternateProfileID = `catalog-alternate-profile-${Math.random().toString(36).slice(2)}`
 const configuredProfileID = `catalog-configured-profile-${Math.random().toString(36).slice(2)}`
 const configuredProviderID = `catalog-configured-provider-${Math.random().toString(36).slice(2)}`
+let alternateFetchCalls = 0
 
 ProviderProfile.register({
   id: providerID,
@@ -31,7 +34,10 @@ ProviderProfile.register({
   modelsDevProviderID: "openai",
   fallbackModels: ["gpt-5.5"],
   modelCatalogIdentity: () => identity,
-  fetchModelCatalog: async () => [{ id: "alternate-model" }],
+  fetchModelCatalog: async () => {
+    alternateFetchCalls++
+    return [{ id: "alternate-model" }]
+  },
 })
 
 let configuredBaseURL: string | undefined
@@ -66,6 +72,7 @@ ProviderProfile.register({
 async function reset() {
   identity = "account-a"
   fetchCatalog = async () => []
+  alternateFetchCalls = 0
   configuredBaseURL = undefined
   configuredDiscovery = new Promise<void>((resolve) => {
     resolveConfiguredDiscovery = resolve
@@ -231,6 +238,33 @@ test("configured account endpoint is passed to live model discovery", async () =
   await configuredDiscovery
 
   expect(configuredBaseURL).toBe("https://account.invalid/v1")
+})
+
+test("explicit refresh honors a configured profile for a registered provider ID", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/synergy.json`,
+        JSON.stringify({
+          provider: {
+            [providerID]: {
+              profile: alternateProfileID,
+              modelsDevProviderID: "openai",
+            },
+          },
+        }),
+      )
+    },
+  })
+  fetchCatalog = async () => [{ id: "wrong-primary-model" }]
+
+  const result = await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: () => ProviderCatalog.refresh(providerID),
+  })
+
+  expect(alternateFetchCalls).toBe(1)
+  expect(result.modelCount).toBe(1)
 })
 
 test("catalog-only account projections are isolated by configuration", async () => {

--- a/packages/synergy/test/provider/codex.test.ts
+++ b/packages/synergy/test/provider/codex.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "../fixture/fixture"
 
 const originalFetch = globalThis.fetch
 const originalCodexHome = process.env.CODEX_HOME
+const secondaryProviderID = "openai-codex-secondary-test"
 
 function nowSeconds() {
   return Math.floor(Date.now() / 1000)
@@ -55,6 +56,7 @@ async function resetCodexState() {
   }
   delete process.env.SYNERGY_CODEX_BASE_URL
   await Auth.remove(CodexProvider.PROVIDER_ID)
+  await Auth.remove(secondaryProviderID)
   await fs.rm(Global.Path.providerModelCatalogCache, { force: true })
   ProviderCatalog.reset()
   await Provider.reload()
@@ -258,6 +260,38 @@ test("codexFetch rewrites authorization, Codex headers, session headers, and req
   const body = JSON.parse(String(captured?.init?.body))
   expect(body.prompt_cache_key).toBe("session-1")
   expect(body.max_output_tokens).toBeUndefined()
+})
+
+test("codexFetchFor binds requests to the selected connection credential", async () => {
+  const canonicalToken = accessToken({ accountID: "acct_canonical" })
+  const secondaryToken = accessToken({ accountID: "acct_secondary" })
+  await Auth.set(CodexProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: canonicalToken,
+    refresh: "refresh-canonical",
+    expires: nowSeconds() + 60 * 60,
+  })
+  await Auth.set(secondaryProviderID, {
+    type: "oauth",
+    access: secondaryToken,
+    refresh: "refresh-secondary",
+    expires: nowSeconds() + 60 * 60,
+  })
+
+  globalThis.fetch = asFetch(async (_input, init) => {
+    const headers = new Headers(init?.headers)
+    expect(headers.get("authorization")).toBe(`Bearer ${secondaryToken}`)
+    expect(headers.get("chatgpt-account-id")).toBe("acct_secondary")
+    return jsonResponse({ ok: true })
+  })
+
+  await CodexProvider.codexFetchFor(secondaryProviderID)("https://chatgpt.com/backend-api/codex/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "gpt-5.6-sol", input: "hello" }),
+  })
+
+  expect(await Auth.get(CodexProvider.PROVIDER_ID)).toMatchObject({ type: "oauth", access: canonicalToken })
+  expect(await Auth.get(secondaryProviderID)).toMatchObject({ type: "oauth", access: secondaryToken })
 })
 
 test("codexFetch rewrites Request input bodies", async () => {
@@ -737,6 +771,35 @@ test("quota remains available when the model catalog refresh times out", async (
   expect(catalog.failure).toBe("timeout")
   expect(usage).toMatchObject({ providerID: CodexProvider.PROVIDER_ID, status: "available", plan: "pro" })
   expect(await Auth.get(CodexProvider.PROVIDER_ID)).toBeDefined()
+})
+
+test("Codex usage reads and reports the selected connection", async () => {
+  const canonicalToken = accessToken({ accountID: "acct_usage_canonical" })
+  const secondaryToken = accessToken({ accountID: "acct_usage_secondary" })
+  await Auth.set(CodexProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: canonicalToken,
+    refresh: "refresh-usage-canonical",
+    expires: nowSeconds() + 60 * 60,
+  })
+  await Auth.set(secondaryProviderID, {
+    type: "oauth",
+    access: secondaryToken,
+    refresh: "refresh-usage-secondary",
+    expires: nowSeconds() + 60 * 60,
+  })
+
+  const usage = await CodexProvider.fetchUsage(async (_input, init) => {
+    const headers = new Headers(init?.headers)
+    expect(headers.get("authorization")).toBe(`Bearer ${secondaryToken}`)
+    expect(headers.get("chatgpt-account-id")).toBe("acct_usage_secondary")
+    return jsonResponse({
+      plan_type: "pro",
+      rate_limit: { primary_window: { used_percent: 10, reset_at: nowSeconds() + 3600 } },
+    })
+  }, secondaryProviderID)
+
+  expect(usage).toMatchObject({ providerID: secondaryProviderID, status: "available", plan: "pro" })
 })
 
 test("live catalog cache isolates Codex accounts without exposing credential secrets", async () => {

--- a/packages/synergy/test/provider/codex.test.ts
+++ b/packages/synergy/test/provider/codex.test.ts
@@ -436,6 +436,21 @@ test("fetchModelIDs preserves future account-visible model slugs", async () => {
   expect(ids).toEqual(["gpt-5.6-sol", "future-codex-model"])
 })
 
+test("Codex discovery uses the configured connection endpoint", async () => {
+  const token = accessToken({ accountID: "acct_custom_endpoint" })
+  const catalog = await CodexProvider.fetchModelCatalog(
+    token,
+    async (input) => {
+      expect(String(input)).toBe("https://codex-proxy.invalid/custom/models?client_version=1.0.0")
+      return jsonResponse({ models: [{ slug: "proxy-model", priority: 1 }] })
+    },
+    secondaryProviderID,
+    "https://codex-proxy.invalid/custom/",
+  )
+
+  expect(catalog.map((entry) => entry.id)).toEqual(["proxy-model"])
+})
+
 test("fetchModelCatalog parses Codex context windows without filtering supported_in_api false", async () => {
   const token = accessToken({ accountID: "acct_catalog" })
   const catalog = await CodexProvider.fetchModelCatalog(token, async (input, init) => {

--- a/packages/synergy/test/provider/codex.test.ts
+++ b/packages/synergy/test/provider/codex.test.ts
@@ -614,6 +614,54 @@ test("provider auth registry exposes built-in Codex OAuth method", async () => {
   })
 })
 
+test("provider auth registry exposes mapped Codex methods under the connection ID", async () => {
+  const token = accessToken({ exp: nowSeconds() + 60 * 60 })
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "synergy.json"),
+        JSON.stringify({
+          provider: {
+            [secondaryProviderID]: {
+              profile: CodexProvider.PROVIDER_ID,
+              modelsDevProviderID: CodexProvider.PROVIDER_ID,
+            },
+          },
+        }),
+      )
+      await Bun.write(
+        path.join(dir, "auth.json"),
+        JSON.stringify({
+          tokens: {
+            access_token: token,
+            refresh_token: "refresh-secondary-import",
+          },
+        }),
+      )
+    },
+  })
+  process.env.CODEX_HOME = tmp.path
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      const methods = await ProviderAuth.methods()
+      expect(methods[secondaryProviderID]).toEqual(methods[CodexProvider.PROVIDER_ID])
+      await ProviderAuth.importCredentials({
+        providerID: secondaryProviderID,
+        method: 1,
+      })
+    },
+  })
+
+  expect(await Auth.get(secondaryProviderID)).toMatchObject({
+    type: "oauth",
+    access: token,
+    refresh: "refresh-secondary-import",
+  })
+  expect(await Auth.get(CodexProvider.PROVIDER_ID)).toBeUndefined()
+})
+
 test("provider auth imports Codex CLI credentials into the Synergy auth store", async () => {
   const token = accessToken({ exp: nowSeconds() + 60 * 60 })
   await using tmp = await tmpdir({

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -417,6 +417,46 @@ test("mapped Copilot requests prefer the connection credential over global token
   }
 })
 
+test("mapped Copilot requests reselect a backup credential after failover", async () => {
+  await Auth.set(mappedCopilotProviderID, { type: "api", key: "primary-copilot-token" })
+  await Auth.addToPool(mappedCopilotProviderID, "backup-copilot", {
+    type: "api",
+    key: "backup-copilot-token",
+  })
+  const initialAuth = await Auth.get(mappedCopilotProviderID)
+  CopilotProvider.clearApiToken(mappedCopilotProviderID)
+  const exchanges: string[] = []
+  globalThis.fetch = asFetch(async (input, init) => {
+    const url = String(input)
+    const authorization = new Headers(init?.headers).get("authorization")
+    if (url === CopilotProvider.TOKEN_EXCHANGE_URL) {
+      exchanges.push(authorization ?? "")
+      if (authorization === "token primary-copilot-token" && exchanges.length === 1) {
+        return jsonResponse({ token: "primary-copilot-api-token", expires_at: nowSeconds() + 3600 })
+      }
+      if (authorization === "token backup-copilot-token") {
+        return jsonResponse({ token: "backup-copilot-api-token", expires_at: nowSeconds() + 3600 })
+      }
+      return jsonResponse({ error: "bad_credentials" }, { status: 401 })
+    }
+    if (authorization === "Bearer backup-copilot-api-token") return jsonResponse({ ok: true })
+    return jsonResponse({ error: "invalid_token" }, { status: 401 })
+  })
+
+  const response = await CopilotProvider.copilotFetchFor(
+    mappedCopilotProviderID,
+    initialAuth,
+  )("https://api.githubcopilot.com/chat/completions")
+
+  expect(response.status).toBe(200)
+  expect(exchanges).toEqual([
+    "token primary-copilot-token",
+    "token primary-copilot-token",
+    "token backup-copilot-token",
+  ])
+  expect((await Auth.select(mappedCopilotProviderID))?.credentialID).toBe("backup-copilot")
+})
+
 test("github copilot device login exchanges a GitHub token for Copilot models", async () => {
   const authorize = await CopilotProvider.authorizeDeviceCode(
     CopilotProvider.PROVIDER_ID,

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -16,6 +16,8 @@ const originalGHToken = process.env.GH_TOKEN
 const originalGITHUBToken = process.env.GITHUB_TOKEN
 const secondaryAnthropicProviderID = "anthropic-secondary-test"
 const secondaryMiniMaxProviderID = "minimax-secondary-test"
+const mappedAnthropicProviderID = "anthropic-mapped-auth-test"
+const mappedCopilotProviderID = "copilot-mapped-auth-test"
 
 function nowSeconds() {
   return Math.floor(Date.now() / 1000)
@@ -43,6 +45,8 @@ async function reset() {
     MiniMaxProvider.PROVIDER_ID,
     secondaryAnthropicProviderID,
     secondaryMiniMaxProviderID,
+    mappedAnthropicProviderID,
+    mappedCopilotProviderID,
   ]) {
     await Auth.remove(provider).catch(() => {})
   }
@@ -98,6 +102,101 @@ test("anthropic oauth code flow exchanges code and Claude Code fetch headers rep
       "x-api-key": "should-be-removed",
     },
   })
+})
+
+test("mapped Anthropic auth methods persist OAuth credentials under the connection ID", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/synergy.json`,
+        JSON.stringify({
+          provider: {
+            [mappedAnthropicProviderID]: {
+              profile: AnthropicOAuthProvider.PROVIDER_ID,
+              modelsDevProviderID: "anthropic",
+            },
+          },
+        }),
+      )
+    },
+  })
+  globalThis.fetch = asFetch(async () =>
+    jsonResponse({
+      access_token: "mapped-anthropic-access",
+      refresh_token: "mapped-anthropic-refresh",
+      expires_in: 3600,
+    }),
+  )
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      const methods = await ProviderAuth.methods()
+      expect(methods[mappedAnthropicProviderID]).toEqual(methods[AnthropicOAuthProvider.PROVIDER_ID])
+      const authorization = await ProviderAuth.authorize({ providerID: mappedAnthropicProviderID, method: 0 })
+      const state = new URL(authorization!.url).searchParams.get("state")
+      await ProviderAuth.callback({
+        providerID: mappedAnthropicProviderID,
+        method: 0,
+        code: `mapped-code#${state}`,
+      })
+    },
+  })
+
+  expect(await Auth.get(mappedAnthropicProviderID)).toMatchObject({
+    type: "oauth",
+    access: "mapped-anthropic-access",
+    refresh: "mapped-anthropic-refresh",
+  })
+  expect(await Auth.get(AnthropicOAuthProvider.PROVIDER_ID)).toBeUndefined()
+})
+
+test("mapped Copilot device auth binds the concrete connection ID", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/synergy.json`,
+        JSON.stringify({
+          provider: {
+            [mappedCopilotProviderID]: {
+              profile: CopilotProvider.PROVIDER_ID,
+              modelsDevProviderID: CopilotProvider.PROVIDER_ID,
+            },
+          },
+        }),
+      )
+    },
+  })
+  globalThis.fetch = asFetch(async (input) => {
+    const url = String(input)
+    if (url.endsWith("/login/device/code")) {
+      return jsonResponse({
+        device_code: "mapped-copilot-device",
+        user_code: "MAPPED-COPILOT",
+        verification_uri: "https://github.com/login/device",
+        interval: 1,
+        expires_in: 60,
+      })
+    }
+    if (url.endsWith("/login/oauth/access_token")) {
+      return jsonResponse({ access_token: "mapped-copilot-token" })
+    }
+    throw new Error(`unexpected URL ${url}`)
+  })
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      await ProviderAuth.authorize({ providerID: mappedCopilotProviderID, method: 0 })
+      await ProviderAuth.callback({ providerID: mappedCopilotProviderID, method: 0 })
+    },
+  })
+
+  expect(await Auth.get(mappedCopilotProviderID)).toEqual({
+    type: "api",
+    key: "mapped-copilot-token",
+  })
+  expect(await Auth.get(CopilotProvider.PROVIDER_ID)).toBeUndefined()
 })
 
 test("anthropic oauth refresh rotates tokens and marks invalid grants dead", async () => {

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -14,6 +14,8 @@ import { tmpdir } from "../fixture/fixture"
 const originalFetch = globalThis.fetch
 const originalGHToken = process.env.GH_TOKEN
 const originalGITHUBToken = process.env.GITHUB_TOKEN
+const secondaryAnthropicProviderID = "anthropic-secondary-test"
+const secondaryMiniMaxProviderID = "minimax-secondary-test"
 
 function nowSeconds() {
   return Math.floor(Date.now() / 1000)
@@ -39,6 +41,8 @@ async function reset() {
     CopilotProvider.PROVIDER_ID,
     CopilotProvider.ENTERPRISE_PROVIDER_ID,
     MiniMaxProvider.PROVIDER_ID,
+    secondaryAnthropicProviderID,
+    secondaryMiniMaxProviderID,
   ]) {
     await Auth.remove(provider).catch(() => {})
   }
@@ -162,6 +166,32 @@ test("anthropic request rejection refreshes once and retries with the rotated to
   expect(response.status).toBe(200)
   expect(refreshes).toBe(1)
   expect(requests).toBe(2)
+})
+
+test("anthropicFetchFor binds requests to the selected connection credential", async () => {
+  await Auth.set(AnthropicOAuthProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: "anthropic-canonical",
+    refresh: "anthropic-canonical-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  await Auth.set(secondaryAnthropicProviderID, {
+    type: "oauth",
+    access: "anthropic-secondary",
+    refresh: "anthropic-secondary-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  globalThis.fetch = asFetch(async (_input, init) => {
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer anthropic-secondary")
+    return jsonResponse({ ok: true })
+  })
+
+  await AnthropicOAuthProvider.anthropicFetchFor(secondaryAnthropicProviderID)("https://api.anthropic.com/v1/messages")
+
+  expect(await Auth.get(AnthropicOAuthProvider.PROVIDER_ID)).toMatchObject({
+    type: "oauth",
+    access: "anthropic-canonical",
+  })
 })
 
 test("github copilot device login exchanges a GitHub token for Copilot models", async () => {
@@ -648,6 +678,32 @@ test("minimax request rejection recovers once and invalid refresh requires recon
   )
   await expect(MiniMaxProvider.minimaxFetch(`${MiniMaxProvider.GLOBAL_INFERENCE}/v1/messages`)).rejects.toMatchObject({
     name: "ProviderAuthenticationRequiredError",
+  })
+})
+
+test("minimaxFetchFor binds requests to the selected connection credential", async () => {
+  await Auth.set(MiniMaxProvider.PROVIDER_ID, {
+    type: "oauth",
+    access: "minimax-canonical",
+    refresh: "minimax-canonical-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  await Auth.set(secondaryMiniMaxProviderID, {
+    type: "oauth",
+    access: "minimax-secondary",
+    refresh: "minimax-secondary-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  globalThis.fetch = asFetch(async (_input, init) => {
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer minimax-secondary")
+    return jsonResponse({ ok: true })
+  })
+
+  await MiniMaxProvider.minimaxFetchFor(secondaryMiniMaxProviderID)(`${MiniMaxProvider.GLOBAL_INFERENCE}/v1/messages`)
+
+  expect(await Auth.get(MiniMaxProvider.PROVIDER_ID)).toMatchObject({
+    type: "oauth",
+    access: "minimax-canonical",
   })
 })
 

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -452,6 +452,37 @@ test("mapped Copilot requests prefer the connection credential over global token
   }
 })
 
+test("inline Copilot auth overrides stored credentials without changing their health", async () => {
+  await Auth.set(mappedCopilotProviderID, { type: "api", key: "stored-copilot-token" })
+  CopilotProvider.clearApiToken(mappedCopilotProviderID)
+  const exchanges: string[] = []
+  let requests = 0
+  globalThis.fetch = asFetch(async (input, init) => {
+    const authorization = new Headers(init?.headers).get("authorization")
+    if (String(input) === CopilotProvider.TOKEN_EXCHANGE_URL) {
+      exchanges.push(authorization ?? "")
+      return jsonResponse({
+        token: `inline-copilot-api-token-${exchanges.length}`,
+        expires_at: nowSeconds() + 3600,
+      })
+    }
+    requests++
+    return requests === 1 ? jsonResponse({ error: "invalid_token" }, { status: 401 }) : jsonResponse({ ok: true })
+  })
+
+  const response = await CopilotProvider.copilotFetchFor(mappedCopilotProviderID, {
+    type: "api",
+    key: "inline-copilot-token",
+  })("https://api.githubcopilot.com/chat/completions")
+
+  expect(response.status).toBe(200)
+  expect(exchanges).toEqual(["token inline-copilot-token", "token inline-copilot-token"])
+  expect(await Auth.get(mappedCopilotProviderID)).toMatchObject({
+    type: "api",
+    key: "stored-copilot-token",
+  })
+})
+
 test("mapped Copilot requests reselect a backup credential after failover", async () => {
   await Auth.set(mappedCopilotProviderID, { type: "api", key: "primary-copilot-token" })
   await Auth.addToPool(mappedCopilotProviderID, "backup-copilot", {

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -201,7 +201,7 @@ test("mapped Copilot device auth binds the concrete connection ID", async () => 
 
 test("mapped Copilot enterprise auth preserves the enterprise host", async () => {
   const previousEnterpriseURL = process.env.COPILOT_GITHUB_ENTERPRISE_URL
-  process.env.COPILOT_GITHUB_ENTERPRISE_URL = "https://github.enterprise.invalid"
+  process.env.COPILOT_GITHUB_ENTERPRISE_URL = "https://global.enterprise.invalid"
   try {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -212,6 +212,9 @@ test("mapped Copilot enterprise auth preserves the enterprise host", async () =>
               [mappedCopilotProviderID]: {
                 profile: CopilotProvider.ENTERPRISE_PROVIDER_ID,
                 modelsDevProviderID: CopilotProvider.PROVIDER_ID,
+                options: {
+                  enterpriseUrl: "https://connection.enterprise.invalid",
+                },
               },
             },
           }),
@@ -224,7 +227,7 @@ test("mapped Copilot enterprise auth preserves the enterprise host", async () =>
       return jsonResponse({
         device_code: "mapped-enterprise-device",
         user_code: "ENTERPRISE",
-        verification_uri: "https://github.enterprise.invalid/login/device",
+        verification_uri: "https://connection.enterprise.invalid/login/device",
         interval: 1,
         expires_in: 60,
       })
@@ -237,7 +240,7 @@ test("mapped Copilot enterprise auth preserves the enterprise host", async () =>
       },
     })
 
-    expect(deviceCodeURL).toBe("https://github.enterprise.invalid/login/device/code")
+    expect(deviceCodeURL).toBe("https://connection.enterprise.invalid/login/device/code")
   } finally {
     if (previousEnterpriseURL === undefined) delete process.env.COPILOT_GITHUB_ENTERPRISE_URL
     else process.env.COPILOT_GITHUB_ENTERPRISE_URL = previousEnterpriseURL

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -486,6 +486,31 @@ test("inline Copilot auth overrides stored credentials without changing their he
   })
 })
 
+test("inline Copilot auth is used for mapped connection catalog discovery", async () => {
+  await Auth.set(mappedCopilotProviderID, { type: "api", key: "stored-copilot-token" })
+  CopilotProvider.clearApiToken(mappedCopilotProviderID)
+  const authorizations: string[] = []
+  const catalog = await CopilotProvider.fetchModelCatalog(
+    mappedCopilotProviderID,
+    asFetch(async (input, init) => {
+      const authorization = new Headers(init?.headers).get("authorization") ?? ""
+      authorizations.push(authorization)
+      if (String(input) === CopilotProvider.TOKEN_EXCHANGE_URL) {
+        return jsonResponse({ token: "inline-copilot-api-token", expires_at: nowSeconds() + 3600 })
+      }
+      return jsonResponse({ data: [{ id: "gpt-inline-catalog" }] })
+    }),
+    { type: "api", key: "inline-copilot-token" },
+  )
+
+  expect(catalog).toEqual([{ id: "gpt-inline-catalog" }])
+  expect(authorizations).toEqual(["token inline-copilot-token", "Bearer inline-copilot-api-token"])
+  expect(await Auth.get(mappedCopilotProviderID)).toMatchObject({
+    type: "api",
+    key: "stored-copilot-token",
+  })
+})
+
 test("mapped Copilot requests reselect a backup credential after failover", async () => {
   await Auth.set(mappedCopilotProviderID, { type: "api", key: "primary-copilot-token" })
   await Auth.addToPool(mappedCopilotProviderID, "backup-copilot", {

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -389,6 +389,34 @@ test("anthropicFetchFor binds requests to the selected connection credential", a
   })
 })
 
+test("mapped Copilot requests prefer the connection credential over global tokens", async () => {
+  const previousGitHubToken = process.env.GITHUB_TOKEN
+  process.env.GITHUB_TOKEN = "global-copilot-token"
+  await Auth.set(mappedCopilotProviderID, { type: "api", key: "mapped-copilot-token" })
+  CopilotProvider.clearApiToken(mappedCopilotProviderID)
+  try {
+    globalThis.fetch = asFetch(async (input, init) => {
+      const url = String(input)
+      if (url === CopilotProvider.TOKEN_EXCHANGE_URL) {
+        expect(new Headers(init?.headers).get("authorization")).toBe("token mapped-copilot-token")
+        return jsonResponse({ token: "mapped-copilot-api-token", expires_at: nowSeconds() + 3600 })
+      }
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer mapped-copilot-api-token")
+      return jsonResponse({ ok: true })
+    })
+
+    const response = await CopilotProvider.copilotFetchFor(mappedCopilotProviderID)(
+      "https://api.githubcopilot.com/chat/completions",
+    )
+    expect(response.status).toBe(200)
+  } finally {
+    CopilotProvider.clearApiToken(mappedCopilotProviderID)
+    await Auth.remove(mappedCopilotProviderID)
+    if (previousGitHubToken === undefined) delete process.env.GITHUB_TOKEN
+    else process.env.GITHUB_TOKEN = previousGitHubToken
+  }
+})
+
 test("github copilot device login exchanges a GitHub token for Copilot models", async () => {
   const authorize = await CopilotProvider.authorizeDeviceCode(
     CopilotProvider.PROVIDER_ID,

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -363,6 +363,41 @@ test("anthropic request rejection refreshes once and retries with the rotated to
   expect(requests).toBe(2)
 })
 
+test("anthropic refresh rejection preserves and retries a healthy backup credential", async () => {
+  await Auth.set(secondaryAnthropicProviderID, {
+    type: "oauth",
+    access: "anthropic-expired-primary",
+    refresh: "anthropic-rejected-refresh",
+    expires: nowSeconds() - 1,
+  })
+  await Auth.addToPool(secondaryAnthropicProviderID, "anthropic-backup", {
+    type: "oauth",
+    access: "anthropic-backup-access",
+    refresh: "anthropic-backup-refresh",
+    expires: nowSeconds() + 3600,
+  })
+  let refreshes = 0
+  globalThis.fetch = asFetch(async (input, init) => {
+    if (AnthropicOAuthProvider.OAUTH_TOKEN_URLS.some((url) => url === String(input))) {
+      refreshes++
+      expect(JSON.parse(String(init?.body)).refresh_token).toBe("anthropic-rejected-refresh")
+      return jsonResponse({ error: "invalid_grant" }, { status: 401 })
+    }
+    const authorization = new Headers(init?.headers).get("authorization")
+    return authorization === "Bearer anthropic-backup-access"
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ type: "authentication_error" }, { status: 401 })
+  })
+
+  const response = await AnthropicOAuthProvider.anthropicFetchFor(secondaryAnthropicProviderID)(
+    "https://api.anthropic.com/v1/messages",
+  )
+
+  expect(response.status).toBe(200)
+  expect(refreshes).toBe(1)
+  expect((await Auth.select(secondaryAnthropicProviderID))?.credentialID).toBe("anthropic-backup")
+})
+
 test("anthropicFetchFor binds requests to the selected connection credential", async () => {
   await Auth.set(AnthropicOAuthProvider.PROVIDER_ID, {
     type: "oauth",

--- a/packages/synergy/test/provider/oauth-providers.test.ts
+++ b/packages/synergy/test/provider/oauth-providers.test.ts
@@ -199,6 +199,102 @@ test("mapped Copilot device auth binds the concrete connection ID", async () => 
   expect(await Auth.get(CopilotProvider.PROVIDER_ID)).toBeUndefined()
 })
 
+test("mapped Copilot enterprise auth preserves the enterprise host", async () => {
+  const previousEnterpriseURL = process.env.COPILOT_GITHUB_ENTERPRISE_URL
+  process.env.COPILOT_GITHUB_ENTERPRISE_URL = "https://github.enterprise.invalid"
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          `${dir}/synergy.json`,
+          JSON.stringify({
+            provider: {
+              [mappedCopilotProviderID]: {
+                profile: CopilotProvider.ENTERPRISE_PROVIDER_ID,
+                modelsDevProviderID: CopilotProvider.PROVIDER_ID,
+              },
+            },
+          }),
+        )
+      },
+    })
+    let deviceCodeURL: string | undefined
+    globalThis.fetch = asFetch(async (input) => {
+      deviceCodeURL = String(input)
+      return jsonResponse({
+        device_code: "mapped-enterprise-device",
+        user_code: "ENTERPRISE",
+        verification_uri: "https://github.enterprise.invalid/login/device",
+        interval: 1,
+        expires_in: 60,
+      })
+    })
+
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      async fn() {
+        await ProviderAuth.authorize({ providerID: mappedCopilotProviderID, method: 0 })
+      },
+    })
+
+    expect(deviceCodeURL).toBe("https://github.enterprise.invalid/login/device/code")
+  } finally {
+    if (previousEnterpriseURL === undefined) delete process.env.COPILOT_GITHUB_ENTERPRISE_URL
+    else process.env.COPILOT_GITHUB_ENTERPRISE_URL = previousEnterpriseURL
+  }
+})
+
+test("mapped Copilot auth forwards cancellation to the device callback", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/synergy.json`,
+        JSON.stringify({
+          provider: {
+            [mappedCopilotProviderID]: {
+              profile: CopilotProvider.PROVIDER_ID,
+              modelsDevProviderID: CopilotProvider.PROVIDER_ID,
+            },
+          },
+        }),
+      )
+    },
+  })
+  let polls = 0
+  globalThis.fetch = asFetch(async (input) => {
+    const url = String(input)
+    if (url.endsWith("/login/device/code")) {
+      return jsonResponse({
+        device_code: "mapped-cancelled-device",
+        user_code: "STOP-MAPPED",
+        verification_uri: "https://github.com/login/device",
+        interval: 1,
+        expires_in: 60,
+      })
+    }
+    if (url.endsWith("/login/oauth/access_token")) {
+      polls++
+      return jsonResponse({ access_token: "unexpected-mapped-token" })
+    }
+    throw new Error(`unexpected URL ${url}`)
+  })
+
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    async fn() {
+      const input = { providerID: mappedCopilotProviderID, method: 0 }
+      await ProviderAuth.authorize(input)
+      const controller = new AbortController()
+      controller.abort()
+      const result = await ProviderAuth.callback({ ...input, signal: controller.signal }).catch((error) => error)
+      expect(result).toBeInstanceOf(ProviderAuth.OauthCallbackFailed)
+    },
+  })
+
+  expect(polls).toBe(0)
+  expect(await Auth.get(mappedCopilotProviderID)).toBeUndefined()
+})
+
 test("anthropic oauth refresh rotates tokens and marks invalid grants dead", async () => {
   await Auth.set(AnthropicOAuthProvider.PROVIDER_ID, {
     type: "oauth",

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -486,6 +486,22 @@ test("mapped Bedrock and SAP profiles consume connection auth and options", asyn
   }
 })
 
+test("Copilot Claude factories honor the merged connection endpoint", async () => {
+  registerBuiltinProviderProfiles()
+  for (const profileID of ["github-copilot", "github-copilot-enterprise"]) {
+    const profile = ProviderProfile.get(profileID)!
+    const model = await profile.getModel!({
+      sdk: {},
+      modelID: "claude-sonnet-4.6",
+      options: {
+        baseURL: "https://copilot-account.invalid",
+        fetch,
+      },
+    })
+    expect((model as any).config.baseURL).toBe("https://copilot-account.invalid")
+  }
+})
+
 test("custom provider resolves runtime behavior through its canonical profile", async () => {
   const profileID = `runtime-profile-${Math.random().toString(36).slice(2)}`
   const connectionID = `${profileID}-secondary`

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -8,6 +8,8 @@ import { ModelsDev } from "../../src/provider/models"
 import { Provider as ProviderConfig } from "../../src/config/schema"
 import { ProviderCatalog } from "../../src/provider/catalog"
 import { ProviderProfile } from "../../src/provider/profile"
+import { ProviderUsage } from "../../src/provider/usage-service"
+import { Auth } from "../../src/provider/api-key"
 
 async function provideTestScope(input: {
   scope: Awaited<ReturnType<Awaited<ReturnType<typeof tmpdir>>["scope"]>>
@@ -396,6 +398,75 @@ test("provider config accepts a non-empty models.dev catalog source", () => {
   expect(ProviderConfig.safeParse({ modelsDevProviderID: "" }).success).toBe(false)
 })
 
+test("provider config accepts a non-empty canonical runtime profile", () => {
+  expect(ProviderConfig.parse({ profile: "anthropic" }).profile).toBe("anthropic")
+  expect(ProviderConfig.safeParse({ profile: "" }).success).toBe(false)
+})
+
+test("custom provider resolves runtime behavior through its canonical profile", async () => {
+  const profileID = `runtime-profile-${Math.random().toString(36).slice(2)}`
+  const connectionID = `${profileID}-secondary`
+  ProviderProfile.register({
+    id: profileID,
+    name: "Runtime profile",
+    authKind: "api_key",
+    modelsDevProviderID: "openai",
+    modelFactory: "openaiResponses",
+    runtimeOptions: async ({ providerID, auth }) => ({
+      resolvedProviderID: providerID,
+      resolvedCredential: auth?.type === "api" ? auth.key : undefined,
+    }),
+    fetchUsage: async ({ providerID }) => ({
+      providerID,
+      status: "available",
+      source: "test",
+      fetchedAt: new Date().toISOString(),
+      windows: [],
+      details: [providerID],
+    }),
+  })
+  ProviderCatalog.reset()
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "synergy.json"),
+        JSON.stringify({
+          $schema: "file:///test/config.schema.json",
+          providerCatalog: { enabled: false, offlineCache: false },
+          provider: {
+            [connectionID]: {
+              profile: profileID,
+              modelsDevProviderID: "openai",
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Auth.set(connectionID, { type: "api", key: "secondary-profile-key" })
+  try {
+    await provideTestScope({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const provider = (await Provider.list())[connectionID]
+        expect(provider.profileID).toBe(profileID)
+        expect(provider.key).toBe("secondary-profile-key")
+        expect(provider.options.resolvedProviderID).toBe(connectionID)
+        expect(provider.options.resolvedCredential).toBe("secondary-profile-key")
+        expect(provider.models["gpt-5.5"].providerID).toBe(connectionID)
+        expect(await ProviderUsage.get(connectionID)).toMatchObject({
+          providerID: connectionID,
+          status: "available",
+          details: [connectionID],
+        })
+      },
+    })
+  } finally {
+    await Auth.remove(connectionID)
+  }
+})
+
 test("custom provider inherits a models.dev catalog without sharing account identity", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -499,6 +570,55 @@ test("custom provider inheritance excludes credential-aware live catalog snapsho
       const providers = await Provider.list()
       expect(providers[connectionID].models["primary-account-only-model"]).toBeUndefined()
       expect(providers[connectionID].models["gpt-5.5"]).toBeDefined()
+    },
+  })
+})
+
+test("custom provider live catalogs are discovered and cached per account connection", async () => {
+  const profileID = `live-runtime-profile-${Math.random().toString(36).slice(2)}`
+  const firstConnectionID = `${profileID}-first`
+  const secondConnectionID = `${profileID}-second`
+  ProviderProfile.register({
+    id: profileID,
+    name: "Live runtime profile",
+    authKind: "none",
+    modelsDevProviderID: "openai",
+    fallbackModels: ["gpt-5.5"],
+    fetchModelCatalog: async ({ providerID }) => [{ id: `${providerID}-model` }],
+  })
+  ProviderCatalog.reset()
+  const config = {
+    $schema: "file:///test/config.schema.json",
+    providerCatalog: { enabled: false, offlineCache: false },
+    provider: {
+      [firstConnectionID]: {
+        profile: profileID,
+        modelsDevProviderID: "openai",
+      },
+      [secondConnectionID]: {
+        profile: profileID,
+        modelsDevProviderID: "openai",
+      },
+    },
+  }
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "synergy.json"), JSON.stringify(config))
+    },
+  })
+  await provideTestScope({
+    scope: await tmp.scope(),
+    fn: async () => {
+      await ProviderCatalog.refresh(firstConnectionID)
+      await ProviderCatalog.refresh(secondConnectionID)
+      ProviderCatalog.reset()
+
+      const catalog = await ProviderCatalog.resolve({ config, includeLive: true })
+      expect(catalog[firstConnectionID].models[`${firstConnectionID}-model`]).toBeDefined()
+      expect(catalog[firstConnectionID].models[`${secondConnectionID}-model`]).toBeUndefined()
+      expect(catalog[secondConnectionID].models[`${secondConnectionID}-model`]).toBeDefined()
+      expect(catalog[secondConnectionID].models[`${firstConnectionID}-model`]).toBeUndefined()
     },
   })
 })

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -580,33 +580,40 @@ test("inline provider credentials initialize mapped profile auth", async () => {
     },
   })
 
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          providerCatalog: { enabled: false, offlineCache: false },
-          provider: {
-            [connectionID]: {
-              profile: profileID,
-              modelsDevProviderID: "openai",
-              options: {
-                apiKey: "inline-provider-key",
+  await Auth.set(connectionID, { type: "api", key: "stored-provider-key" })
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "synergy.json"),
+          JSON.stringify({
+            providerCatalog: { enabled: false, offlineCache: false },
+            provider: {
+              [connectionID]: {
+                profile: profileID,
+                modelsDevProviderID: "openai",
+                options: {
+                  apiKey: "inline-provider-key",
+                },
               },
             },
-          },
-        }),
-      )
-    },
-  })
+          }),
+        )
+      },
+    })
 
-  await provideTestScope({
-    scope: await tmp.scope(),
-    fn: async () => {
-      expect((await Provider.list())[connectionID].profileID).toBe(profileID)
-      expect(resolvedKey).toBe("inline-provider-key")
-    },
-  })
+    await provideTestScope({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const provider = (await Provider.list())[connectionID]
+        expect(provider.profileID).toBe(profileID)
+        expect(provider.key).toBe("inline-provider-key")
+        expect(resolvedKey).toBe("inline-provider-key")
+      },
+    })
+  } finally {
+    await Auth.remove(connectionID)
+  }
 })
 
 test("custom provider resolves runtime behavior through its canonical profile", async () => {

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -506,12 +506,17 @@ test("inline model credentials initialize mapped profiles and reach model loader
   const profileID = `inline-runtime-profile-${Math.random().toString(36).slice(2)}`
   const connectionID = `${profileID}-secondary`
   let loaderOptions: Record<string, any> | undefined
+  const runtimeAuthKeys: string[] = []
   ProviderProfile.register({
     id: profileID,
     name: "Inline runtime profile",
     authKind: "api_key",
     modelsDevProviderID: "openai",
     aiSdkPackage: "@ai-sdk/openai",
+    runtimeOptions: async ({ auth }) => {
+      if (auth?.type === "api") runtimeAuthKeys.push(auth.key)
+      return {}
+    },
     getModel: async ({ options }) => {
       loaderOptions = options
       return { specificationVersion: "v2", provider: profileID, modelId: "test" }
@@ -554,6 +559,7 @@ test("inline model credentials initialize mapped profiles and reach model loader
         apiKey: "inline-model-key",
         baseURL: "https://inline-model.invalid/v1",
       })
+      expect(runtimeAuthKeys).toContain("inline-model-key")
     },
   })
 })

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -502,6 +502,107 @@ test("Copilot Claude factories honor the merged connection endpoint", async () =
   }
 })
 
+test("inline model credentials initialize mapped profiles and reach model loaders", async () => {
+  const profileID = `inline-runtime-profile-${Math.random().toString(36).slice(2)}`
+  const connectionID = `${profileID}-secondary`
+  let loaderOptions: Record<string, any> | undefined
+  ProviderProfile.register({
+    id: profileID,
+    name: "Inline runtime profile",
+    authKind: "api_key",
+    modelsDevProviderID: "openai",
+    aiSdkPackage: "@ai-sdk/openai",
+    getModel: async ({ options }) => {
+      loaderOptions = options
+      return { specificationVersion: "v2", provider: profileID, modelId: "test" }
+    },
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "synergy.json"),
+        JSON.stringify({
+          providerCatalog: { enabled: false, offlineCache: false },
+          provider: {
+            [connectionID]: {
+              profile: profileID,
+              modelsDevProviderID: "openai",
+              models: {
+                "gpt-5.5": {
+                  options: {
+                    apiKey: "inline-model-key",
+                    baseURL: "https://inline-model.invalid/v1",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await provideTestScope({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const provider = (await Provider.list())[connectionID]
+      expect(provider.profileID).toBe(profileID)
+      const model = await Provider.getModel(connectionID, "gpt-5.5")
+      await Provider.getLanguage(model)
+      expect(loaderOptions).toMatchObject({
+        apiKey: "inline-model-key",
+        baseURL: "https://inline-model.invalid/v1",
+      })
+    },
+  })
+})
+
+test("inline provider credentials initialize mapped profile auth", async () => {
+  const profileID = `inline-provider-profile-${Math.random().toString(36).slice(2)}`
+  const connectionID = `${profileID}-secondary`
+  let resolvedKey: string | undefined
+  ProviderProfile.register({
+    id: profileID,
+    name: "Inline provider profile",
+    authKind: "api_key",
+    modelsDevProviderID: "openai",
+    aiSdkPackage: "@ai-sdk/openai",
+    runtimeOptions: async ({ auth }) => {
+      resolvedKey = auth?.type === "api" ? auth.key : undefined
+      return {}
+    },
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "synergy.json"),
+        JSON.stringify({
+          providerCatalog: { enabled: false, offlineCache: false },
+          provider: {
+            [connectionID]: {
+              profile: profileID,
+              modelsDevProviderID: "openai",
+              options: {
+                apiKey: "inline-provider-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await provideTestScope({
+    scope: await tmp.scope(),
+    fn: async () => {
+      expect((await Provider.list())[connectionID].profileID).toBe(profileID)
+      expect(resolvedKey).toBe("inline-provider-key")
+    },
+  })
+})
+
 test("custom provider resolves runtime behavior through its canonical profile", async () => {
   const profileID = `runtime-profile-${Math.random().toString(36).slice(2)}`
   const connectionID = `${profileID}-secondary`

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -525,6 +525,71 @@ test("custom provider inherits a models.dev catalog without sharing account iden
   })
 })
 
+test("catalog-only connections are visible before credentials are connected", async () => {
+  const connectionID = `catalog-only-${Math.random().toString(36).slice(2)}`
+  const config = {
+    providerCatalog: { enabled: false, offlineCache: false },
+    provider: {
+      [connectionID]: {
+        modelsDevProviderID: "openai",
+        name: "OpenAI Secondary",
+      },
+    },
+  }
+
+  const catalog = await ProviderCatalog.resolve({ config })
+
+  expect(catalog[connectionID]).toBeDefined()
+  expect(catalog[connectionID].id).toBe(connectionID)
+  expect(catalog[connectionID].name).toBe("OpenAI Secondary")
+  expect(catalog[connectionID].models["gpt-5.5"]).toBeDefined()
+})
+
+test("SDK cache identity includes the concrete account connection", async () => {
+  const firstID = `sdk-account-a-${Math.random().toString(36).slice(2)}`
+  const secondID = `sdk-account-b-${Math.random().toString(36).slice(2)}`
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "synergy.json"),
+        JSON.stringify({
+          $schema: "file:///test/config.schema.json",
+          provider: {
+            [firstID]: {
+              modelsDevProviderID: "openai",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://shared.example.test/v1",
+              env: ["SDK_ACCOUNT_A_KEY"],
+            },
+            [secondID]: {
+              modelsDevProviderID: "openai",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://shared.example.test/v1",
+              env: ["SDK_ACCOUNT_B_KEY"],
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await provideTestScope({
+    scope: await tmp.scope(),
+    init: async () => {
+      Env.set("SDK_ACCOUNT_A_KEY", "shared-test-key")
+      Env.set("SDK_ACCOUNT_B_KEY", "shared-test-key")
+    },
+    fn: async () => {
+      const firstModel = await Provider.getModel(firstID, "gpt-5.5")
+      const secondModel = await Provider.getModel(secondID, "gpt-5.5")
+      const firstSDK = await Provider.getSDK(firstModel)
+      const secondSDK = await Provider.getSDK(secondModel)
+
+      expect(secondSDK).not.toBe(firstSDK)
+    },
+  })
+})
+
 test("custom provider inheritance excludes credential-aware live catalog snapshots", async () => {
   const profileID = `live-catalog-source-${Math.random().toString(36).slice(2)}`
   const connectionID = `${profileID}-secondary`

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -507,6 +507,7 @@ test("inline model credentials initialize mapped profiles and reach model loader
   const connectionID = `${profileID}-secondary`
   let loaderOptions: Record<string, any> | undefined
   const runtimeAuthKeys: string[] = []
+  const oauthFetch = async () => new Response(null, { status: 200 })
   ProviderProfile.register({
     id: profileID,
     name: "Inline runtime profile",
@@ -515,7 +516,7 @@ test("inline model credentials initialize mapped profiles and reach model loader
     aiSdkPackage: "@ai-sdk/openai",
     runtimeOptions: async ({ auth }) => {
       if (auth?.type === "api") runtimeAuthKeys.push(auth.key)
-      return {}
+      return auth?.type === "oauth" ? { fetch: oauthFetch, authMode: "oauth" } : { authMode: "api" }
     },
     getModel: async ({ options }) => {
       loaderOptions = options
@@ -523,45 +524,57 @@ test("inline model credentials initialize mapped profiles and reach model loader
     },
   })
 
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "synergy.json"),
-        JSON.stringify({
-          providerCatalog: { enabled: false, offlineCache: false },
-          provider: {
-            [connectionID]: {
-              profile: profileID,
-              modelsDevProviderID: "openai",
-              models: {
-                "gpt-5.5": {
-                  options: {
-                    apiKey: "inline-model-key",
-                    baseURL: "https://inline-model.invalid/v1",
+  await Auth.set(connectionID, {
+    type: "oauth",
+    access: "stored-oauth-access",
+    refresh: "stored-oauth-refresh",
+    expires: Math.floor(Date.now() / 1000) + 3600,
+  })
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "synergy.json"),
+          JSON.stringify({
+            providerCatalog: { enabled: false, offlineCache: false },
+            provider: {
+              [connectionID]: {
+                profile: profileID,
+                modelsDevProviderID: "openai",
+                models: {
+                  "gpt-5.5": {
+                    options: {
+                      apiKey: "inline-model-key",
+                      baseURL: "https://inline-model.invalid/v1",
+                    },
                   },
                 },
               },
             },
-          },
-        }),
-      )
-    },
-  })
+          }),
+        )
+      },
+    })
 
-  await provideTestScope({
-    scope: await tmp.scope(),
-    fn: async () => {
-      const provider = (await Provider.list())[connectionID]
-      expect(provider.profileID).toBe(profileID)
-      const model = await Provider.getModel(connectionID, "gpt-5.5")
-      await Provider.getLanguage(model)
-      expect(loaderOptions).toMatchObject({
-        apiKey: "inline-model-key",
-        baseURL: "https://inline-model.invalid/v1",
-      })
-      expect(runtimeAuthKeys).toContain("inline-model-key")
-    },
-  })
+    await provideTestScope({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const provider = (await Provider.list())[connectionID]
+        expect(provider.profileID).toBe(profileID)
+        const model = await Provider.getModel(connectionID, "gpt-5.5")
+        await Provider.getLanguage(model)
+        expect(loaderOptions).toMatchObject({
+          apiKey: "inline-model-key",
+          baseURL: "https://inline-model.invalid/v1",
+          authMode: "api",
+        })
+        expect(loaderOptions?.fetch).toBeUndefined()
+        expect(runtimeAuthKeys).toContain("inline-model-key")
+      },
+    })
+  } finally {
+    await Auth.remove(connectionID)
+  }
 })
 
 test("inline provider credentials initialize mapped profile auth", async () => {
@@ -681,6 +694,73 @@ test("custom provider resolves runtime behavior through its canonical profile", 
   } finally {
     await Auth.remove(connectionID)
   }
+})
+
+test("mapped OpenRouter usage uses inline and environment connection credentials", async () => {
+  const originalFetch = globalThis.fetch
+  const seen: string[] = []
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    seen.push(new Headers(init?.headers).get("authorization") ?? "")
+    const credits = String(input).endsWith("/credits")
+    return new Response(
+      JSON.stringify({
+        data: credits ? { total_credits: 10, total_usage: 2 } : { limit: 10, limit_remaining: 8 },
+      }),
+      { headers: { "content-type": "application/json" } },
+    )
+  }) as typeof fetch
+
+  try {
+    for (const account of [
+      {
+        id: `openrouter-inline-${Math.random().toString(36).slice(2)}`,
+        provider: { profile: "openrouter", options: { apiKey: "inline-openrouter-key" } },
+        expected: "inline-openrouter-key",
+      },
+      {
+        id: `openrouter-environment-${Math.random().toString(36).slice(2)}`,
+        provider: { profile: "openrouter", env: ["MAPPED_OPENROUTER_KEY"] },
+        expected: "environment-openrouter-key",
+      },
+    ]) {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "synergy.json"),
+            JSON.stringify({
+              providerCatalog: { enabled: false, offlineCache: false },
+              provider: {
+                [account.id]: account.provider,
+              },
+            }),
+          )
+        },
+      })
+
+      await provideTestScope({
+        scope: await tmp.scope(),
+        init: async () => {
+          if (account.provider.env) Env.set("MAPPED_OPENROUTER_KEY", account.expected)
+        },
+        fn: async () => {
+          expect(await ProviderUsage.get(account.id)).toMatchObject({
+            providerID: account.id,
+            status: "available",
+            source: "credits_api",
+          })
+        },
+      })
+    }
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  expect(seen).toEqual([
+    "Bearer inline-openrouter-key",
+    "Bearer inline-openrouter-key",
+    "Bearer environment-openrouter-key",
+    "Bearer environment-openrouter-key",
+  ])
 })
 
 test("custom provider inherits a models.dev catalog without sharing account identity", async () => {

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -770,7 +770,7 @@ test("mapped OpenRouter usage uses inline and environment connection credentials
       },
       {
         id: `openrouter-environment-${Math.random().toString(36).slice(2)}`,
-        provider: { profile: "openrouter", env: ["MAPPED_OPENROUTER_KEY"] },
+        provider: { profile: "openrouter", env: ["MISSING_MAPPED_OPENROUTER_KEY", "MAPPED_OPENROUTER_KEY"] },
         expected: "environment-openrouter-key",
       },
     ]) {
@@ -794,6 +794,7 @@ test("mapped OpenRouter usage uses inline and environment connection credentials
           if (account.provider.env) Env.set("MAPPED_OPENROUTER_KEY", account.expected)
         },
         fn: async () => {
+          expect((await Provider.list())[account.id].key).toBe(account.expected)
           expect(await ProviderUsage.get(account.id)).toMatchObject({
             providerID: account.id,
             status: "available",

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -10,6 +10,7 @@ import { ProviderCatalog } from "../../src/provider/catalog"
 import { ProviderProfile } from "../../src/provider/profile"
 import { ProviderUsage } from "../../src/provider/usage-service"
 import { Auth } from "../../src/provider/api-key"
+import { registerBuiltinProviderProfiles } from "../../src/provider/builtin"
 
 async function provideTestScope(input: {
   scope: Awaited<ReturnType<Awaited<ReturnType<typeof tmpdir>>["scope"]>>
@@ -401,6 +402,88 @@ test("provider config accepts a non-empty models.dev catalog source", () => {
 test("provider config accepts a non-empty canonical runtime profile", () => {
   expect(ProviderConfig.parse({ profile: "anthropic" }).profile).toBe("anthropic")
   expect(ProviderConfig.safeParse({ profile: "" }).success).toBe(false)
+})
+
+test("mapped Bedrock and SAP profiles consume connection auth and options", async () => {
+  registerBuiltinProviderProfiles()
+  const bedrockConnectionID = `bedrock-account-${Math.random().toString(36).slice(2)}`
+  const sapConnectionID = `sap-account-${Math.random().toString(36).slice(2)}`
+  const envNames = [
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_PROFILE",
+    "AICORE_SERVICE_KEY",
+    "AICORE_DEPLOYMENT_ID",
+    "AICORE_RESOURCE_GROUP",
+  ] as const
+  const previous = Object.fromEntries(envNames.map((name) => [name, process.env[name]]))
+  for (const name of envNames) delete process.env[name]
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "synergy.json"),
+        JSON.stringify({
+          provider: {
+            [bedrockConnectionID]: {
+              profile: "amazon-bedrock",
+              modelsDevProviderID: "amazon-bedrock",
+              options: {
+                region: "eu-west-1",
+                baseURL: "https://bedrock.account.invalid",
+              },
+            },
+            [sapConnectionID]: {
+              profile: "sap-ai-core",
+              modelsDevProviderID: "sap-ai-core",
+              options: {
+                deploymentId: "mapped-deployment",
+                resourceGroup: "mapped-resource-group",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  try {
+    await provideTestScope({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const bedrock = ProviderProfile.get("amazon-bedrock")!
+        const bedrockInput = {
+          providerID: bedrockConnectionID,
+          auth: { type: "api" as const, key: "mapped-bedrock-token" },
+        }
+        expect(await bedrock.autoload!(bedrockInput)).toBe(true)
+        expect(await bedrock.runtimeOptions!(bedrockInput)).toMatchObject({
+          apiKey: "mapped-bedrock-token",
+          region: "eu-west-1",
+          baseURL: "https://bedrock.account.invalid",
+        })
+
+        const sap = ProviderProfile.get("sap-ai-core")!
+        const sapInput = {
+          providerID: sapConnectionID,
+          auth: { type: "api" as const, key: "mapped-sap-service-key" },
+        }
+        expect(await sap.autoload!(sapInput)).toBe(true)
+        expect(await sap.runtimeOptions!(sapInput)).toMatchObject({
+          apiKey: "mapped-sap-service-key",
+          deploymentId: "mapped-deployment",
+          resourceGroup: "mapped-resource-group",
+        })
+        expect(Env.get("AICORE_SERVICE_KEY")).toBeUndefined()
+      },
+    })
+  } finally {
+    for (const name of envNames) {
+      const value = previous[name]
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+  }
 })
 
 test("custom provider resolves runtime behavior through its canonical profile", async () => {

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -496,6 +496,7 @@ test("custom provider resolves runtime behavior through its canonical profile", 
     modelsDevProviderID: "openai",
     modelFactory: "openaiResponses",
     runtimeOptions: async ({ providerID, auth }) => ({
+      baseURL: "https://canonical-profile.invalid/v1",
       resolvedProviderID: providerID,
       resolvedCredential: auth?.type === "api" ? auth.key : undefined,
     }),
@@ -521,6 +522,7 @@ test("custom provider resolves runtime behavior through its canonical profile", 
             [connectionID]: {
               profile: profileID,
               modelsDevProviderID: "openai",
+              api: "https://secondary-profile.invalid/v1",
             },
           },
         }),
@@ -537,6 +539,7 @@ test("custom provider resolves runtime behavior through its canonical profile", 
         expect(provider.key).toBe("secondary-profile-key")
         expect(provider.options.resolvedProviderID).toBe(connectionID)
         expect(provider.options.resolvedCredential).toBe("secondary-profile-key")
+        expect(provider.options.baseURL).toBe("https://secondary-profile.invalid/v1")
         expect(provider.models["gpt-5.5"].providerID).toBe(connectionID)
         expect(await ProviderUsage.get(connectionID)).toMatchObject({
           providerID: connectionID,

--- a/packages/synergy/test/provider/provider.test.ts
+++ b/packages/synergy/test/provider/provider.test.ts
@@ -486,6 +486,48 @@ test("mapped Bedrock and SAP profiles consume connection auth and options", asyn
   }
 })
 
+test("mapped Cloudflare profile prefers the connection credential over the canonical environment", async () => {
+  registerBuiltinProviderProfiles()
+  const envNames = ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID", "CLOUDFLARE_API_TOKEN"] as const
+  const previous = Object.fromEntries(envNames.map((name) => [name, process.env[name]]))
+
+  try {
+    await using tmp = await tmpdir()
+    await provideTestScope({
+      scope: await tmp.scope(),
+      init: async () => {
+        Env.set("CLOUDFLARE_ACCOUNT_ID", "account-id")
+        Env.set("CLOUDFLARE_GATEWAY_ID", "gateway-id")
+        Env.set("CLOUDFLARE_API_TOKEN", "canonical-token")
+      },
+      fn: async () => {
+        const profile = ProviderProfile.get("cloudflare-ai-gateway")!
+        const mapped = await profile.runtimeOptions!({
+          providerID: "cloudflare-secondary",
+          auth: { type: "api", key: "connection-token" },
+        })
+        expect(mapped.headers).toMatchObject({
+          "cf-aig-authorization": "Bearer connection-token",
+        })
+
+        const canonical = await profile.runtimeOptions!({
+          providerID: "cloudflare-ai-gateway",
+          auth: undefined,
+        })
+        expect(canonical.headers).toMatchObject({
+          "cf-aig-authorization": "Bearer canonical-token",
+        })
+      },
+    })
+  } finally {
+    for (const name of envNames) {
+      const value = previous[name]
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+  }
+})
+
 test("Copilot Claude factories honor the merged connection endpoint", async () => {
   registerBuiltinProviderProfiles()
   for (const profileID of ["github-copilot", "github-copilot-enterprise"]) {
@@ -622,6 +664,15 @@ test("inline provider credentials initialize mapped profile auth", async () => {
         expect(provider.profileID).toBe(profileID)
         expect(provider.key).toBe("inline-provider-key")
         expect(resolvedKey).toBe("inline-provider-key")
+        const plan = await Provider.workerPlan(provider, {
+          ttfbMs: 10,
+          idleMs: 20,
+          wallMs: false,
+        })
+        expect(plan.baseOptions).toBeDefined()
+        expect(plan.explicitOptions).toMatchObject({
+          apiKey: "inline-provider-key",
+        })
       },
     })
   } finally {

--- a/packages/synergy/test/provider/transform.test.ts
+++ b/packages/synergy/test/provider/transform.test.ts
@@ -90,6 +90,25 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
+  test("mapped accounts retain canonical OpenAI-Codex transforms", () => {
+    const mappedCodexModel = {
+      ...mockModel,
+      providerID: "openai-codex-secondary",
+      api: {
+        id: "gpt-5.5",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    }
+
+    const result = ProviderTransform.options(mappedCodexModel, sessionID, {}, "openai-codex")
+    expect(result).toMatchObject({ promptCacheKey: sessionID, store: false })
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
+    expect(ProviderTransform.smallOptions(mappedCodexModel, "openai-codex")).toEqual({ store: false })
+  })
+
   test("sets promptCacheKey and store=false for Azure models", () => {
     const azureModel = {
       ...mockModel,

--- a/packages/synergy/test/provider/worker-plan.test.ts
+++ b/packages/synergy/test/provider/worker-plan.test.ts
@@ -5,7 +5,7 @@ import { ProviderProfile } from "../../src/provider/profile"
 import { Scope } from "../../src/scope"
 import { ScopeContext } from "../../src/scope/context"
 
-test("Agent worker provider plans retain data options without executable callbacks", () => {
+test("Agent worker provider plans retain data options without executable callbacks", async () => {
   const fetch = () => Promise.resolve(new Response())
   const provider = {
     key: "private-key",
@@ -19,7 +19,7 @@ test("Agent worker provider plans retain data options without executable callbac
     },
   } as unknown as Provider.Info
 
-  const plan = Provider.workerPlan(provider, {
+  const plan = await Provider.workerPlan(provider, {
     ttfbMs: 10,
     idleMs: 20,
     wallMs: false as const,
@@ -42,14 +42,14 @@ test("Agent worker provider plans retain data options without executable callbac
   expect(provider.options.fetch).toBe(fetch)
 })
 
-test("Agent worker provider plans retain canonical runtime profile identity", () => {
+test("Agent worker provider plans retain canonical runtime profile identity", async () => {
   const provider = {
     profileID: "canonical-provider",
     options: {},
   } as unknown as Provider.Info
 
   expect(
-    Provider.workerPlan(provider, {
+    await Provider.workerPlan(provider, {
       ttfbMs: 10,
       idleMs: 20,
       wallMs: false,
@@ -259,6 +259,101 @@ test("Agent worker connection options override runtime profile defaults", async 
       },
     })
   } finally {
+    if (previousWorker === undefined) delete process.env.SYNERGY_AGENT_WORKER
+    else process.env.SYNERGY_AGENT_WORKER = previousWorker
+  }
+})
+
+test("Agent worker model credentials replace stored OAuth runtime options", async () => {
+  const previousWorker = process.env.SYNERGY_AGENT_WORKER
+  process.env.SYNERGY_AGENT_WORKER = "1"
+  const providerID = `worker-credential-split-${Math.random().toString(36).slice(2)}`
+  let receivedOptions: Record<string, unknown> | undefined
+  ProviderProfile.register({
+    id: providerID,
+    name: "Worker credential split test",
+    authKind: "api_key",
+    aiSdkPackage: "@ai-sdk/openai-compatible",
+    runtimeOptions: async ({ auth }) =>
+      auth?.type === "oauth"
+        ? {
+            apiKey: "oauth-placeholder",
+            headers: { "x-auth-mode": "oauth" },
+          }
+        : {
+            headers: { "x-auth-mode": "api-key" },
+          },
+    getModel: async ({ options }) => {
+      receivedOptions = options
+      return {} as never
+    },
+  })
+  const model = Provider.Model.parse({
+    id: "worker-credential-split-model",
+    providerID,
+    api: {
+      id: "worker-credential-split-model",
+      url: "https://provider.invalid/v1",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "Worker Credential Split Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 4_096, output: 1_024 },
+    status: "active",
+    options: { apiKey: "inline-model-key" },
+    headers: {},
+    release_date: "2026-01-01",
+    variants: {},
+  })
+
+  try {
+    await Auth.set(providerID, {
+      type: "oauth",
+      access: "stored-access",
+      refresh: "stored-refresh",
+      expires: Date.now() + 60_000,
+    })
+    await ScopeContext.provide({
+      scope: Scope.home(),
+      fn: async () => {
+        await Provider.configureWorkerProvider(model, {
+          profileID: providerID,
+          options: {
+            baseURL: "https://provider.invalid/v1",
+            apiKey: "oauth-placeholder",
+            headers: { "x-auth-mode": "oauth" },
+          },
+          baseOptions: {
+            baseURL: "https://provider.invalid/v1",
+          },
+          explicitOptions: {
+            headers: { "x-account": "selected" },
+          },
+          timeouts: { ttfbMs: 10, idleMs: 20, wallMs: false },
+        })
+        await Provider.getLanguage(model)
+      },
+    })
+
+    expect(receivedOptions).toMatchObject({
+      baseURL: "https://provider.invalid/v1",
+      apiKey: "inline-model-key",
+      headers: {
+        "x-account": "selected",
+        "x-auth-mode": "api-key",
+      },
+    })
+  } finally {
+    await Auth.remove(providerID)
     if (previousWorker === undefined) delete process.env.SYNERGY_AGENT_WORKER
     else process.env.SYNERGY_AGENT_WORKER = previousWorker
   }

--- a/packages/synergy/test/provider/worker-plan.test.ts
+++ b/packages/synergy/test/provider/worker-plan.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { Auth } from "../../src/provider/api-key"
 import { Provider } from "../../src/provider/provider"
 import { ProviderProfile } from "../../src/provider/profile"
 import { Scope } from "../../src/scope"
@@ -101,19 +102,22 @@ test("Agent worker profile hooks receive inline provider and model credentials",
   })
 
   try {
+    await Auth.set(providerID, { type: "api", key: "stored-provider-key" })
     await ScopeContext.provide({
       scope: Scope.home(),
       fn: async () => {
         await Provider.configureWorkerProvider(model, {
           profileID: providerID,
-          options: { apiKey: "inline-provider-key" },
+          key: "inline-provider-key",
+          options: { apiKey: "profile-placeholder" },
           timeouts: { ttfbMs: 10, idleMs: 20, wallMs: false },
         })
         await Provider.configureWorkerProvider(
           { ...model, options: {} },
           {
             profileID: providerID,
-            options: { apiKey: "inline-provider-key" },
+            key: "inline-provider-key",
+            options: { apiKey: "profile-placeholder" },
             timeouts: { ttfbMs: 10, idleMs: 20, wallMs: false },
           },
         )
@@ -122,6 +126,7 @@ test("Agent worker profile hooks receive inline provider and model credentials",
 
     expect(runtimeAuthKeys).toEqual(["inline-model-key", "inline-provider-key"])
   } finally {
+    await Auth.remove(providerID)
     if (previousWorker === undefined) delete process.env.SYNERGY_AGENT_WORKER
     else process.env.SYNERGY_AGENT_WORKER = previousWorker
   }

--- a/packages/synergy/test/provider/worker-plan.test.ts
+++ b/packages/synergy/test/provider/worker-plan.test.ts
@@ -58,6 +58,75 @@ test("Agent worker provider plans retain canonical runtime profile identity", ()
   })
 })
 
+test("Agent worker profile hooks receive inline provider and model credentials", async () => {
+  const previousWorker = process.env.SYNERGY_AGENT_WORKER
+  process.env.SYNERGY_AGENT_WORKER = "1"
+  const providerID = `worker-inline-auth-${Math.random().toString(36).slice(2)}`
+  const runtimeAuthKeys: Array<string | undefined> = []
+  ProviderProfile.register({
+    id: providerID,
+    name: "Worker inline auth test",
+    authKind: "api_key",
+    aiSdkPackage: "@ai-sdk/openai-compatible",
+    runtimeOptions: async ({ auth }) => {
+      runtimeAuthKeys.push(auth?.type === "api" ? auth.key : undefined)
+      return {}
+    },
+  })
+  const model = Provider.Model.parse({
+    id: "worker-inline-model",
+    providerID,
+    api: {
+      id: "worker-inline-model",
+      url: "https://provider.invalid/v1",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "Worker Inline Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 4_096, output: 1_024 },
+    status: "active",
+    options: { apiKey: "inline-model-key" },
+    headers: {},
+    release_date: "2026-01-01",
+    variants: {},
+  })
+
+  try {
+    await ScopeContext.provide({
+      scope: Scope.home(),
+      fn: async () => {
+        await Provider.configureWorkerProvider(model, {
+          profileID: providerID,
+          options: { apiKey: "inline-provider-key" },
+          timeouts: { ttfbMs: 10, idleMs: 20, wallMs: false },
+        })
+        await Provider.configureWorkerProvider(
+          { ...model, options: {} },
+          {
+            profileID: providerID,
+            options: { apiKey: "inline-provider-key" },
+            timeouts: { ttfbMs: 10, idleMs: 20, wallMs: false },
+          },
+        )
+      },
+    })
+
+    expect(runtimeAuthKeys).toEqual(["inline-model-key", "inline-provider-key"])
+  } finally {
+    if (previousWorker === undefined) delete process.env.SYNERGY_AGENT_WORKER
+    else process.env.SYNERGY_AGENT_WORKER = previousWorker
+  }
+})
+
 test("Agent worker model caches follow provider credential changes", async () => {
   const previousWorker = process.env.SYNERGY_AGENT_WORKER
   process.env.SYNERGY_AGENT_WORKER = "1"

--- a/packages/synergy/test/provider/worker-plan.test.ts
+++ b/packages/synergy/test/provider/worker-plan.test.ts
@@ -40,6 +40,23 @@ test("Agent worker provider plans retain data options without executable callbac
   expect(provider.options.fetch).toBe(fetch)
 })
 
+test("Agent worker provider plans retain canonical runtime profile identity", () => {
+  const provider = {
+    profileID: "canonical-provider",
+    options: {},
+  } as unknown as Provider.Info
+
+  expect(
+    Provider.workerPlan(provider, {
+      ttfbMs: 10,
+      idleMs: 20,
+      wallMs: false,
+    }),
+  ).toMatchObject({
+    profileID: "canonical-provider",
+  })
+})
+
 test("Agent worker model caches follow provider credential changes", async () => {
   const previousWorker = process.env.SYNERGY_AGENT_WORKER
   process.env.SYNERGY_AGENT_WORKER = "1"

--- a/packages/synergy/test/provider/worker-plan.test.ts
+++ b/packages/synergy/test/provider/worker-plan.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { Provider } from "../../src/provider/provider"
+import { ProviderProfile } from "../../src/provider/profile"
 import { Scope } from "../../src/scope"
 import { ScopeContext } from "../../src/scope/context"
 
@@ -105,6 +106,82 @@ test("Agent worker model caches follow provider credential changes", async () =>
         const second = await Provider.getLanguage(model)
 
         expect(second).not.toBe(first)
+      },
+    })
+  } finally {
+    if (previousWorker === undefined) delete process.env.SYNERGY_AGENT_WORKER
+    else process.env.SYNERGY_AGENT_WORKER = previousWorker
+  }
+})
+
+test("Agent worker connection options override runtime profile defaults", async () => {
+  const previousWorker = process.env.SYNERGY_AGENT_WORKER
+  process.env.SYNERGY_AGENT_WORKER = "1"
+  const providerID = `worker-profile-${Math.random().toString(36).slice(2)}`
+  let receivedOptions: Record<string, unknown> | undefined
+  ProviderProfile.register({
+    id: providerID,
+    name: "Worker profile precedence test",
+    authKind: "none",
+    aiSdkPackage: "@ai-sdk/openai-compatible",
+    runtimeOptions: async () => ({
+      baseURL: "https://profile.invalid/v1",
+      headers: { "x-profile": "default" },
+    }),
+    getModel: async ({ options }) => {
+      receivedOptions = options
+      return {} as never
+    },
+  })
+  const model = Provider.Model.parse({
+    id: "worker-profile-model",
+    providerID,
+    api: {
+      id: "worker-profile-model",
+      url: "https://model.invalid/v1",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "Worker Profile Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 4_096, output: 1_024 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+    variants: {},
+  })
+
+  try {
+    await ScopeContext.provide({
+      scope: Scope.home(),
+      fn: async () => {
+        await Provider.configureWorkerProvider(model, {
+          profileID: providerID,
+          key: "connection-key",
+          options: {
+            baseURL: "https://connection.invalid/v1",
+            headers: { "x-connection": "selected" },
+          },
+          timeouts: { ttfbMs: 10, idleMs: 20, wallMs: false },
+        })
+        await Provider.getLanguage(model)
+      },
+    })
+
+    expect(receivedOptions).toMatchObject({
+      baseURL: "https://connection.invalid/v1",
+      headers: {
+        "x-profile": "default",
+        "x-connection": "selected",
       },
     })
   } finally {

--- a/packages/synergy/test/runtime/reload.test.ts
+++ b/packages/synergy/test/runtime/reload.test.ts
@@ -15,6 +15,7 @@ import { GitHubStore } from "../../src/github/store"
 import { AgentTurn } from "../../src/session/agent-turn"
 import { Agent } from "../../src/agent/agent"
 import { Provider } from "../../src/provider/provider"
+import { ProviderAuth } from "../../src/provider/auth"
 import { Channel } from "../../src/channel"
 
 const originalConfigReload = Config.reload
@@ -22,6 +23,7 @@ const originalNotifyConfigHooks = Plugin.notifyConfigHooks
 const originalAgentTurnResize = (AgentTurn as any).resize
 const originalAgentReload = Agent.reload
 const originalProviderReload = Provider.reload
+const originalProviderAuthReload = ProviderAuth.reload
 const originalChannelReload = Channel.reload
 
 afterEach(() => {
@@ -30,6 +32,7 @@ afterEach(() => {
   ;(AgentTurn as any).resize = originalAgentTurnResize
   Agent.reload = originalAgentReload
   Provider.reload = originalProviderReload
+  ProviderAuth.reload = originalProviderAuthReload
   Channel.reload = originalChannelReload
   GlobalBus.removeAllListeners("event")
   CortexConcurrency.reset()
@@ -189,6 +192,33 @@ describe("runtime.reload", () => {
         expect(result.liveApplied).toContain("cortex")
         expect(result.restartRequired).not.toContain("cortex")
         expect(CortexConcurrency.globalStatus()).toMatchObject({ configured: 3, effective: 3, source: "config" })
+      },
+    })
+  })
+
+  test("provider config changes rebuild the account auth registry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        Config.reload = mock(async () => ({
+          config: { provider: {} },
+          changedFields: ["provider"],
+          oldConfig: {},
+        })) as typeof Config.reload
+        const authReload = mock(async () => {})
+        const providerReload = mock(async () => {})
+        const agentReload = mock(async () => {})
+        ProviderAuth.reload = authReload
+        Provider.reload = providerReload
+        Agent.reload = agentReload
+
+        const result = await RuntimeReload.reload({ targets: ["config"], scope: "global", reason: "test" })
+
+        expect(authReload).toHaveBeenCalledTimes(1)
+        expect(providerReload).toHaveBeenCalledTimes(1)
+        expect(agentReload).toHaveBeenCalledTimes(1)
+        expect(result.success).toBe(true)
       },
     })
   })


### PR DESCRIPTION
## Summary
- add an explicit `provider.<connection>.profile` mapping, separate from `modelsDevProviderID`
- resolve runtime options, model factories, auth recovery, usage, worker plans, discovery, probes, and request transforms through the canonical profile while retaining the concrete connection ID
- isolate discovery snapshots, retries, health, credentials, environment bindings, and usage by account connection
- document the catalog-only versus runtime-profile boundary and regenerate public schemas

## Stacking
This is Phase 2 of #979 and follows merged Phase 1 PR #980. It is rebased onto the latest `dev`; its diff contains only runtime-profile work. This PR does not close #979.

## Validation
- focused provider/config suites: 231 pass, 0 fail (each file run in an isolated Bun process)
- monorepo typecheck passed
- formatting, oxlint, Turbo typecheck, and package validation passed in the push hook
- full provider suite previously passed except one environment-dependent proxy transport test; the same result reproduced on the Phase 1 base

Related to #979.