### PR TITLE
fix(channel): drive inbox items delivered during a completed turn

### DIFF
--- a/packages/synergy/src/channel/conversation-acceptance.ts
+++ b/packages/synergy/src/channel/conversation-acceptance.ts
@@ -83,7 +83,25 @@ export namespace ChannelConversationAcceptance {
       .then(() => {
         completed = true
       })
-      .finally(() => SessionManager.finish(lease, { requestNextWork: !completed }))
+      .finally(async () => {
+        if (completed) {
+          // The current delivery is materialized and committed by execute, so a
+          // successful turn normally leaves nothing runnable behind. But a new
+          // item can land mid-run (e.g. a cortex completion steer whose drive
+          // request was dropped while the session was busy); that item needs
+          // the release-time drive, otherwise it stays stranded in the inbox.
+          const leftover = await SessionInbox.hasRunnableItem(input.sessionID, {
+            excludeIDs: new Set([delivery.itemID]),
+          })
+          if (leftover) {
+            await SessionManager.finish(lease)
+            return
+          }
+          await SessionManager.finish(lease, { requestNextWork: false })
+          return
+        }
+        await SessionManager.finish(lease)
+      })
     void execution.catch((error) => {
       log.error("conversation execution failed", { sessionID: input.sessionID, error })
     })

--- a/packages/synergy/test/channel/feishu-acceptance-lane.test.ts
+++ b/packages/synergy/test/channel/feishu-acceptance-lane.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { tmpdir } from "../fixture/fixture"
 import { ScopeContext } from "../../src/scope/context"
 import { Session } from "../../src/session"
 import { SessionInbox } from "../../src/session/inbox"
 import { SessionManager } from "../../src/session/manager"
+import { SessionDrive } from "../../src/session/drive"
 import { ChannelConversationAcceptance } from "../../src/channel/conversation-acceptance"
 import { ChannelBusyHandoff } from "../../src/channel/busy-handoff"
 
@@ -333,6 +334,88 @@ describe("Channel conversation acceptance lane", () => {
         if (!acceptance.accepted) throw new Error("expected acceptance")
         await expect(acceptance.execution).rejects.toBe(failure)
         expect(SessionManager.isRunning(session.id)).toBe(false)
+      },
+    })
+  })
+
+  test("release after a completed execution drives a steer item delivered mid-run", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        const { SessionInvoke } = await import("../../src/session/invoke")
+        const originalLoop = SessionInvoke.loop
+        const wakes: string[] = []
+        const wake = Promise.withResolvers<string>()
+        let sessionID = ""
+        ;(SessionInvoke.loop as any) = mock(async (wokenSessionID: string) => {
+          wakes.push(wokenSessionID)
+          await SessionInbox.drainReady(wokenSessionID)
+          wake.resolve(wokenSessionID)
+        })
+
+        try {
+          const session = await Session.create({})
+          sessionID = session.id
+          const rootID = "msg_acceptance_root"
+          await Session.updateMessage({
+            id: rootID,
+            role: "user",
+            sessionID,
+            time: { created: Date.now() },
+            agent: "synergy",
+            model: { providerID: "test-provider", modelID: "test-model" },
+            isRoot: true,
+            rootID,
+          } as any)
+          await Session.updatePart({
+            id: "prt_acceptance_root",
+            messageID: rootID,
+            sessionID,
+            type: "text",
+            text: "root",
+          })
+
+          const acceptance = await ChannelConversationAcceptance.accept({
+            sessionID,
+            deliveryKey: "channel:feishu:acct:msg_midrun",
+            parts: [{ type: "text", text: "main" }],
+            metadata: { channelReply: true },
+            execute: async () => {
+              // A cortex completion notification lands while the turn runs;
+              // its drive request is dropped because the session is busy.
+              await SessionInbox.deliverUnique({
+                sessionID,
+                deliveryKey: "cortex:taskNotification:ctx_midrun",
+                mode: "steer",
+                message: {
+                  role: "user",
+                  metadata: { source: "cortex" },
+                  parts: [{ type: "text", text: "Cortex task completed" }],
+                },
+              })
+            },
+          })
+          expect(acceptance.accepted).toBe(true)
+          if (!acceptance.accepted) throw new Error("expected acceptance")
+          await acceptance.execution
+
+          // The steer item must not stay stranded after the lease release.
+          expect(
+            await Promise.race([
+              wake.promise,
+              Bun.sleep(1_000).then(() => {
+                throw new Error("Completed execution release did not drive the mid-run steer item")
+              }),
+            ]),
+          ).toBe(sessionID)
+          expect(wakes).toEqual([sessionID])
+          expect(await SessionInbox.list(sessionID)).toHaveLength(0)
+        } finally {
+          ;(SessionInvoke.loop as any) = originalLoop
+          if (sessionID) SessionManager.unregisterRuntime(sessionID)
+          SessionDrive.reset()
+        }
       },
     })
   })


### PR DESCRIPTION
## Summary

A cortex completion notification (steer mode) that lands while a foreground channel turn is still running can stay stranded in the session inbox forever:

- The notification's `SessionDrive.request` is dropped because the session is busy.
- On successful completion, the channel acceptance lease releases with `requestNextWork: false`, so nothing re-checks the inbox.

This leaves the notification permanently queued (visible as an endlessly "queued" inbox item) until the user manually sends another message.

## Fix

In `ChannelConversationAcceptance`, after a **completed** execution the release now checks for runnable inbox items other than the current delivery (`excludeIDs`). If any exist (e.g. a steer delivered mid-run), the lease releases normally so the release-time drive wakes the session to consume them; otherwise the original no-wake behavior is preserved. The failure path is unchanged.

## Tests

Added a regression test that delivers a steer item from inside the running execution and asserts the item is drained after release (fails on the old code, passes with the fix).

```bash
cd packages/synergy
bun test test/channel/feishu-acceptance-lane.test.ts
```

11 pass / 0 fail (including the new regression test).