### PR TITLE
fix: allow auxiliary feedback tools in Plan

### DIFF
--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -22,6 +22,8 @@ System control messages, non-root messages, and messages from continuation sourc
 
 Plan prompts instruct the agent to research and author a decision-complete Blueprint instead of executing the result. A finalized Blueprint uses eight shared semantic sections and selects one material implementation route: materially different owners, architectures, data flows, compatibility strategies, domain methods, artifact shapes, and user-visible behaviors must be resolved from evidence, established conventions, or a blocking user decision. Incidental execution mechanics remain delegated to the executor. Tool exposure and execution policy enforce the read-only project boundary in addition to the prompt.
 
+An explicitly auxiliary Tool may remain available for immediate supporting feedback that neither implements nor replaces the requested outcome. Auxiliary purpose affects Plan visibility only; it does not bypass capability, approval, permission, or runtime enforcement. Tools that perform the requested work remain outside Plan even when their output is presented as feedback.
+
 The Note Blueprint policy allows Blueprint creation and modification only in Plan or Lattice. It infers Blueprint intent from `kind` or Blueprint-specific fields and blocks edits to an existing Blueprint outside those workflows. Reading and searching remain available.
 
 ## BlueprintLoop State Machine

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -29,31 +29,31 @@ Identity, compatibility, and descriptive fields come from `definePlugin()`. `com
 
 ## Contribution Kinds
 
-| Kind                    | Executable | Important generated fields                                                   |
-| ----------------------- | ---------- | ---------------------------------------------------------------------------- |
-| `operation`             | yes        | `type`, `expose`, input/output JSON Schema, optional timeout                 |
-| `event`                 | no         | payload JSON Schema                                                          |
-| `tool`                  | yes        | object input JSON Schema, exposure, display metadata, optional `enabledWhen` |
-| `cli.command`           | yes        | description, typed options, optional timeout                                 |
-| `hook`                  | yes        | host hook point and priority                                                 |
-| `agent`                 | no         | agent declaration                                                            |
-| `skill`                 | no         | skill declaration                                                            |
-| `mcp`                   | no         | MCP server declaration and optional `enabledWhen`                            |
-| `authProvider`          | yes        | provider profile                                                             |
-| `ui.workbenchPanel`     | no         | surface, cardinality, optional default resource and trusted component        |
-| `ui.navigationItem`     | no         | placement and optional trusted component                                     |
-| `ui.messageRenderer`    | no         | message type and optional trusted component                                  |
-| `ui.composerAction`     | no         | slot and optional trusted component                                          |
-| `ui.composerExtension`  | no         | ordered trusted headless Composer lifecycle                                  |
-| `ui.selectionExtension` | no         | ordered trusted headless selection lifecycle                                 |
-| `ui.textAction`         | no         | host-rendered selected-text action and command operation reference           |
-| `ui.messageSlot`        | no         | message slot, optional role filter, and trusted component                    |
-| `ui.settings`           | no         | group, form schema, visibility, optional trusted component                   |
-| `ui.theme`              | no         | label and packaged structured-theme JSON path                                |
-| `ui.icon`               | no         | packaged SVG path                                                            |
-| `lifecycle.install`     | yes        | post-commit fresh-install handler identity                                   |
-| `lifecycle.upgrade`     | yes        | handler identity                                                             |
-| `lifecycle.uninstall`   | yes        | handler identity                                                             |
+| Kind                    | Executable | Important generated fields                                                                                         |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| `operation`             | yes        | `type`, `expose`, input/output JSON Schema, optional timeout                                                       |
+| `event`                 | no         | payload JSON Schema                                                                                                |
+| `tool`                  | yes        | object input JSON Schema, exposure including optional Plan compatibility, display metadata, optional `enabledWhen` |
+| `cli.command`           | yes        | description, typed options, optional timeout                                                                       |
+| `hook`                  | yes        | host hook point and priority                                                                                       |
+| `agent`                 | no         | agent declaration                                                                                                  |
+| `skill`                 | no         | skill declaration                                                                                                  |
+| `mcp`                   | no         | MCP server declaration and optional `enabledWhen`                                                                  |
+| `authProvider`          | yes        | provider profile                                                                                                   |
+| `ui.workbenchPanel`     | no         | surface, cardinality, optional default resource and trusted component                                              |
+| `ui.navigationItem`     | no         | placement and optional trusted component                                                                           |
+| `ui.messageRenderer`    | no         | message type and optional trusted component                                                                        |
+| `ui.composerAction`     | no         | slot and optional trusted component                                                                                |
+| `ui.composerExtension`  | no         | ordered trusted headless Composer lifecycle                                                                        |
+| `ui.selectionExtension` | no         | ordered trusted headless selection lifecycle                                                                       |
+| `ui.textAction`         | no         | host-rendered selected-text action and command operation reference                                                 |
+| `ui.messageSlot`        | no         | message slot, optional role filter, and trusted component                                                          |
+| `ui.settings`           | no         | group, form schema, visibility, optional trusted component                                                         |
+| `ui.theme`              | no         | label and packaged structured-theme JSON path                                                                      |
+| `ui.icon`               | no         | packaged SVG path                                                                                                  |
+| `lifecycle.install`     | yes        | post-commit fresh-install handler identity                                                                         |
+| `lifecycle.upgrade`     | yes        | handler identity                                                                                                   |
+| `lifecycle.uninstall`   | yes        | handler identity                                                                                                   |
 
 Contribution IDs are unique within a contribution kind. This permits a command operation and its declarative UI action to share one meaningful local ID while their kind-qualified identities remain distinct. Every `requires` entry must name a top-level capability. Executable declarations require a runtime artifact. A trusted component requires a UI artifact.
 

--- a/docs/plugins/tools-and-delegation.md
+++ b/docs/plugins/tools-and-delegation.md
@@ -34,6 +34,8 @@ export default definePlugin({
 
 Tool IDs are plugin-local. Synergy exposes them as namespaced host tools and validates input from the generated schema. `requires` drives the contribution capability gate and must reference top-level capabilities.
 
+Set `exposure.plan: "auxiliary"` only when a Tool provides immediate supporting feedback or presentation without implementing or replacing the user's requested outcome. This keeps the Tool available in Plan while the Agent remains responsible for producing only a Blueprint. The declaration changes workflow visibility only: ordinary capability, approval, permission, and runtime enforcement still apply. Tools that execute the requested outcome, modify its deliverables, perform external identity actions, or substitute a second workflow must omit it.
+
 ## Delegated Tasks
 
 `context.task` exists only when `task.delegate` is approved. It exposes five finite Host calls:
@@ -71,7 +73,7 @@ Parent Session failures use stable Host Service error codes: `PLUGIN_TASK_PARENT
 
 ## Exposure and Display
 
