### PR TITLE
feat: add compact live reasoning display and balanced default

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -166,19 +166,34 @@ The frontend may mirror the value locally to choose a catalog before the server 
 
 ```jsonc
 {
-  "activityDisplay": "full", // full | balanced | minimal
+  "activityDisplay": "balanced", // full | balanced | minimal
 }
 ```
 
-`full` is the default when the field is absent. Settings manages the preference globally in the installation config. If the key is declared manually in project config, ordinary project-over-global precedence still applies.
+`balanced` is the default when the field is absent. Settings manages the preference globally in the installation config. If the key is declared manually in project config, ordinary project-over-global precedence still applies.
 
 - `full` preserves the detailed turn timeline: every reasoning, text, tool, media, and attachment part stays in its original part order, matching pre-preference behavior. It never invokes the activity-summary nano model.
-- `balanced` replaces raw reasoning with one root-turn status row rather than model-generated reasoning text. After reasoning begins, the working turn shows one stable `Thinking…` row across all assistant messages. When the turn completes, that row disappears if the turn produced text, tool activity, or a receipt; an otherwise empty reasoning-only turn keeps one deterministic `Reasoning` fallback. Reasoning never invokes the `nano` model or writes derived activity metadata.
+- `balanced` replaces raw reasoning with one root-turn status row rather than model-generated reasoning text. After reasoning begins, the working turn shows one stable `Thinking…` row across all assistant messages, or — when `compactReasoning` is enabled — one live single-line reasoning row. When the turn completes, that row disappears if the turn produced text, tool activity, or a receipt; an otherwise empty reasoning-only turn keeps one deterministic `Reasoning` fallback. Reasoning never invokes the `nano` model or writes derived activity metadata.
   Settled ordinary tool tails (completed or error) are grouped by shared user-facing intent through one bounded `nano` call; stable semantic groups carry a concise summary, while deterministic fallback tail groups may omit text. Text, reasoning, attachment, receipt-tool, and message boundaries remain hard boundaries; in settled and persisted semantic membership, an error step stays in its current group, promotes that group to error, and prevents later steps from joining, while transient unpersisted streaming grouping uses deterministic family-and-scope adjacency until persisted signatures arrive. File and URL hints sent for semantic grouping are reduced to bounded non-sensitive forms such as a basename or origin; tool inputs, outputs, full paths, raw errors, and secrets are excluded. The model output must cover every step once, preserve order, and stay within the 24-step group limit. Invalid output, timeout, provider failure, or a manifest larger than 48 steps falls back for the whole unsettled tail.
   Tool-group nano summaries and semantic group signatures remain internal presentation metadata rather than visible parent rows. The group's original tool calls render as flat, independently expandable rows, may span different activity families, and keep their own family action labels, titles, states, results, and specialized content. Balanced mode does not render a group topic, progress marker, step count, connector, or parent indentation.
 - `minimal` collapses each turn into one compact per-turn activity summary with animated count updates and, when available, one latest high-level tool-activity line. Raw reasoning and reasoning-status rows are not rendered. Permission, failure, external-action, and production communication receipts stay standalone, and other non-tool timeline items continue to render in their original position.
 
 The mode changes only activity presentation. It never hides permission requests, failures, or external-action and production communication receipts, and it never rewrites message parts or changes model context. In `balanced` and `minimal`, bounded tool-group nano summaries and semantic group signatures may be persisted as derived assistant `metadata.activity` so reconnects and historical turns retain the same presentation. Historical `reasoning` entries and `now.source: "reasoning"` remain schema-valid read-only compatibility data but are not produced or used by the Balanced reasoning projection. Mode changes update already rendered turns reactively without remounting them.
+
+## Compact reasoning
+
+`compactReasoning` is a global General preference that keeps live reasoning output in a single-line view. It lives in `00-general.jsonc`:
+
+```jsonc
+{
+  "compactReasoning": false,
+}
+```
+
+`false` is the default when the field is absent. Settings → General manages the preference in the installation config. If the key is declared manually in project config, ordinary project-over-global precedence still applies.
+
+While the assistant turn is streaming, the working turn shows only the latest reasoning block projected to one stable plain-text line: the most recent non-structural line of the reasoning markdown, skipping blank lines, code fences, and horizontal rules, and stripping markdown list, quote, and heading prefixes. When the turn settles, the standard reasoning presentation returns. Complete reasoning data is never modified — compact mode changes presentation only, and it takes effect only while the turn is working.
+In `balanced` activity display, the preference upgrades the `Thinking…` status row into the live one-line reasoning row while streaming; the status row remains when the preference is off. In `full` activity display the preference keeps only the latest reasoning block while streaming and restores the complete reasoning blocks once the turn settles.
 
 ## JSONC, Schema, and References
 

