### PR TITLE
fix(app): let Escape reach editable workbench targets

### DIFF
--- a/packages/app/src/components/workspace/workbench-surface.tsx
+++ b/packages/app/src/components/workspace/workbench-surface.tsx
@@ -12,6 +12,7 @@ import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { useWorkbenchPanels } from "@/context/workbench"
 import {
   resolveWorkbenchEscapeAction,
+  isEditableEscapeTarget,
   isWorkbenchPanelLaunchable,
   workbenchPanelMountKey,
 } from "@/context/workbench/panel-model"
@@ -277,6 +278,7 @@ export function WorkbenchSurface(props: { surface: WorkbenchPanelSurface }) {
         opened: state().opened(),
         addOpen: local.addOpen,
         dialogActive: Boolean(dialog.active),
+        editableFocus: isEditableEscapeTarget(event.target),
       })
       if (action === "none") return
       event.preventDefault()

--- a/packages/app/src/context/workbench/panel-model.ts
+++ b/packages/app/src/context/workbench/panel-model.ts
@@ -38,9 +38,39 @@ export function resolveWorkbenchEscapeAction(input: {
   opened: boolean
   addOpen: boolean
   dialogActive: boolean
+  editableFocus?: boolean
 }): WorkbenchEscapeAction {
   if (input.key !== "Escape" || !input.opened || input.dialogActive) return "none"
+  if (input.editableFocus) return "none"
   return input.addOpen ? "close-add-menu" : "close-surface"
+}
+
+interface WorkbenchEscapeTarget {
+  tagName?: string
+  isContentEditable?: boolean
+  closest?: (selector: string) => Element | null
+}
+
+/**
+ * Whether an Escape keydown target should receive the key itself instead of
+ * the workbench surface closing. Matches the session page's protected-focus
+ * predicate: form controls, contentEditable regions, and elements inside a
+ * `[data-prevent-autofocus]` region (terminal and browser surfaces).
+ */
+export function isEditableEscapeTarget(target: unknown): boolean {
+  if (!target || typeof target !== "object") return false
+  const node = target as WorkbenchEscapeTarget
+  const tagName = typeof node.tagName === "string" ? node.tagName.toUpperCase() : ""
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") return true
+  if (node.isContentEditable === true) return true
+  if (typeof node.closest === "function") {
+    try {
+      return Boolean(node.closest("[data-prevent-autofocus]"))
+    } catch {
+      return false
+    }
+  }
+  return false
 }
 
 export function createWorkbenchTab(input: {

--- a/packages/app/test/context/workbench/panel-model.test.ts
+++ b/packages/app/test/context/workbench/panel-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { WorkbenchPanelTab } from "../../../src/plugin/registries/workbench-panel-registry"
 import {
   closeWorkbenchPanelTab,
+  isEditableEscapeTarget,
   isWorkbenchPanelLaunchable,
   moveWorkbenchPanelTab,
   openWorkbenchPanelTab,
@@ -286,6 +287,60 @@ describe("workbench Escape routing", () => {
     expect(resolveWorkbenchEscapeAction({ key: "Enter", opened: true, addOpen: false, dialogActive: false })).toBe(
       "none",
     )
+  })
+
+  test("lets Escape through to editable targets instead of closing the workspace", () => {
+    expect(
+      resolveWorkbenchEscapeAction({
+        key: "Escape",
+        opened: true,
+        addOpen: false,
+        dialogActive: false,
+        editableFocus: true,
+      }),
+    ).toBe("none")
+    expect(
+      resolveWorkbenchEscapeAction({
+        key: "Escape",
+        opened: true,
+        addOpen: true,
+        dialogActive: false,
+        editableFocus: true,
+      }),
+    ).toBe("none")
+  })
+})
+
+describe("isEditableEscapeTarget", () => {
+  test("treats form controls as editable", () => {
+    const input = document.createElement("input")
+    const textarea = document.createElement("textarea")
+    const select = document.createElement("select")
+    expect(isEditableEscapeTarget(input)).toBe(true)
+    expect(isEditableEscapeTarget(textarea)).toBe(true)
+    expect(isEditableEscapeTarget(select)).toBe(true)
+  })
+
+  test("treats contentEditable regions as editable", () => {
+    const editable = document.createElement("div")
+    editable.contentEditable = "true"
+    expect(isEditableEscapeTarget(editable)).toBe(true)
+  })
+
+  test("treats elements inside a protected region as editable", () => {
+    const protectedRoot = document.createElement("div")
+    protectedRoot.setAttribute("data-prevent-autofocus", "")
+    const child = document.createElement("span")
+    protectedRoot.appendChild(child)
+    expect(isEditableEscapeTarget(child)).toBe(true)
+    expect(isEditableEscapeTarget(protectedRoot)).toBe(true)
+  })
+
+  test("leaves ordinary targets untouched", () => {
+    const button = document.createElement("button")
+    expect(isEditableEscapeTarget(button)).toBe(false)
+    expect(isEditableEscapeTarget(null)).toBe(false)
+    expect(isEditableEscapeTarget(undefined)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

- The workbench surface intercepts `Escape` at the `document` capture phase to close the panel, so keys pressed while focus is inside the terminal (e.g. leaving vim insert mode) never reached the PTY and instead closed the whole bottom panel.
- Escape now defers to the focused element when it is a form control (`INPUT`/`TEXTAREA`/`SELECT`), a `contentEditable` region, or inside a `[data-prevent-autofocus]` region (terminal and browser surfaces) — matching the session page's existing protected-focus predicate.
- When the focus is not an editable target, the panel still closes on Escape as before.

## Changes

- `packages/app/src/context/workbench/panel-model.ts`: `resolveWorkbenchEscapeAction` gains an `editableFocus` dimension; new pure helper `isEditableEscapeTarget`.
- `packages/app/src/components/workspace/workbench-surface.tsx`: computes `editableFocus` from `event.target` before deciding.
- `packages/app/test/context/workbench/panel-model.test.ts`: contract tests for the new dimension and the target predicate.

## Verification

- `bun test test/context/workbench/panel-model.test.ts` — 24 pass
- `bun run --cwd packages/app test` — full App suite pass
- `bun run --cwd packages/app typecheck` — pass
- `bun run quality:quick` — pass (format, lint, skill-check, localization, typecheck, monorepo, package)