### PR TITLE
fix(ci): close desktop recovery race and widen Chromium hook budgets

### DIFF
--- a/packages/app/script/test.ts
+++ b/packages/app/script/test.ts
@@ -72,6 +72,6 @@ const tests = (await collectTests("test")).toSorted()
 await run(
   tests.filter((test) => test !== isolated && !browserOnly.includes(test) && !playwrightIsolated.includes(test)),
 )
-for (const file of playwrightIsolated) await run([file], { timeoutMs: 60000 })
+for (const file of playwrightIsolated) await run([file], { timeoutMs: 120000 })
 await run(browserOnly, { browser: true })
 await run([isolated])

--- a/packages/desktop/src/browser-native-page-pool.ts
+++ b/packages/desktop/src/browser-native-page-pool.ts
@@ -377,9 +377,19 @@ export class BrowserNativePagePool {
   private recover(entry: Entry, reason: string): Promise<void> {
     if (entry.closing) return Promise.resolve()
     if (entry.recovery) return entry.recovery
-    const operation = this.recoverEntry(entry, reason).finally(() => {
-      if (entry.recovery === operation) entry.recovery = null
-    })
+    const operation = this.recoverEntry(entry, reason)
+      .then(() => {
+        if (entry.recovery === operation) entry.recovery = null
+        if (entry.closing) return
+        // Signal readiness only after the recovery guard clears so a consumer
+        // reacting to host.status "ready" can immediately issue CDP commands
+        // without racing the restarting guard.
+        entry.input.emit({ type: "host.status", pageId: entry.state().id, status: "ready" })
+      })
+      .catch((error) => {
+        if (entry.recovery === operation) entry.recovery = null
+        throw error
+      })
     entry.recovery = operation
     return operation
   }
@@ -418,7 +428,6 @@ export class BrowserNativePagePool {
           await this.closeGeneration(previous).catch((error) => {
             console.error("Native Browser previous generation cleanup failed.", error)
           })
-          entry.input.emit({ type: "host.status", pageId, status: "ready" })
           return
         } catch (error) {
           lastError = error

--- a/packages/desktop/test/browser-native-page-pool.test.ts
+++ b/packages/desktop/test/browser-native-page-pool.test.ts
@@ -221,6 +221,10 @@ describe("Browser native page pool", () => {
       "ready",
     ])
     expect(first.webContents.destroyed).toBe(true)
+    // The "ready" event is the availability contract: a consumer reacting to
+    // it must be able to issue CDP commands without racing the restarting
+    // guard.
+    await expect(handle.execute({ type: "reload" })).resolves.toBeDefined()
     await pool.destroy()
   })
 

--- a/packages/desktop/test/browser-native-page-pool.test.ts
+++ b/packages/desktop/test/browser-native-page-pool.test.ts
@@ -156,6 +156,8 @@ mock.module("../src/browser-webcontents-control.js", () => ({
   },
 }))
 
