### PR TITLE
feat(app): add editable mode to the workspace Files panel

### DIFF
--- a/docs/architecture/workspace-and-files.md
+++ b/docs/architecture/workspace-and-files.md
@@ -27,7 +27,7 @@ The Settings worktree browser queries only Git project Scopes and keeps successf
 
 ## Web Workspace File Service
 
-The Web file workspace exposes scoped routes for directory children, file metadata, text/image preview, file/content/symbol search, and VCS status. Every path is resolved inside `ScopeContext.current.directory`. Lexical escapes, control characters, and symlinks whose real path escapes the workspace are denied.
+The Web file workspace exposes scoped routes for directory children, file metadata, text/image preview, file/content/symbol search, VCS status, and user-direct file writes. Every path is resolved inside `ScopeContext.current.directory`. Lexical escapes, control characters, and symlinks whose real path escapes the workspace are denied.
 
 Directory results can hide ignored and dot-prefixed entries, are sorted with directories first, and use bounded cursor pages. Reads distinguish:
 
@@ -47,7 +47,14 @@ File-result path enrichment has its own finite timeout and fails open to the com
 
 The classic debug file search is lazy and reuses this same bounded project index. Starting a project Scope does not launch a second fire-and-forget repository scan.
 
-The current public workspace-file routes are read/browse/search/status contracts. Agent write operations use the governed tool pipeline rather than an unguarded file-service write route.
+The current public workspace-file routes are read/browse/search/status contracts plus `POST /workspace/files/write` (operationId `workspace.files.write`), a user-direct edit channel. Writes are bounded by the same path rules as reads — lexical escapes, control characters, and symlinks whose real path escapes the workspace are denied — and additionally:
+
+- sensitive paths are rejected via `SensitivePathPolicy` in write mode (Git metadata and secret/credential files such as `.git`, `.env`, and credential stores are not editable)
+- the target file must already exist; read-only filesystem targets are refused
+- an optional `expectedMtime` optimistic lock rejects a concurrent on-disk change with 409 unless the caller opts into `conflictPolicy: "overwrite"`
+- content is capped at 8 MiB and parent-directory creation is opt-in via `createParents`
+
+A successful write invalidates the Git-status cache and the frontend refreshes through the filesystem watcher; no `file.edited` event is published. This route is the user editing their own workspace directly: it is profile-independent and bypasses the agent approval/sandbox pipeline, so path safety is enforced by the service itself rather than by execution policy. Agent write operations remain separate and use the governed tool pipeline (write/save_file tools with permission decisions, locking, events, formatting, and diagnostics), never this route.
 
 ## File Workbench Ownership and Bounds
 
@@ -109,7 +116,7 @@ Message rollback changes the effective transcript through history events. It doe
 
 - Scope owns project context; workspace owns the execution directory.
 - Worktree removal excludes new execution and binding use before it validates and migrates current bindings.
-- Web file routes never escape the active workspace, including through symlinks.
+- Web file routes never escape the active workspace, including through symlinks; user-direct writes additionally reject sensitive paths, read-only targets, and conflicting mtimes.
 - File workbench state and caches have one frontend owner and explicit concurrency/size bounds.
 - Tool reads and writes still cross execution-policy and sensitive-path checks.
 - Anchored tags prove a file snapshot; seen-line tracking proves the agent observed an edit range.

--- a/docs/architecture/workspace-and-files.md
+++ b/docs/architecture/workspace-and-files.md
@@ -49,10 +49,12 @@ The classic debug file search is lazy and reuses this same bounded project index
 
 The current public workspace-file routes are read/browse/search/status contracts plus `POST /workspace/files/write` (operationId `workspace.files.write`), a user-direct edit channel. Writes are bounded by the same path rules as reads — lexical escapes, control characters, and symlinks whose real path escapes the workspace are denied — and additionally:
 
-- sensitive paths are rejected via `SensitivePathPolicy` in write mode (Git metadata and secret/credential files such as `.git`, `.env`, and credential stores are not editable)
-- the target file must already exist; read-only filesystem targets are refused
+- sensitive paths are rejected via `SensitivePathPolicy` in write mode (Git metadata and secret/credential files such as `.git`, `.env`, and credential stores are not editable), and the check also runs against the resolved real path so a symlink whose target is a sensitive file cannot bypass it
+- the target must be an existing regular file; directories and read-only filesystem targets are refused
 - an optional `expectedMtime` optimistic lock rejects a concurrent on-disk change with 409 unless the caller opts into `conflictPolicy: "overwrite"`
 - content is capped at 8 MiB and parent-directory creation is opt-in via `createParents`
+
+Write failures use the same structured error shape as the rest of the API: `{ name, data: { message } }` with `WorkspaceFileAccessDeniedError` (403), `WorkspaceFileWriteConflictError` (409), `WorkspaceFileTooLargeError` (400), and `NotFoundError` (404).
 
 A successful write invalidates the Git-status cache and the frontend refreshes through the filesystem watcher; no `file.edited` event is published. This route is the user editing their own workspace directly: it is profile-independent and bypasses the agent approval/sandbox pipeline, so path safety is enforced by the service itself rather than by execution policy. Agent write operations remain separate and use the governed tool pipeline (write/save_file tools with permission decisions, locking, events, formatting, and diagnostics), never this route.
 

--- a/packages/app/src/components/file-workbench/content.tsx
+++ b/packages/app/src/components/file-workbench/content.tsx
@@ -2,16 +2,19 @@ import DOMPurify from "dompurify"
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { useLingui } from "@lingui/solid"
 import { FileIcon } from "@ericsanchezok/synergy-ui/file-icon"
+import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { IconButton } from "@ericsanchezok/synergy-ui/icon-button"
 import { Markdown } from "@ericsanchezok/synergy-ui/markdown"
 import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { useFile } from "@/context/file"
 import { usePrompt } from "@/context/prompt"
+import { isFileWriteConflictError, isFileWriteDeniedError } from "@/context/file/errors"
 import type { WorkbenchPanelContentProps } from "@/plugin/registries/workbench-panel-registry"
 import { FileExplorer } from "./explorer"
 import { classifyFilePreview, resolveWorkspaceRelativePath } from "./model"
-import { FileSourceView } from "./source-view"
+import { FileSourceView, type FileSourceViewApi } from "./source-view"
 import "./styles.css"
 import { fileWorkbench as F } from "@/locales/messages"
 import { useLocale } from "@/context/locale"
@@ -236,6 +239,68 @@ export function FileWorkbenchContent(props: WorkbenchPanelContentProps) {
   })
   const selectedLines = createMemo(() => file.view.selectedLines(path()))
   const breadcrumb = createMemo(() => path().split("/").filter(Boolean))
