### PR TITLE
fix(tool): expose github_deliver_fix to the GitHub channel agent

### DIFF
--- a/docs/architecture/github-channel.md
+++ b/docs/architecture/github-channel.md
@@ -119,10 +119,11 @@ When the agent fixes an issue, the fix is delivered as a pull request by default
 
 1. Verifies the session is bound to a GitHub channel thread and the workspace checkout exists.
 2. Resolves the repository default branch as the PR base.
-3. Verifies the local branch exists and has commits ahead of the base.
-4. **When the thread is a pull request**, pushes the fix to that PR's head branch first, updating the PR in place (Codex-style behavior). Same-repository PRs push directly; fork PRs push to the fork only when the App has an installation there. If the push is impossible (fork without App access, protected or moved head branch), it falls back to the next step.
-5. **Fallback / issue threads**: pushes the `synergy/fix/...` branch and opens a deduplicated pull request against the repository default branch (reuses an existing open PR with the same head branch).
-6. Returns the PR URL; the agent reports it in its final comment.
+3. Rejects the request when the supplied branch is the repository base branch itself — delivery must use a dedicated fix branch so the provider never pushes directly to the default branch.
+4. Verifies the local branch exists and has commits ahead of the base.
+5. **When the thread is a pull request**, pushes the fix to that PR's head branch first, updating the PR in place (Codex-style behavior). Same-repository PRs push directly; fork PRs push to the fork only when the App has an installation there. If the push is impossible (fork without App access, protected or moved head branch, or the PR head repository is unknown), it falls back to the next step.
+6. **Fallback / issue threads**: pushes the `synergy/fix/...` branch and opens a deduplicated pull request against the repository default branch (reuses an existing open PR with the same head branch).
+7. Returns the PR URL; the agent reports it in its final comment.
 
 The agent's bash permissions keep `gh`, `git push`, and `git remote` denied — all GitHub writes flow through the provider with the installation token.
 

--- a/docs/architecture/github-channel.md
+++ b/docs/architecture/github-channel.md
@@ -119,13 +119,13 @@ When the agent fixes an issue, the fix is delivered as a pull request by default
 
 1. Verifies the session is bound to a GitHub channel thread and the workspace checkout exists.
 2. Resolves the repository default branch as the PR base.
-3. Rejects the request when the supplied branch is the repository base branch itself — delivery must use a dedicated fix branch so the provider never pushes directly to the default branch.
-4. Verifies the local branch exists and has commits ahead of the base.
+3. Resolves the supplied ref to its canonical local branch (rejecting symbolic refs such as `HEAD`, which would push whatever branch is checked out), then rejects the request when that branch is the repository base branch itself — delivery must use a dedicated fix branch so the provider never pushes directly to the default branch.
+4. Verifies the branch has at least one commit beyond the comparison ref: the fetched PR head for PR threads (so pushing the unchanged PR back is never reported as a delivery), otherwise the repository base branch.
 5. **When the thread is a pull request**, pushes the fix to that PR's head branch first, updating the PR in place (Codex-style behavior). Same-repository PRs push directly; fork PRs push to the fork only when the App has an installation there. If the push is impossible (fork without App access, protected or moved head branch, or the PR head repository is unknown), it falls back to the next step.
 6. **Fallback / issue threads**: pushes the `synergy/fix/...` branch and opens a deduplicated pull request against the repository default branch (reuses an existing open PR with the same head branch).
 7. Returns the PR URL; the agent reports it in its final comment.
 
-The agent's bash permissions keep `gh`, `git push`, and `git remote` denied — all GitHub writes flow through the provider with the installation token.
+All git commands run with the installation-token credential helper (`git -c credential.helper=…`), never the token on argv, and provider-owned pushes use `--no-verify` so repository-controlled pre-push hooks cannot read the token from the child environment. The delivery honors the session abort signal: cancellation terminates in-flight git subprocesses and aborts GitHub API requests.
 
 ## Agent
 

--- a/packages/synergy/src/agent/builtin-internal.ts
+++ b/packages/synergy/src/agent/builtin-internal.ts
@@ -179,6 +179,8 @@ export function createBuiltinInternalAgents(ctx: BuiltinAgentContext): Record<st
         write: "allow",
         todoread: "allow",
         todowrite: "allow",
