### PR TITLE
fix(library): honor documented memory.enabled default for chronicler

### DIFF
--- a/packages/synergy/src/library/chronicler.ts
+++ b/packages/synergy/src/library/chronicler.ts
@@ -17,7 +17,8 @@ export namespace Chronicler {
 
     const config = await Config.current()
     const library = (config as any).library as { memory?: { enabled?: boolean } } | undefined
-    if (!library?.memory?.enabled) return
+    // memory.enabled defaults to true; only an explicit false disables the chronicler
+    if (library?.memory?.enabled === false) return
 
     const agent = await Agent.get("chronicler")
     if (!agent) return


### PR DESCRIPTION
## Summary
- The config schema documents `library.memory.enabled` as defaulting to `true`, but the chronicler gate used `if (!library?.memory?.enabled) return`, so zero-config installs (key absent) silently skipped automatic memory curation after each conversation.
- This regressed in the identity→library refactor (June): the pre-refactor gate defaulted to active. `agent.ts:193` already treats absence as enabled (`?? true`), so the chronicler was the only inconsistent consumer.
- Fix: only an explicit `enabled: false` disables the chronicler.

## Verification
- `bun test test/library/ test/session/loop-job.test.ts test/session/loop-signals.test.ts` — 199 pass.