+  const [editing, setEditing] = createSignal(false)
+  const [dirty, setDirty] = createSignal(false)
+  const [saving, setSaving] = createSignal(false)
+  let sourceApi: FileSourceViewApi | undefined
+  const canEdit = createMemo(() => mode() === "source" && !!textContent())
+
+  async function runSave(overwrite = false) {
+    if (!sourceApi || saving()) return
+    setSaving(true)
+    try {
+      await file.save(path(), sourceApi.getContent(), { overwrite })
+      setDirty(false)
+      setEditing(false)
+      showToast({
+        type: "success",
+        title: lingui._({ id: F.saved.id, message: F.saved.message }),
+      })
+    } catch (error) {
+      if (isFileWriteConflictError(error)) {
+        showToast({
+          type: "warning",
+          title: lingui._({ id: F.saveConflict.id, message: F.saveConflict.message }),
+          description: lingui._({ id: F.saveConflictOverwrite.id, message: F.saveConflictOverwrite.message }),
+          actions: [
+            {
+              label: lingui._({ id: F.overwrite.id, message: F.overwrite.message }),
+              onClick: () => void runSave(true),
+            },
+            { label: lingui._({ id: F.dismiss.id, message: F.dismiss.message }), onClick: "dismiss" },
+          ],
+        })
+      } else if (isFileWriteDeniedError(error)) {
+        showToast({
+          type: "error",
+          title: lingui._({ id: F.saveDenied.id, message: F.saveDenied.message }),
+          description: error instanceof Error ? error.message : undefined,
+        })
+      } else {
+        showToast({
+          type: "error",
+          title: lingui._({ id: F.saveFailed.id, message: F.saveFailed.message }),
+          description: error instanceof Error ? error.message : undefined,
+        })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function startEdit() {
+    if (editing()) return
+    setDirty(false)
+    setEditing(true)
+  }
+
+  function cancelEdit() {
+    if (!editing()) return
+    const value = textContent()
+    if (value) sourceApi?.applyContent(value.content)
+    setDirty(false)
+    setEditing(false)
+  }
 
   createEffect(() => {
     if (!path()) return
@@ -244,6 +309,12 @@ export function FileWorkbenchContent(props: WorkbenchPanelContentProps) {
 
   onMount(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        if (!editing()) return
+        event.preventDefault()
+        void runSave()
+        return
+      }
       if (!(event.metaKey || event.ctrlKey) || !event.shiftKey || event.key.toLowerCase() !== "v") return
       if (!capability().dual) return
       event.preventDefault()
@@ -334,6 +405,47 @@ export function FileWorkbenchContent(props: WorkbenchPanelContentProps) {
               </button>
             </div>
           </Show>
+          <Show when={canEdit()}>
+            <Show
+              when={!editing()}
+              fallback={
+                <>
+                  <button
+                    type="button"
+                    class="file-edit-pill file-edit-pill--save"
+                    disabled={saving() || !dirty()}
+                    onClick={() => void runSave()}
+                  >
+                    <Icon name={getSemanticIcon("state.success")} size="small" />
+                    <span>
+                      {saving()
+                        ? lingui._({ id: F.saving.id, message: F.saving.message })
+                        : lingui._({ id: F.save.id, message: F.save.message })}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    class="file-edit-pill"
+                    disabled={saving()}
+                    onClick={cancelEdit}
+                    aria-label={lingui._({ id: F.discard.id, message: F.discard.message })}
+                  >
+                    <Icon name={getSemanticIcon("action.clear")} size="small" />
+                  </button>
+                </>
+              }
+            >
+              <button
+                type="button"
+                class="file-edit-pill"
+                classList={{ "file-edit-pill--active": editing() }}
+                onClick={startEdit}
+              >
+                <Icon name={getSemanticIcon("action.rename")} size="small" />
+                <span>{lingui._({ id: F.edit.id, message: F.edit.message })}</span>
+              </button>
+            </Show>
+          </Show>
           <IconButton
             icon={getSemanticIcon("workspace.files")}
             variant="ghost"
@@ -389,7 +501,17 @@ export function FileWorkbenchContent(props: WorkbenchPanelContentProps) {
               )}
             </Match>
             <Match when={mode() === "source" ? textContent() : undefined}>
-              {(value) => <FileSourceView path={path()} content={value().content} />}
+              {(value) => (
+                <FileSourceView
+                  path={path()}
+                  content={value().content}
+                  editable={editing()}
+                  onDirtyChange={setDirty}
+                  onRegister={(api) => {
+                    sourceApi = api
+                  }}
+                />
+              )}
             </Match>
             <Match when={capability().kind === "markdown" ? textContent() : undefined}>
               {(value) => <MarkdownPreview path={path()} content={value().content} />}

--- a/packages/app/src/components/file-workbench/content.tsx
+++ b/packages/app/src/components/file-workbench/content.tsx
@@ -10,7 +10,7 @@ import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { useFile } from "@/context/file"
 import { usePrompt } from "@/context/prompt"
-import { isFileWriteConflictError, isFileWriteDeniedError } from "@/context/file/errors"
+import { fileWriteErrorMessage, isFileWriteConflictError, isFileWriteDeniedError } from "@/context/file/errors"
 import type { WorkbenchPanelContentProps } from "@/plugin/registries/workbench-panel-registry"
 import { FileExplorer } from "./explorer"
 import { classifyFilePreview, resolveWorkspaceRelativePath } from "./model"
@@ -243,7 +243,7 @@ export function FileWorkbenchContent(props: WorkbenchPanelContentProps) {
   const [dirty, setDirty] = createSignal(false)
   const [saving, setSaving] = createSignal(false)
   let sourceApi: FileSourceViewApi | undefined
-  const canEdit = createMemo(() => mode() === "source" && !!textContent())
+  const canEdit = createMemo(() => mode() === "source" && !!textContent() && textContent()?.truncationReason !== "size")
 
   async function runSave(overwrite = false) {
     if (!sourceApi || saving()) return
@@ -274,13 +274,13 @@ export function FileWorkbenchContent(props: WorkbenchPanelContentProps) {
         showToast({
           type: "error",
           title: lingui._({ id: F.saveDenied.id, message: F.saveDenied.message }),
-          description: error instanceof Error ? error.message : undefined,
+          description: fileWriteErrorMessage(error),
         })
       } else {
         showToast({
           type: "error",
           title: lingui._({ id: F.saveFailed.id, message: F.saveFailed.message }),
-          description: error instanceof Error ? error.message : undefined,
+          description: fileWriteErrorMessage(error),
         })
       }
     } finally {

--- a/packages/app/src/components/file-workbench/source-view.tsx
+++ b/packages/app/src/components/file-workbench/source-view.tsx
@@ -234,7 +234,11 @@ export function FileSourceView(props: {
   })
 
   createEffect(() => {
-    editor?.updateOptions({ readOnly: !props.editable, domReadOnly: !props.editable })
+    // Read `props.editable` unconditionally: when `editor` is still undefined the
+    // optional chain below short-circuits, and Solid must still track the prop so
+    // the effect re-runs once Monaco exists and the edit toggle changes.
+    const editable = props.editable
+    editor?.updateOptions({ readOnly: !editable, domReadOnly: !editable })
   })
 
   createEffect(() => {

--- a/packages/app/src/components/file-workbench/source-view.tsx
+++ b/packages/app/src/components/file-workbench/source-view.tsx
@@ -98,7 +98,18 @@ function defineSourceTheme(monaco: Monaco, tokens: ResolvedTheme, mode: "light" 
   return theme
 }
 
-export function FileSourceView(props: { path: string; content: string }) {
+export type FileSourceViewApi = {
+  getContent: () => string
+  applyContent: (content: string) => void
+}
+
+export function FileSourceView(props: {
+  path: string
+  content: string
+  editable?: boolean
+  onDirtyChange?: (dirty: boolean) => void
+  onRegister?: (api: FileSourceViewApi) => void
+}) {
   const file = useFile()
   const sdk = useSDK()
   const theme = useTheme()
@@ -108,8 +119,9 @@ export function FileSourceView(props: { path: string; content: string }) {
   let monacoInstance: Monaco | undefined
   let editor: import("monaco-editor").editor.IStandaloneCodeEditor | undefined
   let disposed = false
-  let currentContent = props.content
   let handleFontChange: ((event: Event) => void) | undefined
+  let baseline = props.content
+  const [dirty, setDirty] = createSignal(false)
 
   onMount(() => {
     handleFontChange = (event: Event) => {
@@ -138,8 +150,8 @@ export function FileSourceView(props: { path: string; content: string }) {
       editor = monaco.editor.create(host, {
         model: cached.model,
         theme: sourceTheme,
-        readOnly: true,
-        domReadOnly: true,
+        readOnly: !props.editable,
+        domReadOnly: !props.editable,
         minimap: { enabled: false },
         automaticLayout: true,
         folding: true,
@@ -199,18 +211,42 @@ export function FileSourceView(props: { path: string; content: string }) {
         })
       })
       editor.onDidBlurEditorText(() => textSelectionController.update(undefined))
+      const modelRef = cached.model
+      modelRef.onDidChangeContent(() => {
+        const next = modelRef.getValue() !== baseline
+        setDirty(next)
+        props.onDirtyChange?.(next)
+      })
+      props.onRegister?.({
+        getContent: () => modelRef.getValue(),
+        applyContent: (content: string) => {
+          baseline = content
+          const state = editor?.saveViewState()
+          modelRef.setValue(content)
+          setDirty(false)
+          props.onDirtyChange?.(false)
+          if (state) editor?.restoreViewState(state)
+        },
+      })
       pruneFileSourceModels(key)
       setLoading(false)
     })
   })
 
   createEffect(() => {
-    if (props.content === currentContent) return
-    currentContent = props.content
+    editor?.updateOptions({ readOnly: !props.editable, domReadOnly: !props.editable })
+  })
+
+  createEffect(() => {
+    if (props.content === baseline) return
+    baseline = props.content
     const model = editor?.getModel()
     if (!model || model.getValue() === props.content) return
+    if (dirty()) return
     const state = editor?.saveViewState()
     model.setValue(props.content)
+    setDirty(false)
+    props.onDirtyChange?.(false)
     if (state) editor?.restoreViewState(state)
   })
 

--- a/packages/app/src/components/file-workbench/styles.css
+++ b/packages/app/src/components/file-workbench/styles.css
@@ -313,6 +313,55 @@
   cursor: grab;
 }
 
+.file-edit-pill {
+  display: inline-flex;
+  height: 26px;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--border-weak-base);
+  border-radius: 999px;
+  padding: 0 11px;
+  margin-right: 3px;
+  background: var(--surface-raised-base);
+  color: var(--text-base);
+  font-size: 12px;
+  font-weight: 550;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.file-edit-pill:hover:not(:disabled) {
+  background: var(--surface-raised-base-hover);
+  color: var(--text-strong);
+}
+
+.file-edit-pill:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.file-edit-pill--active {
+  border-color: var(--border-focus);
+  background: var(--surface-raised-base-hover);
+  color: var(--text-strong);
+}
+
+.file-edit-pill--save {
+  border-color: var(--border-focus);
+  background: var(--surface-info-base);
+  color: var(--text-strong);
+}
+
+.file-edit-pill--save:hover:not(:disabled) {
+  background: var(--surface-info-base);
+  color: var(--text-strong);
+}
+
+.file-edit-pill svg {
+  flex-shrink: 0;
+}
 .file-explorer {
   position: relative;
   display: flex;

--- a/packages/app/src/context/file/errors.ts
+++ b/packages/app/src/context/file/errors.ts
@@ -2,6 +2,18 @@ export function isWorkspaceFileNotFoundError(input: unknown): boolean {
   return !!input && typeof input === "object" && "name" in input && input.name === "NotFoundError"
 }
 
+export function isFileWriteConflictError(input: unknown): boolean {
+  if (!(input instanceof Error) || input.name !== "APIError") return false
+  const data = (input as { data?: { statusCode?: number } }).data
+  return data?.statusCode === 409
+}
+
+export function isFileWriteDeniedError(input: unknown): boolean {
+  if (!(input instanceof Error) || input.name !== "APIError") return false
+  const data = (input as { data?: { statusCode?: number } }).data
+  return data?.statusCode === 403
+}
+
 export function removePathTree(paths: string[], missingPath: string): string[] {
   return paths.filter((path) => path !== missingPath && !path.startsWith(missingPath + "/"))
 }

--- a/packages/app/src/context/file/errors.ts
+++ b/packages/app/src/context/file/errors.ts
@@ -3,15 +3,19 @@ export function isWorkspaceFileNotFoundError(input: unknown): boolean {
 }
 
 export function isFileWriteConflictError(input: unknown): boolean {
-  if (!(input instanceof Error) || input.name !== "APIError") return false
-  const data = (input as { data?: { statusCode?: number } }).data
-  return data?.statusCode === 409
+  return !!input && typeof input === "object" && "name" in input && input.name === "WorkspaceFileWriteConflictError"
 }
 
 export function isFileWriteDeniedError(input: unknown): boolean {
-  if (!(input instanceof Error) || input.name !== "APIError") return false
-  const data = (input as { data?: { statusCode?: number } }).data
-  return data?.statusCode === 403
+  return !!input && typeof input === "object" && "name" in input && input.name === "WorkspaceFileAccessDeniedError"
+}
+
+export function fileWriteErrorMessage(input: unknown): string | undefined {
+  if (!input || typeof input !== "object" || input instanceof Error) return undefined
+  const candidate = input as { data?: { message?: unknown }; message?: unknown }
+  if (candidate.data && typeof candidate.data.message === "string") return candidate.data.message
+  if (typeof candidate.message === "string") return candidate.message
+  return undefined
 }
 
 export function removePathTree(paths: string[], missingPath: string): string[] {

--- a/packages/app/src/context/file/index.tsx
+++ b/packages/app/src/context/file/index.tsx
@@ -760,6 +760,30 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
           .then((response) =>
             (response.data?.items ?? []).filter((item) => item.kind === "file").map((item) => item.path),
           ),
+      save: async (input: string, content: string, options?: { overwrite?: boolean }) => {
+        const path = normalize(input)
+        if (!path) throw new Error("Invalid file path")
+        const document = store.documents[path]
+        const expectedMtime = document?.version?.mtime
+        const response = await sdk.client.workspace.files.write({
+          workspaceFileWriteFileInput: {
+            path,
+            content,
+            expectedMtime,
+            conflictPolicy: options?.overwrite ? "overwrite" : "fail",
+          },
+        })
+        const result = response.data
+        if (!result) throw new Error("The server returned an empty write response")
+        setStore(
+          "documents",
+          path,
+          produce((draft) => {
+            draft.version = { mtime: result.mtime, size: result.size }
+          }),
+        )
+        return result
+      },
     }
   },
 })

--- a/packages/app/src/context/file/index.tsx
+++ b/packages/app/src/context/file/index.tsx
@@ -779,7 +779,19 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
           "documents",
           path,
           produce((draft) => {
+            if (draft.content?.kind === "text") {
+              draft.content = {
+                ...draft.content,
+                content,
+                truncated: false,
+                truncationReason: undefined,
+                totalBytes: result.size,
+                lineCount: content.split(/\r?\n/).length,
+              }
+            }
             draft.version = { mtime: result.mtime, size: result.size }
+            draft.stale = false
+            draft.error = undefined
           }),
         )
         return result

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -2227,6 +2227,14 @@ msgid "app.file.action.close"
 msgstr "Close"
 
 #. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.action.dismiss"
+msgstr "Dismiss"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.action.overwrite"
+msgstr "Overwrite"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.action.retry"
 msgstr "Retry"
 
@@ -2287,8 +2295,44 @@ msgid "app.file.mode.source"
 msgstr "Source"
 
 #. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveConflict"
+msgstr "File changed on disk"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveConflictOverwrite"
+msgstr "The file was modified elsewhere since it was loaded. Overwrite it with your changes?"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saved"
+msgstr "File saved"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveDenied"
+msgstr "This file cannot be edited"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveFailed"
+msgstr "Failed to save file"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.toolbar.addToContext"
 msgstr "Add to context"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.discard"
+msgstr "Discard"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.edit"
+msgstr "Edit"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.save"
+msgstr "Save"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.saving"
+msgstr "Saving…"
 
 #. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.toolbar.toggleFileTree"

--- a/packages/app/src/locales/messages.ts
+++ b/packages/app/src/locales/messages.ts
@@ -361,6 +361,20 @@ export const fileWorkbench = {
   zoomIn: { id: "app.file.image.zoomIn", message: "Zoom in" },
   fit: { id: "app.file.image.fit", message: "Fit" },
   loadingSourceViewer: { id: "app.file.loading.sourceViewer", message: "Loading source viewer…" },
+  edit: { id: "app.file.toolbar.edit", message: "Edit" },
+  save: { id: "app.file.toolbar.save", message: "Save" },
+  saving: { id: "app.file.toolbar.saving", message: "Saving…" },
+  discard: { id: "app.file.toolbar.discard", message: "Discard" },
+  saved: { id: "app.file.toast.saved", message: "File saved" },
+  saveConflict: { id: "app.file.toast.saveConflict", message: "File changed on disk" },
+  saveConflictOverwrite: {
+    id: "app.file.toast.saveConflictOverwrite",
+    message: "The file was modified elsewhere since it was loaded. Overwrite it with your changes?",
+  },
+  overwrite: { id: "app.file.action.overwrite", message: "Overwrite" },
+  dismiss: { id: "app.file.action.dismiss", message: "Dismiss" },
+  saveDenied: { id: "app.file.toast.saveDenied", message: "This file cannot be edited" },
+  saveFailed: { id: "app.file.toast.saveFailed", message: "Failed to save file" },
 } as const satisfies Record<string, AppMessageDescriptor>
 
 export const attachmentWorkbench = {

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -2227,6 +2227,14 @@ msgid "app.file.action.close"
 msgstr ""
 
 #. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.action.dismiss"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.action.overwrite"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.action.retry"
 msgstr ""
 
@@ -2287,7 +2295,43 @@ msgid "app.file.mode.source"
 msgstr ""
 
 #. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveConflict"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveConflictOverwrite"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saved"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveDenied"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveFailed"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.toolbar.addToContext"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.discard"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.edit"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.save"
+msgstr ""
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.saving"
 msgstr ""
 
 #. ── File workbench ───────────────────────────────────────────────────────────

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -2227,6 +2227,14 @@ msgid "app.file.action.close"
 msgstr "关闭"
 
 #. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.action.dismiss"
+msgstr "关闭"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.action.overwrite"
+msgstr "覆盖"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.action.retry"
 msgstr "重试"
 
@@ -2287,8 +2295,44 @@ msgid "app.file.mode.source"
 msgstr "源码"
 
 #. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveConflict"
+msgstr "文件已在磁盘上被修改"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveConflictOverwrite"
+msgstr "文件自加载以来已被其他位置修改。要用你的更改覆盖它吗？"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saved"
+msgstr "文件已保存"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveDenied"
+msgstr "此文件无法编辑"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toast.saveFailed"
+msgstr "保存文件失败"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.toolbar.addToContext"
 msgstr "添加到上下文"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.discard"
+msgstr "放弃"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.edit"
+msgstr "编辑"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.save"
+msgstr "保存"
+
+#. ── File workbench ───────────────────────────────────────────────────────────
+msgid "app.file.toolbar.saving"
+msgstr "保存中…"
 
 #. ── File workbench ───────────────────────────────────────────────────────────
 msgid "app.file.toolbar.toggleFileTree"

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -961,7 +961,13 @@ function SessionPageContent() {
     const activeElement = document.activeElement as HTMLElement | undefined
     if (activeElement) {
       const isProtected = activeElement.closest("[data-prevent-autofocus]")
-      const isInput = /^(INPUT|TEXTAREA|SELECT)$/.test(activeElement.tagName) || activeElement.isContentEditable
+      // Monaco's native EditContext input is a div with role="textbox" (not a
+      // TEXTAREA and not contenteditable); treat any textbox role as an input
+      // so type-anywhere does not steal focus from the file editor.
+      const isInput =
+        /^(INPUT|TEXTAREA|SELECT)$/.test(activeElement.tagName) ||
+        activeElement.isContentEditable ||
+        activeElement.getAttribute("role") === "textbox"
       if (isProtected || isInput) return
     }
     if (dialog.active) return

--- a/packages/app/test/context/file/errors.test.ts
+++ b/packages/app/test/context/file/errors.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { isWorkspaceFileNotFoundError, removePathTree } from "../../../src/context/file/errors"
+import {
+  fileWriteErrorMessage,
+  isFileWriteConflictError,
+  isFileWriteDeniedError,
+  isWorkspaceFileNotFoundError,
+  removePathTree,
+} from "../../../src/context/file/errors"
 
 describe("workspace file missing-resource recovery", () => {
   test("recognizes SDK not-found response objects", () => {
@@ -12,5 +18,36 @@ describe("workspace file missing-resource recovery", () => {
       "catalog",
       "src",
     ])
+  })
+})
+
+describe("workspace file write error detection", () => {
+  test("recognizes structured write conflict responses", () => {
+    expect(
+      isFileWriteConflictError({ name: "WorkspaceFileWriteConflictError", data: { message: "changed on disk" } }),
+    ).toBe(true)
+    expect(isFileWriteConflictError({ name: "WorkspaceFileAccessDeniedError", data: { message: "denied" } })).toBe(
+      false,
+    )
+    expect(isFileWriteConflictError(new Error("changed on disk"))).toBe(false)
+  })
+
+  test("recognizes structured write denial responses", () => {
+    expect(isFileWriteDeniedError({ name: "WorkspaceFileAccessDeniedError", data: { message: "not editable" } })).toBe(
+      true,
+    )
+    expect(
+      isFileWriteDeniedError({ name: "WorkspaceFileWriteConflictError", data: { message: "changed on disk" } }),
+    ).toBe(false)
+    expect(isFileWriteDeniedError(new Error("not editable"))).toBe(false)
+  })
+
+  test("extracts the message from structured error responses", () => {
+    expect(fileWriteErrorMessage({ name: "WorkspaceFileAccessDeniedError", data: { message: "denied" } })).toBe(
+      "denied",
+    )
+    expect(fileWriteErrorMessage({ message: "plain message" })).toBe("plain message")
+    expect(fileWriteErrorMessage(new Error("plain"))).toBeUndefined()
+    expect(fileWriteErrorMessage(undefined)).toBeUndefined()
   })
 })

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -558,6 +558,9 @@ import type {
   WorkspaceFilesStatErrors,
   WorkspaceFilesStatResponses,
   WorkspaceFilesStatusResponses,
+  WorkspaceFilesWriteErrors,
+  WorkspaceFilesWriteResponses,
+  WorkspaceFileWriteFileInput,
   WorktreeCreateErrors,
   WorktreeCreateInput,
   WorktreeCreateResponses,
@@ -1447,6 +1450,45 @@ export class Files extends HeyApiClient {
       ...options,
       ...params,
     })
+  }
+
+  /**
+   * Write workspace file
+   *
+   * Write content to an existing workspace file with optional optimistic concurrency control.
+   */
+  public write<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      scopeID?: string
+      workspaceFileWriteFileInput?: WorkspaceFileWriteFileInput
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "scopeID" },
+            { key: "workspaceFileWriteFileInput", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<WorkspaceFilesWriteResponses, WorkspaceFilesWriteErrors, ThrowOnError>(
+      {
+        url: "/workspace/files/write",
+        ...options,
+        ...params,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+          ...params.headers,
+        },
+      },
+    )
   }
 }
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -6326,6 +6326,26 @@ export type WorkspaceFileStatusSummary = {
   }>
 }
 
+export type WorkspaceFileWriteResult = {
+  path: string
+  mtime: number
+  size: number
+  existed: boolean
+}
+
+export type ForbiddenError = {
+  message: string
+}
+
+export type WorkspaceFileWriteFileInput = {
+  path: string
+  content: string
+  encoding?: "utf-8" | "base64"
+  createParents?: boolean
+  conflictPolicy?: "fail" | "overwrite"
+  expectedMtime?: number
+}
+
 export type EmbeddingStatus =
   | {
       mode: "local"
@@ -13646,6 +13666,46 @@ export type WorkspaceFilesStatusResponses = {
 
 export type WorkspaceFilesStatusResponse = WorkspaceFilesStatusResponses[keyof WorkspaceFilesStatusResponses]
 
+export type WorkspaceFilesWriteData = {
+  body?: WorkspaceFileWriteFileInput
+  path?: never
+  query?: {
+    directory?: string
+    scopeID?: string
+  }
+  url: "/workspace/files/write"
+}
+
+export type WorkspaceFilesWriteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Forbidden
+   */
+  403: ForbiddenError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Conflict
+   */
+  409: NoteConflictError
+}
+
+export type WorkspaceFilesWriteError = WorkspaceFilesWriteErrors[keyof WorkspaceFilesWriteErrors]
+
+export type WorkspaceFilesWriteResponses = {
+  /**
+   * Workspace file write result
+   */
+  200: WorkspaceFileWriteResult
+}
+
+export type WorkspaceFilesWriteResponse = WorkspaceFilesWriteResponses[keyof WorkspaceFilesWriteResponses]
+
 export type LibraryEmbeddingStatusData = {
   body?: never
   path?: never
@@ -16895,6 +16955,10 @@ export type PluginInvokeOperationErrors = {
    * Bad request
    */
   400: BadRequestError
+  /**
+   * Forbidden
+   */
+  403: ForbiddenError
   /**
    * Not found
    */

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -6333,8 +6333,11 @@ export type WorkspaceFileWriteResult = {
   existed: boolean
 }
 
-export type ForbiddenError = {
-  message: string
+export type WorkspaceFileWriteError = {
+  name: "WorkspaceFileAccessDeniedError" | "WorkspaceFileWriteConflictError" | "WorkspaceFileTooLargeError"
+  data: {
+    message: string
+  }
 }
 
 export type WorkspaceFileWriteFileInput = {
@@ -7526,6 +7529,10 @@ export type BrowserControlRequest = {
       }
   commandId: string
   traceId?: string
+}
+
+export type ForbiddenError = {
+  message: string
 }
 
 export type PluginConfigUpdate = {
@@ -13680,11 +13687,11 @@ export type WorkspaceFilesWriteErrors = {
   /**
    * Bad request
    */
-  400: BadRequestError
+  400: WorkspaceFileWriteError
   /**
    * Forbidden
    */
-  403: ForbiddenError
+  403: WorkspaceFileWriteError
   /**
    * Not found
    */
@@ -13692,7 +13699,7 @@ export type WorkspaceFilesWriteErrors = {
   /**
    * Conflict
    */
-  409: NoteConflictError
+  409: WorkspaceFileWriteError
 }
 
 export type WorkspaceFilesWriteError = WorkspaceFilesWriteErrors[keyof WorkspaceFilesWriteErrors]

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10723,6 +10723,96 @@
         ]
       }
     },
+    "/workspace/files/write": {
+      "post": {
+        "operationId": "workspace.files.write",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scopeID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Write workspace file",
+        "description": "Write content to an existing workspace file with optional optimistic concurrency control.",
+        "responses": {
+          "200": {
+            "description": "Workspace file write result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceFileWriteResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoteConflictError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceFileWriteFileInput"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createSynergyClient } from \"@ericsanchezok/synergy-sdk\"\n\nconst client = createSynergyClient()\nawait client.workspace.files.write({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/library/embedding/status": {
       "get": {
         "operationId": "library.embedding.status",
@@ -17599,6 +17689,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenError"
                 }
               }
             }
@@ -36948,6 +37048,66 @@
           }
         },
         "required": ["files"]
+      },
+      "WorkspaceFileWriteResult": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "mtime": {
+            "type": "number",
+            "minimum": 0
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "existed": {
+            "type": "boolean"
+          }
+        },
+        "required": ["path", "mtime", "size", "existed"]
+      },
+      "ForbiddenError": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["message"]
+      },
+      "WorkspaceFileWriteFileInput": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "encoding": {
+            "default": "utf-8",
+            "type": "string",
+            "enum": ["utf-8", "base64"]
+          },
+          "createParents": {
+            "default": false,
+            "type": "boolean"
+          },
+          "conflictPolicy": {
+            "default": "fail",
+            "type": "string",
+            "enum": ["fail", "overwrite"]
+          },
+          "expectedMtime": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": ["path", "content"]
       },
       "EmbeddingStatus": {
         "anyOf": [

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10760,7 +10760,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
+                  "$ref": "#/components/schemas/WorkspaceFileWriteError"
                 }
               }
             }
@@ -10770,7 +10770,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ForbiddenError"
+                  "$ref": "#/components/schemas/WorkspaceFileWriteError"
                 }
               }
             }
