### PR TITLE
test(fixture): guard tmpdir() against unisolated test runs

### DIFF
--- a/packages/synergy/test/fixture/fixture.ts
+++ b/packages/synergy/test/fixture/fixture.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs/promises"
-import os from "os"
 import path from "path"
 import type { Config } from "../../src/config/config"
 import { ConfigDomain } from "../../src/config/domain"
@@ -68,7 +67,14 @@ export async function initializeGitFixture(dirpath: string, run: GitFixtureRunne
   )
 }
 export async function tmpdir<T>(options?: TmpDirOptions<T>) {
-  const root = process.env["SYNERGY_TEST_ROOT"] ?? os.tmpdir()
+  const root = process.env["SYNERGY_TEST_ROOT"]
+  if (!root) {
+    throw new Error(
+      "tmpdir() requires SYNERGY_TEST_ROOT to be set. The test preload (test/preload.ts) is not active — " +
+        "running bun test with --isolate (or without the bunfig [test] preload) bypasses isolation and would " +
+        "write fixtures into the real home directory.",
+    )
+  }
   const dirpath = Filesystem.sanitizePath(path.join(root, "synergy-test-" + Math.random().toString(36).slice(2)))
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) await initializeGitFixture(dirpath)

--- a/packages/synergy/test/fixture/guard.test.ts
+++ b/packages/synergy/test/fixture/guard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import { tmpdir } from "./fixture"
+
+describe("tmpdir isolation guard", () => {
+  test("throws when SYNERGY_TEST_ROOT is unset", async () => {
+    const previous = process.env["SYNERGY_TEST_ROOT"]
+    delete process.env["SYNERGY_TEST_ROOT"]
+    try {
+      await expect(tmpdir()).rejects.toThrow(/SYNERGY_TEST_ROOT/)
+    } finally {
+      if (previous === undefined) delete process.env["SYNERGY_TEST_ROOT"]
+      else process.env["SYNERGY_TEST_ROOT"] = previous
+    }
+  })
+
+  test("creates a fixture when SYNERGY_TEST_ROOT is set", async () => {
+    const realRoot = await fs.realpath(process.env["SYNERGY_TEST_ROOT"]!)
+    await using tmp = await tmpdir()
+    expect(tmp.path.startsWith(realRoot)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

`tmpdir()` in the test fixture silently fell back to `os.tmpdir()` when `SYNERGY_TEST_ROOT` was unset. That happens when `bun test --isolate` (or any run without the `bunfig.toml` `[test] preload`) bypasses the isolation preload — the fixture then creates scopes in the **real home directory**, registering a flood of stray `synergy-test-*` projects and empty sessions in `~/.synergy`.

This change makes the fixture fail fast with a diagnostic error instead of writing into the real home.

## Changes

- `packages/synergy/test/fixture/fixture.ts`: `tmpdir()` now requires `SYNERGY_TEST_ROOT` and throws a clear error when it is missing (preload not active). Removed the `os.tmpdir()` fallback and the now-unused `os` import.
- `packages/synergy/test/fixture/guard.test.ts`: new tests covering both branches — throws when `SYNERGY_TEST_ROOT` is unset, creates the fixture inside the configured root when set.

## Verification

- `bun test test/fixture/guard.test.ts test/fixture/git.test.ts` — 8 pass
- Regression: `test/fixture/ test/session/workspace.test.ts test/note/store.test.ts` — 50 pass
- End-to-end probe: with `--isolate` (preload bypassed) `tmpdir()` now throws instead of polluting the real home
- `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test-layout:check` — all pass