### PR TITLE
fix(holos): tolerate transient IO errors during account store reads

### DIFF
--- a/packages/synergy/src/holos/accounts.ts
+++ b/packages/synergy/src/holos/accounts.ts
@@ -9,6 +9,7 @@ import { Global } from "@/global"
 import path from "path"
 import fs from "fs/promises"
 import { Auth } from "@/provider/api-key"
+import { readFileWithRetry } from "@/util/io-retry"
 
 export namespace HolosAccounts {
   export class MalformedStoreError extends Error {
@@ -38,7 +39,7 @@ export namespace HolosAccounts {
   async function readStore(): Promise<Store> {
     let raw: string
     try {
-      raw = await fs.readFile(filepath(), "utf8")
+      raw = await readFileWithRetry(filepath())
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return { activeAccountId: null, accounts: {} }

--- a/packages/synergy/src/holos/migration.ts
+++ b/packages/synergy/src/holos/migration.ts
@@ -3,6 +3,7 @@ import { StoragePath } from "@/storage/path"
 import { Global } from "@/global"
 import { HolosAccounts } from "./accounts"
 import { Log } from "@/util/log"
+import { isRetryableIOError } from "@/util/io-retry"
 import { MigrationRegistry } from "../migration/registry"
 import type { Migration } from "../migration"
 import path from "path"
@@ -65,6 +66,12 @@ async function removePersistedAccountLabels(): Promise<number> {
       await fs.chmod(filepath, 0o600).catch(() => {})
     } catch (error) {
       await fs.rm(temporary, { force: true }).catch(() => {})
+      if (isRetryableIOError(error)) {
+        log.warn("skipping holos account label cleanup because the account store is temporarily unavailable", {
+          error: String(error),
+        })
+        return 0
+      }
       throw error
     }
     return count
@@ -102,9 +109,20 @@ export const migrations: Migration[] = [
     async up(progress) {
       progress(0, 1)
       const account = await HolosAccounts.getActiveAccount().catch((error) => {
-        if (!(error instanceof HolosAccounts.MalformedStoreError)) throw error
-        log.warn("skipping clarus channel account provisioning because the Holos account store is malformed")
-        return undefined
+        if (error instanceof HolosAccounts.MalformedStoreError) {
+          log.warn("skipping clarus channel account provisioning because the Holos account store is malformed")
+          return undefined
+        }
+        if (isRetryableIOError(error)) {
+          log.warn(
+            "skipping clarus channel account provisioning because the Holos account store is temporarily unavailable",
+            {
+              error: String(error),
+            },
+          )
+          return undefined
+        }
+        throw error
       })
       if (account) {
         const { HolosAuth } = await import("./auth")

--- a/packages/synergy/src/provider/api-key.ts
+++ b/packages/synergy/src/provider/api-key.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import path from "path"
 import z from "zod"
 import { ProviderAuthHealth } from "./auth-health"
+import { readFileWithRetry } from "../util/io-retry"
 
 export namespace Auth {
   const removalRevisions = new Map<string, number>()
@@ -271,9 +272,28 @@ export namespace Auth {
   }
 
   async function readStore(): Promise<Store> {
-    const file = Bun.file(filepath())
-    const raw = await file.json().catch(() => undefined)
-    const rawCredentials = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as any).credentials : undefined
+    let raw: string
+    try {
+      raw = await readFileWithRetry(filepath())
+    } catch (error) {
+      // A missing store is a fresh install; any other read failure must not
+      // be treated as an empty store, or a later write would wipe credentials.
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { schemaVersion: 2, credentials: {} }
+      }
+      throw error
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      parsed = undefined
+    }
+    const rawCredentials =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as { credentials?: unknown }).credentials
+        : undefined
     const credentials: Record<string, StoreEntry> = {}
     if (rawCredentials && typeof rawCredentials === "object" && !Array.isArray(rawCredentials)) {
       for (const [providerID, value] of Object.entries(rawCredentials)) {

--- a/packages/synergy/src/util/io-retry.ts
+++ b/packages/synergy/src/util/io-retry.ts
@@ -1,0 +1,39 @@
+import fs from "fs/promises"
+
+/**
+ * Transient filesystem errors that occur when another process briefly holds a
+ * file handle (Windows sharing violations, antivirus scans, OneDrive sync).
+ * Retrying is safe; a permanent permission or data error must not be masked.
+ */
+const RETRYABLE_CODES = new Set(["EPERM", "EACCES", "EBUSY"])
+
+export function isRetryableIOError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false
+  const code = (error as NodeJS.ErrnoException).code
+  return typeof code === "string" && RETRYABLE_CODES.has(code)
+}
+
+/**
+ * Read a file as UTF-8, retrying transient lock errors (EPERM/EACCES/EBUSY).
+ * Non-retryable errors (ENOENT, malformed content) and retry exhaustion
+ * propagate so callers keep fail-closed semantics instead of silently
+ * treating an unreadable store as empty.
+ */
+export async function readFileWithRetry(
+  file: string,
+  options?: { attempts?: number; delayMs?: number },
+): Promise<string> {
+  const attempts = Math.max(1, options?.attempts ?? 3)
+  const delayMs = Math.max(0, options?.delayMs ?? 100)
+  let lastError: unknown
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fs.readFile(file, "utf8")
+    } catch (error) {
+      lastError = error
+      if (!isRetryableIOError(error) || attempt === attempts) throw error
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  throw lastError
+}

--- a/packages/synergy/test/holos/accounts.test.ts
+++ b/packages/synergy/test/holos/accounts.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from "bun:test"
+import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach, spyOn } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import fs from "node:fs/promises"
@@ -298,5 +298,47 @@ describe("writeStore error handling", () => {
     const active = await HolosAccounts.getActiveAccount()
     expect(active!.agentId).toBe("ok_agent")
     expect(active!.agentSecret).toBe("secret_ok")
+  })
+})
+
+// ── Transient IO (EPERM) handling ────────────────────────────────────────
+
+describe("readStore transient IO error handling", () => {
+  function errnoError(code: string): NodeJS.ErrnoException {
+    return Object.assign(new Error(`injected ${code}`), { code })
+  }
+
+  test("transient EPERM during read is retried and then succeeds", async () => {
+    await HolosAccounts.saveAndActivateAccount("agent_ephemeral", "secret_ephemeral")
+
+    const realReadFile = fs.readFile
+    let calls = 0
+    const impl = (async (file: string) => {
+      calls++
+      if (calls === 1) throw errnoError("EPERM")
+      return realReadFile(file, "utf8")
+    }) as unknown as typeof fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation(impl)
+
+    const active = await HolosAccounts.getActiveAccount()
+    expect(calls).toBe(2)
+    expect(active!.agentId).toBe("agent_ephemeral")
+  })
+
+  test("persistent EPERM during read propagates and never wipes the store", async () => {
+    await HolosAccounts.saveAndActivateAccount("agent_persist", "secret_persist")
+    const before = await fs.readFile(accountsPath, "utf8")
+
+    const impl = (async () => {
+      throw errnoError("EPERM")
+    }) as unknown as typeof fs.readFile
+    {
+      using _read = spyOn(fs, "readFile").mockImplementation(impl)
+      await expect(HolosAccounts.getActiveAccount()).rejects.toMatchObject({ code: "EPERM" })
+    }
+
+    // The on-disk store must remain untouched.
+    const after = await fs.readFile(accountsPath, "utf8")
+    expect(after).toBe(before)
   })
 })

--- a/packages/synergy/test/holos/clarus-account-migration.test.ts
+++ b/packages/synergy/test/holos/clarus-account-migration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { Config } from "../../src/config/config"
@@ -207,5 +207,25 @@ describe.serial("Holos Clarus Channel account migration", () => {
     expect(status.pending).toEqual([])
     expect(second.upToDateDomains).toBe(1)
     expect((await Config.globalResolved()).channel?.clarus?.accounts.agent_existing).toEqual({ enabled: false })
+  })
+
+  test("skips provisioning when the Holos account store is temporarily unavailable", async () => {
+    await seedFeishuChannel()
+    await HolosAccounts.saveAndActivateAccount("agent_existing", "secret_existing")
+
+    const accountsPath = Global.Path.authHolosAccounts
+    const realReadFile = fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation((async (file: string) => {
+      if (file === accountsPath) {
+        throw Object.assign(new Error("injected EPERM"), { code: "EPERM" })
+      }
+      return realReadFile(file)
+    }) as unknown as typeof fs.readFile)
+
+    await runMigration()
+
+    const config = await Config.globalResolved()
+    expect(config.channel?.clarus).toBeUndefined()
+    expectFeishuChannel(config)
   })
 })

--- a/packages/synergy/test/provider/auth-store-io.test.ts
+++ b/packages/synergy/test/provider/auth-store-io.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, spyOn, test } from "bun:test"
+import fs from "node:fs/promises"
+import { Global } from "../../src/global"
+import { Auth } from "../../src/provider/api-key"
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`injected ${code}`), { code })
+}
+
+describe("Auth store transient IO error handling", () => {
+  const providerID = `auth-io-${Math.random().toString(36).slice(2)}`
+
+  afterAll(async () => {
+    await Auth.remove(providerID).catch(() => {})
+  })
+
+  test("transient EPERM during read retries and returns the stored credential", async () => {
+    await Auth.set(providerID, { type: "api", key: "stored-key" })
+
+    const realReadFile = fs.readFile
+    let calls = 0
+    const impl = (async (file: string) => {
+      calls++
+      if (calls === 1) throw errnoError("EPERM")
+      return realReadFile(file, "utf8")
+    }) as unknown as typeof fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation(impl)
+
+    const auth = await Auth.get(providerID)
+    expect(auth).toMatchObject({ type: "api", key: "stored-key" })
+    expect(calls).toBe(2)
+  })
+
+  test("persistent EPERM during read propagates and never wipes the store", async () => {
+    await Auth.set(providerID, { type: "api", key: "persist-key" })
+    const before = await fs.readFile(Global.Path.authProvider, "utf8")
+
+    const impl = (async () => {
+      throw errnoError("EPERM")
+    }) as unknown as typeof fs.readFile
+    {
+      using _read = spyOn(fs, "readFile").mockImplementation(impl)
+      await expect(Auth.get(providerID)).rejects.toMatchObject({ code: "EPERM" })
+    }
+
+    // The on-disk store must remain untouched: a failed read must never be
+    // followed by a write that wipes stored provider credentials.
+    const after = await fs.readFile(Global.Path.authProvider, "utf8")
+    expect(after).toBe(before)
+  })
+})

