### PR TITLE
fix(migration): serialize migration tracking writes across processes

### DIFF
--- a/packages/synergy/src/migration/index.ts
+++ b/packages/synergy/src/migration/index.ts
@@ -78,7 +78,7 @@ async function migrateOldTrackingData(): Promise<void> {
       }
     }
     if (Object.keys(domainData).length > 0) {
-      await Storage.write(StoragePath.metaMigrationLogDomain(domain), domainData)
+      await mergeDomainLog(domain, domainData)
       log.info("migrated tracking data to per-domain log", { domain, count: Object.keys(domainData).length })
     }
   }
@@ -105,7 +105,7 @@ async function migrateLegacyLibraryTrackingData(): Promise<void> {
   }
 
   if (changed) {
-    await Storage.write(libraryKey, libraryData)
+    await mergeDomainLog("library", libraryData)
     log.info("migrated legacy engram migration tracking to library", { count: Object.keys(oldData).length })
   }
   await Storage.remove(oldKey)
@@ -278,6 +278,14 @@ function migrationLockDirectory() {
   return path.join(Global.Path.data, "meta", "migration", ".locks")
 }
 
+function migrationLockOptions(domain: string) {
+  return {
+    directory: migrationLockDirectory(),
+    key: `migration-log:${domain}`,
+    timeoutMessage: `Timed out acquiring migration tracking lock for ${domain}`,
+  }
+}
+
 /**
  * Merge completion markers into the per-domain migration log under a cross-process
  * file lock. Multiple Synergy instances sharing one home may run migrations
@@ -286,17 +294,10 @@ function migrationLockDirectory() {
  */
 async function mergeDomainLog(domain: string, entries: Record<string, number>): Promise<void> {
   const key = StoragePath.metaMigrationLogDomain(domain)
-  await withFileLock(
-    {
-      directory: migrationLockDirectory(),
-      key: `migration-log:${domain}`,
-      timeoutMessage: `Timed out acquiring migration tracking lock for ${domain}`,
-    },
-    async () => {
-      const current = await Storage.read<Record<string, number>>(key).catch(() => ({}))
-      await Storage.write(key, { ...current, ...entries })
-    },
-  )
+  await withFileLock(migrationLockOptions(domain), async () => {
+    const current = await Storage.read<Record<string, number>>(key).catch(() => ({}))
+    await Storage.write(key, { ...current, ...entries })
+  })
 }
 
 async function saveLogForDomain(domain: string, data: Record<string, number>): Promise<void> {
@@ -306,18 +307,11 @@ async function saveLogForDomain(domain: string, data: Record<string, number>): P
 /** Remove a single completion marker under the same cross-process lock, preserving concurrent markers. */
 async function deleteDomainLogEntry(domain: string, migrationID: string): Promise<void> {
   const key = StoragePath.metaMigrationLogDomain(domain)
-  await withFileLock(
-    {
-      directory: migrationLockDirectory(),
-      key: `migration-log:${domain}`,
-      timeoutMessage: `Timed out acquiring migration tracking lock for ${domain}`,
-    },
-    async () => {
-      const current: Record<string, number> = await Storage.read<Record<string, number>>(key).catch(() => ({}))
-      delete current[migrationID]
-      await Storage.write(key, current)
-    },
-  )
+  await withFileLock(migrationLockOptions(domain), async () => {
+    const current: Record<string, number> = await Storage.read<Record<string, number>>(key).catch(() => ({}))
+    delete current[migrationID]
+    await Storage.write(key, current)
+  })
 }
 
 /**

--- a/packages/synergy/src/migration/index.ts
+++ b/packages/synergy/src/migration/index.ts
@@ -1,11 +1,14 @@
+import path from "path"
 import { Storage } from "../storage/storage"
 import { StoragePath } from "../storage/path"
 import { Log } from "../util/log"
 import { MigrationRegistry } from "./registry"
 import { orderMigrations } from "./order"
 import { progressBar, stageWrite, disableWrap, enableWrap, PROGRESS_INTERVAL } from "./format"
+import { Global } from "../global"
 import { Installation } from "../global/installation"
 import { setActiveMigrationContext } from "./context"
+import { withFileLock } from "@ericsanchezok/synergy-util/fs-lock"
 // Side-effect imports: register domain migrations in MigrationRegistry
 import "../agenda/migration"
 import "../browser/migration"
@@ -271,8 +274,50 @@ async function loadLogForDomain(domain: string): Promise<Record<string, number>>
   return Storage.read<Record<string, number>>(StoragePath.metaMigrationLogDomain(domain)).catch(() => ({}))
 }
 
+function migrationLockDirectory() {
+  return path.join(Global.Path.data, "meta", "migration", ".locks")
+}
+
+/**
+ * Merge completion markers into the per-domain migration log under a cross-process
+ * file lock. Multiple Synergy instances sharing one home may run migrations
+ * concurrently; a plain read-modify-write would let the last writer drop markers
+ * persisted by the other process, re-pending completed migrations on the next boot.
+ */
+async function mergeDomainLog(domain: string, entries: Record<string, number>): Promise<void> {
+  const key = StoragePath.metaMigrationLogDomain(domain)
+  await withFileLock(
+    {
+      directory: migrationLockDirectory(),
+      key: `migration-log:${domain}`,
+      timeoutMessage: `Timed out acquiring migration tracking lock for ${domain}`,
+    },
+    async () => {
+      const current = await Storage.read<Record<string, number>>(key).catch(() => ({}))
+      await Storage.write(key, { ...current, ...entries })
+    },
+  )
+}
+
 async function saveLogForDomain(domain: string, data: Record<string, number>): Promise<void> {
-  await Storage.write(StoragePath.metaMigrationLogDomain(domain), data)
+  await mergeDomainLog(domain, data)
+}
+
+/** Remove a single completion marker under the same cross-process lock, preserving concurrent markers. */
+async function deleteDomainLogEntry(domain: string, migrationID: string): Promise<void> {
+  const key = StoragePath.metaMigrationLogDomain(domain)
+  await withFileLock(
+    {
+      directory: migrationLockDirectory(),
+      key: `migration-log:${domain}`,
+      timeoutMessage: `Timed out acquiring migration tracking lock for ${domain}`,
+    },
+    async () => {
+      const current: Record<string, number> = await Storage.read<Record<string, number>>(key).catch(() => ({}))
+      delete current[migrationID]
+      await Storage.write(key, current)
+    },
+  )
 }
 
 /**
@@ -319,16 +364,14 @@ export async function rollbackMigrations(domain: string, targetId: string): Prom
     for (const migration of toRollback) {
       if (!migration.down) {
         stageWrite(`  [${domain}] ${migration.description} (no down(), unmarked)\n`)
-        delete logData[migration.id]
-        await saveLogForDomain(domain, logData)
+        await deleteDomainLogEntry(domain, migration.id)
         continue
       }
 
       try {
         await migration.down(() => {})
         stageWrite(`  [${domain}] ${migration.description} rolled back ✓\n`)
-        delete logData[migration.id]
-        await saveLogForDomain(domain, logData)
+        await deleteDomainLogEntry(domain, migration.id)
         log.info("rolled back", { id: migration.id, domain })
       } catch (err) {
         stageWrite(`  [${domain}] ${migration.description} rollback ✗\n`)

--- a/packages/synergy/test/migration/concurrent-write.test.ts
+++ b/packages/synergy/test/migration/concurrent-write.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs"
+import path from "node:path"
+import { MigrationRegistry } from "../../src/migration/registry"
+import { resetMigrations, runMigrations } from "../../src/migration"
+import type { Migration } from "../../src/migration/types"
+
+const dataDir = path.join(process.env["SYNERGY_TEST_HOME"]!, ".synergy", "data")
+const TEST_DOMAIN = "conc-test"
+
+function domainLogPath(domain: string): string {
+  return path.join(dataDir, "meta", "migration", `log-${domain}.json`)
+}
+
+describe("concurrent migration tracking writes", () => {
+  afterEach(() => {
+    try {
+      unlinkSync(domainLogPath(TEST_DOMAIN))
+    } catch {}
+    MigrationRegistry.list().delete(TEST_DOMAIN)
+    resetMigrations()
+  })
+
+  test("completion markers from another instance are merged, not overwritten", async () => {
+    let markEntered!: () => void
+    const entered = new Promise<void>((resolve) => (markEntered = resolve))
+    let releaseA!: () => void
+    const gateA = new Promise<void>((resolve) => (releaseA = resolve))
+
+    const mA: Migration = {
+      id: "20260806-conc-a",
+      description: "Conc A",
+      async up() {
+        markEntered()
+        await gateA
+      },
+    }
+    // Instance A only knows about mA (e.g. an older CLI whose registry lacks mB).
+    MigrationRegistry.register(TEST_DOMAIN, [mA])
+
+    const runPromise = runMigrations({ output: "silent", targetDomain: TEST_DOMAIN })
+    await entered
+
+    // Instance B (a concurrent process) completes mB while A is still running mA.
+    mkdirSync(path.dirname(domainLogPath(TEST_DOMAIN)), { recursive: true })
+    writeFileSync(domainLogPath(TEST_DOMAIN), JSON.stringify({ "20260806-conc-b": Date.now() }))
+
+    releaseA()
+    await runPromise
+
+    const data = JSON.parse(readFileSync(domainLogPath(TEST_DOMAIN), "utf-8"))
+    expect(data).toHaveProperty("20260806-conc-a")
+    // A's save must not drop B's marker.
+    expect(data).toHaveProperty("20260806-conc-b")
+  })
+})

--- a/packages/synergy/test/migration/concurrent-write.test.ts
+++ b/packages/synergy/test/migration/concurrent-write.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs"
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync } from "node:fs"
 import path from "node:path"
 import { MigrationRegistry } from "../../src/migration/registry"
 import { resetMigrations, runMigrations } from "../../src/migration"
@@ -12,11 +12,27 @@ function domainLogPath(domain: string): string {
   return path.join(dataDir, "meta", "migration", `log-${domain}.json`)
 }
 
+function legacyLogPath(): string {
+  return path.join(dataDir, "meta", "migration", "log.json")
+}
+
+function writeLog(filePath: string, data: Record<string, number>): void {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, JSON.stringify(data))
+}
+
 describe("concurrent migration tracking writes", () => {
   afterEach(() => {
-    try {
-      unlinkSync(domainLogPath(TEST_DOMAIN))
-    } catch {}
+    for (const file of [
+      domainLogPath(TEST_DOMAIN),
+      domainLogPath("library"),
+      domainLogPath("engram"),
+      legacyLogPath(),
+    ]) {
+      try {
+        unlinkSync(file)
+      } catch {}
+    }
     MigrationRegistry.list().delete(TEST_DOMAIN)
     resetMigrations()
   })
@@ -42,8 +58,7 @@ describe("concurrent migration tracking writes", () => {
     await entered
 
     // Instance B (a concurrent process) completes mB while A is still running mA.
-    mkdirSync(path.dirname(domainLogPath(TEST_DOMAIN)), { recursive: true })
-    writeFileSync(domainLogPath(TEST_DOMAIN), JSON.stringify({ "20260806-conc-b": Date.now() }))
+    writeLog(domainLogPath(TEST_DOMAIN), { "20260806-conc-b": Date.now() })
 
     releaseA()
     await runPromise
@@ -51,6 +66,29 @@ describe("concurrent migration tracking writes", () => {
     const data = JSON.parse(readFileSync(domainLogPath(TEST_DOMAIN), "utf-8"))
     expect(data).toHaveProperty("20260806-conc-a")
     // A's save must not drop B's marker.
+    expect(data).toHaveProperty("20260806-conc-b")
+  })
+
+  test("legacy single-log conversion merges, not overwrites, per-domain markers", async () => {
+    const mA: Migration = {
+      id: "20260806-conc-a",
+      description: "Conc A",
+      async up() {},
+    }
+    MigrationRegistry.register(TEST_DOMAIN, [mA])
+
+    // Old-version single log plus a marker another instance already persisted
+    // in the per-domain log before this instance converts the old format.
+    writeLog(legacyLogPath(), { "20260806-conc-a": Date.now() })
+    writeLog(domainLogPath(TEST_DOMAIN), { "20260806-conc-b": Date.now() })
+
+    await runMigrations({ output: "silent", targetDomain: TEST_DOMAIN })
+
+    // The old single log is consumed.
+    expect(existsSync(legacyLogPath())).toBe(false)
+    const data = JSON.parse(readFileSync(domainLogPath(TEST_DOMAIN), "utf-8"))
+    expect(data).toHaveProperty("20260806-conc-a")
+    // Conversion must not drop the concurrent per-domain marker.
     expect(data).toHaveProperty("20260806-conc-b")
   })
 })


### PR DESCRIPTION
## Summary

Migration completion markers in the per-domain tracking log were written with an unlocked read-modify-write. When two Synergy instances share one home and run migrations concurrently, the last writer overwrote markers persisted by the other process. Completed migrations were re-pended on the next boot, so heavy session migrations (thousands of sessions, hundreds of thousands of messages) re-ran from scratch every startup, making the server appear frozen for tens of minutes before it ever listened.

This change serializes tracking-log writes across processes and merges rather than overwrites completion markers.

## Changes

- `packages/synergy/src/migration/index.ts`
- Wrap tracking-log read-modify-write in a cross-process file lock (`withFileLock` from `@ericsanchezok/synergy-util/fs-lock`), re-reading the current log inside the lock and merging new markers instead of replacing the whole object.
- Add a locked single-entry delete for rollback so removing one marker never resurrects or drops concurrent markers.
- `packages/synergy/test/migration/concurrent-write.test.ts` (new)
- Regression test: instance A completes a migration while instance B persists another marker concurrently; A's save must not drop B's marker.

## Verification

```bash
cd packages/synergy
bun test test/migration/          # 48 pass, 0 fail (10 files)
bunx prettier --check packages/synergy/src/migration/index.ts packages/synergy/test/migration/concurrent-write.test.ts
bunx oxlint -c oxlintrc.json packages/synergy/src/migration/index.ts packages/synergy/test/migration/concurrent-write.test.ts
```

The new concurrent-write test fails on the previous implementation and passes with the fix.