### PR TITLE
fix(channel): do not suppress outbound bridge for providers without terminal streaming delivery

### DIFF
--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -759,12 +759,6 @@ export namespace Channel {
               })
               void reactionController.setQueued()
 
-              // The foreground streaming card owns this root's terminal reply:
-              // register the root so the outbound bridge skips it and the
-              // answer is not delivered twice. Queued (busy/recovered) roots
-              // are never registered and keep the bridge as their delivery path.
-              ChannelOutbound.beginForeground(sessionID, delivery.messageID)
-
               let streaming = createStreamingSession({
                 accountId: ctx.accountId,
                 chatId: ctx.chatId,
@@ -785,6 +779,19 @@ export namespace Channel {
                   messageId: replyToMessageId,
                   scopeKey: ctx.scopeKey,
                 })
+              }
+
+              // A foreground streaming session that owns the terminal delivery
+              // (e.g. Feishu cards post the final text in close()) must not be
+              // re-delivered by the outbound bridge: register the root so the
+              // bridge skips it. Sessions that do not own delivery (e.g.
+              // GitHub, whose streaming session is a no-op and relies on the
+              // bridge for comments) are never registered, so the bridge
+              // posts the reply. Queued (busy/recovered) roots are never
+              // registered and keep the bridge as their delivery path.
+              const ownsTerminalDelivery = streaming.ownsTerminalDelivery?.() === true
+              if (ownsTerminalDelivery) {
+                ChannelOutbound.beginForeground(sessionID, delivery.messageID)
               }
 
               const assistantTranscript = new Map<string, string>()
@@ -867,8 +874,8 @@ export namespace Channel {
                 // degraded fallback so the user still receives tool outputs.
                 const fallbackText = hasError ? buildDegradedFallback(toolProgress) : undefined
                 await streaming.close(responseText || fallbackText, hasError)
-                if (result.info.role === "assistant") {
-                  // The streaming card already delivered this root's terminal
+                if (result.info.role === "assistant" && ownsTerminalDelivery) {
+                  // The streaming session already delivered this root's terminal
                   // reply. Persist the sent marker so any later message update
                   // (context usage, metadata merge) never re-triggers the
                   // outbound bridge after the foreground registration ends.
@@ -980,6 +987,7 @@ export namespace Channel {
         })
       },
       isActive: () => false,
+      ownsTerminalDelivery: () => true,
     }
   }
 

--- a/packages/synergy/src/channel/provider/feishu/index.ts
+++ b/packages/synergy/src/channel/provider/feishu/index.ts
@@ -1274,6 +1274,10 @@ class NonStreamingSession implements ChannelTypes.StreamingSession {
   isActive(): boolean {
     return false
   }
+
+  ownsTerminalDelivery(): boolean {
+    return true
+  }
 }
 
 // Expose card action registration globally so plugins can register handlers

--- a/packages/synergy/src/channel/provider/feishu/streaming-card.ts
+++ b/packages/synergy/src/channel/provider/feishu/streaming-card.ts
@@ -239,6 +239,10 @@ export class FeishuStreamingCard implements ChannelTypes.StreamingSession {
     return this.state !== null && this.phase === "active"
   }
 
+  ownsTerminalDelivery(): boolean {
+    return true
+  }
+
   private async startCard(): Promise<void> {
     if (this.state) return
 

--- a/packages/synergy/src/channel/types.ts
+++ b/packages/synergy/src/channel/types.ts
@@ -311,6 +311,16 @@ export interface StreamingSession {
   updateToolProgress(progress: StreamingToolProgress[]): Promise<void>
   close(finalText?: string, error?: boolean): Promise<void>
   isActive(): boolean
+  /**
+   * Whether this streaming session delivers the terminal reply itself in
+   * `close()` (e.g. Feishu cards post the final text). When true, the channel
+   * core registers the root as foreground-delivered and persists
+   * `channelOutboundSent`, so the outbound bridge skips it. Providers whose
+   * streaming session is a no-op (e.g. GitHub, which relies on the outbound
+   * bridge for comments) must leave this false — otherwise the bridge is
+   * suppressed and the reply is never posted.
+   */
+  ownsTerminalDelivery?(): boolean
 }
 
 export type ProviderLifecycle = "self_connected" | "borrowed_transport"


### PR DESCRIPTION
# fix(channel): do not suppress outbound bridge for providers without terminal streaming delivery

## Root cause

`c0562ed77` introduced foreground registration so the outbound bridge skips replies already delivered by a streaming card, and persists `channelOutboundSent` after the card closes. It assumed **every** foreground session's streaming session owns the terminal reply — but that is only true for providers whose streaming `close()` actually posts the final text (Feishu cards, text fallback).

Providers with a **no-op streaming session** (GitHub, which relies entirely on the outbound bridge to post comments) were registered anyway:

1. `ChannelOutbound.beginForeground(...)` → the bridge skipped the terminal assistant message
2. `channelOutboundSent: true` was persisted on the assistant message → even after `endForeground`, the durable marker made the bridge skip it forever

Result: GitHub comments were never posted, while the status reactions (👀/🚀, which fire directly in the execution path) still worked — the bot appeared to run but never replied. Empirically reproduced on the deployed instance: sessions completed, reactions appeared, zero comments on GitHub.

## Fix

Add an optional `ownsTerminalDelivery()` capability to `StreamingSession`, and only `beginForeground` / persist `channelOutboundSent` when it returns `true`:

- **Feishu streaming card** → `true` (close() finalizes the card with the answer)
- **Feishu non-streaming send session** → `true` (close() sends the text)
- **Channel text fallback session** → `true` (close() posts via replyMessage)
- **GitHub `NonStreamingSession`** → `false` (default) — the outbound bridge stays the delivery path

## Files

- `packages/synergy/src/channel/types.ts` — `StreamingSession.ownsTerminalDelivery?()`
- `packages/synergy/src/channel/index.ts` — gate `beginForeground` and the `channelOutboundSent` persist on `ownsTerminalDelivery()`
- `packages/synergy/src/channel/provider/feishu/index.ts`, `streaming-card.ts` — declare ownership
- GitHub provider intentionally unchanged (no-op streaming session defaults to `false`)

## Verification

- `bun run typecheck` — clean
- `bun test test/channel/` — 448 pass / 0 fail
