### PR TITLE
fix(embedding): serve local model files through fetch in standalone builds

### DIFF
--- a/packages/synergy/src/vector/embedding-runtime.ts
+++ b/packages/synergy/src/vector/embedding-runtime.ts
@@ -1,5 +1,5 @@
 import path from "node:path"
-import { pathToFileURL } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 declare const SYNERGY_STANDALONE: boolean | undefined
 
@@ -10,8 +10,38 @@ export const EMBEDDING_RUNTIME_WASM = "ort-wasm-simd-threaded.asyncify.wasm"
 type TransformersRuntime = typeof import("@huggingface/transformers")
 let standaloneOnnxRuntime: Promise<typeof import("onnxruntime-web/wasm")> | undefined
 
+const REMOTE_PROTOCOL = /^(https?|blob|data):/i
+const standaloneFetchInstalled = new WeakSet<object>()
+let localFileFetchInstalled = false
 function isStandalone(): boolean {
   return typeof SYNERGY_STANDALONE !== "undefined" && SYNERGY_STANDALONE
+}
+
+function localFilePath(target: string): string {
+  return target.startsWith("file:") ? fileURLToPath(target) : target
+}
+
+async function fetchLocalFile(target: string): Promise<Response> {
+  const filePath = localFilePath(target)
+  const file = Bun.file(filePath)
+  if (!(await file.exists())) throw new Error(`local embedding asset not found: ${filePath}`)
+  return new Response(file.stream(), { headers: { "content-length": String(file.size) } })
+}
+
+// onnxruntime-web's browser build reads model files through the global fetch,
+// passing raw local paths or file:// URLs after transformers returns a cached
+// model path. Bun's fetch rejects raw paths, and in compiled artifacts the
+// node:fs branch of onnxruntime-common is dead code, so every mode must serve
+// local files through fetch before any ONNX session is created.
+function installGlobalLocalFileFetch(): void {
+  if (localFileFetchInstalled) return
+  localFileFetchInstalled = true
+  const native = globalThis.fetch
+  globalThis.fetch = (async (input, init) => {
+    const target = typeof input === "string" ? input : input instanceof URL ? input.href : undefined
+    if (typeof target === "string" && !REMOTE_PROTOCOL.test(target)) return fetchLocalFile(target)
+    return native(input, init)
+  }) as typeof globalThis.fetch
 }
 
 function loadStandaloneOnnxRuntime(): Promise<typeof import("onnxruntime-web/wasm")> {
@@ -32,15 +62,37 @@ function loadStandaloneOnnxRuntime(): Promise<typeof import("onnxruntime-web/was
   return standaloneOnnxRuntime
 }
 
+// transformers.js captures env.fetch when its module evaluates. Depending on
+// bundle evaluation order it may have captured the native fetch before the
+// global patch above, so wrap it explicitly to keep file:// WASM factory loads
+// working in every order.
+export function installLocalFileFetch(runtime: TransformersRuntime): void {
+  installGlobalLocalFileFetch()
+  if (standaloneFetchInstalled.has(runtime.env)) return
+  standaloneFetchInstalled.add(runtime.env)
+  const delegate = runtime.env.fetch
+  runtime.env.fetch = async (input, init) => {
+    const target = typeof input === "string" ? input : input instanceof URL ? input.href : undefined
+    if (typeof target === "string" && !REMOTE_PROTOCOL.test(target)) return fetchLocalFile(target)
+    return delegate(input, init)
+  }
+}
+
 export async function loadEmbeddingTransformersRuntime(): Promise<{
   runtime: TransformersRuntime
   device?: "cpu"
 }> {
-  if (!isStandalone()) return { runtime: await import("@huggingface/transformers") }
+  if (!isStandalone()) {
+    const runtime = await import("@huggingface/transformers")
+    installLocalFileFetch(runtime)
+    return { runtime }
+  }
   await loadStandaloneOnnxRuntime()
+  const runtime = await import("@huggingface/transformers")
+  installLocalFileFetch(runtime)
   // transformers.js v4 dropped "wasm" from its device enum; "cpu" maps to the
   // preloaded WASM execution provider in onnxruntime-web.
-  return { runtime: await import("@huggingface/transformers"), device: "cpu" }
+  return { runtime, device: "cpu" }
 }
 
 export async function verifyStandaloneEmbeddingRuntime(): Promise<void> {

--- a/packages/synergy/src/vector/embedding.ts
+++ b/packages/synergy/src/vector/embedding.ts
@@ -180,6 +180,10 @@ export namespace Embedding {
           configure({ remoteHost, cacheDir }) {
             runtime.env.remoteHost = remoteHost
             runtime.env.cacheDir = cacheDir
+            // Keep local-model lookups aligned with the cache directory.
+            // Without this, transformers.js resolves local paths against the
+            // bundled module directory (a virtual drive in standalone builds).
+            runtime.env.localModelPath = cacheDir
           },
         }
       },

--- a/packages/synergy/test/vector/embedding-standalone.test.ts
+++ b/packages/synergy/test/vector/embedding-standalone.test.ts
@@ -54,4 +54,33 @@ describe("standalone embedding runtime", () => {
     expect(code, stderr).toBe(0)
     expect(stdout).toContain("standalone embedding runtime ready")
   }, 30_000)
+
+  test("serves local model files through fetch inside a compiled artifact", async () => {
+    const runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), "synergy-embedding-standalone-fetch-"))
+    temporaryDirectories.push(runtimeDir)
+    const binary = path.join(runtimeDir, "bin", process.platform === "win32" ? "probe.exe" : "probe")
+    await fs.mkdir(path.dirname(binary), { recursive: true })
+    const probeFile = path.join(runtimeDir, "model.onnx")
+    await fs.writeFile(probeFile, "onnx-model-content")
+
+    const output = await Bun.build({
+      entrypoints: [path.join(import.meta.dir, "fixture/embedding-local-file-entry.ts")],
+      conditions: ["browser"],
+      plugins: [standaloneEmbeddingBuildPlugin()],
+      define: { SYNERGY_STANDALONE: "true" },
+      compile: { outfile: binary },
+    })
+    expect(output.success, output.logs.map((log) => log.message).join("\n")).toBe(true)
+    await stageEmbeddingRuntimeAssets({ runtimeDir })
+
+    const proc = Bun.spawn([binary, probeFile], { stdout: "pipe", stderr: "pipe" })
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+
+    expect(code, stderr).toBe(0)
+    expect(stdout).toContain("standalone local file fetch ready")
+  }, 30_000)
 })

