### PR TITLE
fix(release): install all platform packages when preparing runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
-        run: bun install
+        # Runtime preparation needs every platform package (ast-grep, watcher) in
+        # node_modules/.bun, so install all os/cpu variants instead of host-only.
+        run: bun install --os='*' --cpu='*'
 
       - name: Publish npm candidate and draft assets
         id: publish
@@ -165,7 +167,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libarchive-tools rpm
 
       - name: Install dependencies
-        run: bun install
+        # Runtime preparation needs every platform package (ast-grep, watcher) in
+        # node_modules/.bun, so install all os/cpu variants instead of host-only.
+        run: bun install --os='*' --cpu='*'
 
       - name: Download sandbox assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## Summary
- v3.0.12 release runs failed in `Publish Stable Candidate`: the runner (Linux) could not resolve `bin/ast-grep.exe` for the `windows-x64` / `windows-x64-baseline` runtime targets, and the fail-closed runtime manifest (`script/release/shared/runtime-contract.ts`) aborted the release.
- Root cause: plain `bun install` only links host-platform packages, but `prepareRuntimeAssets` (ast-grep, watcher, etc.) resolves platform packages from `node_modules/.bun` for every `SYNERGY_BUILD_TARGETS` entry regardless of runner OS.
- Fix: the two jobs that prepare runtime assets (`stable_candidate`, `stable_desktop_package`) now install with `bun install --os='*' --cpu='*'` so all declared platform packages are present. Publish-only and finalize jobs keep plain `bun install`.

## Verification
- `bun install --os='*' --cpu='*'` locally: all 5 `@ast-grep/cli-*` variants land in `node_modules/.bun` (plain install links only the linux-x64 one).
- `bun test --config /dev/null test/script/release/runtime-assets.test.ts` — 19 pass.
- Workflow YAML validated by parse; `resolveDependencyAsset` already scans `.bun` caches, no script changes needed.