### PR TITLE
fix(ui): align expanded tool details

### DIFF
--- a/packages/ui/src/components/activity-trace.css
+++ b/packages/ui/src/components/activity-trace.css
@@ -44,7 +44,7 @@
 
   [data-component="tool-result-body"] {
     min-width: 0;
-    margin: 6px 0 0 26px;
+    margin-top: 6px;
   }
 
   [data-component="tool-result-body"] > :first-child {

--- a/packages/ui/src/components/error-card.css
+++ b/packages/ui/src/components/error-card.css
@@ -1,9 +1,9 @@
 [data-component="error-card"] {
   width: 100%;
   min-width: 0;
-  border: 1px solid color-mix(in oklch, var(--border-critical-base) 52%, var(--border-weaker-base));
+  border: 1px solid color-mix(in oklch, var(--border-critical-base) 24%, var(--border-weaker-base));
   border-radius: var(--radius-md);
-  background-color: var(--surface-critical-weak);
+  background-color: var(--surface-raised-base);
   overflow: hidden;
   transition:
     background-color var(--motion-duration-base) var(--motion-ease-standard),
@@ -11,7 +11,7 @@
 }
 
 [data-component="error-card"] [data-slot="error-card-header"]:hover {
-  background-color: color-mix(in srgb, var(--surface-critical-weak) 82%, var(--surface-raised-base-hover));
+  background-color: color-mix(in oklch, var(--surface-raised-base-hover) 94%, var(--surface-critical-weak));
 }
 
 [data-slot="error-card-header"] {
@@ -102,9 +102,9 @@
   margin: 0;
   overflow: auto;
   padding: 10px 12px;
-  border-left: 2px solid var(--border-critical-base);
+  border: 1px solid color-mix(in oklch, var(--border-critical-base) 18%, var(--border-weaker-base));
   border-radius: var(--radius-sm);
-  background-color: var(--surface-raised-base);
+  background-color: var(--surface-inset-base);
   color: var(--text-base);
   font-family: var(--font-family-mono);
   font-size: 0.75rem;

--- a/packages/ui/src/components/error-card.css
+++ b/packages/ui/src/components/error-card.css
@@ -81,7 +81,7 @@
 
 [data-slot="error-card-content"] {
   max-height: min(44vh, 32rem);
-  padding: 2px 12px 12px 40px;
+  padding: 2px 12px 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/packages/ui/test/components/activity-trace-layout.browser.test.ts
+++ b/packages/ui/test/components/activity-trace-layout.browser.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import path from "node:path"
+import { chromium, type Browser, type Page } from "playwright"
+
+let browser: Browser
+let page: Page
+
+beforeAll(async () => {
+  const componentRoot = path.resolve(import.meta.dir, "../../src/components")
+  const css = await Promise.all(
+    ["collapsible.css", "activity-trace.css", "error-card.css"].map((file) =>
+      Bun.file(path.join(componentRoot, file)).text(),
+    ),
+  )
+
+  browser = await chromium.launch({ headless: true })
+  page = await browser.newPage({ viewport: { width: 1200, height: 800 } })
+  await page.setContent(`
+    <style>
+      :root {
+        --surface-critical-weak: rgb(72 16 20);
+        --surface-raised-base: rgb(28 28 30);
+        --surface-raised-base-hover: rgb(36 36 38);
+        --surface-base-hover: rgb(38 38 40);
+        --border-critical-base: rgb(206 70 76);
+        --border-weaker-base: rgb(72 72 76);
+        --text-base: rgb(240 240 242);
+        --text-weak: rgb(184 184 190);
+        --text-subtle: rgb(144 144 150);
+        --icon-critical-base: rgb(236 94 100);
+        --icon-weak: rgb(152 152 158);
+        --radius-sm: 6px;
+        --radius-md: 8px;
+        --motion-duration-fast: 120ms;
+        --motion-duration-base: 160ms;
+        --motion-ease-standard: ease;
+      }
+      ${css.join("\n")}
+    </style>
+    <div data-component="activity-trace" style="width: 800px; margin: 0">
+      <ol data-slot="activity-step-list">
+        <li data-slot="activity-step" data-family="execute" data-state="error">
+          <div data-component="collapsible" data-variant="ghost" data-expanded>
+            <button data-slot="activity-step-trigger" type="button">Run command</button>
+            <div data-slot="collapsible-content" data-expanded>
+              <div data-component="tool-result-body" data-presentation="result">
+                <div data-component="error-card" data-expanded>
+                  <div data-component="collapsible" data-variant="ghost" data-expanded>
+                    <button data-slot="error-card-header" type="button">Permission denied</button>
+                    <div data-slot="collapsible-content" data-expanded>
+                      <div data-slot="error-card-content">
+                        <div data-slot="error-card-label">Error details</div>
+                        <pre data-slot="error-card-text">Blocked by policy</pre>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ol>
+    </div>
+  `)
+})
+
+afterAll(async () => {
+  await browser?.close()
+})
+
+describe("activity trace expanded details", () => {
+  test("aligns the expanded tool result with the activity row", async () => {
+    const positions = await page.evaluate(() => {
+      const trigger = document.querySelector('[data-slot="activity-step-trigger"]')!.getBoundingClientRect()
+      const result = document.querySelector('[data-component="tool-result-body"]')!.getBoundingClientRect()
+      return { triggerLeft: trigger.left, resultLeft: result.left }
+    })
+
+    expect(positions.resultLeft).toBe(positions.triggerLeft)
+  })
+
+  test("keeps the error card surface neutral while reserving red for status accents", async () => {
+    const backgroundColor = await page
+      .locator('[data-component="error-card"]')
+      .evaluate((element) => getComputedStyle(element).backgroundColor)
+
+    expect(backgroundColor).toBe("rgb(28, 28, 30)")
+  })
+})

--- a/packages/ui/test/components/activity-trace-layout.browser.test.ts
+++ b/packages/ui/test/components/activity-trace-layout.browser.test.ts
@@ -86,4 +86,13 @@ describe("activity trace expanded details", () => {
 
     expect(backgroundColor).toBe("rgb(28, 28, 30)")
   })
+
+  test("balances the error card content padding with the card edge", async () => {
+    const padding = await page.locator('[data-slot="error-card-content"]').evaluate((element) => {
+      const style = getComputedStyle(element)
+      return { left: style.paddingLeft, right: style.paddingRight }
+    })
+
+    expect(padding.left).toBe(padding.right)
+  })
 })


### PR DESCRIPTION
## Summary

- align expanded Activity Trace tool results with their trigger row
- replace large critical error surfaces with neutral raised and inset surfaces while preserving critical status accents
- add a browser regression test for alignment and neutral error-card presentation

## Verification

- `bun run --cwd packages/ui test`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run quality:quick`
- isolated dark-theme visual preview and accessibility audit