### PR TITLE
fix(session): preserve structured Agent worker errors

### DIFF
--- a/packages/synergy/src/session/agent-turn/protocol.ts
+++ b/packages/synergy/src/session/agent-turn/protocol.ts
@@ -401,12 +401,24 @@ export namespace AgentTurnProtocol {
       const field = (key: string) => source[key] ?? nested?.[key]
       const rawName = field("name")
       const rawMessage = field("message")
+      const rawCode = field("code")
+      const rawType = field("type")
       const rawStack = field("stack")
       const normalized = Object.assign(
-        new Error(typeof rawMessage === "string" && rawMessage ? rawMessage : "Unknown structured error"),
+        new Error(
+          (typeof rawMessage === "string" && rawMessage ? rawMessage : safeStringify(error)).slice(
+            0,
+            ERROR_MESSAGE_MAX_CHARS,
+          ),
+        ),
         {
           name: typeof rawName === "string" && rawName ? rawName : "Error",
-          code: field("code"),
+          code:
+            typeof rawCode === "string" && rawCode
+              ? rawCode
+              : typeof rawType === "string" && rawType
+                ? rawType
+                : undefined,
           syscall: field("syscall"),
           data: field("data"),
           statusCode: field("statusCode"),
@@ -647,6 +659,24 @@ export namespace AgentTurnProtocol {
         "syscall" in value && value.syscall !== undefined
           ? String(value.syscall).slice(0, ERROR_MESSAGE_MAX_CHARS)
           : undefined,
+    }
+  }
+
+  function safeStringify(value: unknown): string {
+    if (typeof value === "string") return value
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return String(value)
+    }
+    if (value === null) return "null"
+    if (value === undefined) return "undefined"
+    try {
+      return JSON.stringify(value)
+    } catch {
+      const parts: string[] = []
+      for (const [key, entry] of Object.entries(value)) {
+        if (typeof entry === "string") parts.push(`${key}: ${entry}`)
+      }
+      return parts.length > 0 ? parts.join(", ") : String(value)
     }
   }
 }