-`exposure` controls how a tool appears to agents: resident, grouped, searchable, or internal. `display` supplies host-owned presentation metadata. Both are declarations copied into the generated manifest; the executable handler remains in the runtime bundle.
+`exposure` controls how a tool appears to agents: resident, grouped, searchable, or internal. Its optional `plan: "auxiliary"` field identifies a supporting Tool that remains compatible with Plan without becoming part of Blueprint execution. `display` supplies host-owned presentation metadata. These are declarations copied into the generated manifest; the executable handler remains in the runtime bundle.
 
 A handler may return a string or `ToolResult` with title, output, metadata, and attachments. Keep durable business state and provenance in plugin-owned artifacts.
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -42,6 +42,7 @@ export default definePlugin({
 - A contribution's `requires` entries must exist in top-level `capabilities`.
 - `operation()` defaults to `expose: ['ui']`; add `sdk` explicitly for public SDK access.
 - Zod and JSON Schema are accepted for operation, event, and tool schemas.
+- A supporting Tool may declare `exposure.plan: "auxiliary"` to remain visible in Plan when it provides feedback without implementing or replacing the requested outcome; ordinary capability and permission enforcement still applies.
 - `activate()` runs once per runtime generation and does not receive Scope or Session state.
 - Top-level `assets` map project-relative files or directories into package-relative targets. Asset contents are integrity-checked and included in the generation hash.
 - The plugin and plugin-kit npm package versions follow the Synergy product release version; package major versions do not select a Plugin API family.

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -107,9 +107,11 @@ export type PluginToolResult = ToolResult
 export type ToolExposure =
   | {
       mode: "resident"
+      plan?: "auxiliary"
     }
   | {
       mode: "group"
+      plan?: "auxiliary"
       group: string
       title?: string
       description?: string
@@ -117,11 +119,13 @@ export type ToolExposure =
     }
   | {
       mode: "search"
+      plan?: "auxiliary"
       title?: string
       keywords?: string[]
     }
   | {
       mode: "internal"
+      plan?: "auxiliary"
     }
 
 export function tool<Args extends z.ZodRawShape>(input: {

--- a/packages/plugin/test/descriptor.test.ts
+++ b/packages/plugin/test/descriptor.test.ts
@@ -155,6 +155,35 @@ describe("definePlugin", () => {
     })
   })
 
+  test("preserves auxiliary Plan exposure in the manifest", () => {
+    const plugin = definePlugin({
+      id: "language-feedback",
+      version: "1.0.0",
+      description: "Language feedback",
+      contributions: [
+        tool({
+          id: "feedback",
+          description: "Show feedback without replacing the user's task.",
+          exposure: { mode: "resident", plan: "auxiliary" },
+          input: z.object({ message: z.string() }),
+          handler: async () => "ok",
+        }),
+      ],
+    })
+
+    const manifest = compilePluginManifest(plugin, {
+      generation: "generation-1",
+      runtime: { entry: "runtime/index.js", sha256: "a".repeat(64) },
+    })
+
+    expect(manifest.contributions[0]).toMatchObject({
+      kind: "tool",
+      id: "feedback",
+      exposure: { mode: "resident", plan: "auxiliary" },
+    })
+    expect(PluginManifestV4.parse(manifest)).toEqual(manifest)
+  })
+
   test("targets one host tool with a trusted message renderer", () => {
     const plugin = definePlugin({
       id: "correction-card",

--- a/packages/synergy/src/session/prompt/plan.txt
+++ b/packages/synergy/src/session/prompt/plan.txt
@@ -17,6 +17,7 @@ A Blueprint often starts with ambiguity: the user's request may be high-level, a
 You may include Assumptions only when they are locked execution defaults chosen from evidence, project conventions, or explicit user direction. Do not use Assumptions to hide unresolved decisions.
 
 You MAY:
+- Use explicitly auxiliary tools for immediate supporting feedback that does not implement or replace the requested outcome
 - Use read-only tools to inspect code, docs, sessions, memories, and external sources
 - Use bash for read-only repository inspection such as `rg`, `ls`, `cat`, and `git diff`
 - Create research/design tasks and DAGs to gather deeper context

--- a/packages/synergy/src/session/tool-mode-policy.ts
+++ b/packages/synergy/src/session/tool-mode-policy.ts
@@ -72,6 +72,7 @@ export namespace SessionModePolicy {
 
   export function visibility(input: {
     toolName: string
+    planExposure?: "auxiliary"
     session?: Pick<SessionInfo, "workflow" | "blueprint" | "endpoint">
   }): ToolDiagnostic | undefined {
     if (input.toolName === "response_card" && input.session?.endpoint?.kind !== "channel") {
@@ -86,6 +87,7 @@ export namespace SessionModePolicy {
     const latticeDiagnostic = latticeVisibility(input.toolName, input.session)
     if (latticeDiagnostic) return latticeDiagnostic
     if (!isPlan(input.session)) return undefined
+    if (input.planExposure === "auxiliary") return undefined
     if (PLAN_EXPLICIT_ALLOW.has(input.toolName)) return undefined
 
     const taxonomy = ToolTaxonomy.classify(input.toolName)
@@ -103,13 +105,18 @@ export namespace SessionModePolicy {
 
   export function evaluateCall(input: {
     toolName: string
+    planExposure?: "auxiliary"
     args: Record<string, any>
     session?: Pick<SessionInfo, "workflow" | "blueprint">
     capabilities: Capability[]
   }): ToolDiagnostic | undefined {
     if (!isPlan(input.session)) return undefined
 
-    const staticDiagnostic = visibility({ toolName: input.toolName, session: input.session })
+    const staticDiagnostic = visibility({
+      toolName: input.toolName,
+      planExposure: input.planExposure,
+      session: input.session,
+    })
     if (staticDiagnostic) return staticDiagnostic
     return undefined
   }

--- a/packages/synergy/src/session/tool-resolver.ts
+++ b/packages/synergy/src/session/tool-resolver.ts
@@ -1166,7 +1166,11 @@ export namespace ToolResolver {
 
       const modeDiagnostic = isEphemeral
         ? undefined
-        : SessionModePolicy.visibility({ toolName: def.id, session: input.session })
+        : SessionModePolicy.visibility({
+            toolName: def.id,
+            planExposure: def.exposure?.plan,
+            session: input.session,
+          })
       if (modeDiagnostic) {
         diagnostics.set(def.id, modeDiagnostic)
         continue
@@ -1563,6 +1567,7 @@ export namespace ToolResolver {
                 const envelope = await gate.evaluateIsolated(item.id, args as Record<string, any>, ctx.abort)
                 const modeDiagnostic = SessionModePolicy.evaluateCall({
                   toolName: item.id,
+                  planExposure: item.exposure?.plan,
                   args: args as Record<string, any>,
                   session: runtimeInput.session,
                   capabilities: envelope.capabilities,

--- a/packages/synergy/src/tool/exposure.ts
+++ b/packages/synergy/src/tool/exposure.ts
@@ -2,9 +2,11 @@ export namespace ToolExposure {
   export type Info =
     | {
         mode: "resident"
+        plan?: "auxiliary"
       }
     | {
         mode: "group"
+        plan?: "auxiliary"
         group: string
         title?: string
         description?: string
@@ -12,11 +14,13 @@ export namespace ToolExposure {
       }
     | {
         mode: "search"
+        plan?: "auxiliary"
         title?: string
         keywords?: string[]
       }
     | {
         mode: "internal"
+        plan?: "auxiliary"
       }
 
   export interface GroupInfo {

--- a/packages/synergy/test/session/plan-prompt-contract.test.ts
+++ b/packages/synergy/test/session/plan-prompt-contract.test.ts
@@ -39,6 +39,11 @@ describe("Plan Blueprint prompt contract", () => {
     expect(PLAN_SYNERGY_MAX).toContain("mutually exclusive")
   })
 
+  test("keeps supporting feedback compatible with Plan without authorizing execution", () => {
+    expect(PLAN).toContain("auxiliary tools for immediate supporting feedback")
+    expect(PLAN).toContain("does not implement or replace the requested outcome")
+  })
+
   test("requires the shared eight-section Blueprint structure", () => {
     for (const section of REQUIRED_BLUEPRINT_SECTIONS) {
       expect(PLAN).toContain(section)

--- a/packages/synergy/test/session/tool-mode-policy.test.ts
+++ b/packages/synergy/test/session/tool-mode-policy.test.ts
@@ -30,6 +30,22 @@ describe("SessionModePolicy Plan visibility", () => {
     expect(diagnostic?.code).toBe("plan_mode_blocked")
     expect(diagnostic?.mode).toBe("plan")
   })
+
+  test("allows explicitly auxiliary tools without naming a specific integration", () => {
+    expect(
+      SessionModePolicy.visibility({
+        toolName: "plugin__language-coach__feedback",
+        planExposure: "auxiliary",
+        session: planSession,
+      }),
+    ).toBeUndefined()
+    expect(
+      SessionModePolicy.visibility({
+        toolName: "plugin__language-coach__feedback",
+        session: planSession,
+      })?.code,
+    ).toBe("plan_mode_blocked")
+  })
 })
 
 describe("SessionModePolicy Channel visibility", () => {

--- a/packages/synergy/test/tool/exposure.test.ts
+++ b/packages/synergy/test/tool/exposure.test.ts
@@ -778,6 +778,57 @@ describe("tool exposure", () => {
     })
   })
 
+  test("Plan exposes an explicitly auxiliary Tool while keeping an ordinary Tool blocked", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const suffix = Math.random().toString(36).slice(2)
+        const auxiliaryId = `auxiliary_feedback_${suffix}`
+        const ordinaryId = `ordinary_action_${suffix}`
+        await ToolRegistry.register(
+          Tool.define(
+            auxiliaryId,
+            {
+              description: "Provide supporting feedback.",
+              parameters: z.object({}),
+              async execute() {
+                return { title: auxiliaryId, output: "ok", metadata: {} }
+              },
+            },
+            { exposure: { mode: "resident", plan: "auxiliary" } },
+          ),
+        )
+        await ToolRegistry.register(
+          Tool.define(ordinaryId, {
+            description: "Perform an ordinary action.",
+            parameters: z.object({}),
+            async execute() {
+              return { title: ordinaryId, output: "ok", metadata: {} }
+            },
+          }),
+        )
+
+        const session = await Session.create({})
+        await Session.update(session.id, (draft) => {
+          draft.workflow = { kind: "plan" }
+        })
+
+        const ids = await definitionIDs(await Session.get(session.id))
+        expect(ids.has(auxiliaryId)).toBe(true)
+        expect(ids.has(ordinaryId)).toBe(false)
+
+        const denied = await definitionIDs(await Session.get(session.id), {
+          agent: {
+            ...allowAllAgent,
+            permission: PermissionNext.fromConfig({ "*": "allow", [auxiliaryId]: "deny" }),
+          },
+        })
+        expect(denied.has(auxiliaryId)).toBe(false)
+      },
+    })
+  })
+
   test("Plan does not override explicit permission denial for bash", async () => {
     await using tmp = await tmpdir({ git: true })
     await ScopeContext.provide({


### PR DESCRIPTION
## Summary

- add the generic `exposure.plan: "auxiliary"` declaration for plugin tools
- keep explicitly auxiliary feedback and presentation tools available in Plan without allowing them to implement or replace the requested outcome
- preserve capability, permission, approval, and runtime enforcement while continuing to block unmarked tools
- document the public plugin contract and Plan prompt boundary

## Tests

- `bun test test/session/tool-mode-policy.test.ts test/session/plan-prompt-contract.test.ts`
- `bun test test/tool/exposure.test.ts -t "Plan exposes an explicitly auxiliary Tool"`
- `bun test test/descriptor.test.ts`
- `bun run quality:quick`
