### PR TITLE
fix(ui): reveal tool error details inline in activity steps

### DIFF
--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -19173,20 +19173,12 @@ msgid "ui.errorCard.detailsTitle"
 msgstr "Error details"
 
 #. js-lingui-explicit-id
-msgid "ui.errorCard.errorMessage"
-msgstr "Error message"
-
-#. js-lingui-explicit-id
 msgid "ui.errorCard.toolInput"
 msgstr "Tool input"
 
 #. js-lingui-explicit-id
 msgid "ui.errorCard.unknownError"
 msgstr "Unknown error"
-
-#. js-lingui-explicit-id
-msgid "ui.errorCard.viewDetails"
-msgstr "View details"
 
 #. js-lingui-explicit-id
 msgid "ui.imagePreview.close"

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -19173,19 +19173,11 @@ msgid "ui.errorCard.detailsTitle"
 msgstr ""
 
 #. js-lingui-explicit-id
-msgid "ui.errorCard.errorMessage"
-msgstr ""
-
-#. js-lingui-explicit-id
 msgid "ui.errorCard.toolInput"
 msgstr ""
 
 #. js-lingui-explicit-id
 msgid "ui.errorCard.unknownError"
-msgstr ""
-
-#. js-lingui-explicit-id
-msgid "ui.errorCard.viewDetails"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -19173,20 +19173,12 @@ msgid "ui.errorCard.detailsTitle"
 msgstr "错误详情"
 
 #. js-lingui-explicit-id
-msgid "ui.errorCard.errorMessage"
-msgstr "错误消息"
-
-#. js-lingui-explicit-id
 msgid "ui.errorCard.toolInput"
 msgstr "工具输入"
 
 #. js-lingui-explicit-id
 msgid "ui.errorCard.unknownError"
 msgstr "未知错误"
-
-#. js-lingui-explicit-id
-msgid "ui.errorCard.viewDetails"
-msgstr "查看详情"
 
 #. js-lingui-explicit-id
 msgid "ui.imagePreview.close"

