### PR TITLE
fix(session): preserve structured stream errors across Agent worker IPC

### DIFF
--- a/packages/synergy/src/session/agent-turn/protocol.ts
+++ b/packages/synergy/src/session/agent-turn/protocol.ts
@@ -389,9 +389,23 @@ export namespace AgentTurnProtocol {
 
   export function serializeError(error: unknown): SerializedError {
     if (!(error instanceof Error)) {
+      const object = isPlainRecord(error) ? error : undefined
+      const nested = isPlainRecord(object?.error) ? object.error : undefined
+      const message = firstString(
+        object?.message,
+        nested?.message,
+        isPlainRecord(nested?.error) ? nested.error.message : undefined,
+      )
+      const code = firstString(object?.code, nested?.code, object?.type, nested?.type)
+      const statusCode = firstInteger(object?.statusCode, nested?.statusCode)
+      const isRetryable = firstBoolean(object?.isRetryable, nested?.isRetryable)
       return {
-        name: "Error",
-        message: String(error).slice(0, ERROR_MESSAGE_MAX_CHARS),
+        name: firstString(object?.name, nested?.name) ?? "Error",
+        message: (message ?? safeStringify(error)).slice(0, ERROR_MESSAGE_MAX_CHARS),
+        code: code?.slice(0, ERROR_MESSAGE_MAX_CHARS),
+        statusCode,
+        isRetryable,
+        data: object === undefined ? undefined : boundedSerializable(object, ERROR_DATA_MAX_BYTES),
       }
     }
     const code =
@@ -622,6 +636,49 @@ export namespace AgentTurnProtocol {
         "syscall" in value && value.syscall !== undefined
           ? String(value.syscall).slice(0, ERROR_MESSAGE_MAX_CHARS)
           : undefined,
+    }
+  }
+
+  function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+  }
+
+  function firstString(...values: unknown[]): string | undefined {
+    for (const value of values) {
+      if (typeof value === "string" && value.length > 0) return value
+    }
+    return undefined
+  }
+
+  function firstInteger(...values: unknown[]): number | undefined {
+    for (const value of values) {
+      if (typeof value === "number" && Number.isInteger(value)) return value
+    }
+    return undefined
+  }
+
+  function firstBoolean(...values: unknown[]): boolean | undefined {
+    for (const value of values) {
+      if (typeof value === "boolean") return value
+    }
+    return undefined
+  }
+
+  function safeStringify(value: unknown): string {
+    if (typeof value === "string") return value
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return String(value)
+    }
+    if (value === null) return "null"
+    if (value === undefined) return "undefined"
+    try {
+      return JSON.stringify(value)
+    } catch {
+      const parts: string[] = []
+      for (const [key, entry] of Object.entries(value)) {
+        if (typeof entry === "string") parts.push(`${key}: ${entry}`)
+      }
+      return parts.length > 0 ? parts.join(", ") : String(value)
     }
   }
 }

--- a/packages/synergy/src/session/message-v2.ts
+++ b/packages/synergy/src/session/message-v2.ts
@@ -1729,6 +1729,20 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      case e instanceof Error && typeof (e as { isRetryable?: unknown }).isRetryable === "boolean":
+        const structured = e as Error & { statusCode?: unknown; isRetryable?: boolean; code?: unknown }
+        return new MessageV2.APIError(
+          {
+            message: structured.message,
+            statusCode: typeof structured.statusCode === "number" ? structured.statusCode : undefined,
+            isRetryable: structured.isRetryable ?? false,
+            metadata: {
+              ...(typeof structured.code === "string" ? { code: structured.code } : {}),
+              message: structured.message,
+            },
+          },
+          { cause: e },
+        ).toObject()
       case e instanceof Error:
         return new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
       default:

--- a/packages/synergy/test/session/agent-turn-protocol.test.ts
+++ b/packages/synergy/test/session/agent-turn-protocol.test.ts
@@ -463,6 +463,100 @@ describe("AgentTurnProtocol", () => {
     expect(decoded.error).toMatchObject({ statusCode: 503, isRetryable: true })
   })
 
