### PR TITLE
fix(ui): show approval audit icon on balanced activity steps

### DIFF
--- a/packages/ui/src/components/activity-trace.css
+++ b/packages/ui/src/components/activity-trace.css
@@ -11,6 +11,10 @@
 }
 
 [data-component="activity-trace"] {
+  [data-component="collapsible"] {
+    overflow: visible;
+  }
+
   [data-slot="activity-step-trigger"] {
     position: relative;
     display: flex;

--- a/packages/ui/src/components/activity-trace.css
+++ b/packages/ui/src/components/activity-trace.css
@@ -68,13 +68,15 @@
   }
 
   [data-slot="activity-step-audit-icon"] {
-    position: static;
-    display: inline-flex;
-    flex: 0 0 auto;
+    position: absolute;
+    left: -28px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
     align-items: center;
     justify-content: center;
-    width: 18px;
-    height: 18px;
+    width: 24px;
+    height: 24px;
     cursor: help;
     border-radius: var(--radius-full);
     animation: none;

--- a/packages/ui/src/components/activity-trace.css
+++ b/packages/ui/src/components/activity-trace.css
@@ -68,6 +68,7 @@
   }
 
   [data-slot="activity-step-audit-icon"] {
+    position: static;
     display: inline-flex;
     flex: 0 0 auto;
     align-items: center;
@@ -76,6 +77,7 @@
     height: 18px;
     cursor: help;
     border-radius: var(--radius-full);
+    animation: none;
   }
 
   [data-slot="activity-step-audit-icon"]:hover {

--- a/packages/ui/src/components/activity-trace.css
+++ b/packages/ui/src/components/activity-trace.css
@@ -61,7 +61,23 @@
   }
 
   [data-slot="activity-step"] {
+    position: relative;
     min-width: 0;
+  }
+
+  .activity-step-audit-trigger {
+    position: absolute;
+    left: -28px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    cursor: help;
+    border-radius: var(--radius-full);
+  }
+
+  .activity-step-audit-trigger:hover {
+    background: var(--surface-raised-base-hover);
   }
 
   [data-slot="activity-step-icon"] {
@@ -72,22 +88,15 @@
   }
 
   [data-slot="activity-step-audit-icon"] {
-    position: absolute;
-    left: -28px;
-    top: 50%;
-    transform: translateY(-50%);
+    position: static;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 100%;
+    height: 100%;
     cursor: help;
     border-radius: var(--radius-full);
     animation: none;
-  }
-
-  [data-slot="activity-step-audit-icon"]:hover {
-    background: var(--surface-raised-base-hover);
   }
 
   [data-slot="activity-step-copy"] {

--- a/packages/ui/src/components/activity-trace.css
+++ b/packages/ui/src/components/activity-trace.css
@@ -67,6 +67,21 @@
     color: var(--icon-weak-base);
   }
 
+  [data-slot="activity-step-audit-icon"] {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    cursor: help;
+    border-radius: var(--radius-full);
+  }
+
+  [data-slot="activity-step-audit-icon"]:hover {
+    background: var(--surface-raised-base-hover);
+  }
+
   [data-slot="activity-step-copy"] {
     display: flex;
     flex: 1 1 auto;

--- a/packages/ui/src/components/activity-trace.tsx
+++ b/packages/ui/src/components/activity-trace.tsx
@@ -8,10 +8,11 @@ import {
 } from "./activity-count-transition"
 import { Collapsible } from "./collapsible"
 import { specializedActivityDetail } from "./activity-specialized-detail-model"
-import { Icon } from "./icon"
+import { Icon, type IconName } from "./icon"
 import { getSemanticIcon } from "./semantic-icon"
 import { Spinner } from "./spinner"
 import { ToolResultBody } from "./tool-result-body"
+import { getApprovalAudit } from "../utils/approval-audit"
 import type {
   ActivityFamily,
   ActivityGroupItem,
@@ -191,10 +192,21 @@ function ActivityStep(props: { step: ActivityStepProjection; serverUrl: string }
   const familyLabel = createMemo(() => localize(familyDescriptor(props.step.family), _))
   const title = createMemo(() => localize(props.step.title, _))
   const stateLabel = createMemo(() => _(stateDescriptor(props.step.state)))
+  const approval = createMemo(() => {
+    const metadata = props.step.part.state.metadata
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined
+    return (metadata as Record<string, unknown>).approval as Record<string, unknown> | undefined
+  })
+  const audit = createMemo(() => getApprovalAudit(approval()))
   return (
     <li data-slot="activity-step" data-family={props.step.family} data-state={props.step.state}>
       <Collapsible open={open()} onOpenChange={setOpen} variant="ghost">
         <Collapsible.Trigger data-slot="activity-step-trigger" type="button">
+          <Show when={audit().icon}>
+            <span data-component="tool-audit-icon" data-slot="activity-step-audit-icon" title={audit().tooltip}>
+              <Icon name={audit().icon as IconName} size="small" class={audit().iconClass} />
+            </span>
+          </Show>
           <span data-slot="activity-step-icon" aria-hidden="true">
             <Icon name={props.step.icon} size="small" />
           </span>

--- a/packages/ui/src/components/activity-trace.tsx
+++ b/packages/ui/src/components/activity-trace.tsx
@@ -12,6 +12,7 @@ import { Icon, type IconName } from "./icon"
 import { getSemanticIcon } from "./semantic-icon"
 import { Spinner } from "./spinner"
 import { ToolResultBody } from "./tool-result-body"
+import { Tooltip } from "./tooltip"
 import { getApprovalAudit } from "../utils/approval-audit"
 import type {
   ActivityFamily,
@@ -187,7 +188,7 @@ function ActivityState(props: { state: ActivityGroupState; label: string }) {
 }
 
 function ActivityStep(props: { step: ActivityStepProjection; serverUrl: string }) {
-  const { _ } = useLingui()
+  const { i18n, _ } = useLingui()
   const [open, setOpen] = createSignal(false)
   const familyLabel = createMemo(() => localize(familyDescriptor(props.step.family), _))
   const title = createMemo(() => localize(props.step.title, _))
@@ -197,16 +198,35 @@ function ActivityStep(props: { step: ActivityStepProjection; serverUrl: string }
     if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined
     return (metadata as Record<string, unknown>).approval as Record<string, unknown> | undefined
   })
-  const audit = createMemo(() => getApprovalAudit(approval()))
+  const audit = createMemo(() => getApprovalAudit(approval(), i18n()))
   return (
     <li data-slot="activity-step" data-family={props.step.family} data-state={props.step.state}>
+      <Show when={audit().icon}>
+        <Tooltip
+          placement="right"
+          class="activity-step-audit-trigger"
+          value={
+            <div class="max-w-72">
+              <div class="text-12-medium text-text-base">{audit().tooltip.split("\n")[0]}</div>
+              <Show when={audit().tooltip.includes("\n")}>
+                <div class="mt-1 text-11-regular text-text-weak">{audit().tooltip.split("\n").slice(1).join("\n")}</div>
+              </Show>
+            </div>
+          }
+        >
+          <span
+            data-component="tool-audit-icon"
+            data-slot="activity-step-audit-icon"
+            tabindex="0"
+            role="img"
+            aria-label={audit().tooltip}
+          >
+            <Icon name={audit().icon as IconName} size="small" class={audit().iconClass} />
+          </span>
+        </Tooltip>
+      </Show>
       <Collapsible open={open()} onOpenChange={setOpen} variant="ghost">
         <Collapsible.Trigger data-slot="activity-step-trigger" type="button">
-          <Show when={audit().icon}>
-            <span data-component="tool-audit-icon" data-slot="activity-step-audit-icon" title={audit().tooltip}>
-              <Icon name={audit().icon as IconName} size="small" class={audit().iconClass} />
-            </span>
-          </Show>
           <span data-slot="activity-step-icon" aria-hidden="true">
             <Icon name={props.step.icon} size="small" />
           </span>

--- a/packages/ui/test/components/activity-trace.dom.test.ts
+++ b/packages/ui/test/components/activity-trace.dom.test.ts
@@ -181,7 +181,14 @@ beforeAll(async () => {
                 status: "error",
                 input: { command: "bash build.sh" },
                 error: "bash: build.sh: command not found\\nexit code 127",
-                metadata: {},
+                metadata: {
+                  approval: {
+                    status: "auto_allowed",
+                    mode: "autonomous",
+                    risk: "medium",
+                    audit: { visible: true },
+                  },
+                },
                 time: { start: 1, end: 2 },
               },
             },
@@ -676,6 +683,13 @@ describe("ActivityTrace DOM behavior", () => {
     expect(host.querySelector('[data-component="error-card"]')).not.toBeNull()
     expect(host.textContent).toContain("command not found")
     expect(host.textContent).toContain("exit code 127")
+  })
+
+  test("renders the approval audit icon for an auto-allowed step", () => {
+    const host = document.querySelector("#error-host") as HTMLElement
+    const audit = host.querySelector('[data-component="tool-audit-icon"]')
+    expect(audit).not.toBeNull()
+    expect(audit?.querySelector('[data-slot="icon-svg"]')).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

In balanced activity display, tool calls are collapsed into step rows that only render the family icon — the approval audit indicator shown in full mode (e.g. the smart-allow / auto-allowed orbit icon in autonomous mode) was dropped. This derives the audit icon from the step's approval metadata using the same `getApprovalAudit` rules as the full path and renders it inline before the family icon, so auto-allowed tools stay visibly annotated.

## Changes

- `packages/ui/src/components/activity-trace.tsx`: read `part.state.metadata.approval` per step, compute the audit via `getApprovalAudit`, and render `data-component="tool-audit-icon"` (with the approval tooltip as `title`) ahead of the family icon when an icon resolves.
- `packages/ui/src/components/activity-trace.css`: inline (non-absolute) audit icon layout inside the step row, with hover affordance.
- `packages/ui/test/components/activity-trace.dom.test.ts`: DOM coverage asserting the audit icon renders for an `auto_allowed` / autonomous step.

## Verification

- `bun run typecheck` (packages/ui): pass
- `bun test test/components/activity-trace.dom.test.ts test/approval-audit.test.ts ...`: 126 pass
- `bun run format:check` + `bun run lint` (root): pass