--- a/packages/ui/src/components/activity-trace.tsx
+++ b/packages/ui/src/components/activity-trace.tsx
@@ -218,6 +218,7 @@ function ActivityStep(props: { step: ActivityStepProjection; serverUrl: string }
             sessionId={props.step.part.sessionID}
             messageId={props.step.part.messageID}
             resultOnly
+            defaultOpen
           />
         </Collapsible.Content>
       </Collapsible>

--- a/packages/ui/src/components/error-card.css
+++ b/packages/ui/src/components/error-card.css
@@ -1,113 +1,180 @@
-[data-component="card"].error-card-shell {
-  padding: 0;
-  overflow: hidden;
-  background-color: var(--workbench-card-bg, var(--surface-raised-base));
-  border-color: color-mix(
-    in oklch,
-    var(--border-critical-base) 34%,
-    var(--workbench-border, var(--border-weaker-base))
-  );
-  color: var(--text-base);
-}
-
 [data-component="error-card"] {
   width: 100%;
   min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 42px;
-  padding: 8px 10px 8px 12px;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
-
-  &:hover {
-    background: var(--workbench-card-bg-hover, var(--surface-raised-base-hover));
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px var(--border-focus);
-  }
-
-  [data-slot="icon-svg"] {
-    color: var(--icon-critical-base);
-    flex-shrink: 0;
-  }
-
-  [data-slot="error-card-content"] {
-    flex: 1;
-    min-width: 0;
-  }
-
-  [data-slot="error-card-message"] {
-    color: var(--text-base);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: block;
-  }
-
-  [data-slot="error-card-details"] {
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    gap: 2px;
-    color: var(--text-weak);
-    font-size: var(--font-size-small);
-    font-weight: var(--font-weight-medium);
-    white-space: nowrap;
-  }
+  border: 1px solid color-mix(in oklch, var(--border-critical-base) 52%, var(--border-weaker-base));
+  border-radius: var(--radius-md);
+  background-color: var(--surface-critical-weak);
+  overflow: hidden;
+  transition:
+    background-color var(--motion-duration-base) var(--motion-ease-standard),
+    border-color var(--motion-duration-base) var(--motion-ease-standard);
 }
 
-[data-component="dialog"] [data-slot="dialog-content"].error-details-dialog {
-  [data-slot="dialog-body"] {
-    gap: 20px;
-  }
+[data-component="error-card"] [data-slot="error-card-header"]:hover {
+  background-color: color-mix(in srgb, var(--surface-critical-weak) 82%, var(--surface-raised-base-hover));
+}
 
-  [data-slot="error-details-section"] {
-    display: flex;
-    min-width: 0;
-    flex-direction: column;
-    gap: 8px;
-  }
+[data-slot="error-card-header"] {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 10px;
+  padding: 8px 12px;
+  box-sizing: border-box;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
 
-  [data-slot="error-details-label"] {
-    color: var(--text-weak);
-    font-size: var(--type-ui-caption-size, 12px);
-    font-weight: var(--font-weight-medium);
-    line-height: var(--type-ui-caption-line-height, 16px);
-  }
+[data-slot="error-card-header"]:focus-visible {
+  outline: 2px solid var(--color-focus-ring, var(--color-border-focus));
+  outline-offset: -2px;
+}
 
-  [data-slot="error-details-content"] {
-    max-height: 280px;
-    margin: 0;
-    overflow: auto;
-    padding: 12px 14px;
-    border-radius: 10px;
-    background: var(--dialog-control-bg);
-    color: var(--text-base);
-    font-family: var(--font-family-mono);
-    font-size: var(--type-ui-caption-size, 12px);
-    line-height: var(--type-ui-body-line-height, 20px);
-    overflow-wrap: anywhere;
-    white-space: pre-wrap;
-  }
+[data-slot="error-card-leading"] {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--icon-critical-base);
+  flex-shrink: 0;
+}
 
-  [data-slot="dialog-actions"] {
-    padding-top: 14px;
-    border-top: 1px solid var(--dialog-border-weak);
-  }
+[data-slot="error-card-copy"] {
+  min-width: 0;
+  flex: 1 1 auto;
+}
 
-  [data-copy-state="copied"] [data-slot="icon-svg"] {
-    color: var(--icon-success-base);
-  }
+[data-slot="error-card-message"] {
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  font-weight: var(--font-weight-medium);
+  color: var(--text-base);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  [data-copy-state="failed"] [data-slot="icon-svg"] {
-    color: var(--icon-critical-base);
+[data-slot="error-card-arrow"] {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--icon-weak);
+  transition: transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+[data-component="error-card"][data-expanded] [data-slot="error-card-arrow"] {
+  transform: rotate(90deg);
+}
+
+[data-component="error-card"] > [data-component="collapsible"] {
+  background: transparent;
+  border: 0;
+  border-radius: inherit;
+  overflow: visible;
+}
+
+[data-component="error-card"] [data-slot="collapsible-content"] {
+  overflow: hidden;
+}
+
+[data-slot="error-card-content"] {
+  max-height: min(44vh, 32rem);
+  padding: 2px 12px 12px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+[data-slot="error-card-label"] {
+  color: var(--text-on-critical-base);
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.35;
+}
+
+[data-slot="error-card-text"] {
+  max-height: min(32vh, 18rem);
+  margin: 0;
+  overflow: auto;
+  padding: 10px 12px;
+  border-left: 2px solid var(--border-critical-base);
+  border-radius: var(--radius-sm);
+  background-color: var(--surface-raised-base);
+  color: var(--text-base);
+  font-family: var(--font-family-mono);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+[data-slot="error-card-actions"] {
+  display: flex;
+  justify-content: flex-end;
+}
+
+[data-slot="error-card-copy-button"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-weaker-base);
+  border-radius: var(--radius-sm);
+  background-color: var(--surface-raised-base);
+  color: var(--text-base);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition:
+    background-color var(--motion-duration-fast) var(--motion-ease-standard),
+    border-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+[data-slot="error-card-copy-button"]:hover:not(:disabled) {
+  background-color: var(--surface-raised-base-hover);
+}
+
+[data-slot="error-card-copy-button"]:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+[data-slot="error-card-copy-button"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+[data-slot="error-card-copy-button"] [data-slot="icon-svg"] {
+  color: var(--icon-base);
+  transition:
+    color var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+[data-slot="error-card-copy-button"][data-copy-state="copied"] [data-slot="icon-svg"] {
+  color: var(--icon-success-base);
+  transform: scale(1.06);
+}
+
+[data-slot="error-card-copy-button"][data-copy-state="failed"] [data-slot="icon-svg"] {
+  color: var(--icon-critical-base);
+  transform: scale(1.06);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-component="error-card"],
+  [data-component="error-card"] [data-slot="error-card-header"],
+  [data-component="error-card"] [data-slot="error-card-arrow"] {
+    transition: none;
   }
 }

--- a/packages/ui/src/components/error-card.css
+++ b/packages/ui/src/components/error-card.css
@@ -174,7 +174,10 @@
 @media (prefers-reduced-motion: reduce) {
   [data-component="error-card"],
   [data-component="error-card"] [data-slot="error-card-header"],
-  [data-component="error-card"] [data-slot="error-card-arrow"] {
+  [data-component="error-card"] [data-slot="error-card-arrow"],
+  [data-component="error-card"] [data-slot="error-card-copy-button"],
+  [data-component="error-card"] [data-slot="error-card-copy-button"] [data-slot="icon-svg"] {
     transition: none;
+    animation: none;
   }
 }

--- a/packages/ui/src/components/error-card.tsx
+++ b/packages/ui/src/components/error-card.tsx
@@ -15,23 +15,29 @@ const copyFailureDescriptor = { id: "ui.errorCard.copyFailure", message: "Unable
 
 export interface ErrorCardProps {
   error: string
-  compact?: boolean
+  defaultOpen?: boolean
   input?: Record<string, unknown>
 }
 
 export function ErrorCard(props: ErrorCardProps) {
   const { _ } = useLingui()
-  const [local] = splitProps(props, ["error", "input", "compact"])
+  const [local] = splitProps(props, ["error", "input", "defaultOpen"])
   const copy = createCopyController({
     text: () => errorDetailsText(local.error, local.input),
-    copyLabel: _(copyDetailsDescriptor),
-    copiedLabel: _(copiedDescriptor),
-    failureDescription: _(copyFailureDescriptor),
+    get copyLabel() {
+      return _(copyDetailsDescriptor)
+    },
+    get copiedLabel() {
+      return _(copiedDescriptor)
+    },
+    get failureDescription() {
+      return _(copyFailureDescriptor)
+    },
     copyIcon: getSemanticIcon("action.copy"),
     copiedIcon: getSemanticIcon("state.success"),
     failedIcon: getSemanticIcon("state.error"),
   })
-  const [open, setOpen] = createSignal(!local.compact)
+  const [open, setOpen] = createSignal(local.defaultOpen ?? false)
   const expandIcon = createMemo(() =>
     open() ? getSemanticIcon("navigation.collapse") : getSemanticIcon("navigation.expand"),
   )

--- a/packages/ui/src/components/error-card.tsx
+++ b/packages/ui/src/components/error-card.tsx
@@ -1,22 +1,17 @@
-import { Show, splitProps } from "solid-js"
+import { Show, createMemo, createSignal, splitProps } from "solid-js"
 import { useLingui } from "@lingui/solid"
-import { useDialog } from "../context/dialog"
-import { Button } from "./button"
-import { Card } from "./card"
+import { Collapsible } from "./collapsible"
 import { createCopyController } from "./clipboard"
-import { Dialog } from "./dialog"
 import { errorDetailsText, errorInputText, errorPreview } from "./error-card-content"
 import { Icon } from "./icon"
 import "./error-card.css"
 import { getSemanticIcon } from "./semantic-icon"
 
-const errorDetailsTitleDescriptor = { id: "ui.errorCard.detailsTitle", message: "Error details" }
-const errorMessageLabelDescriptor = { id: "ui.errorCard.errorMessage", message: "Error message" }
+const errorDetailsLabelDescriptor = { id: "ui.errorCard.detailsTitle", message: "Error details" }
 const toolInputLabelDescriptor = { id: "ui.errorCard.toolInput", message: "Tool input" }
 const copyDetailsDescriptor = { id: "ui.errorCard.copyDetails", message: "Copy details" }
 const copiedDescriptor = { id: "ui.errorCard.copied", message: "Copied" }
 const copyFailureDescriptor = { id: "ui.errorCard.copyFailure", message: "Unable to copy the error details." }
-const viewDetailsDescriptor = { id: "ui.errorCard.viewDetails", message: "View details" }
 
 export interface ErrorCardProps {
   error: string
@@ -24,10 +19,11 @@ export interface ErrorCardProps {
   input?: Record<string, unknown>
 }
 
-function ErrorDetailsDialog(props: Pick<ErrorCardProps, "error" | "input">) {
+export function ErrorCard(props: ErrorCardProps) {
   const { _ } = useLingui()
+  const [local] = splitProps(props, ["error", "input", "compact"])
   const copy = createCopyController({
-    text: () => errorDetailsText(props.error, props.input),
+    text: () => errorDetailsText(local.error, local.input),
     copyLabel: _(copyDetailsDescriptor),
     copiedLabel: _(copiedDescriptor),
     failureDescription: _(copyFailureDescriptor),
@@ -35,59 +31,53 @@ function ErrorDetailsDialog(props: Pick<ErrorCardProps, "error" | "input">) {
     copiedIcon: getSemanticIcon("state.success"),
     failedIcon: getSemanticIcon("state.error"),
   })
-
-  return (
-    <Dialog title={_(errorDetailsTitleDescriptor)} size="wide" class="error-details-dialog">
-      <section data-slot="error-details-section">
-        <div data-slot="error-details-label">{_(errorMessageLabelDescriptor)}</div>
-        <pre data-slot="error-details-content">{props.error}</pre>
-      </section>
-      <Show when={errorInputText(props.input)}>
-        {(input) => (
-          <section data-slot="error-details-section">
-            <div data-slot="error-details-label">{_(toolInputLabelDescriptor)}</div>
-            <pre data-slot="error-details-content">{input()}</pre>
-          </section>
-        )}
-      </Show>
-      <div data-slot="dialog-actions">
-        <Button
-          type="button"
-          variant="secondary"
-          size="large"
-          icon={copy.icon()}
-          data-copy-state={copy.state()}
-          disabled={copy.disabled()}
-          onClick={() => void copy.copy()}
-        >
-          {copy.tooltip()}
-        </Button>
-      </div>
-    </Dialog>
+  const [open, setOpen] = createSignal(!local.compact)
+  const expandIcon = createMemo(() =>
+    open() ? getSemanticIcon("navigation.collapse") : getSemanticIcon("navigation.expand"),
   )
-}
-
-export function ErrorCard(props: ErrorCardProps) {
-  const { _ } = useLingui()
-  const [local] = splitProps(props, ["error", "input"])
-  const dialog = useDialog()
-
-  const openDetails = () => {
-    dialog.show(() => <ErrorDetailsDialog error={local.error} input={local.input} />)
-  }
 
   return (
-    <Card variant="error" class="error-card-shell">
-      <button type="button" data-component="error-card" onClick={openDetails}>
-        <Icon name={getSemanticIcon("state.error")} size="small" />
-        <div data-slot="error-card-content">
-          <span data-slot="error-card-message">{errorPreview(local.error)}</span>
-        </div>
-        <span data-slot="error-card-details">
-          {_(viewDetailsDescriptor)}
-          <Icon name={getSemanticIcon("navigation.expand")} size="small" />
-        </span>
-      </button>
-    </Card>
+    <div data-component="error-card" data-expanded={open() ? "" : undefined}>
+      <Collapsible open={open()} onOpenChange={setOpen} variant="ghost">
+        <Collapsible.Trigger data-slot="error-card-header" type="button">
+          <span data-slot="error-card-leading" aria-hidden="true">
+            <Icon name={getSemanticIcon("state.error")} size="small" />
+          </span>
+          <div data-slot="error-card-copy">
+            <span data-slot="error-card-message">{errorPreview(local.error)}</span>
+          </div>
+          <span data-slot="error-card-arrow" aria-hidden="true">
+            <Icon name={expandIcon()} size="small" />
+          </span>
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <div data-slot="error-card-content">
+            <div data-slot="error-card-label">{_(errorDetailsLabelDescriptor)}</div>
+            <pre data-slot="error-card-text">{local.error}</pre>
+            <Show when={errorInputText(local.input)}>
+              {(input) => (
+                <>
+                  <div data-slot="error-card-label">{_(toolInputLabelDescriptor)}</div>
+                  <pre data-slot="error-card-text">{input()}</pre>
+                </>
+              )}
+            </Show>
+            <div data-slot="error-card-actions">
+              <button
+                type="button"
+                data-slot="error-card-copy-button"
+                data-copy-state={copy.state()}
+                disabled={copy.disabled()}
+                aria-label={copy.tooltip()}
+                onClick={() => void copy.copy()}
+              >
+                <Icon name={copy.icon()} size="small" />
+                <span>{copy.tooltip()}</span>
+              </button>
+            </div>
+          </div>
+        </Collapsible.Content>
+      </Collapsible>
+    </div>
   )
 }

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -1317,7 +1317,7 @@ export function SessionTurn(
                       </div>
                     </Show>
                     <Show when={error()}>
-                      <ErrorCard error={errorMessage()} compact />
+                      <ErrorCard error={errorMessage()} />
                     </Show>
                     {renderMessageSlot("message.after-message")}
                   </Match>

--- a/packages/ui/src/components/tool-result-body.tsx
+++ b/packages/ui/src/components/tool-result-body.tsx
@@ -135,7 +135,13 @@ export function ToolResultBody(props: {
         />
       }
     >
-      {(message) => <ErrorCard error={message()} input={error()?.input as Record<string, unknown> | undefined} />}
+      {(message) => (
+        <ErrorCard
+          error={message()}
+          input={error()?.input as Record<string, unknown> | undefined}
+          defaultOpen={props.defaultOpen}
+        />
+      )}
     </Show>
   )
 

--- a/packages/ui/test/components/activity-trace.dom.test.ts
+++ b/packages/ui/test/components/activity-trace.dom.test.ts
@@ -165,6 +165,36 @@ beforeAll(async () => {
         ],
         topic: { state: "stable", text: "Read the Activity Trace source" },
       }
+      const errorGroup = {
+        kind: "activity-group",
+        key: "group-error",
+        message,
+        family: "execute",
+        scopeKey: "build.sh",
+        state: "error",
+        steps: [
+          {
+            part: {
+              id: "p-error",
+              tool: "bash",
+              state: {
+                status: "error",
+                input: { command: "bash build.sh" },
+                error: "bash: build.sh: command not found\\nexit code 127",
+                metadata: {},
+                time: { start: 1, end: 2 },
+              },
+            },
+            family: "execute",
+            scopeKey: "build.sh",
+            icon: "terminal",
+            title: "Run build.sh",
+            subtitle: "build.sh",
+            state: "error",
+          },
+        ],
+        receipt: false,
+      }
       function CodeFixture(props: { file: { contents: string } }) {
         return <pre data-component="code-fixture">{props.file.contents}</pre>
       }
@@ -247,6 +277,9 @@ beforeAll(async () => {
               </div>
               <div id="view-file-host">
                 <ActivityTrace group={viewFileGroup} serverUrl="http://localhost" />
+              </div>
+              <div id="error-host">
+                <ActivityTrace group={errorGroup} serverUrl="http://localhost" />
               </div>
               <ActivityReceipt item={dagReceipt} serverUrl="http://localhost" />
               <div id="reasoning-summary-host">
@@ -542,7 +575,7 @@ describe("ActivityTrace DOM behavior", () => {
 
   test("each child activity is a keyboard-accessible result toggle", async () => {
     const triggers = stepTriggers()
-    expect(triggers).toHaveLength(5)
+    expect(triggers).toHaveLength(6)
     expect(triggers[0]?.tagName).toBe("BUTTON")
     expect(triggers[0]?.getAttribute("type")).toBe("button")
     expect(triggers[0]?.getAttribute("aria-expanded")).toBe("false")
@@ -628,6 +661,21 @@ describe("ActivityTrace DOM behavior", () => {
     expect(viewHost.querySelector('[data-component="code-fixture"]')?.textContent).toBe("const parity = true")
     expect(viewHost.querySelector('[data-component="tool-output-text"]')).toBeNull()
     expect(viewHost.querySelector('[data-component="collapsible"][data-variant="tool"]')).toBeNull()
+  })
+
+  test("keeps a failed step collapsed by default and reveals the full error inline after one click", async () => {
+    const host = document.querySelector("#error-host") as HTMLElement
+    const trigger = host.querySelector('[data-slot="activity-step-trigger"]') as HTMLButtonElement
+    expect(trigger.getAttribute("aria-expanded")).toBe("false")
+    expect(host.querySelector('[data-component="error-card"]')).toBeNull()
+
+    trigger.click()
+    await wait(0)
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true")
+    expect(host.querySelector('[data-component="error-card"]')).not.toBeNull()
+    expect(host.textContent).toContain("command not found")
+    expect(host.textContent).toContain("exit code 127")
   })
 })
 


### PR DESCRIPTION
## Summary

Tool call failures in the balanced activity display previously required two clicks to inspect: expand the collapsed activity step, then open a details dialog. This changes the error card to an inline collapsible rendered in the compaction failure card style, so a single step click reveals the full error (monospace details + copy action) directly in the timeline.

## Changes

- `packages/ui/src/components/error-card.tsx` / `error-card.css`: replace the dialog-based error card with an inline `Collapsible`; header shows the error preview, expanded body shows the full error, optional tool input, and a copy-details button. `compact` mode defaults to collapsed.
- `packages/ui/test/components/activity-trace.dom.test.ts`: add DOM coverage for a failed step — collapsed by default, full error visible after one click.
- Locale catalogs: drop the retired `ui.errorCard.viewDetails` / `ui.errorCard.errorMessage` entries.

## Verification

- `bun test test/components/activity-trace.dom.test.ts` (packages/ui): 20 pass
- `bun run typecheck` (packages/ui): pass
- `bun run i18n:check` (packages/app): pass
- `bun run quality:quick` (root): pass
- Manually verified in an isolated dev instance: failed tool step collapses by default; one click reveals the full error inline.