@@ -10790,7 +10790,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NoteConflictError"
+                  "$ref": "#/components/schemas/WorkspaceFileWriteError"
                 }
               }
             }
@@ -37070,14 +37070,24 @@
         },
         "required": ["path", "mtime", "size", "existed"]
       },
-      "ForbiddenError": {
+      "WorkspaceFileWriteError": {
         "type": "object",
         "properties": {
-          "message": {
-            "type": "string"
+          "name": {
+            "type": "string",
+            "enum": ["WorkspaceFileAccessDeniedError", "WorkspaceFileWriteConflictError", "WorkspaceFileTooLargeError"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": ["message"]
           }
         },
-        "required": ["message"]
+        "required": ["name", "data"]
       },
       "WorkspaceFileWriteFileInput": {
         "type": "object",
@@ -40788,6 +40798,15 @@
         },
         "required": ["protocolVersion", "command", "commandId"],
         "additionalProperties": false
+      },
+      "ForbiddenError": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["message"]
       },
       "PluginConfigUpdate": {
         "type": "object",

--- a/packages/synergy/src/server/error.ts
+++ b/packages/synergy/src/server/error.ts
@@ -17,12 +17,26 @@ export const ServiceUnavailableError = z
   })
   .meta({ ref: "ServiceUnavailableError" })
 
