### PR TITLE
fix(embedding): map standalone WASM backend to transformers v4 cpu device

### DIFF
--- a/packages/synergy/src/vector/embedding-runtime.ts
+++ b/packages/synergy/src/vector/embedding-runtime.ts
@@ -30,16 +30,18 @@ function loadStandaloneOnnxRuntime(): Promise<typeof import("onnxruntime-web/was
 
 export async function loadEmbeddingTransformersRuntime(): Promise<{
   runtime: TransformersRuntime
-  device?: "wasm"
+  device?: "cpu"
 }> {
   if (!isStandalone()) return { runtime: await import("@huggingface/transformers") }
   await loadStandaloneOnnxRuntime()
-  return { runtime: await import("@huggingface/transformers"), device: "wasm" }
+  // transformers.js v4 dropped "wasm" from its device enum; "cpu" maps to the
+  // preloaded WASM execution provider in onnxruntime-web.
+  return { runtime: await import("@huggingface/transformers"), device: "cpu" }
 }
 
 export async function verifyStandaloneEmbeddingRuntime(): Promise<void> {
   const loaded = await loadEmbeddingTransformersRuntime()
-  if (loaded.device !== "wasm") throw new Error("Standalone embedding runtime did not select the WASM backend")
+  if (loaded.device !== "cpu") throw new Error("Standalone embedding runtime did not select the WASM backend")
   const runtime = await loadStandaloneOnnxRuntime()
   try {
     await runtime.InferenceSession.create(new Uint8Array([0]), { executionProviders: ["wasm"] })

--- a/packages/synergy/src/vector/embedding.ts
+++ b/packages/synergy/src/vector/embedding.ts
@@ -99,7 +99,7 @@ export namespace Embedding {
     dtype: "q8"
     progress_callback: (info: ProgressInfo) => void
     local_files_only?: true
-    device?: "wasm"
+    device?: "cpu"
   }
   type LocalRuntime = {
     pipeline(task: string, model: string, options: PipelineOptions): Promise<LocalExtractor>


### PR DESCRIPTION
## Summary
- Packaged standalone servers (v3.0.13) fail to load the local embedding model with `Unsupported device: "wasm". Should be one of: cuda, webgpu, cpu.` — dev pins `@huggingface/transformers@4.2.0`, which removed `"wasm"` from the pipeline device enum (valid in the v3 era).
- The standalone runtime preloads onnxruntime-web WASM assets (`script/embedding-runtime-assets`) and previously forced `device: "wasm"`. In transformers.js v4 the `"cpu"` device resolves to the WASM execution provider in onnxruntime-web, so the fix maps the standalone backend to `device: "cpu"` and keeps the asset staging/verification path unchanged.
- Memory/vector recall was degrading on packaged installs because of this; configuring `embedding.apiKey` (remote embedding) remains a valid workaround until this ships.

## Verification
- `bun test test/library/embedding-local.test.ts test/vector/embedding-standalone.test.ts` — 12 pass (the standalone test compiles a probe binary with `SYNERGY_STANDALONE` and verifies the WASM backend initializes).
- Pre-existing `tsc` error in `test/tool/arxiv-download.test.ts` on dev is unrelated (present without this change).