--- a/packages/synergy/test/util/io-retry.test.ts
+++ b/packages/synergy/test/util/io-retry.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, describe, expect, spyOn, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import fs from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { isRetryableIOError, readFileWithRetry } from "../../src/util/io-retry"
+
+const dir = mkdtempSync(join(tmpdir(), "io-retry-"))
+const target = join(dir, "store.json")
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`injected ${code}`), { code })
+}
+
+describe("readFileWithRetry", () => {
+  test("returns file content on success", async () => {
+    await fs.writeFile(target, "hello")
+    expect(await readFileWithRetry(target)).toBe("hello")
+  })
+
+  test("retries a transient EPERM and succeeds", async () => {
+    await fs.writeFile(target, "retried")
+    let calls = 0
+    const impl = (async () => {
+      calls++
+      if (calls === 1) throw errnoError("EPERM")
+      return "retried"
+    }) as unknown as typeof fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation(impl)
+    expect(await readFileWithRetry(target, { attempts: 3, delayMs: 0 })).toBe("retried")
+    expect(calls).toBe(2)
+  })
+
+  test("propagates after transient retries are exhausted", async () => {
+    await fs.writeFile(target, "content")
+    const impl = (async () => {
+      throw errnoError("EBUSY")
+    }) as unknown as typeof fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation(impl)
+    await expect(readFileWithRetry(target, { attempts: 2, delayMs: 0 })).rejects.toMatchObject({ code: "EBUSY" })
+  })
+
+  test("does not retry non-transient errors", async () => {
+    await fs.writeFile(target, "content")
+    let calls = 0
+    const impl = (async () => {
+      calls++
+      throw errnoError("ENOENT")
+    }) as unknown as typeof fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation(impl)
+    await expect(readFileWithRetry(target, { attempts: 3, delayMs: 0 })).rejects.toMatchObject({ code: "ENOENT" })
+    expect(calls).toBe(1)
+  })
+})
+
+describe("isRetryableIOError", () => {
+  test("classifies transient errno codes", () => {
+    for (const code of ["EPERM", "EACCES", "EBUSY"]) {
+      expect(isRetryableIOError(errnoError(code))).toBe(true)
+    }
+  })
+
+  test("rejects non-errno errors", () => {
+    expect(isRetryableIOError(new Error("boom"))).toBe(false)
+    expect(isRetryableIOError(undefined)).toBe(false)
+    expect(isRetryableIOError("EPERM")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

`synergy migration run` crashed on Windows with an unhandled `EPERM` while reading `holos-accounts.json` (a transient sharing violation when another process briefly holds the file). The Clarus provisioning migration only degraded on `MalformedStoreError`, so the errno error propagated and the fail-fast runner aborted the whole migration batch — and because `ensureMigrations` runs on server/daemon startup, the same failure could block application startup.

This change makes account-store reads resilient to transient IO errors and keeps best-effort migrations non-blocking:

- **New shared helper** `util/io-retry.ts`: retries `EPERM`/`EACCES`/`EBUSY` file reads (3 attempts) while leaving `ENOENT` and permanent errors fail-closed.
- **`HolosAccounts.readStore`**: uses the retry helper; a transient lock now succeeds on retry instead of crashing the run.
- **Migration `20260728-provision-clarus-channel-account`**: skips provisioning with a warning when the store is temporarily unreadable, matching its best-effort semantics (it already skipped on malformed store).
- **Migration `20260629-holos-account-profile-source-of-truth`**: label cleanup (decorative) degrades with a warning on transient write errors instead of aborting the run.
- **`Auth.readStore`**: no longer treats any read failure as an empty store — a failed read must never be followed by a write that wipes stored provider credentials. `ENOENT` still means fresh install; other errors propagate.

## Tests

Added regression coverage:

- `test/util/io-retry.test.ts` — retry helper behavior (success, transient retry, exhaustion, non-transient passthrough).
- `test/holos/accounts.test.ts` — transient EPERM retried then succeeds; persistent EPERM propagates without wiping the store.
- `test/holos/clarus-account-migration.test.ts` — provisioning skipped when the account store is temporarily unavailable.

Verified:

- `bun test test/util/io-retry.test.ts test/holos/accounts.test.ts test/holos/clarus-account-migration.test.ts` — 31 pass
- `bun test test/provider/ test/migration/` — 405 pass
- `bun run typecheck` (package) — pass
- `bun run lint` — 0 warnings, 0 errors
- `bun run quality:quick` — pass
- prettier — clean