+export const ForbiddenError = z
+  .object({
+    message: z.string(),
+  })
+  .meta({ ref: "ForbiddenError" })
+
 export const ERRORS = {
   400: {
     description: "Bad request",
     content: {
       "application/json": {
         schema: resolver(BadRequestError),
+      },
+    },
+  },
+  403: {
+    description: "Forbidden",
+    content: {
+      "application/json": {
+        schema: resolver(ForbiddenError),
       },
     },
   },

--- a/packages/synergy/src/server/workspace-files.ts
+++ b/packages/synergy/src/server/workspace-files.ts
@@ -198,3 +198,35 @@ export const WorkspaceFilesRoute = new Hono()
       return c.json(await WorkspaceFileStatus.summary())
     },
   )
+  .post(
+    "/write",
+    describeRoute({
+      summary: "Write workspace file",
+      description: "Write content to an existing workspace file with optional optimistic concurrency control.",
+      operationId: "workspace.files.write",
+      responses: {
+        200: {
+          description: "Workspace file write result",
+          content: {
+            "application/json": {
+              schema: resolver(WorkspaceFile.WriteFileResult),
+            },
+          },
+        },
+        ...errors(400, 404, 409, 403),
+      },
+    }),
+    validator("json", WorkspaceFile.WriteFileInput),
+    async (c) => {
+      const body = c.req.valid("json")
+      try {
+        return c.json(await WorkspaceFileService.write(body))
+      } catch (err: any) {
+        if (err instanceof WorkspaceFileService.AccessDeniedError) return c.json({ message: err.message }, 403)
+        if (err instanceof WorkspaceFileService.WriteConflictError) return c.json({ message: err.message }, 409)
+        if (err instanceof WorkspaceFileService.NotFoundError) return c.json({ message: err.message }, 404)
+        if (err instanceof WorkspaceFileService.TooLargeError) return c.json({ message: err.message }, 400)
+        throw err
+      }
+    },
+  )

