### PR TITLE
feat(plugin): add manual refresh for the plugin marketplace

### DIFF
--- a/docs/plugins/marketplace.md
+++ b/docs/plugins/marketplace.md
@@ -24,6 +24,8 @@ Registry identity, generated manifest ID, approval ID, lockfile key, signature p
 
 When an official registry read cannot reach its upstream source and no cached data can satisfy the request, the server returns a structured `503 Service Unavailable` response. The Marketplace keeps installed or cached plugin details usable when possible, shows a registry-unavailable state instead of a generic application error, and offers an explicit retry action.
 
+The Marketplace header offers a manual refresh action that re-fetches the official registry index immediately, bypassing the hourly cache TTL, and drops cached entry details so the next detail view is fresh. When the refresh cannot reach the upstream registry, the previous cached data stays intact and the action reports an error instead of clearing the list.
+
 ## Publish Flow
 
 ```bash

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -6041,6 +6041,18 @@ msgid "app.plugin.marketplace.pluginApi.label"
 msgstr "Plugin API {version}"
 
 #. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.button"
+msgstr "Refresh plugins"
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.failed"
+msgstr "Plugin catalog refresh failed"
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.updated"
+msgstr "Plugin catalog updated"
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
 msgid "app.plugin.marketplace.registryUnavailable.description"
 msgstr "Synergy couldn't reach this plugin registry. Check your connection and try again."
 

--- a/packages/app/src/locales/messages.ts
+++ b/packages/app/src/locales/messages.ts
@@ -1343,6 +1343,9 @@ export const pluginMarketplace = {
     message: "Synergy couldn't reach this plugin registry. Check your connection and try again.",
   },
   retry: { id: "app.plugin.marketplace.registryUnavailable.retry", message: "Retry" },
+  refreshButton: { id: "app.plugin.marketplace.refresh.button", message: "Refresh plugins" },
+  refreshUpdated: { id: "app.plugin.marketplace.refresh.updated", message: "Plugin catalog updated" },
+  refreshFailed: { id: "app.plugin.marketplace.refresh.failed", message: "Plugin catalog refresh failed" },
 } as const satisfies Record<string, AppMessageDescriptor>
 
 // ── Plugin permission groups ──────────────────────────────────────────────────

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -6041,6 +6041,18 @@ msgid "app.plugin.marketplace.pluginApi.label"
 msgstr ""
 
 #. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.button"
+msgstr ""
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.failed"
+msgstr ""
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.updated"
+msgstr ""
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
 msgid "app.plugin.marketplace.registryUnavailable.description"
 msgstr ""
 

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -6041,6 +6041,18 @@ msgid "app.plugin.marketplace.pluginApi.label"
 msgstr "Plugin API {version}"
 
 #. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.button"
+msgstr "刷新插件"
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.failed"
+msgstr "插件目录刷新失败"
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
+msgid "app.plugin.marketplace.refresh.updated"
+msgstr "插件目录已更新"
+
+#. ── Plugin marketplace ────────────────────────────────────────────────────────
 msgid "app.plugin.marketplace.registryUnavailable.description"
 msgstr "Synergy 无法连接到此插件注册表。请检查网络连接后重试。"
 

--- a/packages/app/src/plugin/marketplace/MarketplacePage.tsx
+++ b/packages/app/src/plugin/marketplace/MarketplacePage.tsx
@@ -205,7 +205,11 @@ export function MarketplacePage(props: MarketplacePageProps) {
                 disabled={refreshing()}
                 onClick={() => void handleRefresh()}
               >
-                <Icon name="refresh-ccw" size="small" class={refreshing() ? "animate-spin" : ""} />
+                <Icon
+                  name={getSemanticIcon("action.refresh")}
+                  size="small"
+                  class={refreshing() ? "animate-spin" : ""}
+                />
               </button>
             </div>
           </div>

--- a/packages/app/src/plugin/marketplace/MarketplacePage.tsx
+++ b/packages/app/src/plugin/marketplace/MarketplacePage.tsx
@@ -10,6 +10,7 @@ import { AppPanel } from "@/components/app-panel"
 import { WorkspaceMobileHeader } from "@/components/workspace/mobile-header"
 import { useWorkspaceMobileHeaderClose } from "@/components/workspace/mobile-header-close"
 import { useGlobalSDK } from "@/context/global-sdk"
+import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { useLocale } from "@/context/locale"
 
 import { VerifiedBadge } from "./VerifiedBadge"
@@ -107,6 +108,31 @@ export function MarketplacePage(props: MarketplacePageProps) {
     await Promise.all([refetchInstalledPlugins(), refetchSearchResults()])
   }
 
+  const [refreshing, setRefreshing] = createSignal(false)
+
+  async function handleRefresh() {
+    if (refreshing()) return
+    setRefreshing(true)
+    try {
+      const res = await globalSDK.client.registry.refresh()
+      if (res.data?.refreshedAt) {
+        showToast({
+          type: "info",
+          title: _(pluginMarketplace.refreshUpdated),
+        })
+      }
+      await refreshMarketplace()
+    } catch (error) {
+      showToast({
+        type: "error",
+        title: _(pluginMarketplace.refreshFailed),
+        description: error instanceof Error ? error.message : undefined,
+      })
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   function openPlugin(
     pluginId: string,
     options: { source?: RegistrySource; closeToMarketplace?: boolean; installedPlugin?: InstalledPlugin } = {},
@@ -171,6 +197,16 @@ export function MarketplacePage(props: MarketplacePageProps) {
                   </button>
                 </Show>
               </div>
+              <button
+                type="button"
+                class="plugin-marketplace-refresh"
+                aria-label={_(pluginMarketplace.refreshButton)}
+                title={_(pluginMarketplace.refreshButton)}
+                disabled={refreshing()}
+                onClick={() => void handleRefresh()}
+              >
+                <Icon name="refresh-ccw" size="small" class={refreshing() ? "animate-spin" : ""} />
+              </button>
             </div>
           </div>
         </AppPanel.Header>

--- a/packages/app/src/plugin/marketplace/marketplace.css
+++ b/packages/app/src/plugin/marketplace/marketplace.css
@@ -106,6 +106,33 @@
   color: var(--icon-base);
 }
 
+.plugin-marketplace-refresh {
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.75rem;
+  color: var(--icon-weak);
+  background: var(--plugin-input-bg);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--border-base) 24%, transparent);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.plugin-marketplace-refresh:hover:not(:disabled) {
+  background: var(--plugin-control-bg-hover);
+  color: var(--icon-base);
+}
+
+.plugin-marketplace-refresh:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
 .plugin-marketplace-body {
   display: flex;
   flex-direction: column;

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -423,6 +423,8 @@ import type {
   RegistryPluginsVersionsErrors,
   RegistryPluginsVersionsResponses,
   RegistryPublishInput,
+  RegistryRefreshErrors,
+  RegistryRefreshResponses,
   RewardsInfo,
   RuntimeReloadErrors,
   RuntimeReloadResponses,
@@ -10389,6 +10391,36 @@ export class Api extends HeyApiClient {
 }
 
 export class Registry extends HeyApiClient {
+  /**
+   * Force refresh the official plugin registry cache
+   *
+   * Re-fetch the official plugin registry index immediately, bypassing the cache TTL.
+   */
+  public refresh<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      scopeID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "scopeID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<RegistryRefreshResponses, RegistryRefreshErrors, ThrowOnError>({
+      url: "/api/registry/refresh",
+      ...options,
+      ...params,
+    })
+  }
+
   plugins = new Plugins({ client: this.client })
 }
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -17521,6 +17521,36 @@ export type RegistryPluginsSearchResponses = {
 
 export type RegistryPluginsSearchResponse = RegistryPluginsSearchResponses[keyof RegistryPluginsSearchResponses]
 
+export type RegistryRefreshData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    scopeID?: string
+  }
+  url: "/api/registry/refresh"
+}
+
+export type RegistryRefreshErrors = {
+  /**
+   * Service unavailable
+   */
+  503: ServiceUnavailableError
+}
+
+export type RegistryRefreshError = RegistryRefreshErrors[keyof RegistryRefreshErrors]
+
+export type RegistryRefreshResponses = {
+  /**
+   * Registry refreshed
+   */
+  200: {
+    refreshedAt: string | null
+  }
+}
+
+export type RegistryRefreshResponse = RegistryRefreshResponses[keyof RegistryRefreshResponses]
+
 export type RegistryPluginsGetData = {
   body?: never
   path: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -18896,6 +18896,70 @@
         ]
       }
     },
+    "/api/registry/refresh": {
+      "post": {
+        "operationId": "registry.refresh",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scopeID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Force refresh the official plugin registry cache",
+        "description": "Re-fetch the official plugin registry index immediately, bypassing the cache TTL.",
+        "responses": {
+          "200": {
+            "description": "Registry refreshed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "refreshedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["refreshedAt"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createSynergyClient } from \"@ericsanchezok/synergy-sdk\"\n\nconst client = createSynergyClient()\nawait client.registry.refresh({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/api/registry/{id}": {
       "get": {
         "operationId": "registry.plugins.get",

--- a/packages/synergy/src/plugin/marketplace-registry.ts
+++ b/packages/synergy/src/plugin/marketplace-registry.ts
@@ -474,6 +474,7 @@ export namespace PluginMarketplaceRegistry {
   }
 
   const pendingRefreshes = new Map<string, Promise<z.infer<typeof RemoteRegistry>>>()
+  const pendingForcedRefreshes = new Map<string, Promise<{ refreshedAt: string | null }>>()
 
   async function backgroundRefreshRegistry(config: Awaited<ReturnType<typeof currentConfig>>) {
     const cachedPath = registryCachePath(config.registryUrl)
@@ -525,6 +526,37 @@ export namespace PluginMarketplaceRegistry {
     const cachedPath = registryCachePath(config.registryUrl)
     if (await isFresh(cachedPath, config.cacheTtlMs)) return
     await backgroundRefreshRegistry(config)
+  }
+
+  /**
+   * Force-refresh the remote registry cache immediately, bypassing the TTL.
+   * On success the registry.json cache is rewritten and the entry cache is
+   * dropped so detail reads re-fetch fresh entries; on failure the old caches
+   * are preserved and the error propagates to the caller.
+   */
+  export async function refreshNow(
+    inputConfig?: Awaited<ReturnType<typeof currentConfig>>,
+  ): Promise<{ refreshedAt: string | null }> {
+    const config = inputConfig ?? (await currentConfig())
+    if (!config.enabled) return { refreshedAt: null }
+    const cachedPath = registryCachePath(config.registryUrl)
+    const key = cachedPath
+    const existing = pendingForcedRefreshes.get(key)
+    if (existing) return existing
+    const promise = (async () => {
+      try {
+        const registry = await fetchJson(config.registryUrl, RemoteRegistry, config.requestTimeoutMs)
+        await writeJsonFile(cachedPath, registry)
+        const entriesRoot = cachePaths(config.registryUrl).entries
+        await fs.rm(entriesRoot, { recursive: true, force: true })
+        await fs.mkdir(entriesRoot, { recursive: true })
+        return { refreshedAt: new Date().toISOString() }
+      } finally {
+        pendingForcedRefreshes.delete(key)
+      }
+    })()
+    pendingForcedRefreshes.set(key, promise)
+    return promise
   }
 
   export async function searchOfficial(input: { q?: string; offset?: number; limit?: number } = {}) {

--- a/packages/synergy/src/server/plugin-registry-routes.ts
+++ b/packages/synergy/src/server/plugin-registry-routes.ts
@@ -412,6 +412,36 @@ export const RegistryRoute = new Hono()
     },
   )
 
+  // POST /refresh — Force-refresh the official registry cache immediately
+  .post(
+    "/refresh",
+    describeRoute({
+      summary: "Force refresh the official plugin registry cache",
+      description: "Re-fetch the official plugin registry index immediately, bypassing the cache TTL.",
+      operationId: "registry.refresh",
+      responses: {
+        200: {
+          description: "Registry refreshed",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({ refreshedAt: z.string().nullable() })),
+            },
+          },
+        },
+        ...errors(503),
+      },
+    }),
+    async (c) => {
+      try {
+        const result = await PluginMarketplaceRegistry.refreshNow()
+        return c.json(result)
+      } catch (error) {
+        log.warn("official plugin registry refresh failed", { error })
+        return c.json({ message: OFFICIAL_REGISTRY_UNAVAILABLE_MESSAGE }, 503)
+      }
+    },
+  )
+
   // GET /:id — Get full plugin entry with latest version
   .get(
     "/:id",

--- a/packages/synergy/test/server/plugin-registry-routes.test.ts
+++ b/packages/synergy/test/server/plugin-registry-routes.test.ts
@@ -636,4 +636,248 @@ describe("plugin registry routes v2", () => {
       },
     })
   })
+
+  test("manual refresh bypasses TTL and drops entry cache", async () => {
+    const stub = startOfficialRegistryStub("1.0.0")
+    const registryUrl = stub.url
+    const previousDomain = await Config.domainGet("plugins")
+    cleanRegistry()
+    await writeOfficialRegistryCache(registryUrl, 2)
+
+    try {
+      await Config.domainUpdate(
+        "plugins",
+        {
+          ...previousDomain,
+          pluginMarketplace: {
+            ...PLUGIN_MARKETPLACE_DEFAULTS,
+            enabled: true,
+            registryUrl,
+          },
+        },
+        { mode: "replace-domain" },
+      )
+      await Config.reload("global")
+
+      await ScopeContext.provide({
+        scope: Scope.home(),
+        fn: async () => {
+          const config = await PluginMarketplaceRegistry.currentConfig()
+          expect(config.enabled).toBe(true)
+
+          // A fresh cache serves the old version without touching the network.
+          const before = await PluginMarketplaceRegistry.searchOfficial()
+          expect(before.total).toBe(1)
+          expect(before.plugins[0].latestVersion).toBe("1.0.0")
+          expect(stub.requestCount).toBe(0)
+
+          // The remote registry publishes a new version; force refresh picks it up.
+          stub.setLatestVersion("2.0.0")
+          const app = Server.App()
+          const refreshRes = await app.request("/api/registry/refresh", { method: "POST" })
+          expect(refreshRes.status).toBe(200)
+          const refreshBody = await refreshRes.json()
+          expect(refreshBody.refreshedAt).toBeTruthy()
+
+          // The registry index cache was rewritten and the entry cache was dropped.
+          const marketRoot = PluginMarketplaceRegistry.cachePaths(registryUrl)
+          expect(fs.readdirSync(marketRoot.entries)).toEqual([])
+
+          const after = await PluginMarketplaceRegistry.searchOfficial()
+          expect(after.plugins[0].latestVersion).toBe("2.0.0")
+
+          // The detail route re-fetches the fresh entry after the cache drop.
+          const detailRes = await app.request("/api/registry/official-test-plugin?source=official")
+          expect(detailRes.status).toBe(200)
+          const detail = await detailRes.json()
+          expect(detail.versions[0].version).toBe("2.0.0")
+        },
+      })
+    } finally {
+      await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
+      await Config.reload("global")
+      await stub.stop()
+    }
+  })
+
+  test("manual refresh returns 503 and preserves stale cache when registry is unreachable", async () => {
+    const registryUrl = "http://127.0.0.1:1/registry.json"
+    const previousDomain = await Config.domainGet("plugins")
+    cleanRegistry()
+    await writeOfficialRegistryCache(registryUrl, 2)
+
+    try {
+      await Config.domainUpdate(
+        "plugins",
+        {
+          ...previousDomain,
+          pluginMarketplace: {
+            ...PLUGIN_MARKETPLACE_DEFAULTS,
+            enabled: true,
+            registryUrl,
+            requestTimeoutMs: 50,
+          },
+        },
+        { mode: "replace-domain" },
+      )
+      await Config.reload("global")
+
+      await ScopeContext.provide({
+        scope: Scope.home(),
+        fn: async () => {
+          const app = Server.App()
+          const refreshRes = await app.request("/api/registry/refresh", { method: "POST" })
+          expect(refreshRes.status).toBe(503)
+          expect(await refreshRes.json()).toEqual({ message: "Official plugin registry temporarily unavailable" })
+
+          // The old registry cache remains intact and still serves the stale list.
+          const cachedPath = PluginMarketplaceRegistry.cachePaths(registryUrl).registry
+          expect(fs.existsSync(cachedPath)).toBe(true)
+
+          const searchRes = await app.request("/api/registry/search?source=official")
+          expect(searchRes.status).toBe(200)
+          const body = await searchRes.json()
+          expect(body.total).toBe(1)
+          expect(body.plugins[0].latestVersion).toBe("1.0.0")
+        },
+      })
+    } finally {
+      await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
+      await Config.reload("global")
+    }
+  })
+
+  test("concurrent manual refreshes are deduplicated", async () => {
+    const stub = startOfficialRegistryStub("1.0.0")
+    const registryUrl = stub.url
+    const previousDomain = await Config.domainGet("plugins")
+    cleanRegistry()
+
+    try {
+      await Config.domainUpdate(
+        "plugins",
+        {
+          ...previousDomain,
+          pluginMarketplace: {
+            ...PLUGIN_MARKETPLACE_DEFAULTS,
+            enabled: true,
+            registryUrl,
+          },
+        },
+        { mode: "replace-domain" },
+      )
+      await Config.reload("global")
+
+      await ScopeContext.provide({
+        scope: Scope.home(),
+        fn: async () => {
+          const app = Server.App()
+          const [first, second] = await Promise.all([
+            app.request("/api/registry/refresh", { method: "POST" }),
+            app.request("/api/registry/refresh", { method: "POST" }),
+          ])
+          expect(first.status).toBe(200)
+          expect(second.status).toBe(200)
+          expect(stub.requestCount).toBe(1)
+        },
+      })
+    } finally {
+      await Config.domainUpdate("plugins", previousDomain, { mode: "replace-domain" })
+      await Config.reload("global")
+      await stub.stop()
+    }
+  })
 })
+
+function startOfficialRegistryStub(initialLatestVersion: string) {
+  let latestVersion = initialLatestVersion
+  let requestCount = 0
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      requestCount += 1
+      const url = new URL(request.url)
+      if (url.pathname.endsWith("/registry.json")) {
+        return Response.json({
+          schemaVersion: 2,
+          updatedAt: "2026-06-26T00:00:00.000Z",
+          plugins: [
+            {
+              id: "official-test-plugin",
+              name: "official-test-plugin",
+              description: "Official cached plugin",
+              repo: "https://github.com/SII-Holos/official-test-plugin",
+              entry: "plugins/official-test-plugin.json",
+              author: { name: "SII Holos" },
+              verified: true,
+              official: true,
+              keywords: ["synergy-plugin", "official"],
+              latestVersion,
+              updatedAt: "2026-06-26T00:00:00.000Z",
+              runtimeMode: "process",
+              tools: ["greet"],
+              uiSurfaces: ["toolRenderers"],
+            },
+          ],
+        })
+      }
+      if (url.pathname.endsWith("/plugins/official-test-plugin.json")) {
+        return Response.json({
+          schemaVersion: 2,
+          id: "official-test-plugin",
+          name: "official-test-plugin",
+          description: "Official cached plugin",
+          repo: "https://github.com/SII-Holos/official-test-plugin",
+          author: { name: "SII Holos" },
+          verified: true,
+          official: true,
+          keywords: ["synergy-plugin", "official"],
+          compatibility: { synergy: ">=2.4.3" },
+          versions: [
+            {
+              version: latestVersion,
+              apiVersion: "4.0",
+              compatibility: { synergy: ">=2.4.3" },
+              downloadUrl: `https://github.com/SII-Holos/official-test-plugin/releases/download/v${latestVersion}/official-test-plugin-${latestVersion}.synergy-plugin.tgz`,
+              signatureUrl: `https://github.com/SII-Holos/official-test-plugin/releases/download/v${latestVersion}/official-test-plugin-${latestVersion}.synergy-plugin.tgz.sig`,
+              signature: {
+                algorithm: "ed25519",
+                signer: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              },
+              integrity: "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              manifestHash: "manifest-hash",
+              permissionsHash: "permissions-hash",
+              runtimeMode: "process",
+              featuresSummary: [{ key: "tool:greet", title: "Greeting", description: "Adds a greeting tool." }],
+              permissionsSummary: [
+                {
+                  key: "file_read",
+                  description: "Read workspace files",
+                  category: "files",
+                  title: "Read workspace files",
+                },
+              ],
+              tools: ["greet"],
+              uiSurfaces: ["toolRenderers"],
+              publishedAt: "2026-06-26T00:00:00.000Z",
+            },
+          ],
+          yankedVersions: [],
+        })
+      }
+      return new Response("Not found", { status: 404 })
+    },
+  })
+  return {
+    url: `http://127.0.0.1:${server.port}/registry.json`,
+    setLatestVersion(version: string) {
+      latestVersion = version
+    },
+    get requestCount() {
+      return requestCount
+    },
+    async stop() {
+      await server.stop(true)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

The plugin Marketplace sidebar refreshed the official plugin catalog only on the hourly cache TTL, so new plugin versions from the `synergy-plugins` registry were invisible for up to an hour. This adds a manual refresh action that bypasses the cache immediately.

- **Backend**: new `POST /api/registry/refresh` endpoint backed by `PluginMarketplaceRegistry.refreshNow()` — force-fetches the remote registry index (bypassing `cacheTtlMs`), atomically rewrites `registry.json`, and drops the entry cache so detail views re-fetch fresh data. On failure the stale caches are preserved and the route returns the existing structured `503` response.
- **Frontend**: a refresh button in the Marketplace header (all views) calls the endpoint through the generated SDK, shows a spinner while running, toasts on success/failure, and refetches the search and installed lists so "Update available" states appear immediately.
- **SDK/OpenAPI**: regenerated (`client.registry.refresh()`).
- **i18n + docs**: new copy for en / zh-CN / pseudo; `docs/plugins/marketplace.md` documents the manual refresh behavior.

## Verification

- `packages/synergy`: `bun test test/server/plugin-registry-routes.test.ts` — 16 pass (3 new tests: TTL bypass + entry cache drop, 503 with stale cache preserved, concurrent dedupe)
- `packages/app`: `bun run typecheck` + `bun run test` pass
- `bun run localization:check` pass
- `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run quality:quick` pass