+  test("preserves plain object stream errors across the protocol boundary", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: {
+            type: "server_error",
+            code: "upstream_unavailable",
+            message: "temporarily unavailable",
+          },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error }>
+
+    expect(decoded.type).toBe("error")
+    expect(decoded.error).toBeInstanceOf(Error)
+    expect(decoded.error.message).toContain("temporarily unavailable")
+    expect(decoded.error.message).not.toContain("[object Object]")
+  })
+
+  test("preserves nested error payloads from plain object stream errors", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: { error: { message: "upstream refused", code: "connection_refused" } },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error & { code?: string; data?: unknown } }>
+
+    expect(decoded.error.message).toBe("upstream refused")
+    expect(decoded.error.code).toBe("connection_refused")
+  })
+
+  test("keeps retry metadata on plain object stream errors", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: {
+            type: "server_error",
+            code: "overloaded",
+            message: "provider overloaded",
+            statusCode: 503,
+            isRetryable: true,
+          },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error & { statusCode?: number; isRetryable?: boolean } }>
+
+    expect(decoded.error.statusCode).toBe(503)
+    expect(decoded.error.isRetryable).toBe(true)
+    expect(decoded.error.message).toBe("provider overloaded")
+  })
+
+  test("falls back to bounded JSON for plain object errors without a message", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([{ type: "error", error: { type: "server_error", code: "unavailable" } }]),
+    ) as Array<{ type: string; error: Error }>
+
+    expect(decoded.error.message).not.toContain("[object Object]")
+    expect(decoded.error.message).toContain("unavailable")
+  })
+
+  test("never fails serialization on circular plain object errors", () => {
+    const circular: Record<string, unknown> = { type: "server_error", message: "circular provider error" }
+    circular.self = circular
+
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([{ type: "error", error: circular }]),
+    ) as Array<{ type: string; error: Error }>
+
+    expect(decoded.error.message).toBe("circular provider error")
+    expect(decoded.error.message).not.toContain("[object Object]")
+  })
+
+  test("bounds oversized plain object error data without failing", () => {
+    const [decoded] = AgentTurnProtocol.decodeEvents(
+      AgentTurnProtocol.encodeEvents([
+        {
+          type: "error",
+          error: {
+            type: "server_error",
+            message: "oversized payload",
+            huge: "x".repeat(AgentTurnProtocol.ERROR_DATA_MAX_BYTES + 1024),
+          },
+        },
+      ]),
+    ) as Array<{ type: string; error: Error & { data?: unknown } }>
+
+    expect(decoded.error.message).toBe("oversized payload")
+    expect(decoded.error.data).toBeUndefined()
+  })
+
   test("rejects unknown protocol fields and invalid frame counters", () => {
     expect(() =>
       AgentTurnProtocol.parseHostToWorker({

--- a/packages/synergy/test/session/retry.test.ts
+++ b/packages/synergy/test/session/retry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { AgentTurnProtocol } from "../../src/session/agent-turn/protocol"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
 import { APICallError } from "ai"
@@ -207,5 +208,34 @@ describe("session.message-v2.fromError", () => {
     expect(result).toMatchObject({
       data: { providerID: "test", modelID: "model-retained", reason: "rejected_by_provider" },
     })
+  })
+
+  test("converts protocol-rehydrated structured errors into retryable APIError", () => {
+    const restored = AgentTurnProtocol.deserializeError(
+      AgentTurnProtocol.serializeError({
+        type: "server_error",
+        code: "upstream_unavailable",
+        message: "The upstream service is temporarily unavailable",
+        statusCode: 503,
+        isRetryable: true,
+      }),
+    )
+
+    const result = MessageV2.fromError(restored, { providerID: "test" })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.statusCode).toBe(503)
+    expect(SessionRetry.retryable(result)).toBe("The upstream service is temporarily unavailable")
+  })
+
+  test("keeps unknown errors unknown when no retry metadata survives", () => {
+    const restored = AgentTurnProtocol.deserializeError(
+      AgentTurnProtocol.serializeError({ type: "server_error", message: "boom" }),
+    )
+
+    const result = MessageV2.fromError(restored, { providerID: "test" })
+
+    expect(result.name).toBe("UnknownError")
   })
 })


### PR DESCRIPTION
Closes #1122

## Summary

- Structured provider errors emitted through an AI SDK stream can be plain JSON objects rather than `Error` instances. When such an event crossed the Agent worker IPC boundary, `AgentTurnProtocol.serializeError()` handled the non-`Error` branch with `String(error)`, collapsing it to `[object Object]`. The host then rehydrated `Error("[object Object]")`, `SessionProcessor` threw it, and `MessageV2.fromError()` persisted an `UnknownError` whose only useful field was `Error: [object Object]` — losing provider `message`, `code`, `type`, nested error fields, and retry metadata, and turning retryable provider failures into terminal `UnknownError` turns.

## Changes

- `packages/synergy/src/session/agent-turn/protocol.ts`
  - `serializeError()` now extracts structured fields (`message`, `code`/`type`, `statusCode`, `isRetryable`) from plain-object errors, including nested `{ error: { ... } }` payloads.
  - Fallback is bounded safe JSON (never `String(object)`), and circular/oversized values never fail serialization.
  - Preserves existing size limits and reuses `boundedSerializable()` for the `data` payload.
- `packages/synergy/src/session/message-v2.ts`
  - `fromError()` now recognizes protocol-rehydrated structured errors (identified by the `isRetryable` boolean marker that plain native `Error`s never carry) and converts them into `APIError`, so `SessionRetry.retryable()` can classify and retry them instead of persisting `UnknownError`.

## Tests

- `test/session/agent-turn-protocol.test.ts`: plain-object stream error regression (issue reproduction), nested payload, retry metadata retention, bounded-JSON fallback, circular safety, oversized data bounding.
- `test/session/retry.test.ts`: downstream `fromError()` + `SessionRetry.retryable()` closed-loop coverage, plus unknown-error preservation when no retry metadata survives.

## Verification

- `bun test test/session/agent-turn-protocol.test.ts` — 24 pass
- `bun test test/session/retry.test.ts` — 18 pass
- `bun run test:changed` — 3801 pass (2 unrelated pre-existing timeout flakes in migration tests, pass in isolation)
- `bun run typecheck`, `bun run lint`, `bunx prettier --check` — clean