--- a/packages/synergy/src/server/workspace-files.ts
+++ b/packages/synergy/src/server/workspace-files.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
 import z from "zod"
+import { Storage } from "../storage/storage"
 import { WorkspaceFile } from "../workspace-file/types"
 import { WorkspaceFileSearch } from "../workspace-file/search"
 import { WorkspaceFileService } from "../workspace-file/service"
@@ -213,7 +214,38 @@ export const WorkspaceFilesRoute = new Hono()
             },
           },
         },
-        ...errors(400, 404, 409, 403),
+        400: {
+          description: "Bad request",
+          content: {
+            "application/json": {
+              schema: resolver(WorkspaceFile.WriteFileError),
+            },
+          },
+        },
+        403: {
+          description: "Forbidden",
+          content: {
+            "application/json": {
+              schema: resolver(WorkspaceFile.WriteFileError),
+            },
+          },
+        },
+        404: {
+          description: "Not found",
+          content: {
+            "application/json": {
+              schema: resolver(Storage.NotFoundError.Schema),
+            },
+          },
+        },
+        409: {
+          description: "Conflict",
+          content: {
+            "application/json": {
+              schema: resolver(WorkspaceFile.WriteFileError),
+            },
+          },
+        },
       },
     }),
     validator("json", WorkspaceFile.WriteFileInput),