+import type { BrowserNativePageHandle } from "../src/browser-native-page-pool.js"
+
 const { BrowserNativePagePool, MAX_RECOVERY_BUDGET } = await import("../src/browser-native-page-pool.js")
 
 function input(ownerKey: string, emit: (event: any) => void = () => undefined) {
@@ -205,8 +207,22 @@ describe("Browser native page pool", () => {
     views.length = 0
     partitions.length = 0
     const events: any[] = []
+    let executeAtReady: Promise<unknown> | null = null
+    let handle!: BrowserNativePageHandle
     const pool = new BrowserNativePagePool({ recoveryDelaysMs: [0] })
-    const handle = await pool.create(input("crash", (event) => events.push(event)))
+    handle = await pool.create(
+      input("crash", (event) => {
+        events.push(event)
+        if (event.type === "host.status" && event.status === "ready") {
+          // The ready event is the availability contract: a consumer reacting
+          // to it must be able to issue CDP commands without racing the
+          // restarting guard. Capturing the command synchronously from the
+          // emit callback makes this test fail on the parent implementation,
+          // where ready fired before the recovery guard cleared.
+          executeAtReady = handle.execute({ type: "reload" })
+        }
+      }),
+    )
     const first = views.at(-1)!
 
     first.webContents.emit("render-process-gone")
@@ -221,10 +237,7 @@ describe("Browser native page pool", () => {
       "ready",
     ])
     expect(first.webContents.destroyed).toBe(true)
-    // The "ready" event is the availability contract: a consumer reacting to
-    // it must be able to issue CDP commands without racing the restarting
-    // guard.
-    await expect(handle.execute({ type: "reload" })).resolves.toBeDefined()
+    await expect(executeAtReady).resolves.toBeDefined()
     await pool.destroy()
   })
 

--- a/packages/desktop/test/fixture/browser-native-page-pool.ts
+++ b/packages/desktop/test/fixture/browser-native-page-pool.ts
@@ -14,6 +14,7 @@ async function run() {
   await app.whenReady()
   try {
     const pool = new BrowserNativePagePool()
+    let hostReady = false
     const input = {
       ownerKey: "scope:native-smoke:session:native-smoke",
       page: {
@@ -25,7 +26,9 @@ async function run() {
       },
       networkProxy: { server: "direct://", username: "unused", password: "unused" },
       downloadDir: directory,
-      emit() {},
+      emit(event: { type: string; status?: string }) {
+        if (event.type === "host.status" && event.status === "ready") hostReady = true
+      },
     }
     const first = await pool.create(input)
     const window = new BrowserWindow({ show: false })
@@ -108,7 +111,10 @@ async function run() {
       throw new Error("Native page did not receive an isolated renderer process.")
     }
     process.kill(rendererProcessId, "SIGKILL")
-    await waitFor(() => recovered, 10_000, "native renderer recovery")
+    // host.status "ready" is emitted only after the pool clears its recovery
+    // guard, so waiting for it guarantees the recovered page accepts CDP
+    // commands without racing the restarting guard.
+    await waitFor(() => recovered && hostReady, 10_000, "native renderer recovery readiness")
     const recoveredPage = first.state()
     if (recoveredPage.id !== input.page.id) throw new Error("Native renderer recovery changed the stable page ID.")
     const recoveredEvaluation = await first.execute({

--- a/packages/ui/script/test.ts
+++ b/packages/ui/script/test.ts
@@ -35,7 +35,7 @@ async function collectTests(directory: string): Promise<string[]> {
 async function run(files: string[], options: { browser?: boolean } = {}) {
   if (files.length === 0) return
   const child = Bun.spawn(
-    [process.execPath, "test", "--timeout", "60000", ...(options.browser ? ["--conditions=browser"] : []), ...files],
+    [process.execPath, "test", "--timeout", "120000", ...(options.browser ? ["--conditions=browser"] : []), ...files],
     {
       cwd: root,
       stdin: "inherit",


### PR DESCRIPTION
## Summary

Two remaining CI flakes after the previous stabilization pass (PR #1141):

1. **Desktop smoke `recovers a crashed native renderer`** — `host.status "ready"` was emitted before the pool cleared its `entry.recovery` guard, so a consumer reacting to the ready signal could immediately issue a CDP command and hit `BrowserProtocolError: The Desktop native Browser is restarting` (failed on dev merge #1141 and session-005540 PR runs).
2. **app/ui Chromium suites** — cold Chromium + Vite dependency optimization under turbo cross-package parallelism occasionally exceeds the 60s bun hook budget (60000.12ms / 60002.22ms failures on multiple PR runs).

## Changes

- `packages/desktop/src/browser-native-page-pool.ts`: move the `host.status "ready"` emission out of `recoverEntry` into `recover`'s completion handler, after `entry.recovery` is cleared (with a closing guard) — the ready event now means the page accepts CDP commands.
- `packages/desktop/test/fixture/browser-native-page-pool.ts`: capture the ready event and wait for it (not just the generation swap) before issuing the post-crash CDP command.
- `packages/desktop/test/browser-native-page-pool.test.ts`: assert the availability contract — a command issued after ready resolves.
- `packages/app/script/test.ts`, `packages/ui/script/test.ts`: raise the Playwright-suite hook timeout 60s → 120s.

## Verification

- `bun test --cwd packages/desktop`: 12/12 pass.
- `packages/desktop` typecheck, `packages/ui` full suite, `packages/app` full suite: all pass.
- `bun run format:check`: pass.