--- a/packages/synergy/src/session/agent-turn/protocol.ts
+++ b/packages/synergy/src/session/agent-turn/protocol.ts
@@ -389,10 +389,35 @@ export namespace AgentTurnProtocol {
 
   export function serializeError(error: unknown): SerializedError {
     if (!(error instanceof Error)) {
-      return {
-        name: "Error",
-        message: String(error).slice(0, ERROR_MESSAGE_MAX_CHARS),
+      if (!error || typeof error !== "object") {
+        return {
+          name: "Error",
+          message: String(error).slice(0, ERROR_MESSAGE_MAX_CHARS),
+        }
       }
+      const source = error as Record<string, unknown>
+      const nested =
+        source.error && typeof source.error === "object" ? (source.error as Record<string, unknown>) : undefined
+      const field = (key: string) => source[key] ?? nested?.[key]
+      const rawName = field("name")
+      const rawMessage = field("message")
+      const rawStack = field("stack")
+      const normalized = Object.assign(
+        new Error(typeof rawMessage === "string" && rawMessage ? rawMessage : "Unknown structured error"),
+        {
+          name: typeof rawName === "string" && rawName ? rawName : "Error",
+          code: field("code"),
+          syscall: field("syscall"),
+          data: field("data"),
+          statusCode: field("statusCode"),
+          responseHeaders: field("responseHeaders"),
+          responseBody: field("responseBody"),
+          isRetryable: field("isRetryable"),
+          cause: field("cause"),
+        },
+      )
+      normalized.stack = typeof rawStack === "string" ? rawStack : undefined
+      return serializeError(normalized)
     }
     const code =
       "code" in error && error.code !== undefined ? String(error.code).slice(0, ERROR_MESSAGE_MAX_CHARS) : undefined

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -1729,6 +1729,20 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      case e instanceof Error && typeof (e as { isRetryable?: unknown }).isRetryable === "boolean":
+        const structured = e as Error & { statusCode?: unknown; isRetryable?: boolean; code?: unknown }
+        return new MessageV2.APIError(
+          {
+            message: structured.message,
+            statusCode: typeof structured.statusCode === "number" ? structured.statusCode : undefined,
+            isRetryable: structured.isRetryable ?? false,
+            metadata: {
+              ...(typeof structured.code === "string" ? { code: structured.code } : {}),
+              message: structured.message,
+            },
+          },
+          { cause: e },
+        ).toObject()
       case e instanceof Error:
         return new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
       default:

--- a/packages/synergy/test/session/agent-turn-protocol.test.ts
+++ b/packages/synergy/test/session/agent-turn-protocol.test.ts
@@ -510,6 +510,76 @@ describe("AgentTurnProtocol", () => {
     })
   })
 
+  test("maps issue repro type field into code and keeps message", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: {
+            type: "server_error",
+            code: "upstream_unavailable",
+            message: "temporarily unavailable",
+            statusCode: 503,
+            isRetryable: true,
+          },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error & { code?: unknown; statusCode?: unknown; isRetryable?: boolean } }>
+
+    expect(decoded.error.message).toBe("temporarily unavailable")
+    expect(decoded.error.code).toBe("upstream_unavailable")
+    expect(decoded.error.statusCode).toBe(503)
+    expect(decoded.error.isRetryable).toBe(true)
+  })
+
+  test("falls back to bounded JSON for plain object errors without a message", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([{ type: "error", error: { type: "server_error", code: "unavailable" } }]),
+    ) as Array<{ type: string; error: Error }>
+
+    expect(decoded.error.message).toContain("unavailable")
+    expect(decoded.error.message).not.toContain("Unknown structured error")
+    expect(decoded.error.message).not.toContain("[object Object]")
+  })
+
+  test("never fails serialization on circular plain object errors", () => {
+    const circular: Record<string, unknown> = { type: "server_error", message: "circular provider error" }
+    circular.self = circular
+
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([{ type: "error", error: circular }]),
+    ) as Array<{ type: string; error: Error }>
+
+    expect(decoded.error.message).toBe("circular provider error")
+  })
+
+  test("bounds oversized plain object error data without failing", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: {
+            type: "server_error",
+            message: "oversized payload",
+            huge: "x".repeat(AgentTurnProtocol.ERROR_DATA_MAX_BYTES + 1024),
+          },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error & { data?: unknown } }>
+
+    expect(decoded.error.message).toBe("oversized payload")
+    expect(decoded.error.data).toBeUndefined()
+  })
+
+  test("preserves scalar non-object errors unchanged", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([{ type: "error", error: "plain failure" }]),
+    ) as Array<{ type: string; error: Error }>
+
+    expect(decoded.error).toBeInstanceOf(Error)
+    expect(decoded.error.message).toBe("plain failure")
+  })
+
   test("rejects unknown protocol fields and invalid frame counters", () => {
     expect(() =>
       AgentTurnProtocol.parseHostToWorker({

--- a/packages/synergy/test/session/agent-turn-protocol.test.ts
+++ b/packages/synergy/test/session/agent-turn-protocol.test.ts
@@ -463,6 +463,53 @@ describe("AgentTurnProtocol", () => {
     expect(decoded.error).toMatchObject({ statusCode: 503, isRetryable: true })
   })
 
+  test("preserves plain structured errors embedded in stream events", () => {
+    const [decoded, nested] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: {
+            name: "ProviderResponseError",
+            message: "upstream request failed",
+            code: "upstream_unavailable",
+            statusCode: 503,
+            isRetryable: true,
+            data: { requestID: "request_1" },
+          },
+        },
+        {
+          type: "error",
+          error: {
+            statusCode: 429,
+            error: {
+              name: "RateLimitError",
+              message: "retry later",
+              code: "rate_limit",
+              isRetryable: true,
+            },
+          },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error & Record<string, unknown> }>
+
+    expect(decoded.type).toBe("error")
+    expect(decoded.error).toMatchObject({
+      name: "ProviderResponseError",
+      message: "upstream request failed",
+      code: "upstream_unavailable",
+      statusCode: 503,
+      isRetryable: true,
+      data: { requestID: "request_1" },
+    })
+    expect(nested.error).toMatchObject({
+      name: "RateLimitError",
+      message: "retry later",
+      code: "rate_limit",
+      statusCode: 429,
+      isRetryable: true,
+    })
+  })
+
   test("rejects unknown protocol fields and invalid frame counters", () => {
     expect(() =>
       AgentTurnProtocol.parseHostToWorker({

--- a/packages/synergy/test/session/retry.test.ts
+++ b/packages/synergy/test/session/retry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { AgentTurnProtocol } from "../../src/session/agent-turn/protocol"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 import { APICallError } from "ai"
@@ -207,5 +208,34 @@ describe("session.message-v2.fromError", () => {
     expect(result).toMatchObject({
       data: { providerID: "test", modelID: "model-retained", reason: "rejected_by_provider" },
     })
+  })
+
+  test("converts protocol-rehydrated structured errors into retryable APIError", () => {
+    const restored = AgentTurnProtocol.deserializeError(
+      AgentTurnProtocol.serializeError({
+        type: "server_error",
+        code: "upstream_unavailable",
+        message: "The upstream service is temporarily unavailable",
+        statusCode: 503,
+        isRetryable: true,
+      }),
+    )
+
+    const result = MessageV2.fromError(restored, { providerID: "test" })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.statusCode).toBe(503)
+    expect(SessionRetry.retryable(result)).toBe("The upstream service is temporarily unavailable")
+  })
+
+  test("keeps unknown errors unknown when no retry metadata survives", () => {
+    const restored = AgentTurnProtocol.deserializeError(
+      AgentTurnProtocol.serializeError({ type: "server_error", message: "boom" }),
+    )
+
+    const result = MessageV2.fromError(restored, { providerID: "test" })
+
+    expect(result.name).toBe("UnknownError")
   })
 })


### PR DESCRIPTION
## Summary

- preserve messages and retry metadata when Agent worker stream errors are plain objects
- support the common nested `{ error: { message, code } }` provider response shape
- keep scalar and existing `Error`/`APICallError` handling unchanged

Fixes #1122.

## Changes

| File | Change |
|------|--------|
| `packages/synergy/src/session/agent-turn/protocol.ts` | Normalize structured object errors through the existing bounded error serializer |
| `packages/synergy/test/session/agent-turn-protocol.test.ts` | Cover direct and nested structured stream errors |

## Verification

- `bun test test/session/agent-turn-protocol.test.ts` (19 passed)
- `bun run typecheck` in `packages/synergy`
- pre-push formatting, lint, monorepo typecheck, and package consistency checks
