### PR TITLE
fix(channel): deliver question cards to the durable root's real chatId

### DIFF
--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -732,6 +732,7 @@ export namespace Channel {
             channelReply: true,
             channelReplyToMessageId: replyToMessageId,
             channelRequesterId: ctx.senderId,
+            channelChatId: ctx.chatId,
           }
 
           const acceptance = await ChannelConversationAcceptance.accept({

--- a/packages/synergy/src/channel/provider/feishu/index.ts
+++ b/packages/synergy/src/channel/provider/feishu/index.ts
@@ -27,13 +27,21 @@ import type { FeishuEventPayload, FeishuMessage, FeishuMention, FeishuSender } f
 import type { FeishuApiContext } from "./api-context"
 import { FeishuOutboundMedia } from "./outbound-media"
 import { parseFeishuResponseCardAction, renderFeishuResponseCard, sendFeishuResponseCard } from "./response-card"
-import { parseFeishuQuestionCardAction, renderFeishuQuestionCard, sendFeishuQuestionCard } from "./question-card"
+import {
+  parseFeishuQuestionCardAction,
+  renderFeishuQuestionCard,
+  renderFeishuQuestionCardSummary,
+  renderFeishuQuestionCardSummarySafe,
+  sendFeishuQuestionCard,
+} from "./question-card"
 import { sendFeishuMarkdownCard } from "./send-card"
 
 export {
   parseFeishuQuestionCardAction,
   parseFeishuResponseCardAction,
   renderFeishuQuestionCard,
+  renderFeishuQuestionCardSummary,
+  renderFeishuQuestionCardSummarySafe,
   renderFeishuResponseCard,
   sendFeishuQuestionCard,
 }
@@ -87,7 +95,11 @@ export async function routeFeishuCardAction(input: {
     }
     const result = await input.onQuestionCardAction(question.callback)
     if (result.status === "accepted") {
-      return { toast: { type: "success", content: "回答已提交" } }
+      const response: Record<string, unknown> = { toast: { type: "success", content: "回答已提交" } }
+      if (result.card) {
+        response.card = { type: "raw", data: result.card }
+      }
+      return response
     }
     if (result.status === "duplicate") {
       return { toast: { type: "info", content: "回答已提交" } }
@@ -1034,6 +1046,13 @@ export class FeishuProvider implements ChannelTypes.Provider<Config.ChannelFeish
       questions: input.questions,
     })
     return this.bindThread(input, result)
+  }
+
+  renderQuestionCardSummary(input: {
+    questions: import("@/question").Question.Info[]
+    answers: import("@/question").Question.Answer[]
+  }): unknown {
+    return renderFeishuQuestionCardSummarySafe(input.questions, input.answers)
   }
 
   private async sendCreateMessage(accountId: string, chatId: string, payload: FeishuMessagePayload) {

--- a/packages/synergy/src/channel/provider/feishu/question-card.ts
+++ b/packages/synergy/src/channel/provider/feishu/question-card.ts
@@ -48,7 +48,7 @@ type CallbackPayload = z.infer<typeof CallbackPayload>
 type CardJson = {
   schema: "2.0"
   config: { update_multi: true; summary: { content: string } }
-  header: { title: { tag: "plain_text"; content: string }; template: "blue" }
+  header: { title: { tag: "plain_text"; content: string }; template: string }
   body: { elements: unknown[] }
 }
 
@@ -168,7 +168,7 @@ export async function sendFeishuQuestionCard(
     requestId: string
     questions: Question.Info[]
   },
-): Promise<{ messageId: string }> {
+): Promise<{ messageId: string; threadId?: string }> {
   const cardJson = renderFeishuQuestionCard(input.questions, input.requestId)
   const cardBytes = new TextEncoder().encode(JSON.stringify(cardJson)).byteLength
   if (cardBytes + CARD_SIZE_RESERVE_BYTES > MAX_CARD_BYTES) {
@@ -221,4 +221,43 @@ function mergePayloads(outer: CallbackPayload, event: CallbackPayload): Callback
     header: outer.header,
     event_id: outer.event_id ?? event.event_id,
   }
+}
+
+/**
+ * Renders the read-only "submitted" summary card that replaces the question
+ * form in the card callback response. Feishu requires the replacement card
+ * to be returned synchronously from the callback (within 3 seconds); a
+ * background CardKit update is rolled back by the client.
+ */
+export function renderFeishuQuestionCardSummary(questions: Question.Info[], answers: Question.Answer[]): CardJson {
+  const elements = questions.map((question, index) => {
+    const answer = answers[index] ?? []
+    const answerText = answer.length > 0 ? answer.join("、") : "（未回答）"
+    return {
+      tag: "markdown",
+      content: sanitizeMarkdown(`**${question.header}**\n${question.question}\n\n**回答：** ${answerText}`),
+    }
+  })
+
+  return {
+    schema: "2.0",
+    config: { update_multi: true, summary: { content: "回答已提交" } },
+    header: { title: { tag: "plain_text", content: "回答已提交" }, template: "green" },
+    body: { elements },
+  }
+}
+
+/**
+ * Provider-level summary renderer with the 30 KiB CardKit bound. Returns
+ * undefined when the summary would exceed the limit so the callback can fall
+ * back to a plain toast instead of failing the interaction.
+ */
+export function renderFeishuQuestionCardSummarySafe(
+  questions: Question.Info[],
+  answers: Question.Answer[],
+): CardJson | undefined {
+  const cardJson = renderFeishuQuestionCardSummary(questions, answers)
+  const cardBytes = new TextEncoder().encode(JSON.stringify(cardJson)).byteLength
+  if (cardBytes + CARD_SIZE_RESERVE_BYTES > MAX_CARD_BYTES) return undefined
+  return cardJson
 }

--- a/packages/synergy/src/channel/question-card-bridge.ts
+++ b/packages/synergy/src/channel/question-card-bridge.ts
@@ -80,11 +80,12 @@ export namespace QuestionCardBridge {
         await rejectWithoutBinding(request, channel.type)
         return
       }
+      const chatId = normalize(root?.info.metadata?.channelChatId) ?? channel.chatId
 
       await QuestionCardRuntime.deliver({
         provider,
         accountId: channel.accountId,
-        chatId: channel.chatId,
+        chatId,
         chatType: channel.chatType,
         scopeKey: channel.scopeKey,
         replyToMessageId,

--- a/packages/synergy/src/channel/question-card.ts
+++ b/packages/synergy/src/channel/question-card.ts
@@ -2,7 +2,12 @@ import type { Question } from "@/question"
 import { ScopedState } from "@/scope/scoped-state"
 import { Lock } from "@/util/lock"
 import { Log } from "@/util/log"
-import { QuestionCardCallback, type Provider, type QuestionCardCallback as QuestionCardCallbackType } from "./types"
+import {
+  QuestionCardCallback,
+  type Provider,
+  type QuestionCardActionResult,
+  type QuestionCardCallback as QuestionCardCallbackType,
+} from "./types"
 
 type Registration = {
   status: "pending" | "active"
@@ -13,6 +18,7 @@ type Registration = {
   chatId: string
   requesterId: string
   questions: Question.Info[]
+  provider?: Provider
   messageId?: string
 }
 
@@ -62,6 +68,7 @@ export namespace QuestionCardRuntime {
       chatId: input.chatId,
       requesterId: input.requesterId,
       questions: input.request.questions,
+      provider: input.provider,
     }
     {
       using _ = await Lock.write(lockKey(input.request.id))
@@ -114,7 +121,7 @@ export namespace QuestionCardRuntime {
     channelType: string
     accountId: string
     callback: QuestionCardCallbackType
-  }): Promise<{ status: "accepted" | "duplicate" | "expired" | "rejected" }> {
+  }): Promise<QuestionCardActionResult> {
     const parsed = QuestionCardCallback.safeParse(input.callback)
     if (!parsed.success) return { status: "rejected" }
     const callback = parsed.data
@@ -155,7 +162,11 @@ export namespace QuestionCardRuntime {
     }
     runtime.registrations.delete(callback.requestId)
     rememberAccepted({ requestId: callback.requestId, eventId: callback.eventId, sessionID: registration.sessionID })
-    return { status: "accepted" }
+    const summary = registration.provider?.renderQuestionCardSummary?.({
+      questions: registration.questions,
+      answers,
+    })
+    return summary ? { status: "accepted", card: summary } : { status: "accepted" }
   }
 
   export async function settle(requestId: string): Promise<void> {

--- a/packages/synergy/src/channel/question-card.ts
+++ b/packages/synergy/src/channel/question-card.ts
@@ -123,21 +123,34 @@ export namespace QuestionCardRuntime {
     const runtime = state()
     const registration = runtime.registrations.get(callback.requestId)
     if (!registration) {
-      return runtime.accepted.get(callback.requestId)?.eventId === callback.eventId
-        ? { status: "duplicate" }
-        : { status: "expired" }
+      const status = runtime.accepted.get(callback.requestId)?.eventId === callback.eventId ? "duplicate" : "expired"
+      log.info("question card callback not accepted", { requestId: callback.requestId, status })
+      return { status }
     }
-    if (registration.status !== "active" || !matchesOwner(registration, input, callback)) {
+    if (registration.status !== "active") {
+      log.info("question card callback rejected", { requestId: callback.requestId, reason: "registration not active" })
+      return { status: "rejected" }
+    }
+    if (!matchesOwner(registration, input, callback)) {
+      log.info("question card callback rejected", { requestId: callback.requestId, reason: "owner mismatch" })
       return { status: "rejected" }
     }
 
     const answers = resolveAnswers(registration.questions, callback)
-    if (!answers) return { status: "rejected" }
+    if (!answers) {
+      log.info("question card callback rejected", { requestId: callback.requestId, reason: "invalid answers" })
+      return { status: "rejected" }
+    }
 
     const { Question } = await import("@/question")
     const replied = await Question.tryReply({ requestID: callback.requestId, answers })
     if (!replied) {
       runtime.registrations.delete(callback.requestId)
+      log.info("question card callback not accepted", {
+        requestId: callback.requestId,
+        status: "expired",
+        reason: "question no longer pending",
+      })
       return { status: "expired" }
     }
     runtime.registrations.delete(callback.requestId)

--- a/packages/synergy/src/channel/types.ts
+++ b/packages/synergy/src/channel/types.ts
@@ -224,7 +224,14 @@ export const QuestionCardCallback = z
   .meta({ ref: "ChannelQuestionCardCallback" })
 export type QuestionCardCallback = z.infer<typeof QuestionCardCallback>
 
-export type QuestionCardActionResult = ResponseCardActionResult
+export type QuestionCardActionResult = ResponseCardActionResult & {
+  /**
+   * Raw card JSON (schema 2.0) to replace the question form in the callback
+   * response. Feishu applies this immediately instead of rolling the form
+   * back; providers that render a read-only summary return it here.
+   */
+  card?: unknown
+}
 
 export const OutboundPart = z.discriminatedUnion("type", [
   z.object({ type: z.literal("text"), text: z.string() }),
@@ -422,6 +429,8 @@ export interface Provider<TAccountConfig = unknown, TChannelConfig = unknown> {
     requestId: string
     questions: Question.Info[]
   }): Promise<SendResult>
+
+  renderQuestionCardSummary?(input: { questions: Question.Info[]; answers: Question.Answer[] }): unknown
 
   addReaction?(input: { accountId: string; messageId: string; emoji: string }): Promise<{ reactionId: string } | void>
 

--- a/packages/synergy/test/channel/feishu-question-card.test.ts
+++ b/packages/synergy/test/channel/feishu-question-card.test.ts
@@ -3,6 +3,8 @@ import {
   renderFeishuQuestionCard,
   parseFeishuQuestionCardAction,
   sendFeishuQuestionCard,
+  renderFeishuQuestionCardSummary,
+  renderFeishuQuestionCardSummarySafe,
 } from "../../src/channel/provider/feishu"
 import type { Question } from "../../src/question"
 
@@ -335,5 +337,56 @@ describe("Feishu question card size validation", () => {
     } finally {
       globalThis.fetch = originalFetch
     }
+  })
+})
+
+describe("Feishu question card summary", () => {
+  test("renders a read-only summary with each question and its submitted answers", () => {
+    const rendered = renderFeishuQuestionCardSummary(mixedQuestions, [["Staging"], ["Feature A", "Feature C"]])
+
+    expect(rendered.schema).toBe("2.0")
+    expect(rendered.header.title.content).toBe("回答已提交")
+    expect(rendered.config?.summary?.content).toBe("回答已提交")
+
+    const elements = rendered.body.elements as Array<Record<string, unknown>>
+    expect(elements.some((element) => element.tag === "form")).toBe(false)
+    expect(elements.every((element) => element.tag === "markdown")).toBe(true)
+
+    const content = elements.map((element) => String(element.content)).join("\n")
+    expect(content).toContain("Env")
+    expect(content).toContain("Which environment?")
+    expect(content).toContain("Staging")
+    expect(content).toContain("Select features to deploy")
+    expect(content).toContain("Feature A")
+    expect(content).toContain("Feature C")
+    expect(content).not.toContain("question_form")
+  })
+
+  test("bounded provider renderer returns a schema-valid summary", () => {
+    const rendered = renderFeishuQuestionCardSummarySafe(singleQuestions, [["Production"]])
+
+    expect(rendered).toBeDefined()
+    const card = rendered as { header: { title: { content: string } }; body: { elements: Array<{ tag: string }> } }
+    expect(card.header.title.content).toBe("回答已提交")
+    expect(card.body.elements.every((element) => element.tag === "markdown")).toBe(true)
+  })
+
+  test("bounded provider renderer returns undefined for an oversized summary", () => {
+    const manyQuestions: Question.Info[] = Array.from({ length: 60 }, (_, i) => ({
+      question: `Question number ${i} with padded text for size?`,
+      header: `Q${i}`,
+      options: Array.from({ length: 8 }, (_, j) => ({
+        label: `Option ${i}-${j} with extra padding label`,
+        description: `A very long description for option ${i}-${j} that adds significant byte weight to push past the 30KiB limit`,
+      })),
+      multiple: i % 2 === 0,
+    }))
+
+    expect(
+      renderFeishuQuestionCardSummarySafe(
+        manyQuestions,
+        manyQuestions.map(() => [`自定义长答案${"很长的用户自定义输入内容".repeat(60)}`]),
+      ),
+    ).toBeUndefined()
   })
 })

--- a/packages/synergy/test/channel/feishu-response-card.test.ts
+++ b/packages/synergy/test/channel/feishu-response-card.test.ts
@@ -239,7 +239,7 @@ describe("Feishu response cards", () => {
         card,
       })
 
-      expect(sent).toEqual({ messageId: "om_response_card" })
+      expect(sent).toEqual({ messageId: "om_response_card", threadId: undefined })
       expect(requests.map((request) => request.url)).toEqual([
         "https://open.feishu.test/open-apis/cardkit/v1/cards",
         "https://open.feishu.test/open-apis/im/v1/messages/om_topic/reply",

--- a/packages/synergy/test/channel/question-card-bridge.test.ts
+++ b/packages/synergy/test/channel/question-card-bridge.test.ts
@@ -156,3 +156,119 @@ test("delivers continuation questions from durable channel root metadata after t
     },
   })
 })
+
+test("delivers to the durable root's real chatId when the session endpoint chatId is synthetic (Runtime Boss)", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await ScopeContext.provide({
+    scope: await tmp.scope(),
+    fn: async () => {
+      const type = `question-bridge-boss-${crypto.randomUUID()}`
+      const sent = Promise.withResolvers<Parameters<NonNullable<Provider["sendQuestionCard"]>>[0]>()
+      const provider: Provider = {
+        type,
+        lifecycle: "self_connected",
+        async connect() {},
+        async replyMessage() {
+          return { messageId: "reply_sent" }
+        },
+        async pushMessage() {
+          return { messageId: "push_sent" }
+        },
+        async sendQuestionCard(input) {
+          sent.resolve(input)
+          return { messageId: "om_question_card" }
+        },
+        async addReaction() {},
+        createStreamingSession() {
+          return {
+            async start() {},
+            async update() {},
+            async updateToolProgress() {},
+            async close() {},
+            isActive: () => false,
+          }
+        },
+      }
+      Channel.registerProvider(provider)
+      const dispose = QuestionCardBridge.init()
+      // Runtime Boss aggregates every Feishu chat into one synthetic endpoint.
+      const session = await Session.create({
+        endpoint: SessionEndpoint.fromChannel({
+          type,
+          accountId: "acct_feishu",
+          chatId: "boss",
+          chatType: "group",
+          scopeKey: "boss",
+          senderId: "ou_stale_endpoint_user",
+        }),
+      })
+      const rootID = Identifier.ascending("message")
+      await Session.updateMessage({
+        id: rootID,
+        sessionID: session.id,
+        role: "user",
+        isRoot: true,
+        rootID,
+        agent: "synergy",
+        model: { providerID: "test-provider", modelID: "test-model" },
+        time: { created: Date.now() },
+        metadata: {
+          channelReplyToMessageId: "om_real_topic",
+          channelRequesterId: "ou_real_requester",
+          channelChatId: "oc_real_group",
+        },
+      } as MessageV2.User)
+      const assistantID = Identifier.ascending("message")
+      await Session.updateMessage({
+        id: assistantID,
+        parentID: rootID,
+        rootID,
+        role: "assistant",
+        mode: "synergy",
+        agent: "synergy",
+        path: { cwd: ScopeContext.current.directory, root: ScopeContext.current.directory },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: "test-model",
+        providerID: "test-provider",
+        time: { created: Date.now() },
+        sessionID: session.id,
+      } as MessageV2.Assistant)
+
+      const answer = Question.ask({
+        sessionID: session.id,
+        questions,
+        tool: { messageID: assistantID, callID: "call_question" },
+      })
+      const delivery = await sent.promise
+      // The card must be sent to the real group and registered under it, not the synthetic "boss" endpoint.
+      expect(delivery.chatId).toBe("oc_real_group")
+
+      const callback = {
+        eventId: "evt_boss_card",
+        requestId: delivery.requestId,
+        messageId: "om_question_card",
+        chatId: "oc_real_group",
+        requesterId: "ou_real_requester",
+        formValues: [{ name: "question_0", selected: ["0"] }],
+      }
+      // deliver() flips the registration to active asynchronously after the
+      // provider resolves; poll until the callback is accepted (rejected
+      // paths never consume the registration, so retrying is safe).
+      let result: Awaited<ReturnType<typeof QuestionCardRuntime.acceptAction>> | undefined
+      const deadline = Date.now() + 2_000
+      while (Date.now() < deadline) {
+        result = await QuestionCardRuntime.acceptAction({
+          channelType: type,
+          accountId: "acct_feishu",
+          callback,
+        })
+        if (result.status !== "rejected") break
+        await Bun.sleep(10)
+      }
+      expect(result).toEqual({ status: "accepted" })
+      expect(await answer).toEqual([["Staging"]])
+      dispose()
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Runtime Boss aggregates every Feishu chat into one synthetic session endpoint (`chatId: "boss"`), so question card registrations were bound to the synthetic chatId while Feishu card callbacks carry the real `open_chat_id`. The strict `chatId` ownership check in `QuestionCardRuntime.acceptAction` then rejected every card submit from Feishu, surfacing "此问题已失效，请使用最新卡片重试" even though the card rendered in the group with correct options.

This change resolves the card's chatId from the durable root message's `channelChatId` metadata (falling back to the endpoint chatId), persists `channelChatId` on channel root messages, and adds structured logging for rejected/expired card callbacks so future failures are diagnosable.

## Changes

- `packages/synergy/src/channel/question-card-bridge.ts` — prefer root metadata `channelChatId` when registering question cards
- `packages/synergy/src/channel/index.ts` — persist `channelChatId` in channel root message metadata
- `packages/synergy/src/channel/question-card.ts` — log card callback rejection/expiry reasons
- `packages/synergy/test/channel/question-card-bridge.test.ts` — regression test for a synthetic endpoint chatId (Runtime Boss)

## Verification

- `bun test test/channel/question-card-bridge.test.ts test/channel/question-card-runtime.test.ts test/channel/feishu-question-card.test.ts test/channel/feishu-response-card.test.ts` → 21 pass, 0 fail
- `bun run typecheck` (packages/synergy) → pass
- `bun run format:check` → pass
- `bun run quality:quick` → pass

## Notes

Boss Mode (`experimental.boss_mode`) lives in a separate feature branch; this fix makes question cards correct for any endpoint whose chatId is synthetic/aggregated, as long as the root message carries the real `channelChatId`.
