### PR TITLE
fix(ui): stub createUniqueId in session-turn-projection test mock

### DIFF
--- a/packages/ui/test/components/session-turn-projection.test.ts
+++ b/packages/ui/test/components/session-turn-projection.test.ts
@@ -23,6 +23,7 @@ mock.module("solid-js", () => ({
     let value = initial
     return [() => value, (next: unknown) => (value = typeof next === "function" ? next(value) : next)]
   },
+  createUniqueId: () => "mock-unique-id",
   ErrorBoundary: Empty,
   For: Empty,
   Match: Empty,


### PR DESCRIPTION
## Summary

`compact-reasoning.tsx` imports `createUniqueId` from `solid-js` (added in fb168bf27c for the disclosure detail aria pairing). The `session-turn-projection.test.ts` solid-js mock does not provide it, so bun resolves the real solid-js server entry where the DOM-only export does not exist, failing the UI test suite with:

```
SyntaxError: Export named 'createUniqueId' not found in module '.../solid-js/dist/server.js'
```

This breaks CI on dev (e.g. run 31764133837) at the `@ericsanchezok/synergy-ui#test` step.

## Change

Add the missing stub to the solid-js mock, matching the sibling tests (`session-turn-activity.test.ts`, `session-turn-timeline.test.ts`, `compact-reasoning*.dom.test.ts`).

## Verification

- `bun test test/components/session-turn-projection.test.ts` — 7 pass
- Sibling session-turn / compact-reasoning suites — 95 pass