@@ -222,10 +254,18 @@ export const WorkspaceFilesRoute = new Hono()
       try {
         return c.json(await WorkspaceFileService.write(body))
       } catch (err: any) {
-        if (err instanceof WorkspaceFileService.AccessDeniedError) return c.json({ message: err.message }, 403)
-        if (err instanceof WorkspaceFileService.WriteConflictError) return c.json({ message: err.message }, 409)
-        if (err instanceof WorkspaceFileService.NotFoundError) return c.json({ message: err.message }, 404)
-        if (err instanceof WorkspaceFileService.TooLargeError) return c.json({ message: err.message }, 400)
+        if (err instanceof WorkspaceFileService.AccessDeniedError) {
+          return c.json({ name: "WorkspaceFileAccessDeniedError", data: { message: err.message } }, 403)
+        }
+        if (err instanceof WorkspaceFileService.WriteConflictError) {
+          return c.json({ name: "WorkspaceFileWriteConflictError", data: { message: err.message } }, 409)
+        }
+        if (err instanceof WorkspaceFileService.NotFoundError) {
+          return c.json({ name: "NotFoundError", data: { message: err.message } }, 404)
+        }
+        if (err instanceof WorkspaceFileService.TooLargeError) {
+          return c.json({ name: "WorkspaceFileTooLargeError", data: { message: err.message } }, 400)
+        }
         throw err
       }
     },

--- a/packages/synergy/src/workspace-file/service.ts
+++ b/packages/synergy/src/workspace-file/service.ts
@@ -255,18 +255,31 @@ export namespace WorkspaceFileService {
     }
   }
 
+  async function assertRealpathWritable(absolute: string) {
+    // The lexical path check above can be bypassed through a symlink whose
+    // target is a sensitive file (for example `link.env` -> `.env`). Bun.write
+    // follows symlinks, so re-check the resolved target with the same policy.
+    const real = await realpathIfExists(absolute)
+    if (!real || real === absolute) return
+    assertWritableTarget(real)
+  }
+
   export async function write(input: WorkspaceFile.WriteFileInput): Promise<WorkspaceFile.WriteFileResult> {
     const absolute = resolve(input.path)
     await assertRealpathInside(absolute)
     assertWritableTarget(absolute)
+    await assertRealpathWritable(absolute)
 
-    const file = Bun.file(absolute)
-    const existed = await file.exists()
-    if (!existed) {
+    let stat: Awaited<ReturnType<typeof fs.stat>>
+    try {
+      stat = await fs.stat(absolute)
+    } catch {
       throw new NotFoundError(`File does not exist: ${displayRelative(absolute)}`)
     }
-
-    const stat = await file.stat()
+    const existed = true
+    if (!stat.isFile()) {
+      throw new AccessDeniedError(`Access denied: path is not a file (${displayRelative(absolute)})`)
+    }
     if ((stat.mode & 0o200) === 0) {
       throw new AccessDeniedError(`Access denied: file is read-only (${displayRelative(absolute)})`)
     }

--- a/packages/synergy/src/workspace-file/service.ts
+++ b/packages/synergy/src/workspace-file/service.ts
@@ -7,6 +7,7 @@ import { WorkspaceFile } from "./types"
 import { WorkspaceFileRead, likelyBinaryByExtension } from "./read"
 import { WorkspaceFileStatus } from "./status"
 import { isPathContained } from "../util/path-contain"
+import { SensitivePathPolicy } from "../enforcement/sensitive-path"
 
 const DEFAULT_CHILDREN_LIMIT = 200
 const NODE_CONCURRENCY = 16
@@ -50,6 +51,26 @@ export namespace WorkspaceFileService {
     constructor(message: string) {
       super(message)
       this.name = "WorkspaceFileAccessDeniedError"
+    }
+  }
+
+  export class WriteConflictError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = "WorkspaceFileWriteConflictError"
+    }
+  }
+  export class NotFoundError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = "WorkspaceFileNotFoundError"
+    }
+  }
+
+  export class TooLargeError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = "WorkspaceFileTooLargeError"
     }
   }
 
@@ -219,5 +240,68 @@ export namespace WorkspaceFileService {
     mode?: "range" | "document"
   }): Promise<WorkspaceFile.ReadResult> {
     return WorkspaceFileRead.read(input, { resolve, node })
+  }
+  const WRITE_MAX_BYTES = 8 * 1024 * 1024
+
+  function assertWritableTarget(absolute: string) {
+    const relativePath = displayRelative(absolute)
+    const protectedMatch = SensitivePathPolicy.classify(relativePath, {
+      mode: "write",
+      workspaceRoot: root(),
+    })
+    if (protectedMatch.matched) {
+      const kind = protectedMatch.category === "vcs" ? "Git metadata" : "secret or credential path"
+      throw new AccessDeniedError(`Access denied: ${kind} is not editable (${relativePath})`)
+    }
+  }
+
+  export async function write(input: WorkspaceFile.WriteFileInput): Promise<WorkspaceFile.WriteFileResult> {
+    const absolute = resolve(input.path)
+    await assertRealpathInside(absolute)
+    assertWritableTarget(absolute)
+
+    const file = Bun.file(absolute)
+    const existed = await file.exists()
+    if (!existed) {
+      throw new NotFoundError(`File does not exist: ${displayRelative(absolute)}`)
+    }
+
+    const stat = await file.stat()
+    if ((stat.mode & 0o200) === 0) {
+      throw new AccessDeniedError(`Access denied: file is read-only (${displayRelative(absolute)})`)
+    }
+
+    if (input.expectedMtime !== undefined && Math.abs(stat.mtimeMs - input.expectedMtime) > 1) {
+      if (input.conflictPolicy !== "overwrite") {
+        throw new WriteConflictError(`File changed on disk since it was loaded (${displayRelative(absolute)})`)
+      }
+    }
+
+    const content = input.encoding === "base64" ? Buffer.from(input.content, "base64").toString("utf-8") : input.content
+    const byteLength = Buffer.byteLength(content, "utf-8")
+    if (byteLength > WRITE_MAX_BYTES) {
+      throw new TooLargeError(`File too large to write (${byteLength} bytes, limit ${WRITE_MAX_BYTES})`)
+    }
+
+    const parentDir = path.dirname(absolute)
+    if (input.createParents) {
+      await fs.mkdir(parentDir, { recursive: true }).catch(() => {})
+    } else {
+      const parentStat = await fs.stat(parentDir).catch(() => undefined)
+      if (!parentStat?.isDirectory()) {
+        throw new NotFoundError(`Parent directory does not exist: ${displayRelative(parentDir)}`)
+      }
+    }
+
+    await Bun.write(absolute, content)
+    WorkspaceFileStatus.invalidate()
+
+    const after = await Bun.file(absolute).stat()
+    return {
+      path: displayRelative(absolute),
+      mtime: after.mtimeMs,
+      size: after.size,
+      existed,
+    }
   }
 }

