### PR TITLE
fix(ui): render tool diffs instantly with progressive pierre upgrade

### DIFF
--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -9281,6 +9281,14 @@ msgstr "Total"
 msgid "diff.file-diff-preview"
 msgstr "File diff preview"
 
+#. ── Diff preview ────────────────────────────────────────────────────
+msgid "diff.preview-omitted"
+msgstr "Diff preview omitted in this view."
+
+#. ── Diff preview ────────────────────────────────────────────────────
+msgid "diff.preview-truncated"
+msgstr "Preview truncated"
+
 #. js-lingui-explicit-id
 msgid "list.for-label"
 msgstr "for"

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -9281,6 +9281,14 @@ msgstr ""
 msgid "diff.file-diff-preview"
 msgstr ""
 
+#. ── Diff preview ────────────────────────────────────────────────────
+msgid "diff.preview-omitted"
+msgstr ""
+
+#. ── Diff preview ────────────────────────────────────────────────────
+msgid "diff.preview-truncated"
+msgstr ""
+
 #. js-lingui-explicit-id
 msgid "list.for-label"
 msgstr ""

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -9281,6 +9281,14 @@ msgstr "总计"
 msgid "diff.file-diff-preview"
 msgstr "文件差异预览"
 
+#. ── Diff preview ────────────────────────────────────────────────────
+msgid "diff.preview-omitted"
+msgstr "此视图中已省略差异预览。"
+
+#. ── Diff preview ────────────────────────────────────────────────────
+msgid "diff.preview-truncated"
+msgstr "预览已截断"
+
 #. js-lingui-explicit-id
 msgid "list.for-label"
 msgstr "用于"