--- a/packages/app/src/components/session/conversation.tsx
+++ b/packages/app/src/components/session/conversation.tsx
@@ -37,6 +37,7 @@ export function SessionConversation(props: {
   activeMessage: Accessor<UserMessage | undefined>
   workspaceOpen?: Accessor<boolean>
   isWorking: Accessor<boolean>
+  compactReasoning: Accessor<boolean>
   turnStart: number
   turnBatch: number
   onSetTurnStart: (start: number) => void
@@ -205,6 +206,7 @@ export function SessionConversation(props: {
                 compactionParentIDs={turnProjection().compactionParentIDs}
                 activityDisplay={props.activityDisplay()}
                 lastUserMessageID={props.lastUserMessage()?.id}
+                compactReasoning={props.compactReasoning()}
                 onRewind={messageAllowsCanonicalActions(msg) ? () => props.onRewind?.(msg as UserMessage) : undefined}
                 rollbackActive={props.rollbackActive}
                 onReviewChanges={props.onReviewChanges}

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -32,6 +32,9 @@ export function buildPatch(params: BuildPatchParams): Record<string, unknown> {
 function buildGeneralPatch(cfg: Config, state: SettingsState, patch: Record<string, unknown>) {
   const { general } = state
   if (general.snapshot !== (cfg.snapshot ?? UI_DEFAULTS.snapshot)) patch.snapshot = general.snapshot
+  if (general.compactReasoning !== (cfg.compactReasoning ?? UI_DEFAULTS.compactReasoning)) {
+    patch.compactReasoning = general.compactReasoning
+  }
 
   const username = general.username.trim()
   if (username !== (cfg.username ?? UI_DEFAULTS.username)) patch.username = username || undefined

--- a/packages/app/src/components/settings/hooks/useSettingsForm.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.ts
@@ -34,6 +34,7 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
   params.setSettings("general", {
     colorScheme: params.colorScheme(),
     snapshot: cfg.snapshot ?? UI_DEFAULTS.snapshot,
+    compactReasoning: cfg.compactReasoning ?? UI_DEFAULTS.compactReasoning,
     username: cfg.username ?? UI_DEFAULTS.username,
     theme: cfg.theme ?? UI_DEFAULTS.theme,
     locale: cfg.locale ?? UI_DEFAULTS.locale,

--- a/packages/app/src/components/settings/panels/GeneralPanel.tsx
+++ b/packages/app/src/components/settings/panels/GeneralPanel.tsx
@@ -100,6 +100,11 @@ const copy = {
     id: "settings.general.snapshots.description",
     message: "Keep restore points when Synergy edits files",
   },
+  compactReasoningTitle: { id: "settings.general.compactReasoning.title", message: "Compact reasoning" },
+  compactReasoningDescription: {
+    id: "settings.general.compactReasoning.description",
+    message: "Show live reasoning in a single-line view",
+  },
   notificationsTitle: { id: "settings.general.notifications.title", message: "Notifications" },
   notificationsDescription: {
     id: "settings.general.notifications.description",
@@ -304,6 +309,16 @@ export function GeneralPanel(props: {
           description={_(copy.snapshotsDescription)}
           trailing={
             <Switch checked={props.general.snapshot} onChange={(value) => props.onGeneralChange("snapshot", value)} />
+          }
+        />
+        <SettingRow
+          title={_(copy.compactReasoningTitle)}
+          description={_(copy.compactReasoningDescription)}
+          trailing={
+            <Switch
+              checked={props.general.compactReasoning}
+              onChange={(value) => props.onGeneralChange("compactReasoning", value)}
+            />
           }
         />
         <ProductUpdates mode={props.desktopUpdateMode} onModeChange={props.onDesktopUpdateModeChange} />

--- a/packages/app/src/components/settings/types.ts
+++ b/packages/app/src/components/settings/types.ts
@@ -40,9 +40,10 @@ export const MODEL_DEFAULTS: Record<ModelKey, string> = {
 export const UI_DEFAULTS = {
   locale: "system" as LocalePreference,
   theme: "" as string,
-  activityDisplay: "full" as ActivityDisplay,
+  activityDisplay: "balanced" as ActivityDisplay,
   username: "" as string,
   snapshot: true,
+  compactReasoning: false,
   permission: "ask" as string, // resolved from backend { "*": "ask" } object
   sandboxEnabled: "true" as string,
   sandboxFallbackPolicy: "warn" as string,
@@ -275,6 +276,7 @@ export function groupByProvider(list: ProviderModel[]): ProviderGroup[] {
 export type GeneralStore = {
   colorScheme: ColorScheme
   snapshot: boolean
+  compactReasoning: boolean
   username: string
   theme: string
   locale: LocalePreference
@@ -384,6 +386,7 @@ export function defaultSettingsState(sendShortcut: SendShortcut, colorScheme: Co
     general: {
       colorScheme,
       snapshot: UI_DEFAULTS.snapshot,
+      compactReasoning: UI_DEFAULTS.compactReasoning,
       username: UI_DEFAULTS.username,
       theme: UI_DEFAULTS.theme,
       locale: UI_DEFAULTS.locale,

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -11557,6 +11557,10 @@ msgid "session-status.working-with-notes"
 msgstr "Working with notes"
 
 #. ── Session turn chrome ─────────────────────────────────────────────
+msgid "session-turn.compact-reasoning-thinking"
+msgstr "Thinking"
+
+#. ── Session turn chrome ─────────────────────────────────────────────
 msgid "session-turn.completed"
 msgstr "Completed"
 
@@ -14859,6 +14863,14 @@ msgstr "Auto"
 #. js-lingui-explicit-id
 msgid "settings.general.colorScheme.system.description"
 msgstr "Follow this device"
+
+#. js-lingui-explicit-id
+msgid "settings.general.compactReasoning.description"
+msgstr "Show live reasoning in a single-line view"
+
+#. js-lingui-explicit-id
+msgid "settings.general.compactReasoning.title"
+msgstr "Compact reasoning"
 
 #. js-lingui-explicit-id
 msgid "settings.general.font.applied"

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -11557,6 +11557,10 @@ msgid "session-status.working-with-notes"
 msgstr ""
 
 #. ── Session turn chrome ─────────────────────────────────────────────
+msgid "session-turn.compact-reasoning-thinking"
+msgstr ""
+
+#. ── Session turn chrome ─────────────────────────────────────────────
 msgid "session-turn.completed"
 msgstr ""
 
@@ -14858,6 +14862,14 @@ msgstr ""
 
 #. js-lingui-explicit-id
 msgid "settings.general.colorScheme.system.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+msgid "settings.general.compactReasoning.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+msgid "settings.general.compactReasoning.title"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -11557,6 +11557,10 @@ msgid "session-status.working-with-notes"
 msgstr "正在处理笔记"
 
 #. ── Session turn chrome ─────────────────────────────────────────────
+msgid "session-turn.compact-reasoning-thinking"
+msgstr "思考中"
+
+#. ── Session turn chrome ─────────────────────────────────────────────
 msgid "session-turn.completed"
 msgstr "已完成"
 
@@ -14859,6 +14863,14 @@ msgstr "自动"
 #. js-lingui-explicit-id
 msgid "settings.general.colorScheme.system.description"
 msgstr "跟随此设备"
+
+#. js-lingui-explicit-id
+msgid "settings.general.compactReasoning.description"
+msgstr "以单行视图显示实时推理"
+
+#. js-lingui-explicit-id
+msgid "settings.general.compactReasoning.title"
+msgstr "紧凑推理"
 
 #. js-lingui-explicit-id
 msgid "settings.general.font.applied"

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1416,6 +1416,7 @@ function SessionPageContent() {
                           lastUserMessage={lastRenderableUserMessage}
                           activeMessage={activeMessage}
                           isWorking={isWorking}
+                          compactReasoning={() => sync.data.config.compactReasoning === true}
                           turnStart={store.turnStart}
                           turnBatch={turnBatch}
                           onSetTurnStart={(start) => setStore("turnStart", start)}

--- a/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
@@ -571,29 +571,29 @@ describe("settings config patch locale", () => {
 })
 
 describe("settings config patch activity display", () => {
-  test("does not emit activityDisplay when the form is at the full default", () => {
+  test("does not emit activityDisplay when the form is at the balanced default", () => {
     const state = defaultSettingsState("enter")
     expect(buildPatch({ cfg: {} as Config, state, originalMcps: {} })).not.toHaveProperty("activityDisplay")
   })
 
   test("emits activityDisplay when the form diverges from an absent server value", () => {
     const state = defaultSettingsState("enter")
-    state.general.activityDisplay = "balanced"
-    expect(buildPatch({ cfg: {} as Config, state, originalMcps: {} }).activityDisplay).toBe("balanced")
+    state.general.activityDisplay = "full"
+    expect(buildPatch({ cfg: {} as Config, state, originalMcps: {} }).activityDisplay).toBe("full")
   })
 
   test("emits activityDisplay when the form diverges from an explicit server value", () => {
     const state = defaultSettingsState("enter")
     state.general.activityDisplay = "minimal"
-    expect(buildPatch({ cfg: { activityDisplay: "full" } as Config, state, originalMcps: {} }).activityDisplay).toBe(
-      "minimal",
-    )
+    expect(
+      buildPatch({ cfg: { activityDisplay: "balanced" } as Config, state, originalMcps: {} }).activityDisplay,
+    ).toBe("minimal")
   })
 
   test("does not emit activityDisplay when the form matches the server value", () => {
     const state = defaultSettingsState("enter")
-    state.general.activityDisplay = "balanced"
-    expect(buildPatch({ cfg: { activityDisplay: "balanced" } as Config, state, originalMcps: {} })).not.toHaveProperty(
+    state.general.activityDisplay = "full"
+    expect(buildPatch({ cfg: { activityDisplay: "full" } as Config, state, originalMcps: {} })).not.toHaveProperty(
       "activityDisplay",
     )
   })

--- a/packages/app/test/components/settings/hooks/useSettingsForm.test.ts
+++ b/packages/app/test/components/settings/hooks/useSettingsForm.test.ts
@@ -205,8 +205,8 @@ describe("settings form locale hydration", () => {
 })
 
 describe("settings form activity display hydration", () => {
-  test("defaults to full when absent from config", () => {
-    expect(initializedActivityDisplay({})).toBe("full")
+  test("defaults to balanced when absent from config", () => {
+    expect(initializedActivityDisplay({})).toBe("balanced")
   })
 
   test("hydrates explicit full display from config", () => {

--- a/packages/app/test/components/settings/types.test.ts
+++ b/packages/app/test/components/settings/types.test.ts
@@ -19,8 +19,8 @@ describe("settings types", () => {
     expect(defaultSettingsState("enter").runtime.cortexConcurrency).toBe("8")
   })
 
-  test("defaults activity display to full in the general store", () => {
-    expect(UI_DEFAULTS.activityDisplay).toBe("full")
-    expect(defaultSettingsState("enter").general.activityDisplay).toBe("full")
+  test("defaults activity display to balanced in the general store", () => {
+    expect(UI_DEFAULTS.activityDisplay).toBe("balanced")
+    expect(defaultSettingsState("enter").general.activityDisplay).toBe("balanced")
   })
 })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3512,7 +3512,7 @@ export type Config = {
    */
   theme?: string
   /**
-   * How much activity detail to show in the interface: full = everything and the default, balanced = semantic activity grouping, minimal = only essential activity (default: full)
+   * How much activity detail to show in the interface: full = everything, balanced = semantic activity grouping, minimal = only essential activity (default: balanced)
    */
   activityDisplay?: "full" | "balanced" | "minimal"
   keybinds?: KeybindsConfig
@@ -3701,6 +3701,10 @@ export type Config = {
   pluginRuntimePolicy?: PluginRuntimePolicyConfig
   pluginMarketplace?: PluginMarketplaceConfig
   snapshot?: boolean
+  /**
+   * Show live reasoning in a compact single-line viewport
+   */
+  compactReasoning?: boolean
   /**
    * Disable providers that are loaded automatically. Empty arrays are ignored in each config layer, preserving lower-priority filters
    */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -32802,7 +32802,7 @@
             "type": "string"
           },
           "activityDisplay": {
-            "description": "How much activity detail to show in the interface: full = everything and the default, balanced = semantic activity grouping, minimal = only essential activity (default: full)",
+            "description": "How much activity detail to show in the interface: full = everything, balanced = semantic activity grouping, minimal = only essential activity (default: balanced)",
             "type": "string",
             "enum": ["full", "balanced", "minimal"]
           },
@@ -33121,6 +33121,10 @@
             "$ref": "#/components/schemas/PluginMarketplaceConfig"
           },
           "snapshot": {
+            "type": "boolean"
+          },
+          "compactReasoning": {
+            "description": "Show live reasoning in a compact single-line viewport",
             "type": "boolean"
           },
           "disabled_providers": {

--- a/packages/synergy/schema/config.schema.json
+++ b/packages/synergy/schema/config.schema.json
@@ -17,7 +17,7 @@
       "type": "string"
     },
     "activityDisplay": {
-      "description": "How much activity detail to show in the interface: full = everything and the default, balanced = semantic activity grouping, minimal = only essential activity (default: full)",
+      "description": "How much activity detail to show in the interface: full = everything, balanced = semantic activity grouping, minimal = only essential activity (default: balanced)",
       "type": "string",
       "enum": ["full", "balanced", "minimal"]
     },
@@ -539,6 +539,10 @@
       "additionalProperties": false
     },
     "snapshot": {
+      "type": "boolean"
+    },
+    "compactReasoning": {
+      "description": "Show live reasoning in a compact single-line viewport",
       "type": "boolean"
     },
     "disabled_providers": {

--- a/packages/synergy/src/config/config.ts
+++ b/packages/synergy/src/config/config.ts
@@ -381,7 +381,8 @@ export namespace Config {
     // Apply centralized defaults for fields shown in Settings UI.
     // These fill undefined values only — user-set values are preserved.
     if (result.snapshot === undefined) result.snapshot = true
-    if (result.activityDisplay === undefined) result.activityDisplay = "full"
+    if (result.activityDisplay === undefined) result.activityDisplay = "balanced"
+    if (result.compactReasoning === undefined) result.compactReasoning = false
     if (result.lspWriteDiagnostics === undefined) result.lspWriteDiagnostics = true
     if (result.default_agent === undefined) result.default_agent = "synergy"
     if (result.project_doc_fallback_filenames === undefined) result.project_doc_fallback_filenames = []

--- a/packages/synergy/src/config/domain.ts
+++ b/packages/synergy/src/config/domain.ts
@@ -46,6 +46,7 @@ export namespace ConfigDomain {
       "toast",
       "logLevel",
       "snapshot",
+      "compactReasoning",
       "username",
       "locale",
       "activityDisplay",

--- a/packages/synergy/src/config/schema.ts
+++ b/packages/synergy/src/config/schema.ts
@@ -1396,7 +1396,7 @@ export const Info = z
       .enum(["full", "balanced", "minimal"])
       .optional()
       .describe(
-        "How much activity detail to show in the interface: full = everything and the default, balanced = semantic activity grouping, minimal = only essential activity (default: full)",
+        "How much activity detail to show in the interface: full = everything, balanced = semantic activity grouping, minimal = only essential activity (default: balanced)",
       ),
     keybinds: Keybinds.optional().describe("Custom keybind configurations"),
     logLevel: Log.Level.optional().describe("Log level"),
@@ -1684,6 +1684,7 @@ export const Info = z
     pluginRuntimePolicy: PluginRuntimePolicy.optional().describe("Plugin runtime isolation policy configuration"),
     pluginMarketplace: PluginMarketplace.optional().describe("Public plugin marketplace registry configuration"),
     snapshot: z.boolean().optional(),
+    compactReasoning: z.boolean().optional().describe("Show live reasoning in a compact single-line viewport"),
     disabled_providers: z
       .array(z.string())
       .optional()

--- a/packages/synergy/test/config/config.test.ts
+++ b/packages/synergy/test/config/config.test.ts
@@ -23,13 +23,13 @@ test("loads config with defaults when no files exist", async () => {
     },
   })
 })
-test("defaults activity display to full without materializing a preference", async () => {
+test("defaults activity display to balanced without materializing a preference", async () => {
   await using tmp = await tmpdir()
   await ScopeContext.provide({
     scope: await tmp.scope(),
     fn: async () => {
       const config = await Config.current()
-      expect(config.activityDisplay).toBe("full")
+      expect(config.activityDisplay).toBe("balanced")
       expect((await Config.globalRaw()).activityDisplay).toBeUndefined()
     },
   })

--- a/packages/ui/script/test.ts
+++ b/packages/ui/script/test.ts
@@ -7,6 +7,7 @@ const root = path.resolve(import.meta.dir, "..")
 const isolated = new Set([
   "test/components/message-part-error-boundary.test.ts",
   "test/components/activity-trace.dom.test.ts",
+  "test/components/compact-reasoning.dom.test.ts",
   "test/components/session-turn-activity.test.ts",
   "test/components/session-turn-activity-switch.dom.test.ts",
   "test/components/session-turn-timeline.test.ts",

--- a/packages/ui/src/components/compact-reasoning.css
+++ b/packages/ui/src/components/compact-reasoning.css
@@ -1,0 +1,47 @@
+[data-component="compact-reasoning"] {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  min-width: 0;
+  color: var(--text-weak);
+  font-size: var(--font-size-small);
+  font-style: normal;
+  line-height: 1.55;
+
+  [data-slot="compact-reasoning-leading"] {
+    display: grid;
+    flex: 0 0 auto;
+    place-items: center;
+    color: var(--icon-weak-base);
+  }
+
+  [data-component="spinner"] {
+    width: 12px;
+    height: 12px;
+  }
+
+  [data-slot="compact-reasoning-label"] {
+    flex: 0 0 auto;
+    color: var(--text-base);
+  }
+
+  [data-slot="compact-reasoning-scroller"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  [data-slot="compact-reasoning-text"] {
+    font-style: italic;
+    white-space: nowrap;
+    padding-inline-end: 6px;
+  }
+}

--- a/packages/ui/src/components/compact-reasoning.tsx
+++ b/packages/ui/src/components/compact-reasoning.tsx
@@ -1,0 +1,54 @@
+import { createEffect, createSignal, on, onCleanup } from "solid-js"
+import { useLingui } from "@lingui/solid"
+import { Spinner } from "./spinner"
+import { SESSION_TURN_DESC } from "./tool-title-descriptors"
+import "./compact-reasoning.css"
+
+export function CompactReasoningLine(props: { text: string }) {
+  const { _ } = useLingui()
+  const [userScrolled, setUserScrolled] = createSignal(false)
+  let scroller: HTMLElement | undefined
+  let scrollFrame: number | undefined
+
+  const flushToTail = () => {
+    scrollFrame = undefined
+    const el = scroller
+    if (!el || userScrolled()) return
+    const tail = Math.max(0, el.scrollWidth - el.clientWidth)
+    if (tail <= 0 || tail - el.scrollLeft < 2) return
+    el.scrollLeft = tail
+  }
+
+  createEffect(
+    on(
+      () => props.text,
+      () => {
+        if (scrollFrame !== undefined) return
+        scrollFrame = requestAnimationFrame(flushToTail)
+      },
+    ),
+  )
+
+  onCleanup(() => {
+    if (scrollFrame !== undefined) cancelAnimationFrame(scrollFrame)
+  })
+
+  const handleScroll = () => {
+    const el = scroller
+    if (!el) return
+    const tail = Math.max(0, el.scrollWidth - el.clientWidth)
+    setUserScrolled(tail - el.scrollLeft >= 2)
+  }
+
+  return (
+    <div data-component="compact-reasoning" aria-live="off">
+      <span data-slot="compact-reasoning-leading" aria-hidden="true">
+        <Spinner />
+      </span>
+      <span data-slot="compact-reasoning-label">{_(SESSION_TURN_DESC.compactReasoningThinking)}</span>
+      <span data-slot="compact-reasoning-scroller" ref={(el) => (scroller = el)} onScroll={handleScroll}>
+        <span data-slot="compact-reasoning-text">{props.text}</span>
+      </span>
+    </div>
+  )
+}

--- a/packages/ui/src/components/session-turn-activity.tsx
+++ b/packages/ui/src/components/session-turn-activity.tsx
@@ -1,5 +1,5 @@
 import type { MessageDescriptor } from "@lingui/core"
-import type { AssistantMessage, PermissionRequest, ToolPart } from "@ericsanchezok/synergy-sdk/client"
+import type { AssistantMessage, PermissionRequest, ReasoningPart, ToolPart } from "@ericsanchezok/synergy-sdk/client"
 import {
   ACTIVITY_FAMILY_ORDER,
   ActivityDerivedMetadataSchema,
@@ -362,6 +362,8 @@ export function projectBalancedReasoningItems<T>(
   options?: {
     anchorMessage?: AssistantMessage
     frontier?: BalancedReasoningFrontier
+    /** Latest live reasoning part; when working, replaces the Thinking… status row with one streaming reasoning line. */
+    compactReasoningPart?: ReasoningPart
   },
 ): (ActivityTimelineItem | T)[] {
   const activityItems = items.filter(isActivityTimelineItem)
@@ -376,8 +378,17 @@ export function projectBalancedReasoningItems<T>(
 
   const anchorMessage = options?.anchorMessage ?? activityItems[0]?.message ?? frontier.message
   const hasOutput = activityItems.some(isBalancedTurnOutput)
-  const summary: ActivityReasoningSummaryItem | undefined =
-    working || !hasOutput
+  const liveItem: ActivityPassthroughItem | undefined =
+    working && options?.compactReasoningPart
+      ? {
+          kind: "passthrough",
+          item: { kind: "reasoning", message: anchorMessage, part: options.compactReasoningPart },
+          message: anchorMessage,
+        }
+      : undefined
+  const summary: ActivityReasoningSummaryItem | undefined = liveItem
+    ? undefined
+    : working || !hasOutput
       ? {
           kind: "activity-reasoning-summary",
           key: `activity-reasoning:${rootMessageID}`,
@@ -390,15 +401,18 @@ export function projectBalancedReasoningItems<T>(
     activityItems.flatMap((item) => (item.kind === "activity-reasoning-summary" ? [] : [item.message.id])),
   )
   if (summary) keptMessageIDs.add(summary.message.id)
+  if (liveItem) keptMessageIDs.add(liveItem.message.id)
 
   const result: (ActivityTimelineItem | T)[] = []
   const boundaryMessageIDs = new Set<string>()
-  let insertedSummary = false
+  const inserted = summary ?? liveItem
+  const insertedMessageID = inserted?.message.id
+  let insertedFlag = false
   for (const item of items) {
     if (isActivityTimelineItem(item)) {
-      if (!insertedSummary && summary && item.message.id === summary.message.id) {
-        result.push(summary)
-        insertedSummary = true
+      if (!insertedFlag && inserted && item.message.id === insertedMessageID) {
+        result.push(inserted)
+        insertedFlag = true
       }
       if (item.kind === "activity-reasoning-summary") {
         if (!keptMessageIDs.has(item.message.id) && !boundaryMessageIDs.has(item.message.id)) {
@@ -414,7 +428,7 @@ export function projectBalancedReasoningItems<T>(
     }
     result.push(item)
   }
-  if (summary && !insertedSummary) result.push(summary)
+  if (inserted && !insertedFlag) result.push(inserted)
   return result
 }
 

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -314,6 +314,11 @@
     margin-top: 0;
   }
 
+  [data-slot="session-turn-timeline-item"][data-compact-reasoning="true"] {
+    overflow: hidden;
+    overflow-anchor: none;
+  }
+
   /* ── Assistant message footer (Copy Markdown + timestamp) ────── */
   [data-slot="assistant-message-meta"] {
     max-width: min(54rem, 100%);

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -40,6 +40,7 @@ import { CompactionCard } from "./compaction-card"
 import { createCopyController } from "./clipboard"
 import { hasVisibleUserMessageContent, isSystemPart } from "./user-message-utils"
 import { ActivityReasoningSummary, ActivityReceipt, ActivityTrace, MinimalActivitySummary } from "./activity-trace"
+import { CompactReasoningLine } from "./compact-reasoning"
 import {
   activityItemStableKey,
   isActivityTimelineItem,
@@ -331,6 +332,22 @@ export function collectSessionTurnTimelineItems(
 
   return items
 }
+
+export function compactReasoningTimelineItems<T extends { kind: string }>(items: readonly T[]): T[] {
+  const latestReasoning = items.findLastIndex((item) => item.kind === "reasoning")
+  if (latestReasoning < 0) return [...items]
+  return items.filter((item, index) => item.kind !== "reasoning" || index === latestReasoning)
+}
+
+export function compactReasoningText(text: string): string {
+  const lines = text.split(/\r?\n/)
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index]?.trim()
+    if (!line || /^(`{3,}|~{3,})\S*$/.test(line) || /^(?:-{3,}|\*{3,}|_{3,})$/.test(line)) continue
+    return line.replace(/^(?:#{1,6}\s+|>\s*|[-*+]\s+|\d+[.)]\s+)/, "").trim()
+  }
+  return ""
+}
 /** A non-root, visible user message rendered as an inline chip inside its turn. */
 export function isGuidedContextUserMessage(message: Pick<UserMessage, "isRoot" | "visible">): boolean {
   return message.isRoot === false && message.visible !== false
@@ -470,9 +487,12 @@ export function shouldShowProviderPrelude(input: {
   return input.latestAssistantTimelineItems.length === 0
 }
 
-function TimelineItemDisplay(props: { item: SessionTurnTimelineItem; serverUrl: string }) {
+function TimelineItemDisplay(props: { item: SessionTurnTimelineItem; serverUrl: string; compactReasoning?: boolean }) {
   if (props.item.kind === "compaction") {
     return <CompactionCard part={props.item.part} message={props.item.message} />
+  }
+  if (props.item.kind === "reasoning" && props.compactReasoning) {
+    return <CompactReasoningLine text={compactReasoningText(props.item.part.text)} />
   }
   if (props.item.kind === "part" || props.item.kind === "reasoning") {
     return <Part part={props.item.part} message={props.item.message} />
@@ -601,6 +621,7 @@ function TimelineDisplay(props: {
   serverUrl: string
   rollbackActive: boolean
   onRewind?: () => void
+  compactReasoning?: boolean
 }) {
   const { _ } = useLingui()
   const activityGroup = createMemo(() => {
@@ -663,7 +684,11 @@ function TimelineDisplay(props: {
           </div>
         )}
       </Match>
-      <Match when={timelineItem()}>{(item) => <TimelineItemDisplay item={item()} serverUrl={props.serverUrl} />}</Match>
+      <Match when={timelineItem()}>
+        {(item) => (
+          <TimelineItemDisplay item={item()} serverUrl={props.serverUrl} compactReasoning={props.compactReasoning} />
+        )}
+      </Match>
     </Switch>
   )
 }
@@ -746,6 +771,7 @@ export function SessionTurn(
     rollbackActive?: boolean
     onReviewChanges?: (input: { messageID: string; file?: string }) => void
     activityDisplay?: ActivityDisplayMode
+    compactReasoning?: boolean
     classes?: {
       root?: string
       content?: string
@@ -900,21 +926,22 @@ export function SessionTurn(
           (item): item is AssistantMessage =>
             item.role === "assistant" && !isCompactionAssistant(item as AssistantMessage),
         )
-        const frontier = assistants.reduce<{ message: AssistantMessage; partID: string } | undefined>(
+        const frontier = assistants.reduce<{ message: AssistantMessage; part: ReasoningPart } | undefined>(
           (latest, assistant) => {
             const reasoningPart = (data.store.part[assistant.id] ?? emptyParts).findLast(
               (part): part is ReasoningPart => part.type === "reasoning" && Boolean(part.text.trim()),
             )
-            return reasoningPart ? { message: assistant, partID: reasoningPart.id } : latest
+            return reasoningPart ? { message: assistant, part: reasoningPart } : latest
           },
           undefined,
         )
         return projectBalancedReasoningItems(result, msg?.id ?? props.messageID, working(), {
           anchorMessage: assistants[0],
-          frontier,
+          frontier: frontier ? { message: frontier.message, partID: frontier.part.id } : undefined,
+          compactReasoningPart: props.compactReasoning && working() ? frontier?.part : undefined,
         }) as SessionTurnDisplayItem[]
       }
-      return result
+      return props.compactReasoning && working() ? compactReasoningTimelineItems(result) : result
     },
     emptyDisplayItems,
     { equals: same },
@@ -1188,12 +1215,24 @@ export function SessionTurn(
                                       data-activity-continues={activityContinues() ? "" : undefined}
                                       data-activity-follows={activityFollows() ? "" : undefined}
                                       hidden={isActivityBoundaryDisplayItem(current())}
+                                      data-compact-reasoning={
+                                        props.compactReasoning &&
+                                        working() &&
+                                        displayItemVisualKind(current()) === "reasoning"
+                                          ? "true"
+                                          : undefined
+                                      }
                                     >
                                       <TimelineDisplay
                                         item={current()}
                                         serverUrl={data.serverUrl}
                                         rollbackActive={props.rollbackActive === true}
                                         onRewind={props.onRewind}
+                                        compactReasoning={
+                                          props.compactReasoning &&
+                                          working() &&
+                                          displayItemVisualKind(current()) === "reasoning"
+                                        }
                                       />
                                     </div>
                                     <Show when={index() === timelineSlotIndexes().lastReasoning}>

--- a/packages/ui/src/components/tool-title-descriptors.ts
+++ b/packages/ui/src/components/tool-title-descriptors.ts
@@ -368,6 +368,7 @@ export const SESSION_TURN_DESC = {
   cacheWrite: d("session-turn.token-cache-write", "cache write"),
   output: d("session-turn.token-output", "output"),
   reasoning: d("session-turn.token-reasoning", "reasoning"),
+  compactReasoningThinking: d("session-turn.compact-reasoning-thinking", "Thinking"),
   modelUnavailable: d(
     "session-turn.model-unavailable",
     "Model {modelID} is unavailable from {providerID}. Choose another model to continue.",

--- a/packages/ui/test/components/compact-reasoning.dom.test.ts
+++ b/packages/ui/test/components/compact-reasoning.dom.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { JSDOM } from "jsdom"
+import { build } from "vite"
+import solidPlugin from "vite-plugin-solid"
+
+// The fixture compiles the real CompactReasoningLine through Vite before
+// exercising the scroll-follow behavior, matching the activity-trace DOM
+// harness. JSDOM has no layout engine, so scroll geometry is stubbed on the
+// scroller element.
+interface CompactReasoningHarness {
+  setText: (text: string) => void
+}
+
+let fixtureDirectory: string
+let dom: JSDOM
+let harness: CompactReasoningHarness
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function scroller(): HTMLElement {
+  return document.querySelector('[data-slot="compact-reasoning-scroller"]') as HTMLElement
+}
+
+function setScrollerGeometry(scrollWidth: number, clientWidth: number) {
+  const el = scroller()
+  Object.defineProperty(el, "scrollWidth", { configurable: true, get: () => scrollWidth })
+  Object.defineProperty(el, "clientWidth", { configurable: true, get: () => clientWidth })
+}
+
+function userScrollTo(left: number) {
+  const el = scroller()
+  el.scrollLeft = left
+  el.dispatchEvent(new dom.window.Event("scroll"))
+}
+
+beforeAll(async () => {
+  fixtureDirectory = await mkdtemp(path.join(import.meta.dir, ".compact-reasoning-dom-fixture-"))
+  const componentPath = path.resolve(import.meta.dir, "../../src/components/compact-reasoning.tsx")
+  const i18nPath = path.resolve(import.meta.dir, "../../src/testing/i18n.tsx")
+  const entry = path.join(fixtureDirectory, "main.tsx")
+
+  await Bun.write(
+    entry,
+    `
+      import { createSignal } from "solid-js"
+      import { render } from "solid-js/web"
+      import { I18nProvider } from "@lingui/solid"
+      import { setupI18n } from ${JSON.stringify(i18nPath)}
+      import { CompactReasoningLine } from ${JSON.stringify(componentPath)}
+
+      const i18n = setupI18n()
+      const [text, setText] = createSignal("Planning the reply")
+      const root = document.getElementById("root")
+      render(
+        () => (
+          <I18nProvider i18n={i18n}>
+            <CompactReasoningLine text={text()} />
+          </I18nProvider>
+        ),
+        root,
+      )
+      ;(globalThis as unknown as { __compactReasoningHarness: unknown }).__compactReasoningHarness = { setText }
+    `,
+  )
+
+  await build({
+    configFile: false,
+    logLevel: "silent",
+    plugins: [solidPlugin()],
+    worker: { format: "es" },
+    build: {
+      outDir: path.join(fixtureDirectory, "dist"),
+      emptyOutDir: true,
+      minify: false,
+      lib: {
+        entry,
+        formats: ["es"],
+        fileName: "fixture",
+      },
+      rollupOptions: {
+        output: { inlineDynamicImports: true },
+      },
+    },
+  })
+
+  dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+    url: "http://localhost/",
+  })
+  const window = dom.window
+
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    Node: window.Node,
+    Element: window.Element,
+    HTMLElement: window.HTMLElement,
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 0),
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+  })
+
+  await import(`${pathToFileURL(path.join(fixtureDirectory, "dist", "fixture.js")).href}?test=${Date.now()}`)
+  harness = (globalThis as unknown as { __compactReasoningHarness: CompactReasoningHarness }).__compactReasoningHarness
+}, 60000)
+
+afterAll(async () => {
+  dom?.window.close()
+  if (fixtureDirectory) await rm(fixtureDirectory, { recursive: true, force: true })
+})
+
+describe("CompactReasoningLine DOM behavior", () => {
+  test("renders a Thinking prefix with spinner and the streamed text", () => {
+    expect(document.querySelector('[data-slot="compact-reasoning-leading"] [data-component="spinner"]')).not.toBeNull()
+    expect(document.querySelector('[data-slot="compact-reasoning-label"]')?.textContent).toBe("Thinking")
+    expect(document.querySelector('[data-slot="compact-reasoning-text"]')?.textContent).toBe("Planning the reply")
+  })
+
+  test("follows the newest text to the tail when the line overflows", async () => {
+    setScrollerGeometry(500, 100)
+    harness.setText("Continuing the reasoning well past the visible edge of the row")
+    await wait(20)
+    expect(scroller().scrollLeft).toBe(400)
+  })
+
+  test("stops following when the user scrolls back, and resumes at the tail", async () => {
+    setScrollerGeometry(500, 100)
+    userScrollTo(150)
+    harness.setText("The user is reading earlier reasoning, so do not steal the view")
+    await wait(20)
+    expect(scroller().scrollLeft).toBe(150)
+
+    userScrollTo(400)
+    harness.setText("The user returned to the tail, so follow again")
+    await wait(20)
+    expect(scroller().scrollLeft).toBe(400)
+  })
+})

--- a/packages/ui/test/components/session-turn-activity.test.ts
+++ b/packages/ui/test/components/session-turn-activity.test.ts
@@ -4,6 +4,7 @@ import type {
   AttachmentPart,
   Part as PartType,
   PermissionRequest,
+  ReasoningPart,
   ToolPart,
 } from "@ericsanchezok/synergy-sdk/client"
 import type { ActivityTimelineItem } from "../../src/components/session-turn-activity"
@@ -308,12 +309,27 @@ describe("balanced reasoning projection", () => {
       message: second,
     })
   })
+  test("replaces the Thinking status row with a live reasoning line while compact streaming", () => {
+    const first = assistant("assistant-a")
+    const part = reasoning("reason-a", first.id) as ReasoningPart
+    const projected = projectBalancedReasoningItems(
+      project({ message: first, parts: [part, text("answer-a", first.id)], working: true }),
+      "root-user",
+      true,
+      { anchorMessage: first, frontier: { message: first, partID: part.id }, compactReasoningPart: part },
+    )
+
+    expect(projected.some((item) => item.kind === "activity-reasoning-summary")).toBe(false)
+    const live = projected.find((item) => item.kind === "passthrough" && item.item.kind === "reasoning")
+    expect(live).toBeTruthy()
+    expect((live as { item: { part: { id: string } } }).item.part.id).toBe("reason-a")
+  })
 })
 
 describe("activity display preference", () => {
-  test("falls back missing and unknown values to full", () => {
-    expect(resolveActivityDisplay(undefined)).toBe("full")
-    expect(resolveActivityDisplay("unknown")).toBe("full")
+  test("falls back missing and unknown values to balanced", () => {
+    expect(resolveActivityDisplay(undefined)).toBe("balanced")
+    expect(resolveActivityDisplay("unknown")).toBe("balanced")
     expect(resolveActivityDisplay("full")).toBe("full")
     expect(resolveActivityDisplay("balanced")).toBe("balanced")
     expect(resolveActivityDisplay("minimal")).toBe("minimal")

--- a/packages/ui/test/components/session-turn-timeline.test.ts
+++ b/packages/ui/test/components/session-turn-timeline.test.ts
@@ -98,6 +98,8 @@ const {
   collectMessagesForTurnDisplay,
   collectMessagesForTurnLifecycle,
   collectSessionTurnTimelineItems,
+  compactReasoningTimelineItems,
+  compactReasoningText,
   collectUserCompactionTimelineItems,
   isGuidedContextUserMessage,
   shouldShowTurnDiffs,
@@ -930,6 +932,52 @@ describe("session turn timeline", () => {
 
       expect(items.map((item) => item.kind)).toEqual(["media-pending"])
     }
+  })
+
+  test("compact reasoning keeps only the latest reasoning display item without changing source parts", () => {
+    const message = assistant("assistant-a")
+    const first = {
+      id: "reasoning-a",
+      sessionID: "session",
+      messageID: message.id,
+      type: "reasoning",
+      text: "First reasoning block.\nStill original.",
+    } as PartType
+    const latest = {
+      id: "reasoning-b",
+      sessionID: "session",
+      messageID: message.id,
+      type: "reasoning",
+      text: "Latest reasoning block.\nStill original.",
+    } as PartType
+    const text = {
+      id: "text-a",
+      sessionID: "session",
+      messageID: message.id,
+      type: "text",
+      text: "Visible answer",
+    } as PartType
+    const items = collectSessionTurnTimelineItems([message], { [message.id]: [first, latest, text] }, true)
+
+    const compact = compactReasoningTimelineItems(items)
+
+    expect(compact.map((item) => item.kind)).toEqual(["reasoning", "part"])
+    expect(compact[0]).toMatchObject({ kind: "reasoning", part: { id: "reasoning-b" } })
+    expect(first).toMatchObject({ text: "First reasoning block.\nStill original." })
+    expect(latest).toMatchObject({ text: "Latest reasoning block.\nStill original." })
+    expect(items.map((item) => item.kind)).toEqual(["reasoning", "reasoning", "part"])
+  })
+
+  test("compact reasoning projects a stable plain-text tail line from streaming markdown", () => {
+    const source = "Planning\n\n- Format: Chinese response, structured with short headers\n\n"
+
+    expect(compactReasoningText(source)).toBe("Format: Chinese response, structured with short headers")
+    expect(source).toBe("Planning\n\n- Format: Chinese response, structured with short headers\n\n")
+    expect(compactReasoningText("## Next step")).toBe("Next step")
+    expect(compactReasoningText("> checking evidence")).toBe("checking evidence")
+    expect(compactReasoningText("   \n\t")).toBe("")
+    expect(compactReasoningText("Evaluating result\n```")).toBe("Evaluating result")
+    expect(compactReasoningText("Checking another path\n---")).toBe("Checking another path")
   })
 
   test("hides completed-turn reasoning without moving later parts", () => {

--- a/packages/util/src/activity.ts
+++ b/packages/util/src/activity.ts
@@ -371,7 +371,7 @@ export function isActivityGroupableTool(tool: string, metadata: Record<string, u
 }
 
 export function resolveActivityDisplay(value: unknown): ActivityDisplayMode {
-  return value === "full" || value === "minimal" || value === "balanced" ? value : "full"
+  return value === "full" || value === "minimal" || value === "balanced" ? value : "balanced"
 }
 
 export function classifySemanticCategory(toolName: string, input: Record<string, unknown> = {}): SemanticCategory {


### PR DESCRIPTION
## Summary

Adds compact live reasoning display and makes balanced the default activity display.

- New `compactReasoning` General preference (default off). While a turn streams, reasoning collapses into one stable line: spinner + "Thinking" prefix + latest reasoning text with tail-follow horizontal scroll. The prefix is upright and uses the `text-base` semantic token; the streamed text stays muted italic. Scrolling back pauses tail-following, returning to the tail resumes it.
- `activityDisplay` now defaults to `balanced` instead of `full` across the server config fallback, the settings UI defaults, and the util resolver fallback; unknown values also fall back to balanced.
- In balanced mode with `compactReasoning` on, the live one-line reasoning row replaces the `Thinking…` status row while streaming. With the preference off, balanced keeps the status row; settled behavior is unchanged.
- Settings panel (General), i18n catalogs (en / zh-CN / pseudo), config schema, and SDK/OpenAPI contracts regenerated. Docs updated in `docs/reference/configuration.md`.

## Test commands

- packages/ui: `bun test test/components/compact-reasoning.dom.test.ts test/components/session-turn-timeline.test.ts test/components/session-turn-activity.test.ts test/components/session-turn-activity-switch.dom.test.ts` → 88 pass
- packages/synergy: `bun test test/config/config.test.ts test/config/domain.test.ts` → 80 pass
- packages/app: `bun test test/components/settings/types.test.ts test/components/settings/hooks/useSettingsForm.test.ts test/components/settings/hooks/useConfigPatch.test.ts` → 56 pass
- `bun run typecheck` in packages/app, packages/ui, packages/synergy
- `bun run i18n:check` in packages/app
- `bun run quality:quick` (repository root) → pass

## Notes

- The Thinking prefix reuses the balanced reasoning label styling cues but has its own message key (`session-turn.compact-reasoning-thinking`) so the ellipsis is dropped.
- Vertical auto-scroll behaviors of the message list are untouched; only the horizontal tail-follow inside the compact row is new.