--- a/packages/synergy/src/workspace-file/types.ts
+++ b/packages/synergy/src/workspace-file/types.ts
@@ -205,6 +205,14 @@ export namespace WorkspaceFile {
     .meta({ ref: "WorkspaceFileWriteResult" })
   export type WriteFileResult = z.infer<typeof WriteFileResult>
 
+  export const WriteFileError = z
+    .object({
+      name: z.enum(["WorkspaceFileAccessDeniedError", "WorkspaceFileWriteConflictError", "WorkspaceFileTooLargeError"]),
+      data: z.object({ message: z.string() }),
+    })
+    .meta({ ref: "WorkspaceFileWriteError" })
+  export type WriteFileError = z.infer<typeof WriteFileError>
+
   export const CreateDirectoryInput = z
     .object({
       path: z.string(),

--- a/packages/synergy/src/workspace-file/types.ts
+++ b/packages/synergy/src/workspace-file/types.ts
@@ -190,10 +190,20 @@ export namespace WorkspaceFile {
       encoding: z.enum(["utf-8", "base64"]).default("utf-8"),
       createParents: z.boolean().default(false),
       conflictPolicy: WriteConflictPolicy.default("fail"),
-      expectedMtime: z.number().int().nonnegative().optional(),
+      expectedMtime: z.number().nonnegative().optional(),
     })
     .meta({ ref: "WorkspaceFileWriteFileInput" })
   export type WriteFileInput = z.infer<typeof WriteFileInput>
+
+  export const WriteFileResult = z
+    .object({
+      path: z.string(),
+      mtime: z.number().nonnegative(),
+      size: z.number().int().nonnegative(),
+      existed: z.boolean(),
+    })
+    .meta({ ref: "WorkspaceFileWriteResult" })
+  export type WriteFileResult = z.infer<typeof WriteFileResult>
 
   export const CreateDirectoryInput = z
     .object({

--- a/packages/synergy/test/server/workspace-files.test.ts
+++ b/packages/synergy/test/server/workspace-files.test.ts
@@ -181,7 +181,8 @@ describe("POST /workspace/files/write", () => {
     })
     expect(response.status).toBe(409)
     const body = await response.json()
-    expect(body.message).toContain("changed on disk")
+    expect(body.name).toBe("WorkspaceFileWriteConflictError")
+    expect(body.data.message).toContain("changed on disk")
     expect(await Bun.file(file).text()).toBe("v2")
   })
 
@@ -214,7 +215,8 @@ describe("POST /workspace/files/write", () => {
     const response = await postWrite(Server.App(), tmp.path, { path: "missing.txt", content: "x" })
     expect(response.status).toBe(404)
     const body = await response.json()
-    expect(body.message).toContain("does not exist")
+    expect(body.name).toBe("NotFoundError")
+    expect(body.data.message).toContain("does not exist")
     expect(JSON.stringify(body)).not.toContain(tmp.path)
   })
 
@@ -224,14 +226,18 @@ describe("POST /workspace/files/write", () => {
 
     const relativeEscape = await postWrite(app, tmp.path, { path: "../outside.txt", content: "x" })
     expect(relativeEscape.status).toBe(403)
-    expect((await relativeEscape.json()).message).toContain("Access denied")
+    const relativeBody = await relativeEscape.json()
+    expect(relativeBody.name).toBe("WorkspaceFileAccessDeniedError")
+    expect(relativeBody.data.message).toContain("Access denied")
 
     const absoluteEscape = await postWrite(app, tmp.path, {
       path: path.join(tmp.path, "..", "outside-absolute.txt"),
       content: "x",
     })
     expect(absoluteEscape.status).toBe(403)
-    expect((await absoluteEscape.json()).message).toContain("Access denied")
+    const absoluteBody = await absoluteEscape.json()
+    expect(absoluteBody.name).toBe("WorkspaceFileAccessDeniedError")
+    expect(absoluteBody.data.message).toContain("Access denied")
   })
 
   test("rejects sensitive paths like .env with 403", async () => {
@@ -244,8 +250,55 @@ describe("POST /workspace/files/write", () => {
     const response = await postWrite(Server.App(), tmp.path, { path: ".env", content: "SECRET=2" })
     expect(response.status).toBe(403)
     const body = await response.json()
-    expect(body.message).toContain("Access denied")
+    expect(body.name).toBe("WorkspaceFileAccessDeniedError")
+    expect(body.data.message).toContain("Access denied")
     expect(await Bun.file(path.join(tmp.path, ".env")).text()).toBe("SECRET=1")
+  })
+
+  test("rejects a symlink pointing at a sensitive path with 403", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".env"), "SECRET=1")
+        await fs.symlink(path.join(dir, ".env"), path.join(dir, "link.env"))
+      },
+    })
+    const response = await postWrite(Server.App(), tmp.path, { path: "link.env", content: "SECRET=2" })
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body.name).toBe("WorkspaceFileAccessDeniedError")
+    expect(await Bun.file(path.join(tmp.path, ".env")).text()).toBe("SECRET=1")
+  })
+
+  test("rejects a directory target with 403", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "folder"), { recursive: true })
+      },
+    })
+    const response = await postWrite(Server.App(), tmp.path, { path: "folder", content: "x" })
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body.name).toBe("WorkspaceFileAccessDeniedError")
+    expect(body.data.message).toContain("not a file")
+  })
+
+  test("rejects content larger than the write cap with 400", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "big.txt"), "small")
+      },
+    })
+    const response = await postWrite(Server.App(), tmp.path, {
+      path: "big.txt",
+      content: "x".repeat(8 * 1024 * 1024 + 1),
+    })
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.name).toBe("WorkspaceFileTooLargeError")
+    expect(await Bun.file(path.join(tmp.path, "big.txt")).text()).toBe("small")
   })
 
   test("rejects read-only files with 403", async () => {
@@ -257,9 +310,9 @@ describe("POST /workspace/files/write", () => {
       },
     })
     const response = await postWrite(Server.App(), tmp.path, { path: "locked.txt", content: "unlocked?" })
-    expect(response.status).toBe(403)
     const body = await response.json()
-    expect(body.message).toContain("read-only")
+    expect(body.name).toBe("WorkspaceFileAccessDeniedError")
+    expect(body.data.message).toContain("read-only")
     expect(await Bun.file(path.join(tmp.path, "locked.txt")).text()).toBe("locked")
   })
 

--- a/packages/synergy/test/server/workspace-files.test.ts
+++ b/packages/synergy/test/server/workspace-files.test.ts
@@ -92,3 +92,185 @@ describe("GET /workspace/files", () => {
     expect(JSON.stringify(body)).not.toContain(tmp.path)
   })
 })