--- a/packages/ui/script/test.ts
+++ b/packages/ui/script/test.ts
@@ -7,6 +7,7 @@ const root = path.resolve(import.meta.dir, "..")
 const isolated = new Set([
   "test/components/message-part-error-boundary.test.ts",
   "test/components/activity-trace.dom.test.ts",
+  "test/components/diff-patch.dom.test.ts",
   "test/components/session-turn-activity.test.ts",
   "test/components/session-turn-activity-switch.dom.test.ts",
   "test/components/session-turn-timeline.test.ts",

--- a/packages/ui/src/components/activity-specialized-detail.tsx
+++ b/packages/ui/src/components/activity-specialized-detail.tsx
@@ -1,6 +1,6 @@
 import { Show } from "solid-js"
 import { DagGraph } from "./dag-graph"
-import { DiffPatch, canRenderPatch } from "./diff-patch"
+import { DiffPatchGate } from "./diff-patch"
 import type { SpecializedActivityDetail } from "./activity-specialized-detail-model"
 import { ToolDiffPreview } from "./tool/diff-preview"
 
@@ -16,9 +16,11 @@ export function ActivitySpecializedDetail(props: { detail: SpecializedActivityDe
         }
       >
         {(detail) => (
-          <Show when={canRenderPatch(detail().patch)} fallback={<ToolDiffPreview diff={detail().diff} />}>
-            <DiffPatch patch={detail().patch!} diffStyle="unified" />
-          </Show>
+          <DiffPatchGate
+            patch={detail().patch}
+            diffStyle="unified"
+            fallback={<ToolDiffPreview diff={detail().diff} />}
+          />
         )}
       </Show>
     </div>

--- a/packages/ui/src/components/anchored-tool-card.tsx
+++ b/packages/ui/src/components/anchored-tool-card.tsx
@@ -11,7 +11,7 @@ import { ToolTextOutput } from "./tool-output-text"
 import { DiagnosticsDisplay, getDiagnostics, getDirectory, type ToolProps } from "./message-part"
 import { ToolDiffPreview, type ToolDiffPreviewFileDiff } from "./tool/diff-preview"
 import { hasSaveFileContentInput, saveFilePreviewDiff } from "./tool/save-file-preview"
-import { DiffPatch, canRenderPatch } from "./diff-patch"
+import { DiffPatchGate } from "./diff-patch"
 
 type FileDiff = ToolDiffPreviewFileDiff
 
@@ -411,11 +411,7 @@ export function AnchoredReviseTool(props: ToolProps) {
       <Show when={filediff()} fallback={<RawOutput output={props.output} />}>
         {(diff) => {
           const patch = () => (props.metadata?.diff as string | undefined) ?? (diff().preview as string | undefined)
-          return (
-            <Show when={canRenderPatch(patch())} fallback={<ToolDiffPreview diff={diff()} />}>
-              <DiffPatch patch={patch()!} diffStyle="unified" />
-            </Show>
-          )
+          return <DiffPatchGate patch={patch()} diffStyle="unified" fallback={<ToolDiffPreview diff={diff()} />} />
         }}
       </Show>
     </BasicTool>
@@ -461,11 +457,7 @@ export function AnchoredResolveConflictsTool(props: ToolProps) {
       <Show when={filediff()} fallback={<RawOutput output={props.output} />}>
         {(diff) => {
           const patch = () => (props.metadata?.diff as string | undefined) ?? (diff().preview as string | undefined)
-          return (
-            <Show when={canRenderPatch(patch())} fallback={<ToolDiffPreview diff={diff()} />}>
-              <DiffPatch patch={patch()!} diffStyle="unified" />
-            </Show>
-          )
+          return <DiffPatchGate patch={patch()} diffStyle="unified" fallback={<ToolDiffPreview diff={diff()} />} />
         }}
       </Show>
     </BasicTool>
@@ -525,11 +517,7 @@ export function AnchoredSaveTool(props: ToolProps) {
       >
         {(diff) => {
           const patch = () => (props.metadata?.diff as string | undefined) ?? (diff().preview as string | undefined)
-          return (
-            <Show when={canRenderPatch(patch())} fallback={<ToolDiffPreview diff={diff()} />}>
-              <DiffPatch patch={patch()!} diffStyle="unified" />
-            </Show>
-          )
+          return <DiffPatchGate patch={patch()} diffStyle="unified" fallback={<ToolDiffPreview diff={diff()} />} />
         }}
       </Show>
     </BasicTool>

--- a/packages/ui/src/components/diff-patch-utils.ts
+++ b/packages/ui/src/components/diff-patch-utils.ts
@@ -1,4 +1,4 @@
-import { parsePatchFiles } from "@pierre/diffs"
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
 
 /**
  * Returns true when `patch` is a parseable unified diff for exactly one real
@@ -18,15 +18,22 @@ function hasUnrenderableTrailingBlankLine(lines: readonly string[]): boolean {
   return /^\r?\n$/.test(lines.at(-1) ?? "")
 }
 
-export function canRenderPatch(patch: string | undefined | null): boolean {
-  if (!patch || !patch.trim()) return false
+/**
+ * Parses `patch` once and returns the single-file metadata when pierre can
+ * render it, or `undefined` otherwise. Callers use the same result for both
+ * the renderability decision and the render itself so streaming projections
+ * that rebuild wrapper objects around an unchanged patch string do not pay a
+ * fresh `parsePatchFiles` cost per chunk.
+ */
+export function parseRenderablePatch(patch: string | undefined | null): FileDiffMetadata | undefined {
+  if (!patch || !patch.trim()) return undefined
   // Truncated previews (middle-omitted by SessionBounds) still parse as valid
   // unified diffs but render as broken/incomplete hunks — keep them on the
   // lightweight fallback that surfaces the truncation notice.
-  if (TRUNCATION_MARKER.test(patch)) return false
+  if (TRUNCATION_MARKER.test(patch)) return undefined
   try {
     const parsed = parsePatchFiles(patch)
-    if (parsed.length !== 1 || parsed[0].files.length !== 1) return false
+    if (parsed.length !== 1 || parsed[0].files.length !== 1) return undefined
     const metadata = parsed[0].files[0]
     // The combined revise_file diff embeds `=== path ===` section headers in
     // the hunk content lines (each section's before/after is concatenated
@@ -38,7 +45,7 @@ export function canRenderPatch(patch: string | undefined | null): boolean {
       metadata.deletionLines?.some((line) => SECTION_MARKER.test(line)) ||
       metadata.additionLines?.some((line) => SECTION_MARKER.test(line))
     ) {
-      return false
+      return undefined
     }
     // Pierre strips the final newline before highlighting, so an empty final
     // hunk line leaves its renderer with a line index but no highlighted row.
@@ -46,10 +53,14 @@ export function canRenderPatch(patch: string | undefined | null): boolean {
       hasUnrenderableTrailingBlankLine(metadata.deletionLines) ||
       hasUnrenderableTrailingBlankLine(metadata.additionLines)
     ) {
-      return false
+      return undefined
     }
-    return true
+    return metadata
   } catch {
-    return false
+    return undefined
   }
+}
+
+export function canRenderPatch(patch: string | undefined | null): boolean {
+  return parseRenderablePatch(patch) !== undefined
 }

--- a/packages/ui/src/components/diff-patch.tsx
+++ b/packages/ui/src/components/diff-patch.tsx
@@ -1,49 +1,48 @@
-import { FileDiff, parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
+import { FileDiff, type FileDiffMetadata } from "@pierre/diffs"
 import { useLingui } from "@lingui/solid"
 import { createMediaQuery } from "@solid-primitives/media"
-import { createEffect, createMemo, onCleanup, splitProps, type ComponentProps } from "solid-js"
+import { createEffect, createMemo, onCleanup, Show, splitProps, type ComponentProps, type JSX } from "solid-js"
 import { createDefaultOptions, styleVariables } from "../pierre"
 import { getWorkerPool } from "../pierre/worker"
 import { ensureSynergyHighlightTheme } from "../context/marked"
-import { canRenderPatch } from "./diff-patch-utils"
+import { parseRenderablePatch } from "./diff-patch-utils"
 import { DIFF_DESC } from "./tool-title-descriptors"
 import "./tool/diff-preview.css"
+
+export { canRenderPatch } from "./diff-patch-utils"
 
 export interface DiffPatchProps {
   patch: string
   diffStyle?: "unified" | "split"
   class?: string
   classList?: ComponentProps<"div">["classList"]
+  /** Pre-parsed single-file metadata; DiffPatch parses `patch` when omitted. */
+  metadata?: FileDiffMetadata
 }
-
-export { canRenderPatch }
 
 /**
  * Renders a single-file unified diff text with pierre (syntax highlighting,
- * unified/split layout, line numbers). Callers can gate mounting via
- * `canRenderPatch`; parsing or rendering failures fall back to plain text.
+ * unified/split layout, line numbers). Plain text is painted synchronously and
+ * swapped for the highlighter render once the theme and worker pool are ready,
+ * so the container is never blank — including during streaming when the worker
+ * pool is still cold. Parsing or rendering failures stay on plain text.
  */
 export function DiffPatch(props: DiffPatchProps) {
   const { _ } = useLingui()
   let container!: HTMLDivElement
-  const [local, others] = splitProps(props, ["patch", "diffStyle", "class", "classList"])
+  const [local] = splitProps(props, ["patch", "diffStyle", "class", "classList", "metadata"])
 
   const mobile = createMediaQuery("(max-width: 640px)")
 
-  const fileDiff = createMemo<FileDiffMetadata | undefined>(() => {
-    try {
-      const parsed = parsePatchFiles(local.patch)
-      const files = parsed[0]?.files
-      return files?.length === 1 ? files[0] : undefined
-    } catch {
-      return undefined
-    }
-  })
+  // Value-stable gate: streaming projections rebuild wrapper objects around
+  // an unchanged patch string. The string memo stops that churn here so the
+  // parse and render effects below only re-run when the patch truly changes.
+  const patchText = createMemo(() => local.patch)
+  const metadata = createMemo<FileDiffMetadata | undefined>(() => local.metadata ?? parseRenderablePatch(patchText()))
 
   const options = createMemo(() => {
     const opts = {
       ...createDefaultOptions(local.diffStyle),
-      ...others,
       disableErrorHandling: true,
     }
     if (!mobile()) return opts
@@ -67,9 +66,9 @@ export function DiffPatch(props: DiffPatchProps) {
   }
 
   createEffect(() => {
-    const metadata = fileDiff()
-    const patch = local.patch
-    if (!metadata) {
+    const parsed = metadata()
+    const patch = patchText()
+    if (!parsed) {
       renderPlainPatch(patch)
       return
     }
@@ -77,6 +76,12 @@ export function DiffPatch(props: DiffPatchProps) {
     // change must re-run this effect and re-render with the new layout.
     const opts = options()
     let alive = true
+
+    // Paint readable plain text immediately. The async upgrade below replaces
+    // it in place; if this effect re-runs (new patch or layout) the stale
+    // upgrade is discarded via `alive` and the next cycle paints plain text
+    // first, so the container never sits empty.
+    renderPlainPatch(patch)
     void ensureSynergyHighlightTheme()
       .then(() => {
         if (!alive) return
@@ -87,7 +92,7 @@ export function DiffPatch(props: DiffPatchProps) {
           const nextInstance = new FileDiff(opts, pool)
           instance = nextInstance
           container.innerHTML = ""
-          nextInstance.render({ fileDiff: metadata, containerWrapper: container })
+          nextInstance.render({ fileDiff: parsed, containerWrapper: container })
         } catch {
           if (alive) renderPlainPatch(patch)
         }
@@ -114,5 +119,27 @@ export function DiffPatch(props: DiffPatchProps) {
       style={styleVariables}
       ref={container}
     />
+  )
+}
+
+export interface DiffPatchGateProps extends Omit<DiffPatchProps, "patch" | "metadata"> {
+  patch: string | undefined | null
+  fallback?: JSX.Element
+}
+
+/**
+ * Decides between the rich pierre render and `fallback` with a single parse
+ * per patch-string change, then forwards the parsed metadata so DiffPatch does
+ * not parse again. Streaming projections that rebuild wrapper objects around
+ * an unchanged patch string cost nothing here.
+ */
+export function DiffPatchGate(props: DiffPatchGateProps) {
+  const [local, others] = splitProps(props, ["patch", "fallback"])
+  const patchText = createMemo(() => local.patch ?? "")
+  const metadata = createMemo(() => parseRenderablePatch(patchText()))
+  return (
+    <Show when={metadata()} fallback={local.fallback}>
+      {(parsed) => <DiffPatch {...others} patch={patchText()} metadata={parsed()} />}
+    </Show>
   )
 }

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -3,7 +3,7 @@ import { Button } from "./button"
 import { RadioGroup } from "./radio-group"
 import { DiffChanges } from "./diff-changes"
 import { DiffPreview } from "./tool/diff-preview"
-import { DiffPatch, canRenderPatch } from "./diff-patch"
+import { DiffPatchGate } from "./diff-patch"
 import { FileIcon } from "./file-icon"
 import { Icon } from "./icon"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
@@ -139,9 +139,11 @@ export const SessionReview = (props: SessionReviewProps) => {
                   </Accordion.Trigger>
                 </StickyAccordionHeader>
                 <Accordion.Content data-slot="session-review-accordion-content">
-                  <Show when={canRenderPatch(diff.patch)} fallback={<DiffPreview diff={diff} variant="review" />}>
-                    <DiffPatch patch={diff.patch!} diffStyle={diffStyle()} />
-                  </Show>
+                  <DiffPatchGate
+                    patch={diff.patch}
+                    diffStyle={diffStyle()}
+                    fallback={<DiffPreview diff={diff} variant="review" />}
+                  />
                 </Accordion.Content>
               </Accordion.Item>
             )}

--- a/packages/ui/src/components/tool-title-descriptors.ts
+++ b/packages/ui/src/components/tool-title-descriptors.ts
@@ -456,6 +456,8 @@ export const DIAGRAM_DESC = {
 // ── Diff preview ────────────────────────────────────────────────────
 export const DIFF_DESC = {
   fileDiffPreview: d("diff.file-diff-preview", "File diff preview"),
+  previewTruncated: d("diff.preview-truncated", "Preview truncated"),
+  previewOmitted: d("diff.preview-omitted", "Diff preview omitted in this view."),
 } as const
 
 // ── Anchored-tool chip labels ──────────────────────────────────────

--- a/packages/ui/src/components/tool/diff-preview.tsx
+++ b/packages/ui/src/components/tool/diff-preview.tsx
@@ -26,7 +26,6 @@ export interface DiffPreviewProps {
 }
 
 export const TOOL_DIFF_PREVIEW_EMPTY_MESSAGE = "No text preview available."
-export const TOOL_DIFF_PREVIEW_OMITTED_MESSAGE = "Diff preview omitted in this view."
 
 export function classifyToolDiffLine(text: string): ToolDiffLineKind {
   if (text === "\\ No newline at end of file") return "note"
@@ -51,11 +50,17 @@ export function parseToolDiffPreview(preview: string | undefined): ToolDiffPrevi
   }))
 }
 
-export function formatToolDiffPreviewSummary(diff: ToolDiffPreviewFileDiff | undefined): string {
-  if (diff?.truncated) return "Preview truncated"
-  if (!diff?.preview && (diff?.beforeBytes !== undefined || diff?.afterBytes !== undefined))
-    return TOOL_DIFF_PREVIEW_OMITTED_MESSAGE
-  return ""
+export type ToolDiffPreviewSummaryKind = "truncated" | "omitted"
+
+export function formatToolDiffPreviewSummary(
+  diff: ToolDiffPreviewFileDiff | undefined,
+): ToolDiffPreviewSummaryKind | undefined {
+  // Only summarize explicitly-truncated diffs. Missing previews without the
+  // truncation marker (e.g. binary diffs with byte counts) are not "omitted".
+  if (!diff?.truncated) return undefined
+  // A dropped preview (snapshot aggregate cap) reads as omitted; a shortened
+  // preview that is still present reads as truncated.
+  return diff.preview ? "truncated" : "omitted"
 }
 
 export function DiffPreview(props: DiffPreviewProps) {
@@ -67,7 +72,11 @@ export function DiffPreview(props: DiffPreviewProps) {
   return (
     <div data-component="diff-preview" data-variant={variant()}>
       <Show keyed when={summary()}>
-        {(text) => <div data-slot="diff-preview-summary">{text}</div>}
+        {(kind) => (
+          <div data-slot="diff-preview-summary">
+            {_(kind === "omitted" ? DIFF_DESC.previewOmitted : DIFF_DESC.previewTruncated)}
+          </div>
+        )}
       </Show>
       <Show
         when={lines().length > 0}

--- a/packages/ui/src/components/tool/diff-preview.tsx
+++ b/packages/ui/src/components/tool/diff-preview.tsx
@@ -26,6 +26,7 @@ export interface DiffPreviewProps {
 }
 
 export const TOOL_DIFF_PREVIEW_EMPTY_MESSAGE = "No text preview available."
+export const TOOL_DIFF_PREVIEW_OMITTED_MESSAGE = "Diff preview omitted in this view."
 
 export function classifyToolDiffLine(text: string): ToolDiffLineKind {
   if (text === "\\ No newline at end of file") return "note"
@@ -51,7 +52,10 @@ export function parseToolDiffPreview(preview: string | undefined): ToolDiffPrevi
 }
 
 export function formatToolDiffPreviewSummary(diff: ToolDiffPreviewFileDiff | undefined): string {
-  return diff?.truncated ? "Preview truncated" : ""
+  if (diff?.truncated) return "Preview truncated"
+  if (!diff?.preview && (diff?.beforeBytes !== undefined || diff?.afterBytes !== undefined))
+    return TOOL_DIFF_PREVIEW_OMITTED_MESSAGE
+  return ""
 }
 
 export function DiffPreview(props: DiffPreviewProps) {

--- a/packages/ui/src/components/tool/renders/file-ops.tsx
+++ b/packages/ui/src/components/tool/renders/file-ops.tsx
@@ -16,7 +16,7 @@ import {
 import { ToolRegistry, getDiagnostics, DiagnosticsDisplay } from "../../message-part"
 import { ToolTextOutput } from "../../tool-output-text"
 import { ToolDiffPreview } from "../diff-preview"
-import { DiffPatch, canRenderPatch } from "../../diff-patch"
+import { DiffPatchGate } from "../../diff-patch"
 
 ToolRegistry.register({ name: "view_file", render: AnchoredViewTool })
 ToolRegistry.register({ name: "scan_files", render: AnchoredScanFilesTool })
@@ -74,9 +74,7 @@ ToolRegistry.register({
             const patch = () =>
               (props.metadata.diff as string | undefined) ?? (filediff().preview as string | undefined)
             return (
-              <Show when={canRenderPatch(patch())} fallback={<ToolDiffPreview diff={filediff()} />}>
-                <DiffPatch patch={patch()!} diffStyle="unified" />
-              </Show>
+              <DiffPatchGate patch={patch()} diffStyle="unified" fallback={<ToolDiffPreview diff={filediff()} />} />
             )
           }}
         </Show>
@@ -143,9 +141,11 @@ ToolRegistry.register({
                   const patch = () =>
                     (lastResult?.diff as string | undefined) ?? (filediff().preview as string | undefined)
                   return (
-                    <Show when={canRenderPatch(patch())} fallback={<ToolDiffPreview diff={filediff()} />}>
-                      <DiffPatch patch={patch()!} diffStyle="unified" />
-                    </Show>
+                    <DiffPatchGate
+                      patch={patch()}
+                      diffStyle="unified"
+                      fallback={<ToolDiffPreview diff={filediff()} />}
+                    />
                   )
                 }}
               </Show>

--- a/packages/ui/test/components/diff-patch.dom.test.ts
+++ b/packages/ui/test/components/diff-patch.dom.test.ts
@@ -1,0 +1,306 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { JSDOM } from "jsdom"
+import { build, type Plugin } from "vite"
+import solidPlugin from "vite-plugin-solid"
+
+// The fixture compiles the real Solid DiffPatch component through Vite before
+// exercising lifecycle behavior, matching the activity-trace DOM harness.
+// @pierre/diffs, the worker pool, the theme loader, and the pierre wrapper are
+// replaced with deterministic fake modules (enforce:"pre" resolveId) so the
+// bundle is offline-safe and the render/parse counts are observable.
+// Keep this hook well above the default test timeout so cold caches pass.
+const PATCH = [
+  "--- a/src/foo.ts",
+  "+++ b/src/foo.ts",
+  "@@ -1,3 +1,4 @@",
+  " const a = 1",
+  "+const b = 2",
+  " const c = 3",
+].join("\n")
+
+const OTHER_PATCH = ["--- a/src/bar.ts", "+++ b/src/bar.ts", "@@ -1,2 +1,2 @@", "-old", "+new"].join("\n")
+
+interface DiffHarness {
+  reset: () => void
+  resolveTheme: () => void
+  setGatePatch: (patch: string) => void
+  churnSame: () => void
+  churnChange: () => void
+  counts: () => { parse: number; render: number }
+}
+
+let fixtureDirectory: string
+let dom: JSDOM
+let harness: DiffHarness
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function directFallback(): Element | null {
+  return document.querySelector('#direct-host [data-component="diff-patch-fallback"]')
+}
+function richRender(host: string): Element | null {
+  return document.querySelector(`${host} [data-component="fake-pierre-render"]`)
+}
+function gateFallback(): Element | null {
+  return document.querySelector('#gate-host [data-component="gate-fallback"]')
+}
+function churnFallback(): Element | null {
+  return document.querySelector('#churn-host [data-component="diff-patch-fallback"]')
+}
+
+const FAKE_PIERRE = `
+type FixtureState = { parseCalls: number; renderCalls: number }
+const state = ((globalThis as any).__diffFixtureState ??= { parseCalls: 0, renderCalls: 0 }) as FixtureState
+
+export function parsePatchFiles(patch: string): any[] {
+  state.parseCalls++
+  if (typeof patch === "string" && patch.includes("@@") && !patch.includes("===")) {
+    return [{ files: [{ file: "fake", additions: 1, deletions: 1, deletionLines: [], additionLines: [] }] }]
+  }
+  return []
+}
+
+export class FileDiff {
+  render(opts: { containerWrapper: HTMLElement }): void {
+    state.renderCalls++
+    const el = document.createElement("div")
+    el.setAttribute("data-component", "fake-pierre-render")
+    opts.containerWrapper.replaceChildren(el)
+  }
+  cleanUp(): void {}
+}
+`
+
+const FAKE_WORKER = `export function getWorkerPool() { return undefined }`
+
+const FAKE_MARKED = `
+type ThemeState = { promise?: Promise<unknown>; resolve?: () => void }
+const state = ((globalThis as any).__diffThemeState ??= {}) as ThemeState
+export function ensureSynergyHighlightTheme(): Promise<unknown> {
+  state.promise ??= new Promise((resolve) => { state.resolve = resolve })
+  return state.promise
+}
+`
+
+const FAKE_PIERRE_WRAPPER = `
+export function createDefaultOptions(style: string | undefined) {
+  return { theme: "Synergy", themeType: "system", disableLineNumbers: false, diffStyle: style ?? "unified" }
+}
+export const styleVariables = {}
+`
+
+beforeAll(async () => {
+  fixtureDirectory = await mkdtemp(path.join(import.meta.dir, ".diff-patch-dom-fixture-"))
+  const uiRoot = path.resolve(import.meta.dir, "../..")
+  const diffPatchPath = path.join(uiRoot, "src/components/diff-patch.tsx")
+  const i18nPath = path.join(uiRoot, "src/testing/i18n.tsx")
+
+  const fakePierrePath = path.join(fixtureDirectory, "fake-pierre.ts")
+  const fakeWorkerPath = path.join(fixtureDirectory, "fake-worker.ts")
+  const fakeMarkedPath = path.join(fixtureDirectory, "fake-marked.ts")
+  const fakeWrapperPath = path.join(fixtureDirectory, "fake-pierre-wrapper.ts")
+  await Bun.write(fakePierrePath, FAKE_PIERRE)
+  await Bun.write(fakeWorkerPath, FAKE_WORKER)
+  await Bun.write(fakeMarkedPath, FAKE_MARKED)
+  await Bun.write(fakeWrapperPath, FAKE_PIERRE_WRAPPER)
+
+  const fixtureMocks: Plugin = {
+    name: "fixture-diff-mocks",
+    // Runs ahead of vite:resolve so the real @pierre/diffs is never bundled.
+    enforce: "pre",
+    resolveId(source, importer) {
+      if (!importer || !importer.startsWith(uiRoot)) return null
+      if (source === "@pierre/diffs") return fakePierrePath
+      if (/^..\/pierre\/worker(\.ts)?$/.test(source)) return fakeWorkerPath
+      if (/^..\/context\/marked(\.tsx)?$/.test(source)) return fakeMarkedPath
+      if (/^..\/pierre$/.test(source)) return fakeWrapperPath
+      return null
+    },
+  }
+
+  const entry = path.join(fixtureDirectory, "main.tsx")
+  await Bun.write(
+    entry,
+    `
+import { createSignal } from "solid-js"
+import { render } from "solid-js/web"
+import { I18nProvider } from "@lingui/solid"
+import { setupI18n } from ${JSON.stringify(i18nPath)}
+import { DiffPatch, DiffPatchGate } from ${JSON.stringify(diffPatchPath)}
+
+const PATCH = ${JSON.stringify(PATCH)}
+const OTHER = ${JSON.stringify(OTHER_PATCH)}
+
+const [directPatch] = createSignal(PATCH)
+const [gatePatch, setGatePatch] = createSignal("garbage text")
+const [wrapper, setWrapper] = createSignal({ patch: PATCH })
+
+const i18n = setupI18n()
+const root = document.querySelector("#root")!
+render(
+  () => (
+    <I18nProvider i18n={i18n}>
+      <div>
+        <div id="direct-host">
+          <DiffPatch patch={directPatch()} diffStyle="unified" />
+        </div>
+        <div id="gate-host">
+          <DiffPatchGate
+            patch={gatePatch()}
+            diffStyle="unified"
+            fallback={<div data-component="gate-fallback">fallback body</div>}
+          />
+        </div>
+        <div id="churn-host">
+          <DiffPatchGate patch={wrapper().patch} diffStyle="unified" fallback={<div>never</div>} />
+        </div>
+      </div>
+    </I18nProvider>
+  ),
+  root,
+)
+
+;(globalThis as any).__diffHarness = {
+  reset: () => {
+    const state = (globalThis as any).__diffFixtureState
+    state.parseCalls = 0
+    state.renderCalls = 0
+  },
+  resolveTheme: () => (globalThis as any).__diffThemeState?.resolve?.(),
+  setGatePatch: (patch: string) => setGatePatch(patch),
+  churnSame: () => setWrapper((current) => ({ patch: current.patch })),
+  churnChange: () => setWrapper({ patch: OTHER }),
+  counts: () => {
+    const state = (globalThis as any).__diffFixtureState
+    return { parse: state.parseCalls, render: state.renderCalls }
+  },
+}
+`,
+  )
+
+  await build({
+    configFile: false,
+    logLevel: "silent",
+    plugins: [solidPlugin(), fixtureMocks],
+    worker: { format: "es" },
+    build: {
+      outDir: path.join(fixtureDirectory, "dist"),
+      emptyOutDir: true,
+      minify: false,
+      lib: {
+        entry,
+        formats: ["es"],
+        fileName: "fixture",
+      },
+      rollupOptions: {
+        output: { inlineDynamicImports: true },
+      },
+    },
+  })
+
+  dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+    url: "http://localhost/",
+  })
+  const window = dom.window
+  // JSDOM reports animationName as "" instead of "none"; normalize it so
+  // solid-presence treats unanimated content as settled.
+  const realGetComputedStyle = window.getComputedStyle.bind(window)
+  window.getComputedStyle = ((element: Element) => {
+    const style = realGetComputedStyle(element)
+    Object.defineProperty(style, "animationName", { configurable: true, value: "none" })
+    return style
+  }) as typeof window.getComputedStyle
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    Node: window.Node,
+    Element: window.Element,
+    HTMLElement: window.HTMLElement,
+    SVGElement: window.SVGElement,
+    customElements: window.customElements,
+    MutationObserver: window.MutationObserver,
+    ResizeObserver: window.ResizeObserver,
+    getComputedStyle: window.getComputedStyle.bind(window),
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 0),
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+  })
+
+  await import(`${pathToFileURL(path.join(fixtureDirectory, "dist", "fixture.js")).href}?test=${Date.now()}`)
+  harness = (globalThis as unknown as { __diffHarness: DiffHarness }).__diffHarness
+}, 60000)
+
+afterAll(async () => {
+  dom?.window.close()
+  if (fixtureDirectory) await rm(fixtureDirectory, { recursive: true, force: true })
+})
+
+describe("DiffPatch progressive rendering", () => {
+  test("paints readable plain text before the highlighter upgrade, never blank", async () => {
+    harness.reset()
+    // The theme promise is deliberately pending: the first frame must still
+    // be readable plain text, and the rich render must not exist yet.
+    expect(directFallback()?.textContent).toBe(PATCH)
+    expect(richRender("#direct-host")).toBeNull()
+    expect(churnFallback()?.textContent).toBe(PATCH)
+    expect(gateFallback()).not.toBeNull()
+    expect(harness.counts()).toEqual({ parse: 0, render: 0 })
+
+    harness.resolveTheme()
+    await wait(0)
+    expect(richRender("#direct-host")).not.toBeNull()
+    expect(directFallback()).toBeNull()
+    expect(richRender("#churn-host")).not.toBeNull()
+    // The upgrade reuses the already-parsed metadata — no second parse.
+    expect(harness.counts()).toEqual({ parse: 0, render: 2 })
+  })
+})
+
+describe("DiffPatchGate streaming stability", () => {
+  test("wrapper churn around an identical patch string does not re-parse or re-render", async () => {
+    harness.reset()
+    harness.churnSame()
+    await wait(0)
+    expect(harness.counts()).toEqual({ parse: 0, render: 0 })
+
+    harness.churnSame()
+    await wait(0)
+    expect(harness.counts()).toEqual({ parse: 0, render: 0 })
+
+    harness.churnChange()
+    await wait(0)
+    expect(harness.counts()).toEqual({ parse: 1, render: 1 })
+    expect(richRender("#churn-host")).not.toBeNull()
+  })
+
+  test("falls back for unrenderable patches and transitions when the patch becomes renderable", async () => {
+    harness.reset()
+    expect(gateFallback()?.textContent).toBe("fallback body")
+    expect(document.querySelector('#gate-host [data-component="diff-patch"]')).toBeNull()
+
+    harness.setGatePatch(PATCH)
+    await wait(0)
+    expect(gateFallback()).toBeNull()
+    expect(richRender("#gate-host")).not.toBeNull()
+    expect(harness.counts()).toEqual({ parse: 1, render: 1 })
+  })
+})

--- a/packages/ui/test/components/tool/diff-preview.test.ts
+++ b/packages/ui/test/components/tool/diff-preview.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
   TOOL_DIFF_PREVIEW_EMPTY_MESSAGE,
-  TOOL_DIFF_PREVIEW_OMITTED_MESSAGE,
   classifyToolDiffLine,
   formatToolDiffPreviewSummary,
   parseToolDiffPreview,
@@ -59,11 +58,15 @@ describe("tool diff preview", () => {
     expect(TOOL_DIFF_PREVIEW_EMPTY_MESSAGE).toBe("No text preview available.")
   })
 
-  test("formats truncation and omitted-preview summary text", () => {
-    expect(formatToolDiffPreviewSummary({ beforeBytes: 134, afterBytes: 164 })).toBe(TOOL_DIFF_PREVIEW_OMITTED_MESSAGE)
-    expect(formatToolDiffPreviewSummary({ beforeBytes: 134, afterBytes: 164, truncated: true })).toBe(
-      "Preview truncated",
-    )
-    expect(formatToolDiffPreviewSummary({ preview: "--- a\n+++ b", beforeBytes: 134, afterBytes: 164 })).toBe("")
+  test("classifies truncation and omitted-preview summary states", () => {
+    // Aggregate-capped: preview dropped with the truncation marker.
+    expect(
+      formatToolDiffPreviewSummary({ truncated: true, preview: undefined, beforeBytes: 134, afterBytes: 164 }),
+    ).toBe("omitted")
+    // Shortened but still present.
+    expect(formatToolDiffPreviewSummary({ truncated: true, preview: "--- a\n+++ b" })).toBe("truncated")
+    // Byte counts without the truncation marker (binary diffs) are neither.
+    expect(formatToolDiffPreviewSummary({ beforeBytes: 134, afterBytes: 164 })).toBeUndefined()
+    expect(formatToolDiffPreviewSummary(undefined)).toBeUndefined()
   })
 })

--- a/packages/ui/test/components/tool/diff-preview.test.ts
+++ b/packages/ui/test/components/tool/diff-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   TOOL_DIFF_PREVIEW_EMPTY_MESSAGE,
+  TOOL_DIFF_PREVIEW_OMITTED_MESSAGE,
   classifyToolDiffLine,
   formatToolDiffPreviewSummary,
   parseToolDiffPreview,
@@ -58,10 +59,11 @@ describe("tool diff preview", () => {
     expect(TOOL_DIFF_PREVIEW_EMPTY_MESSAGE).toBe("No text preview available.")
   })
 
-  test("formats truncation summary text", () => {
-    expect(formatToolDiffPreviewSummary({ beforeBytes: 134, afterBytes: 164 })).toBe("")
+  test("formats truncation and omitted-preview summary text", () => {
+    expect(formatToolDiffPreviewSummary({ beforeBytes: 134, afterBytes: 164 })).toBe(TOOL_DIFF_PREVIEW_OMITTED_MESSAGE)
     expect(formatToolDiffPreviewSummary({ beforeBytes: 134, afterBytes: 164, truncated: true })).toBe(
       "Preview truncated",
     )
+    expect(formatToolDiffPreviewSummary({ preview: "--- a\n+++ b", beforeBytes: 134, afterBytes: 164 })).toBe("")
   })
 })

--- a/packages/ui/test/components/tool/renders/file-ops.test.tsx
+++ b/packages/ui/test/components/tool/renders/file-ops.test.tsx
@@ -49,8 +49,7 @@ beforeAll(async () => {
   mock.module("../../../../src/components/tool-output-text", () => ({ ToolTextOutput: () => null }))
   mock.module("../../../../src/components/tool/diff-preview", () => ({ ToolDiffPreview: () => null }))
   mock.module("../../../../src/components/diff-patch", () => ({
-    DiffPatch: () => null,
-    canRenderPatch: () => false,
+    DiffPatchGate: () => null,
   }))
   mock.module("../../../../src/components/tool/save-file-preview", () => ({
     hasSaveFileContentInput: () => false,


### PR DESCRIPTION
## Summary

Fixes two streaming-era failures when expanding file-tool details with diffs: the details pane could stall on a blank diff, and some diffs never rendered at all.

Root causes in the `@pierre/diffs` wrapper (`packages/ui/src/components/diff-patch.tsx`):

1. **Blank-until-worker-ready**: `DiffPatch` cleared its container and waited for the theme import + worker pool before painting anything. During streaming, that window is long (cold worker pool, busy main thread), so the expanded pane sat empty — perceived as a stall or failed load.
2. **Per-chunk re-parse on the main thread**: every streaming projection churn re-ran `canRenderPatch()` → `parsePatchFiles()` synchronously (up to ~1 MB of patch text) at each of 6 call sites, then `DiffPatch` parsed the same patch a second time.
3. **Misleading empty state**: diffs dropped by the snapshot size cap showed "No text preview available." even though the diff existed.

## Changes

- `DiffPatch` now **paints plain text synchronously** and swaps in the pierre highlight render once the theme and worker pool are ready — the container is never blank, and render failures stay on plain text.
- New **`DiffPatchGate`** component: a single `parseRenderablePatch()` per patch-string change (memoized on the value-stable patch string), forwarding parsed metadata so `DiffPatch` never re-parses. Wrapper-object churn around an identical patch string re-runs nothing.
- Added `parseRenderablePatch` to `diff-patch-utils.ts` (returns `FileDiffMetadata | undefined`); `canRenderPatch` is now a thin wrapper over it.
- Migrated all call sites to `DiffPatchGate`: anchored tool cards (revise/resolve-conflicts/save), edit/multiedit renderers, activity receipts, and session review.
- `ToolDiffPreview` shows "Diff preview omitted in this view." when preview was dropped by the snapshot cap but byte metadata is present.

## Tests

- New fixture-based DOM regression test `packages/ui/test/components/diff-patch.dom.test.ts` (registered in the isolated suite) covering: plain-first progressive rendering with a pending theme promise, zero re-parse/re-render under streaming wrapper churn, fallback ↔ rich transitions.
- Updated `diff-preview` unit tests for the new omitted-preview message.

## Verification

```bash
bun test test/components/diff-patch.test.ts test/components/diff-patch.dom.test.ts test/components/tool/diff-preview.test.ts test/components/tool/renders/file-ops.test.tsx  # 23 pass
bun run typecheck
bun x prettier --check <changed files>
bun run lint
```

Full `bun run test` still fails on one pre-existing, unrelated issue in this worktree: an isolated DOM fixture can't resolve `@ericsanchezok/synergy-plugin/theme` because `packages/plugin/dist` was never built here. Confirmed unaffected by this change via a clean-baseline comparison; CI's `turbo test` builds dependencies first (`dependsOn: ["^build"]`), so it does not apply there.