+        // The fix-delivery tool must be callable from the whitelist.
+        github_deliver_fix: "allow",
         bash: {
           "*": "allow",
           "gh*": "deny",

--- a/packages/synergy/src/channel/provider/github/index.ts
+++ b/packages/synergy/src/channel/provider/github/index.ts
@@ -1,4 +1,3 @@
-import { $ } from "bun"
 import { Config } from "@/config/config"
 import { Scope } from "@/scope"
 import { Log } from "@/util/log"
@@ -83,7 +82,8 @@ function splitRepository(repository: string): { owner: string; repo: string } {
 /**
  * Reject a fix-delivery branch that equals the resolved repository base
  * branch: pushing it would update the default branch directly instead of
- * opening a pull request.
+ * opening a pull request. The caller passes the canonical branch name
+ * (resolved from the supplied ref by `resolveCanonicalBranch`).
  */
 export function assertNotBaseBranch(branch: string, baseBranch: string): void {
   // "refs/heads/main" pushes the same remote ref as "main"; normalize the
@@ -94,6 +94,24 @@ export function assertNotBaseBranch(branch: string, baseBranch: string): void {
       `Branch "${branch}" is the repository base branch; create a dedicated fix branch (e.g. synergy/fix/<issue>-<slug>) before delivering`,
     )
   }
+}
+
+/**
+ * Resolve a ref to its canonical local branch (e.g. `HEAD` resolves to
+ * `refs/heads/<branch>` when a branch is checked out). Returns undefined when
+ * the ref does not name a local branch (missing ref, tag, detached HEAD).
+ */
+export async function resolveCanonicalBranch(directory: string, ref: string): Promise<string | undefined> {
+  const proc = Bun.spawn(["git", "rev-parse", "--verify", "--symbolic-full-name", ref], {
+    cwd: directory,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  const exitCode = await proc.exited
+  if (exitCode !== 0) return undefined
+  const canonical = stdout.trim()
+  return canonical.startsWith("refs/heads/") ? canonical : undefined
 }
 
 function joinOutboundText(parts: ChannelTypes.OutboundPart[]): string {
@@ -302,17 +320,18 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
     return scope
   }
 
-  private async resolveInstallationToken(owner: string, repo: string): Promise<string> {
+  private async resolveInstallationToken(owner: string, repo: string, signal?: AbortSignal): Promise<string> {
     const appId = Number(process.env.SYNERGY_GITHUB_APP_ID)
     const privateKey = process.env.SYNERGY_GITHUB_APP_PRIVATE_KEY?.replaceAll("\\n", "\n") ?? ""
     const jwt = GitHubChannelAuth.generateJWT({ appId, privateKey })
     const installation = await GitHubChannelAuth.GitHubClient.send<{ id?: unknown }>(
       GitHubChannelAuth.GitHubClient.resolveInstallation({ owner, repo, jwt }),
+      signal,
     )
     if (typeof installation?.id !== "number" || !Number.isInteger(installation.id) || installation.id <= 0) {
       throw new Error(`GitHub App installation for ${owner}/${repo} has no valid ID`)
     }
-    return GitHubChannelAuth.getInstallationToken(installation.id)
+    return GitHubChannelAuth.getInstallationToken(installation.id, signal)
   }
 
   /**
@@ -325,12 +344,15 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
    * moved head branch), it falls back to opening a deduplicated PR against
    * the repository default branch.
    */
-  async deliverFix(input: {
-    sessionID: string
-    branch: string
-    title: string
-    body: string
-  }): Promise<{ pullRequestURL: string; pullNumber: number; headBranch: string }> {
+  async deliverFix(
+    input: {
+      sessionID: string
+      branch: string
+      title: string
+      body: string
+    },
+    signal?: AbortSignal,
+  ): Promise<{ pullRequestURL: string; pullNumber: number; headBranch: string }> {
     if (!/^[A-Za-z0-9_.\-/]+$/.test(input.branch) || input.branch.startsWith("/") || input.branch.includes("..")) {
       throw new Error(`Invalid branch name: ${input.branch}`)
     }
@@ -352,37 +374,49 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
 
     // Resolve the base branch (repository default branch preferred).
     const { owner, repo } = splitRepository(parsed.repository)
-    const token = await this.resolveInstallationToken(owner, repo)
+    const token = await this.resolveInstallationToken(owner, repo, signal)
     const facts = this.accounts.get(accountId)?.threadFacts.get(`${parsed.repository}#${parsed.issueNumber}`)
-    const baseBranch = facts?.defaultBranch ?? (await this.resolveDefaultBranch(owner, repo, token)) ?? "main"
+    const baseBranch = facts?.defaultBranch ?? (await this.resolveDefaultBranch(owner, repo, token, signal)) ?? "main"
 
-    assertNotBaseBranch(input.branch, baseBranch)
+    // Resolve the supplied ref to its canonical local branch. This rejects
+    // symbolic refs such as `HEAD` (which would push whatever branch is
+    // checked out — potentially the default branch) before the base-branch
+    // comparison, and verifies the branch exists.
+    const canonical = await resolveCanonicalBranch(record.directory, input.branch)
+    if (!canonical) throw new Error(`Local branch ${input.branch} does not exist`)
+    const canonicalBranch = canonical.replace(/^refs\/heads\//, "")
+    assertNotBaseBranch(canonicalBranch, baseBranch)
 
     const credential = buildCredentialCommand({ token, args: [] })
 
-    // Verify the local branch exists and is ahead of the base branch.
-    const exists = await $`git rev-parse --verify ${input.branch}`.cwd(record.directory).quiet().nothrow()
-    if (exists.exitCode !== 0) throw new Error(`Local branch ${input.branch} does not exist`)
-    const ahead = await $`git rev-list --count ${input.branch} ^origin/${baseBranch}`
-      .cwd(record.directory)
-      .quiet()
-      .nothrow()
-    const aheadCount = Number(ahead.stdout.toString().trim())
+    // Require at least one commit beyond the comparison ref: for PR threads
+    // the fetched PR head (so pushing the unchanged PR back is never reported
+    // as a delivery), otherwise the repository base branch.
+    const aheadRef = facts?.pullNumber ? `origin/pr-${facts.pullNumber}` : `origin/${baseBranch}`
+    const ahead = await this.runGit(["git", "rev-list", "--count", canonicalBranch, `^${aheadRef}`], {
+      cwd: record.directory,
+      env: credential.env,
+      signal,
+    })
+    const aheadCount = Number(ahead.stdout.trim())
     if (!Number.isFinite(aheadCount) || aheadCount <= 0) {
-      throw new Error(`Local branch ${input.branch} has no commits ahead of ${baseBranch}`)
+      throw new Error(`Local branch ${canonicalBranch} has no commits ahead of ${aheadRef}`)
     }
 
     // When the thread is a pull request, prefer pushing the fix to the PR
     // head branch so the PR updates in place (Codex-style behavior).
     if (facts?.pullNumber && facts.headRef) {
-      const updated = await this.tryPushToPullRequestHead({
-        repository: parsed.repository,
-        pullNumber: facts.pullNumber,
-        headRef: facts.headRef,
-        headRepoFullName: facts.headRepoFullName,
-        branch: input.branch,
-        directory: record.directory,
-      })
+      const updated = await this.tryPushToPullRequestHead(
+        {
+          repository: parsed.repository,
+          pullNumber: facts.pullNumber,
+          headRef: facts.headRef,
+          headRepoFullName: facts.headRepoFullName,
+          branch: canonicalBranch,
+          directory: record.directory,
+        },
+        signal,
+      )
       if (updated) {
         log.info("github fix pushed to existing pull request", {
           repository: parsed.repository,
@@ -398,9 +432,13 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
     }
 
     // Fallback: push the fix branch and open (or reuse) a PR against the base.
-    const pushed = await $`git push origin ${input.branch}`.cwd(record.directory).env(credential.env).quiet().nothrow()
+    const pushed = await this.runGit(["git", ...credential.args, "push", "--no-verify", "origin", canonicalBranch], {
+      cwd: record.directory,
+      env: credential.env,
+      signal,
+    })
     if (pushed.exitCode !== 0) {
-      throw new Error(`Failed to push branch ${input.branch}: ${pushed.stderr.toString().slice(0, 500)}`)
+      throw new Error(`Failed to push branch ${canonicalBranch}: ${pushed.stderr.slice(0, 500)}`)
     }
 
     // Deduplicate: reuse an existing open PR with the same head branch.
@@ -409,9 +447,10 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
         owner,
         repo,
         state: "open",
-        head: `${owner}:${input.branch}`,
+        head: `${owner}:${canonicalBranch}`,
         installationToken: token,
       }),
+      signal,
     )
     const open = existing?.find((item) => typeof item?.number === "number")
     if (open) {
@@ -421,7 +460,7 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
             ? open.html_url
             : `https://github.com/${parsed.repository}/pull/${open.number}`,
         pullNumber: open.number as number,
-        headBranch: input.branch,
+        headBranch: canonicalBranch,
       }
     }
 
@@ -431,15 +470,16 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
         repo,
         title: input.title,
         body: input.body,
-        head: input.branch,
+        head: canonicalBranch,
         base: baseBranch,
         installationToken: token,
       }),
+      signal,
     )
     if (typeof created?.number !== "number" || typeof created.html_url !== "string") {
       throw new Error(`GitHub PR creation returned an invalid response for ${input.branch}`)
     }
-    return { pullRequestURL: created.html_url, pullNumber: created.number, headBranch: input.branch }
+    return { pullRequestURL: created.html_url, pullNumber: created.number, headBranch: canonicalBranch }
   }
 
   /**
@@ -449,14 +489,17 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
    * the push cannot be performed (fork without App access, protected or
    * moved head branch), so the caller falls back to a new PR.
    */
-  private async tryPushToPullRequestHead(input: {
-    repository: string
-    pullNumber: number
-    headRef: string
-    headRepoFullName: string | undefined
-    branch: string
-    directory: string
-  }): Promise<{ pullRequestURL: string; pullNumber: number; headBranch: string } | undefined> {
+  private async tryPushToPullRequestHead(
+    input: {
+      repository: string
+      pullNumber: number
+      headRef: string
+      headRepoFullName: string | undefined
+      branch: string
+      directory: string
+    },
+    signal?: AbortSignal,
+  ): Promise<{ pullRequestURL: string; pullNumber: number; headBranch: string } | undefined> {
     // Only push to the base repository when the head repository is positively
     // known to be the same repository. An unknown head repo (e.g. the source
     // fork disappeared) must fall back to a new PR rather than risk pushing a
@@ -485,17 +528,16 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
     }
 
     const credential = buildCredentialCommand({ token: pushToken, args: [] })
-    const result = await $`git push ${pushURL} ${input.branch}:${input.headRef}`
-      .cwd(input.directory)
-      .env(credential.env)
-      .quiet()
-      .nothrow()
+    const result = await this.runGit(
+      ["git", ...credential.args, "push", "--no-verify", pushURL, `${input.branch}:${input.headRef}`],
+      { cwd: input.directory, env: credential.env, signal },
+    )
     if (result.exitCode !== 0) {
       log.warn("push to pull request head failed; falling back to a new PR", {
         repository: input.repository,
         pullNumber: input.pullNumber,
         headRef: input.headRef,
-        stderr: result.stderr.toString().slice(0, 300),
+        stderr: result.stderr.slice(0, 300),
       })
       return undefined
     }
@@ -506,9 +548,31 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
     }
   }
 
-  private async resolveDefaultBranch(owner: string, repo: string, token: string): Promise<string | undefined> {
+  private async runGit(
+    args: string[],
+    options: { cwd: string; env: Record<string, string | undefined>; signal?: AbortSignal },
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn(args, {
+      cwd: options.cwd,
+      env: options.env,
+      signal: options.signal,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const exitCode = await proc.exited
+    return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() }
+  }
+
+  private async resolveDefaultBranch(
+    owner: string,
+    repo: string,
+    token: string,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
     const repository = await GitHubChannelAuth.GitHubClient.send<{ default_branch?: unknown }>(
       GitHubChannelAuth.GitHubClient.getRepository({ owner, repo, installationToken: token }),
+      signal,
     ).catch(() => undefined)
     return typeof repository?.default_branch === "string" ? repository.default_branch : undefined
   }

--- a/packages/synergy/src/channel/provider/github/index.ts
+++ b/packages/synergy/src/channel/provider/github/index.ts
@@ -80,6 +80,21 @@ function splitRepository(repository: string): { owner: string; repo: string } {
   if (!owner || !repo || extra.length > 0) throw new Error(`Invalid GitHub repository name: ${repository}`)
   return { owner, repo }
 }
+/**
+ * Reject a fix-delivery branch that equals the resolved repository base
+ * branch: pushing it would update the default branch directly instead of
+ * opening a pull request.
+ */
+export function assertNotBaseBranch(branch: string, baseBranch: string): void {
+  // "refs/heads/main" pushes the same remote ref as "main"; normalize the
+  // ref prefix so both forms are rejected.
+  const normalized = branch.replace(/^refs\/heads\//, "")
+  if (normalized === baseBranch) {
+    throw new Error(
+      `Branch "${branch}" is the repository base branch; create a dedicated fix branch (e.g. synergy/fix/<issue>-<slug>) before delivering`,
+    )
+  }
+}
 
 function joinOutboundText(parts: ChannelTypes.OutboundPart[]): string {
   const chunks: string[] = []
@@ -341,6 +356,8 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
     const facts = this.accounts.get(accountId)?.threadFacts.get(`${parsed.repository}#${parsed.issueNumber}`)
     const baseBranch = facts?.defaultBranch ?? (await this.resolveDefaultBranch(owner, repo, token)) ?? "main"
 
+    assertNotBaseBranch(input.branch, baseBranch)
+
     const credential = buildCredentialCommand({ token, args: [] })
 
     // Verify the local branch exists and is ahead of the base branch.
@@ -440,14 +457,19 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
     branch: string
     directory: string
   }): Promise<{ pullRequestURL: string; pullNumber: number; headBranch: string } | undefined> {
-    const isFork = input.headRepoFullName !== undefined && input.headRepoFullName !== input.repository
+    // Only push to the base repository when the head repository is positively
+    // known to be the same repository. An unknown head repo (e.g. the source
+    // fork disappeared) must fall back to a new PR rather than risk pushing a
+    // same-named branch — potentially the default branch — into the base.
+    if (input.headRepoFullName === undefined) return undefined
+    const isFork = input.headRepoFullName !== input.repository
     let pushURL: string
     let pushToken: string
     if (!isFork) {
       const { owner, repo } = splitRepository(input.repository)
       pushURL = `https://github.com/${input.repository}.git`
       pushToken = await this.resolveInstallationToken(owner, repo)
-    } else if (input.headRepoFullName) {
+    } else {
       const fork = splitRepository(input.headRepoFullName)
       try {
         pushURL = `https://github.com/${input.headRepoFullName}.git`
@@ -460,8 +482,6 @@ export class GithubProvider implements ChannelTypes.Provider<Config.ChannelGithu
         })
         return undefined
       }
-    } else {
-      return undefined
     }
 
     const credential = buildCredentialCommand({ token: pushToken, args: [] })

--- a/packages/synergy/src/channel/provider/github/workspace.ts
+++ b/packages/synergy/src/channel/provider/github/workspace.ts
@@ -137,20 +137,28 @@ export namespace GithubChannelWorkspace {
 
     if (!(await fs.stat(gitDir).catch(() => undefined))) {
       log.info("cloning repository workspace", { repository: input.repository, directory })
-      await $`git clone --no-checkout ${repoUrl} ${directory}`.env(credential.env).quiet().nothrow()
+      await $`git ${credential.args} clone --no-checkout ${repoUrl} ${directory}`.env(credential.env).quiet().nothrow()
       if (!(await fs.stat(gitDir).catch(() => undefined))) {
         throw new Error(`GithubChannelWorkspaceError: clone failed for ${input.repository}`)
       }
       if (input.defaultBranch) {
-        await $`git checkout ${input.defaultBranch}`.cwd(directory).env(credential.env).quiet().nothrow()
+        await $`git ${credential.args} checkout ${input.defaultBranch}`
+          .cwd(directory)
+          .env(credential.env)
+          .quiet()
+          .nothrow()
       }
     } else {
-      await $`git fetch origin --prune`.cwd(directory).env(credential.env).quiet().nothrow()
+      await $`git ${credential.args} fetch origin --prune`.cwd(directory).env(credential.env).quiet().nothrow()
     }
 
     if (input.pullNumber && branch) {
       const fetchRef = `pull/${input.pullNumber}/head:refs/remotes/origin/${branch}`
-      const fetched = await $`git fetch origin ${fetchRef}`.cwd(directory).env(credential.env).quiet().nothrow()
+      const fetched = await $`git ${credential.args} fetch origin ${fetchRef}`
+        .cwd(directory)
+        .env(credential.env)
+        .quiet()
+        .nothrow()
       if (fetched.exitCode === 0) {
         await $`git checkout ${branch}`.cwd(directory).quiet().nothrow()
         await $`git reset --hard origin/${branch}`.cwd(directory).quiet().nothrow()
@@ -162,7 +170,11 @@ export namespace GithubChannelWorkspace {
       }
     } else if (input.defaultBranch) {
       await $`git checkout ${input.defaultBranch}`.cwd(directory).quiet().nothrow()
-      await $`git pull --ff-only origin ${input.defaultBranch}`.cwd(directory).env(credential.env).quiet().nothrow()
+      await $`git ${credential.args} pull --ff-only origin ${input.defaultBranch}`
+        .cwd(directory)
+        .env(credential.env)
+        .quiet()
+        .nothrow()
     }
 
     const { scope } = await Scope.fromDirectory(directory, { persist: true })

--- a/packages/synergy/src/channel/provider/github/workspace.ts
+++ b/packages/synergy/src/channel/provider/github/workspace.ts
@@ -135,31 +135,38 @@ export namespace GithubChannelWorkspace {
 
     const credential = buildCredentialCommand({ token: input.token, args: [] })
 
+    // Run git with the credential helper as a plain argv array so static
+    // analysis (knip) recognizes the subcommand; template interpolation of
+    // the credential args would otherwise hide `clone`/`fetch`/`pull` behind
+    // a dynamic token and trip the unlisted-binaries check.
+    const runGit = async (args: string[], options?: { cwd?: string }): Promise<number> => {
+      const proc = Bun.spawn(["git", ...credential.args, ...args], {
+        ...(options?.cwd ? { cwd: options.cwd } : {}),
+        env: credential.env,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+      return proc.exited
+    }
+
     if (!(await fs.stat(gitDir).catch(() => undefined))) {
       log.info("cloning repository workspace", { repository: input.repository, directory })
-      await $`git ${credential.args} clone --no-checkout ${repoUrl} ${directory}`.env(credential.env).quiet().nothrow()
-      if (!(await fs.stat(gitDir).catch(() => undefined))) {
+      const cloneExit = await runGit(["clone", "--no-checkout", repoUrl, directory])
+      if (cloneExit !== 0 || !(await fs.stat(gitDir).catch(() => undefined))) {
         throw new Error(`GithubChannelWorkspaceError: clone failed for ${input.repository}`)
       }
       if (input.defaultBranch) {
-        await $`git ${credential.args} checkout ${input.defaultBranch}`
-          .cwd(directory)
-          .env(credential.env)
-          .quiet()
-          .nothrow()
+        await runGit(["checkout", input.defaultBranch], { cwd: directory })
       }
     } else {
-      await $`git ${credential.args} fetch origin --prune`.cwd(directory).env(credential.env).quiet().nothrow()
+      await runGit(["fetch", "origin", "--prune"], { cwd: directory })
     }
 
     if (input.pullNumber && branch) {
       const fetchRef = `pull/${input.pullNumber}/head:refs/remotes/origin/${branch}`
-      const fetched = await $`git ${credential.args} fetch origin ${fetchRef}`
-        .cwd(directory)
-        .env(credential.env)
-        .quiet()
-        .nothrow()
-      if (fetched.exitCode === 0) {
+      const fetched = await runGit(["fetch", "origin", fetchRef], { cwd: directory })
+      if (fetched === 0) {
         await $`git checkout ${branch}`.cwd(directory).quiet().nothrow()
         await $`git reset --hard origin/${branch}`.cwd(directory).quiet().nothrow()
       } else {
@@ -170,11 +177,7 @@ export namespace GithubChannelWorkspace {
       }
     } else if (input.defaultBranch) {
       await $`git checkout ${input.defaultBranch}`.cwd(directory).quiet().nothrow()
-      await $`git ${credential.args} pull --ff-only origin ${input.defaultBranch}`
-        .cwd(directory)
-        .env(credential.env)
-        .quiet()
-        .nothrow()
+      await runGit(["pull", "--ff-only", "origin", input.defaultBranch], { cwd: directory })
     }
 
     const { scope } = await Scope.fromDirectory(directory, { persist: true })

--- a/packages/synergy/src/enforcement/gate.ts
+++ b/packages/synergy/src/enforcement/gate.ts
@@ -1041,6 +1041,13 @@ export namespace EnforcementGate {
         caps.push({ class: "session_state", nonBypassable: false })
         return { capabilities: caps }
       }
+      // GitHub fix delivery — pushes a branch and opens a pull request through
+      // the provider's installation token (external platform write).
+      if (toolName === "github_deliver_fix") {
+        caps.push({ class: "platform_control", nonBypassable: true })
+        caps.push({ class: "network_request", nonBypassable: true })
+        return { capabilities: caps }
+      }
       // Default: unknown tool, no capabilities
       return { capabilities: caps }
     }

--- a/packages/synergy/src/session/tool-mode-policy.ts
+++ b/packages/synergy/src/session/tool-mode-policy.ts
@@ -112,6 +112,15 @@ export namespace SessionModePolicy {
       }
     }
 
+    if (input.toolName === "github_deliver_fix" && input.session?.endpoint?.kind !== "channel") {
+      return {
+        code: "tool_unavailable",
+        toolName: input.toolName,
+        message: `The "${input.toolName}" tool is only available in GitHub Channel sessions.`,
+        metadata: { requiredEndpoint: "channel" },
+      }
+    }
+
     const latticeDiagnostic = latticeVisibility(input.toolName, input.session)
     if (latticeDiagnostic) return latticeDiagnostic
     const bossDiagnostic = bossVisibility(input.toolName, input.session)

--- a/packages/synergy/src/session/tool-mode-policy.ts
+++ b/packages/synergy/src/session/tool-mode-policy.ts
@@ -112,12 +112,15 @@ export namespace SessionModePolicy {
       }
     }
 
-    if (input.toolName === "github_deliver_fix" && input.session?.endpoint?.kind !== "channel") {
+    if (
+      input.toolName === "github_deliver_fix" &&
+      (input.session?.endpoint?.kind !== "channel" || input.session?.endpoint?.channel?.type !== "github")
+    ) {
       return {
         code: "tool_unavailable",
         toolName: input.toolName,
         message: `The "${input.toolName}" tool is only available in GitHub Channel sessions.`,
-        metadata: { requiredEndpoint: "channel" },
+        metadata: { requiredEndpoint: "github" },
       }
     }
 

--- a/packages/synergy/src/tool/github-deliver-fix.ts
+++ b/packages/synergy/src/tool/github-deliver-fix.ts
@@ -73,10 +73,13 @@ export const GithubDeliverFixTool = Tool.define(
     },
   },
   {
+    // The GitHub channel agent runs under a strict whitelist permission and
+    // has no expand_tools/search_tools activation path, so a search-mode
+    // exposure would leave the tool permanently invisible. Expose it as
+    // resident; the tool itself validates that the session is bound to a
+    // GitHub channel thread and errors otherwise.
     exposure: {
-      mode: "search",
-      title: "Deliver GitHub Fix as PR",
-      keywords: ["github", "fix", "pull request", "deliver", "push", "branch"],
+      mode: "resident",
     },
   },
 )

--- a/packages/synergy/src/tool/github-deliver-fix.ts
+++ b/packages/synergy/src/tool/github-deliver-fix.ts
@@ -36,12 +36,15 @@ export const GithubDeliverFixTool = Tool.define(
         throw toolError("GITHUB_PROVIDER_UNAVAILABLE", "The GitHub Channel provider is unavailable")
       }
       try {
-        const result = await provider.deliverFix({
-          sessionID: ctx.sessionID,
-          branch: params.branch,
-          title: params.title,
-          body: params.body,
-        })
+        const result = await provider.deliverFix(
+          {
+            sessionID: ctx.sessionID,
+            branch: params.branch,
+            title: params.title,
+            body: params.body,
+          },
+          ctx.abort,
+        )
         return {
           title: "GitHub fix delivered as pull request",
           output: `Pull request #${result.pullNumber} is ready: ${result.pullRequestURL}`,

--- a/packages/synergy/src/tool/github-deliver-fix.ts
+++ b/packages/synergy/src/tool/github-deliver-fix.ts
@@ -62,6 +62,9 @@ export const GithubDeliverFixTool = Tool.define(
         if (message.includes("does not exist")) {
           throw toolError("GITHUB_DELIVERY_BRANCH_MISSING", message)
         }
+        if (message.includes("is the repository base branch")) {
+          throw toolError("GITHUB_DELIVERY_BASE_BRANCH", message)
+        }
         if (message.includes("no commits ahead")) {
           throw toolError("GITHUB_DELIVERY_BRANCH_EMPTY", message)
         }

--- a/packages/synergy/test/enforcement/gate.test.ts
+++ b/packages/synergy/test/enforcement/gate.test.ts
@@ -732,6 +732,39 @@ describe("EnforcementGate network classification", () => {
     expect(inspire).toContainEqual({ class: "network_request", nonBypassable: true })
   })
 
+  test("github_deliver_fix classifies as platform control plus network request", async () => {
+    const gate = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+    })
+
+    const caps = gate.classify("github_deliver_fix", {
+      branch: "synergy/fix/1-x",
+      title: "Fix",
+      body: "Fixed",
+    }).capabilities
+    expect(caps).toContainEqual({ class: "platform_control", nonBypassable: true })
+    expect(caps).toContainEqual({ class: "network_request", nonBypassable: true })
+
+    // The external write must be visible to the gate: guarded asks before the
+    // platform write; autonomous allows it (platform_control is in
+    // AUTONOMOUS_HIGH_ALLOWED, so the unattended GitHub channel agent can
+    // still deliver fixes) while explicit policy denies still apply.
+    const guarded = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "guarded",
+    })
+    expect(guarded.evaluate("github_deliver_fix", {}).decision).toBe("ask")
+
+    const autonomous = await EnforcementGate.create({
+      activeWorkspace: "/Users/test/synergy-control-profile",
+      workspaceType: "worktree",
+      profileId: "autonomous",
+    })
+    expect(autonomous.evaluate("github_deliver_fix", {}).decision).toBe("allow")
+  })
+
   //  test("agora collaboration tools classify as external network and platform control", async () => {
   //    const { EnforcementGate } = require("../../src/enforcement/gate")
   //    const gate = await EnforcementGate.create({

--- a/packages/synergy/test/session/tool-mode-policy.test.ts
+++ b/packages/synergy/test/session/tool-mode-policy.test.ts
@@ -55,6 +55,28 @@ describe("SessionModePolicy Channel visibility", () => {
     ).toBeUndefined()
     expect(SessionModePolicy.visibility({ toolName: "read", session: {} })).toBeUndefined()
   })
+
+  test("exposes github_deliver_fix only to Channel sessions", () => {
+    const diagnostic = SessionModePolicy.visibility({ toolName: "github_deliver_fix", session: {} })
+    expect(diagnostic).toMatchObject({
+      code: "tool_unavailable",
+      toolName: "github_deliver_fix",
+      metadata: { requiredEndpoint: "channel" },
+    })
+    expect(diagnostic?.message).toContain("only available in GitHub Channel sessions")
+
+    expect(
+      SessionModePolicy.visibility({
+        toolName: "github_deliver_fix",
+        session: {
+          endpoint: {
+            kind: "channel",
+            channel: { type: "github", accountId: "account_test", chatId: "owner/repo#1" },
+          },
+        } as any,
+      }),
+    ).toBeUndefined()
+  })
 })
 
 describe("SessionModePolicy Plan bash calls", () => {

--- a/packages/synergy/test/session/tool-mode-policy.test.ts
+++ b/packages/synergy/test/session/tool-mode-policy.test.ts
@@ -56,14 +56,31 @@ describe("SessionModePolicy Channel visibility", () => {
     expect(SessionModePolicy.visibility({ toolName: "read", session: {} })).toBeUndefined()
   })
 
-  test("exposes github_deliver_fix only to Channel sessions", () => {
+  test("exposes github_deliver_fix only to GitHub Channel sessions", () => {
     const diagnostic = SessionModePolicy.visibility({ toolName: "github_deliver_fix", session: {} })
     expect(diagnostic).toMatchObject({
       code: "tool_unavailable",
       toolName: "github_deliver_fix",
-      metadata: { requiredEndpoint: "channel" },
+      metadata: { requiredEndpoint: "github" },
     })
     expect(diagnostic?.message).toContain("only available in GitHub Channel sessions")
+
+    // A non-GitHub channel session (e.g. Feishu) must not see the tool.
+    expect(
+      SessionModePolicy.visibility({
+        toolName: "github_deliver_fix",
+        session: {
+          endpoint: {
+            kind: "channel",
+            channel: { type: "feishu", accountId: "account_test", chatId: "chat_test" },
+          },
+        } as any,
+      }),
+    ).toMatchObject({
+      code: "tool_unavailable",
+      toolName: "github_deliver_fix",
+      metadata: { requiredEndpoint: "github" },
+    })
 
     expect(
       SessionModePolicy.visibility({

--- a/packages/synergy/test/tool/github-deliver-fix.test.ts
+++ b/packages/synergy/test/tool/github-deliver-fix.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import { Channel } from "../../src/channel"
-import { GithubProvider, assertNotBaseBranch } from "../../src/channel/provider/github"
+import { GithubProvider, assertNotBaseBranch, resolveCanonicalBranch } from "../../src/channel/provider/github"
 import { GithubDeliverFixTool } from "../../src/tool/github-deliver-fix"
 import { ToolRegistry } from "../../src/tool/registry"
 import type { Tool } from "../../src/tool/tool"
@@ -139,4 +139,20 @@ test("github_deliver_fix surfaces GITHUB_DELIVERY_BASE_BRANCH when the provider 
       }
     },
   })
+})
+
+test("resolveCanonicalBranch resolves HEAD and branch names, rejects missing refs", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  // HEAD on the initial branch resolves to that branch's canonical ref.
+  const head = await resolveCanonicalBranch(tmp.path, "HEAD")
+  expect(head).toBeDefined()
+  expect(head?.startsWith("refs/heads/")).toBe(true)
+
+  // An explicit branch name resolves to the same canonical ref.
+  const branch = head!.replace(/^refs\/heads\//, "")
+  expect(await resolveCanonicalBranch(tmp.path, branch)).toBe(head)
+
+  // Missing refs are not local branches.
+  expect(await resolveCanonicalBranch(tmp.path, "definitely-missing")).toBeUndefined()
 })

--- a/packages/synergy/test/tool/github-deliver-fix.test.ts
+++ b/packages/synergy/test/tool/github-deliver-fix.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import { Channel } from "../../src/channel"
-import { GithubProvider } from "../../src/channel/provider/github"
+import { GithubProvider, assertNotBaseBranch } from "../../src/channel/provider/github"
 import { GithubDeliverFixTool } from "../../src/tool/github-deliver-fix"
 import { ToolRegistry } from "../../src/tool/registry"
 import type { Tool } from "../../src/tool/tool"
@@ -96,6 +96,43 @@ test("github_deliver_fix surfaces GITHUB_PROVIDER_UNAVAILABLE when the provider 
           ),
         ).rejects.toMatchObject({
           code: "GITHUB_PROVIDER_UNAVAILABLE",
+        })
+      } finally {
+        if (previous) Channel.registerProvider(previous as never)
+      }
+    },
+  })
+})
+
+test("assertNotBaseBranch rejects the resolved repository base branch", () => {
+  expect(() => assertNotBaseBranch("main", "main")).toThrow(/is the repository base branch/)
+  expect(() => assertNotBaseBranch("refs/heads/main", "main")).toThrow(/is the repository base branch/)
+  expect(() => assertNotBaseBranch("dev", "dev")).toThrow(/is the repository base branch/)
+  expect(() => assertNotBaseBranch("synergy/fix/1-slug", "main")).not.toThrow()
+})
+
+test("github_deliver_fix surfaces GITHUB_DELIVERY_BASE_BRANCH when the provider rejects a base-branch delivery", async () => {
+  await using tmp = await tmpdir()
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      // A provider subclass that fails exactly like deliverFix does when the
+      // requested branch equals the repository base branch.
+      class BaseBranchRejectingProvider extends GithubProvider {
+        override async deliverFix(): Promise<never> {
+          throw new Error(
+            'Branch "main" is the repository base branch; create a dedicated fix branch before delivering',
+          )
+        }
+      }
+      const previous = Channel.getProvider("github")
+      Channel.registerProvider(new BaseBranchRejectingProvider() as never)
+      try {
+        const tool = await GithubDeliverFixTool.init()
+        await expect(
+          tool.execute({ branch: "main", title: "Fix", body: "Fixed" }, toolContext(`ses_${crypto.randomUUID()}`)),
+        ).rejects.toMatchObject({
+          code: "GITHUB_DELIVERY_BASE_BRANCH",
         })
       } finally {
         if (previous) Channel.registerProvider(previous as never)


### PR DESCRIPTION
# fix(tool): expose github_deliver_fix to the GitHub channel agent

## Root cause

The `github_deliver_fix` tool was never visible to the `github-channel-agent`, so fix delivery never happened — the agent could only commit locally:

1. **Permission gate**: `github-channel-agent` runs under a strict whitelist (`"*": "deny"` + explicit allows). `PermissionNext.disabled()` disables every tool not explicitly allowed — empirically verified that `github_deliver_fix` (plus `expand_tools`/`search_tools`) landed in the disabled set. The agent had no activation path at all.
2. **Exposure gate**: the tool's exposure was `mode: "search"`, which keeps it invisible until activated via `expand_tools`/`search_tools` — both of which were themselves disabled by the whitelist.

## Fix

- `github-deliver-fix.ts` — expose the tool as `resident` so it is visible without activation. The tool already validates that the session is bound to a GitHub channel thread and errors otherwise (`GITHUB_TOOL_NOT_IN_CHANNEL_SESSION`).
- `tool-mode-policy.ts` — restrict `github_deliver_fix` to Channel sessions (same pattern as `response_card`), so the resident exposure does not leak into non-channel sessions.
- `builtin-internal.ts` — add `github_deliver_fix: "allow"` to the `github-channel-agent` whitelist so the permission system does not disable it.

## Verification

- `PermissionNext.disabled()` no longer contains `github_deliver_fix` for the agent's ruleset
- `bun run typecheck` — 11/11 packages clean
- `bun test test/session/tool-mode-policy.test.ts test/tool/github-deliver-fix.test.ts` — 13 pass / 0 fail (new coverage: channel-only visibility of `github_deliver_fix`)
