### PR TITLE
fix(embedding): resolve local model paths to buffers in standalone wasm shim

### DIFF
--- a/packages/synergy/script/embedding-onnxruntime-web.ts
+++ b/packages/synergy/script/embedding-onnxruntime-web.ts
@@ -1,2 +1,35 @@
+import fs from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+import * as onnx from "onnxruntime-web/wasm"
+
+type CreateOptions = Parameters<typeof onnx.InferenceSession.create>[1]
+
+const originalCreate = onnx.InferenceSession.create.bind(onnx.InferenceSession)
+
+// transformers.js runs in Node mode under Bun and passes local model file
+// paths (strings) to InferenceSession.create(). The WASM backend only accepts
+// buffers — its node:fs branch is compiled out — and rejects disk paths with
+// "fetch() URL is invalid". Resolve any string input (disk path, file:// URL,
+// or http(s) URL) to a buffer before handing it to the backend.
+async function resolveModel(model: Uint8Array | string): Promise<Uint8Array> {
+  if (typeof model !== "string") return model
+  if (/^https?:\/\//i.test(model)) {
+    const response = await fetch(model)
+    if (!response.ok) {
+      throw new Error(`failed to load model from ${model}: ${response.status} ${response.statusText}`)
+    }
+    return new Uint8Array(await response.arrayBuffer())
+  }
+  const filePath = model.startsWith("file://") ? fileURLToPath(model) : model
+  return new Uint8Array(await fs.readFile(filePath))
+}
+
+export const InferenceSession = {
+  ...onnx.InferenceSession,
+  async create(model: Uint8Array | string, options?: CreateOptions) {
+    return originalCreate(await resolveModel(model), options)
+  },
+}
+
 export * from "onnxruntime-web/wasm"
 export { default } from "onnxruntime-web/wasm"

--- a/packages/synergy/test/vector/embedding-standalone.test.ts
+++ b/packages/synergy/test/vector/embedding-standalone.test.ts
@@ -54,4 +54,36 @@ describe("standalone embedding runtime", () => {
     expect(code, stderr).toBe(0)
     expect(stdout).toContain("standalone embedding runtime ready")
   }, 30_000)
+
+  test("loads local model paths into buffers before reaching the WASM backend", async () => {
+    // Regression: transformers.js runs in Node mode under Bun and passes local
+    // model file paths to InferenceSession.create(). The WASM backend cannot
+    // read disk paths and falls back to fetch(path), which Bun rejects with
+    // "fetch() URL is invalid". The build plugin shim must convert paths to
+    // buffers so the backend reaches ONNX protobuf parsing instead.
+    const runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-embedding-standalone-path-"))
+    temporaryDirectories.push(runtimeDir)
+    const binary = path.join(runtimeDir, "bin", process.platform === "win32" ? "probe.exe" : "probe")
+    await fs.mkdir(path.dirname(binary), { recursive: true })
+
+    const output = await Bun.build({
+      entrypoints: [path.join(import.meta.dir, "fixture/embedding-standalone-path-entry.ts")],
+      conditions: ["browser"],
+      plugins: [standaloneEmbeddingBuildPlugin()],
+      define: { SYNERGY_STANDALONE: "true" },
+      compile: { outfile: binary },
+    })
+    expect(output.success, output.logs.map((log) => log.message).join("\n")).toBe(true)
+    await stageEmbeddingRuntimeAssets({ runtimeDir })
+
+    const proc = Bun.spawn([binary], { stdout: "pipe", stderr: "pipe" })
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+
+    expect(code, stderr).toBe(0)
+    expect(stdout).toContain("standalone embedding path shim ready")
+  }, 30_000)
 })

--- a/packages/synergy/test/vector/fixture/embedding-standalone-path-entry.ts
+++ b/packages/synergy/test/vector/fixture/embedding-standalone-path-entry.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { loadEmbeddingTransformersRuntime } from "../../../src/vector/embedding-runtime"
+import { InferenceSession } from "../../../script/embedding-onnxruntime-web"
+
+// Regression: transformers.js runs in Node mode under Bun and passes local
+// model file paths to InferenceSession.create(). The WASM backend cannot read
+// disk paths — its node:fs branch is compiled out — and falls back to
+// fetch(path), which Bun rejects with "fetch() URL is invalid". The build
+// plugin shim must convert local paths to buffers so the backend reaches ONNX
+// protobuf parsing instead.
+const loaded = await loadEmbeddingTransformersRuntime()
+if (!loaded.device) {
+  throw new Error("expected the standalone embedding runtime to select the WASM backend")
+}
+
+const modelDir = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-embedding-path-"))
+const modelPath = path.join(modelDir, "model.onnx")
+await fs.writeFile(modelPath, new Uint8Array([0]))
+
+try {
+  await InferenceSession.create(modelPath, { executionProviders: ["wasm"] })
+  throw new Error("expected an invalid ONNX model to be rejected")
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (!message.includes("protobuf parsing failed")) {
+    throw new Error(`expected protobuf parsing failure, got: ${message}`)
+  }
+}
+
+console.log("standalone embedding path shim ready")


### PR DESCRIPTION
## Summary
Fixes local embedding models failing to load in the standalone binary with `fetch() URL is invalid`.

## Root Cause
- transformers.js runs in Node mode under Bun (`process.release.name === "node"`), so it passes **local model file paths (strings)** to `InferenceSession.create()`.
- The standalone build plugin (`standaloneEmbeddingBuildPlugin`) replaces `onnxruntime-node` with the WASM backend (`onnxruntime-web/wasm`).
- The WASM backend's `node:fs` branch is compiled out (`if(!1)`), so it falls back to `fetch(path)`.
- Bun's `fetch()` rejects bare file paths with `TypeError: fetch() URL is invalid` (verified empirically: `file://` URLs work, bare paths don't).

Result: local embedding model download succeeds, but the extractor fails to load at pipeline initialization — both the network and `local_files_only` retry paths hit the same failure. The `wasmPaths`/`wasmBinary` preloading fix was working correctly; the failure happens one step later, when loading the ONNX **model file**.

## Fix
The build plugin shim (`script/embedding-onnxruntime-web.ts`) now wraps `InferenceSession.create` to resolve string inputs before reaching the WASM backend:
- disk paths / `file://` URLs → read into `Uint8Array` via `node:fs`
- `http(s)` URLs → fetched into `Uint8Array`
- already-buffered inputs pass through unchanged

## Verification
- Added regression test `loads local model paths into buffers before reaching the WASM backend` that compiles a standalone probe with the same build plugin + `SYNERGY_STANDALONE: true`, then calls `InferenceSession.create(localPath)`. Before the fix it failed with exactly `fetch() URL is invalid`; after the fix it reaches ONNX protobuf parsing as expected.
- All 3 tests in `test/vector/embedding-standalone.test.ts` pass.
- `tsc --noEmit`, oxlint, and prettier all clean.