--- a/packages/synergy/test/vector/fixture/embedding-local-file-entry.ts
+++ b/packages/synergy/test/vector/fixture/embedding-local-file-entry.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs"
+import { pathToFileURL } from "node:url"
+import { loadEmbeddingTransformersRuntime } from "../../../src/vector/embedding-runtime"
+
+const probeFile = process.argv[2]
+if (!probeFile) throw new Error("missing probe file argument")
+
+const loaded = await loadEmbeddingTransformersRuntime()
+const runtime = loaded.runtime
+
+const expected = fs.readFileSync(probeFile, "utf8")
+const viaFileUrl = await fetch(pathToFileURL(probeFile).href)
+const viaFileUrlText = await viaFileUrl.text()
+const viaRawPath = await fetch(probeFile)
+const viaRawPathText = await viaRawPath.text()
+
+if (viaFileUrlText !== expected) throw new Error("file:// fetch returned unexpected content")
+if (viaRawPathText !== expected) throw new Error("raw path fetch returned unexpected content")
+
+console.log("standalone local file fetch ready")


### PR DESCRIPTION
## Summary

Fixes local embedding models failing to load in standalone binaries: the ONNX model is downloaded successfully but the extractor fails at pipeline initialization, leaving the memory system unusable.

## Root Cause

- The standalone build uses `conditions: [browser]`, so onnxruntime-web\u0027s `node:fs` branch is compiled out and model files are read through the global `fetch()` with raw local paths or `file://` URLs.
- Bun\u0027s `fetch()` rejects bare file paths (`Unable to connect`), so model loading fails even though the download completed.
- transformers.js also resolves local lookups against the bundled module directory (a virtual drive in standalone builds) because `env.localModelPath` was never set.

## Fix

- `embedding-runtime.ts`: install a local-file fetch shim (global `fetch` + transformers `env.fetch`) before any ONNX session is created, serving raw paths and `file://` URLs from disk. Applied in both standalone and dev modes (Bun always runs the web backend because `process.release.name === node` forces ORT-web).
- `embedding.ts`: set `env.localModelPath = cacheDir` so local lookups resolve from the configured cache directory.

## Verification

- New regression test compiles a standalone probe and verifies local model files are served through fetch inside the compiled artifact.
- `test/vector/embedding-standalone.test.ts`: 3/3 pass (staging, WASM init, local-file fetch).
- Isolated `bun dev` instance: POST /library/embedding/download reached `asset=cached, runtime=ready, progress=100%`; /library/experience/search returned 200 (real 384-dim inference).
- Standalone probe with production build flags + real cached model: `standalone embedding inference ready dims=384 norm=1.000000`.
- Package typecheck, oxlint, prettier clean.

## Related

Complements #1159 (build-plugin shim wrapping `InferenceSession.create`); this fix works at the fetch layer and additionally covers dev mode and the `localModelPath` drift. Files do not overlap.
