### PR TITLE
test: raise concurrent server lock test deadline to 30s

### DIFF
--- a/packages/synergy/test/daemon/server-process-lock.test.ts
+++ b/packages/synergy/test/daemon/server-process-lock.test.ts
@@ -80,7 +80,7 @@ describe("ServerProcessLock", () => {
       await Promise.all(children.map((child) => child.exited.catch(() => -1)))
       await fs.rm(home, { recursive: true, force: true })
     }
-  })
+  }, 90_000)
 
   test("recovers stale locks and rejects a reused pid with a different start identity", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-server-lock-stale-"))

--- a/packages/synergy/test/daemon/server-process-lock.test.ts
+++ b/packages/synergy/test/daemon/server-process-lock.test.ts
@@ -46,7 +46,7 @@ describe("ServerProcessLock", () => {
             stderr: "inherit",
           }),
         )
-        const readyDeadline = Date.now() + 10_000
+        const readyDeadline = Date.now() + 30_000
         while (!(await fs.readFile(readyPath, "utf8").catch(() => "")).split("\n").includes(String(index))) {
           if (Date.now() >= readyDeadline) throw new Error(`Lock worker ${index} did not become ready`)
           await Bun.sleep(10)
@@ -55,7 +55,7 @@ describe("ServerProcessLock", () => {
 
       await Bun.write(startPath, "go\n")
 
-      const resultDeadline = Date.now() + 10_000
+      const resultDeadline = Date.now() + 30_000
       let results: WorkerResult[] = []
       while (results.length < count) {
         if (Date.now() >= resultDeadline) throw new Error("Lock workers did not finish competing")


### PR DESCRIPTION
## Summary

- The 24-worker concurrent acquisition test in `packages/synergy/test/daemon/server-process-lock.test.ts` flaked twice on Windows CI (runs #30801905999, #30801229756) with `Lock workers did not finish competing` after 10s.
- The failure is a timing-sensitive flake: on Windows runners, spawning 24 `bun run` workers, per-worker WMIC/PowerShell process-start identity queries, and file I/O are slower; the 10s deadline is a wait cap, not the contract under test (exactly one winner, clean rejections, clean release).
- Raised the ready and result deadlines of that one test from 10s to 30s. Other single-worker tests keep their 10s caps.

## Verification

- `bun test --timeout 30000 test/daemon/server-process-lock.test.ts` → 9 pass, 0 fail (5.1s) locally.

## Notes

- Same test passed on the PR branch's final CI run (#30801274331) and locally (~0.9s on macOS), confirming the lock semantics themselves are sound.