+
+describe("POST /workspace/files/write", () => {
+  function postWrite(app: ReturnType<typeof Server.App>, directory: string, body: Record<string, unknown>) {
+    return app.request(workspaceUrl("write", directory), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  }
+
+  test("writes content to an existing file and returns the write result", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "hello.txt"), "original")
+      },
+    })
+    const app = Server.App()
+
+    const response = await postWrite(app, tmp.path, { path: "hello.txt", content: "updated content" })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.path).toBe("hello.txt")
+    expect(body.existed).toBe(true)
+    expect(body.size).toBe(Buffer.byteLength("updated content", "utf-8"))
+    expect(typeof body.mtime).toBe("number")
+    expect(body.mtime).toBeGreaterThan(0)
+    expect(await Bun.file(path.join(tmp.path, "hello.txt")).text()).toBe("updated content")
+  })
+
+  test("allows overwriting without expectedMtime", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "notes.txt"), "first")
+      },
+    })
+    const app = Server.App()
+
+    const first = await postWrite(app, tmp.path, { path: "notes.txt", content: "second" })
+    expect(first.status).toBe(200)
+    const second = await postWrite(app, tmp.path, { path: "notes.txt", content: "third" })
+    expect(second.status).toBe(200)
+    expect(await Bun.file(path.join(tmp.path, "notes.txt")).text()).toBe("third")
+  })
+
+  test("succeeds when expectedMtime matches the on-disk mtime", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "edit.txt"), "before")
+      },
+    })
+    const app = Server.App()
+
+    const statResponse = await app.request(workspaceUrl("stat", tmp.path, { path: "edit.txt" }))
+    expect(statResponse.status).toBe(200)
+    const statBody = await statResponse.json()
+
+    const response = await postWrite(app, tmp.path, {
+      path: "edit.txt",
+      content: "after",
+      expectedMtime: statBody.mtime,
+    })
+    expect(response.status).toBe(200)
+    expect(await Bun.file(path.join(tmp.path, "edit.txt")).text()).toBe("after")
+  })
+
+  test("rejects a stale expectedMtime with 409 and leaves the file untouched", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "conflict.txt"), "v1")
+      },
+    })
+    const app = Server.App()
+
+    const file = path.join(tmp.path, "conflict.txt")
+    const staleMtime = (await fs.stat(file)).mtimeMs
+    await Bun.sleep(25)
+    await Bun.write(file, "v2")
+
+    const response = await postWrite(app, tmp.path, {
+      path: "conflict.txt",
+      content: "v3",
+      expectedMtime: staleMtime,
+    })
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.message).toContain("changed on disk")
+    expect(await Bun.file(file).text()).toBe("v2")
+  })
+
+  test("skips the mtime conflict check with conflictPolicy overwrite", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "force.txt"), "v1")
+      },
+    })
+    const app = Server.App()
+
+    const file = path.join(tmp.path, "force.txt")
+    const staleMtime = (await fs.stat(file)).mtimeMs
+    await Bun.sleep(25)
+    await Bun.write(file, "v2")
+
+    const response = await postWrite(app, tmp.path, {
+      path: "force.txt",
+      content: "v3",
+      expectedMtime: staleMtime,
+      conflictPolicy: "overwrite",
+    })
+    expect(response.status).toBe(200)
+    expect(await Bun.file(file).text()).toBe("v3")
+  })
+
+  test("returns 404 for a missing file", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const response = await postWrite(Server.App(), tmp.path, { path: "missing.txt", content: "x" })
+    expect(response.status).toBe(404)
+    const body = await response.json()
+    expect(body.message).toContain("does not exist")
+    expect(JSON.stringify(body)).not.toContain(tmp.path)
+  })
+
+  test("rejects paths escaping the workspace with 403", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const app = Server.App()
+
+    const relativeEscape = await postWrite(app, tmp.path, { path: "../outside.txt", content: "x" })
+    expect(relativeEscape.status).toBe(403)
+    expect((await relativeEscape.json()).message).toContain("Access denied")
+
+    const absoluteEscape = await postWrite(app, tmp.path, {
+      path: path.join(tmp.path, "..", "outside-absolute.txt"),
+      content: "x",
+    })
+    expect(absoluteEscape.status).toBe(403)
+    expect((await absoluteEscape.json()).message).toContain("Access denied")
+  })
+
+  test("rejects sensitive paths like .env with 403", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".env"), "SECRET=1")
+      },
+    })
+    const response = await postWrite(Server.App(), tmp.path, { path: ".env", content: "SECRET=2" })
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body.message).toContain("Access denied")
+    expect(await Bun.file(path.join(tmp.path, ".env")).text()).toBe("SECRET=1")
+  })
+
+  test("rejects read-only files with 403", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "locked.txt"), "locked")
+        await fs.chmod(path.join(dir, "locked.txt"), 0o444)
+      },
+    })
+    const response = await postWrite(Server.App(), tmp.path, { path: "locked.txt", content: "unlocked?" })
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body.message).toContain("read-only")
+    expect(await Bun.file(path.join(tmp.path, "locked.txt")).text()).toBe("locked")
+  })
+
+  test("requires a Scope instead of silently using home", async () => {
+    const response = await Server.App().request("/workspace/files/write", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "hello.txt", content: "x" }),
+    })
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.name).toBe("ScopeRequired")
+  })
+})


### PR DESCRIPTION
## Summary

- Files 面板工具栏新增「编辑」胶囊按钮，点击后 Monaco 源码查看器切换为可编辑模式，支持保存/放弃操作与 Ctrl/Cmd+S 快捷保存
- 新增 `POST /workspace/files/write` 路由 + `WorkspaceFileService.write()`：工作区路径包含校验、敏感路径拒绝（Git 元数据/`.env`/凭证文件）、只读目标拒绝、`expectedMtime` 乐观锁（并发修改返回 409，可选 `conflictPolicy: "overwrite"`）、8 MiB 内容上限
- 该通道是用户直接编辑自己工作区的入口，与 profile 无关，独立于 agent 工具管线（write/save_file 工具 + 审批 + 沙箱）；写后失效 git 状态缓存，前端经文件系统 watcher 刷新

## Changes

- `packages/synergy/src/workspace-file/service.ts`、`types.ts` — 写服务与请求/响应 schema
- `packages/synergy/src/server/workspace-files.ts`、`error.ts` — write 路由（operationId `workspace.files.write`）与 403 错误 schema
- `packages/sdk/js/src/gen/*`、`packages/sdk/openapi.json` — 重新生成契约（`workspace.files.write` + `WorkspaceFileWriteFileInput`/`WorkspaceFileWriteResult`）
- `packages/app/src/components/file-workbench/source-view.tsx` — 可编辑模式、dirty 检测、外部更新保护
- `packages/app/src/components/file-workbench/content.tsx`、`styles.css` — 工具栏胶囊按钮（编辑/保存/放弃）与样式
- `packages/app/src/context/file/index.tsx`、`errors.ts` — `save()` 保存管线与冲突/拒绝错误识别
- `packages/app/src/locales/*` — 新增 11 条消息（en/zh-CN/pseudo 同步）
- `docs/architecture/workspace-and-files.md` — 路由契约与安全模型文档
- `packages/synergy/test/server/workspace-files.test.ts` — 新增 10 个 write 路由测试

## Verification

- `bun run typecheck` — 11/11 通过
- `cd packages/synergy && bun test test/server/workspace-files.test.ts` — 14/14 通过（含成功/覆盖/409 冲突/越界 403/敏感路径 403/只读 403/ScopeRequired）
- `bun run quality:quick` — 退出码 0
