### PR TITLE
TTAWDTT: Add viewport-safe UI zoom

### DIFF
--- a/packages/app/src/app-i18n.ts
+++ b/packages/app/src/app-i18n.ts
@@ -170,6 +170,9 @@ export const AP = {
     message: "Search sessions across all projects",
   },
   layoutColorSchemeUse: { id: "app.layout.colorScheme.use", message: "Use color scheme: {scheme}" },
+  layoutZoomIn: { id: "app.layout.zoom.in", message: "Zoom in" },
+  layoutZoomOut: { id: "app.layout.zoom.out", message: "Zoom out" },
+  layoutZoomReset: { id: "app.layout.zoom.reset", message: "Reset zoom" },
   layoutLeftWorktree: { id: "app.layout.worktree.left", message: "Left worktree" },
   layoutMovedToWorktree: { id: "app.layout.worktree.moved", message: "Moved to worktree" },
   layoutWorktreeDesc: {

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -25,6 +25,7 @@ import { AuthProvider } from "@/context/auth"
 import { HolosProvider } from "@/context/holos"
 import { InputProvider } from "@/context/input"
 import { FontPreferenceProvider } from "@/context/font-preference"
+import { ZoomController } from "@/context/zoom"
 import Layout from "@/pages/layout"
 import DirectoryLayout from "@/pages/directory-layout"
 import { FatalErrorPage } from "./pages/fatal-error"
@@ -122,6 +123,7 @@ export function AppBaseProviders(props: ParentProps) {
   return (
     <MetaProvider>
       <Font />
+      <ZoomController />
       <LocaleProvider>
         <FontPreferenceProvider>
           <ThemeProvider>

--- a/packages/app/src/components/file-workbench/explorer.tsx
+++ b/packages/app/src/components/file-workbench/explorer.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { VList, type VListHandle } from "virtua/solid"
 import { useFile } from "@/context/file"
+import { zoom } from "@/context/zoom"
 import { fileExplorer as X } from "@/locales/messages"
 
 type TreeNodeRow = { kind: "node"; path: string; level: number; parent: string }
@@ -159,6 +160,7 @@ export function FileExplorer(props: { onClose: () => void }) {
         direction="horizontal"
         edge="start"
         size={file.explorer.width()}
+        coordinateScale={zoom()}
         min={220}
         max={420}
         collapseThreshold={180}

--- a/packages/app/src/components/workspace/workbench-surface.tsx
+++ b/packages/app/src/components/workspace/workbench-surface.tsx
@@ -26,6 +26,8 @@ import type {
 import "./workbench-surface.css"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
 import { workspace as W } from "@/locales/messages"
+import { zoom } from "@/context/zoom"
+import { layoutSizeForZoom } from "@/context/zoom-layout"
 import {
   DragDropProvider,
   DragDropSensors,
@@ -293,14 +295,21 @@ export function WorkbenchSurface(props: { surface: WorkbenchPanelSurface }) {
     onCleanup(() => document.removeEventListener("keydown", onKey, { capture: true }))
   })
 
-  const size = () => state().size()
   const isSide = () => props.surface === "side"
   const maxSideWidth = () =>
     Math.max(
       WORKSPACE_MIN_WIDTH,
-      computeMaxWorkspaceWidth(window.innerWidth, { sessionMinWidth: WORKSPACE_SESSION_MIN_WIDTH }),
+      computeMaxWorkspaceWidth(layoutSizeForZoom(window.innerWidth, zoom()), {
+        sessionMinWidth: WORKSPACE_SESSION_MIN_WIDTH,
+      }),
     )
-  const maxBottomHeight = () => window.innerHeight * 0.6
+  const maxBottomHeight = () => layoutSizeForZoom(window.innerHeight, zoom()) * 0.6
+
+  const maxSize = () => (isSide() ? maxSideWidth() : maxBottomHeight())
+  const size = () => {
+    const min = isSide() ? WORKSPACE_MIN_WIDTH : 120
+    return Math.min(maxSize(), Math.max(min, state().size()))
+  }
 
   const rootStyle = () =>
     isSide()
@@ -339,8 +348,9 @@ export function WorkbenchSurface(props: { surface: WorkbenchPanelSurface }) {
         direction={isSide() ? "horizontal" : "vertical"}
         edge={isSide() ? "start" : undefined}
         size={size()}
+        coordinateScale={zoom()}
         min={isSide() ? WORKSPACE_MIN_WIDTH : 120}
-        max={isSide() ? maxSideWidth() : maxBottomHeight()}
+        max={maxSize()}
         collapseThreshold={isSide() ? 200 : 50}
         onResize={state().setSize}
         onResizeStart={() => setLocal("resizing", true)}

--- a/packages/app/src/context/zoom-layout.ts
+++ b/packages/app/src/context/zoom-layout.ts
@@ -1,0 +1,8 @@
+/**
+ * Convert a viewport measurement from browser pixels to the layout coordinate
+ * space used by elements below a CSS zoom root.
+ */
+export function layoutSizeForZoom(size: number, zoom: number): number {
+  if (!Number.isFinite(size) || !Number.isFinite(zoom) || zoom <= 0) return size
+  return size / zoom
+}

--- a/packages/app/src/context/zoom.ts
+++ b/packages/app/src/context/zoom.ts
@@ -1,0 +1,97 @@
+import { createEffect, createSignal, onCleanup } from "solid-js"
+
+const STORAGE_KEY = "synergy.ui.zoom"
+const MIN_ZOOM = 0.5
+const MAX_ZOOM = 2.0
+const ZOOM_STEP = 0.1
+const WHEEL_THROTTLE_MS = 50
+
+/** Round to the nearest 0.1 (ZOOM_STEP) to avoid float drift. */
+function roundStep(value: number): number {
+  return Math.round(value / ZOOM_STEP) * ZOOM_STEP
+}
+
+function clamp(value: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, roundStep(value)))
+}
+
+function readStoredZoom(): number {
+  const stored = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null
+  if (!stored) return 1
+  const parsed = Number.parseFloat(stored)
+  if (!Number.isFinite(parsed)) return 1
+  return clamp(parsed)
+}
+
+/** The global zoom factor in use (1 = 100%). */
+export const [zoom, setZoom] = createSignal(readStoredZoom())
+
+export function zoomIn(): void {
+  setZoom(clamp(zoom() + ZOOM_STEP))
+}
+
+export function zoomOut(): void {
+  setZoom(clamp(zoom() - ZOOM_STEP))
+}
+
+export function zoomReset(): void {
+  setZoom(1)
+}
+
+function applyZoom(value: number): void {
+  if (typeof document === "undefined") return
+  const root = document.documentElement
+  root.style.zoom = String(value)
+
+  // CSS zoom changes the visual size of the root, but viewport units and the
+  // browser's innerWidth/innerHeight remain in unscaled pixels. Keep the
+  // layout box in the inverse coordinate space so its visual size still fits
+  // the window at every zoom level.
+  root.style.width = `calc(100vw / ${value})`
+  root.style.height = `calc(100vh / ${value})`
+}
+
+// Apply on signal change + persist.
+createEffect(() => {
+  applyZoom(zoom())
+  try {
+    localStorage.setItem(STORAGE_KEY, String(zoom()))
+  } catch {
+    // storage may be unavailable (private mode); ignore
+  }
+})
+
+function handleWheel(event: WheelEvent): void {
+  if (!event.ctrlKey && !event.metaKey) return
+  if (event.deltaY === 0) return
+  const direction = event.deltaY < 0 ? 1 : -1
+  setZoom(clamp(zoom() + direction * ZOOM_STEP))
+}
+
+let lastWheelAt = 0
+function handleWheelThrottled(event: WheelEvent): void {
+  if (!event.ctrlKey && !event.metaKey) return
+  event.preventDefault()
+  const now = Date.now()
+  if (now - lastWheelAt < WHEEL_THROTTLE_MS) return
+  lastWheelAt = now
+  handleWheel(event)
+}
+
+/**
+ * Mounts global zoom listeners. Call once from the app root.
+ * Captures wheel before the browser's native ctrl+wheel page zoom.
+ */
+export function ZoomController(): null {
+  createEffect(() => {
+    const onWheel = (event: WheelEvent) => handleWheelThrottled(event)
+
+    // capture phase so we win over any app-level wheel handlers
+    window.addEventListener("wheel", onWheel, { capture: true, passive: false })
+    onCleanup(() => {
+      window.removeEventListener("wheel", onWheel, { capture: true })
+    })
+  })
+
+  return null
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -14,6 +14,14 @@ html[data-color-scheme] #root {
   color: var(--text-base, var(--synergy-boot-text));
 }
 
+html,
+body,
+#root {
+  /* ZoomController sizes the html box in inverse zoom coordinates. */
+  width: 100%;
+  height: 100%;
+}
+
 a {
   cursor: default;
 }

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -3524,6 +3524,21 @@ msgstr "Move to worktree failed"
 msgid "app.layout.worktree.refreshFailed"
 msgstr "Workspace status refresh failed"
 
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.in"
+msgstr "Zoom in"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.out"
+msgstr "Zoom out"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.reset"
+msgstr "Reset zoom"
+
 #. ── Library ───────────────────────────────────────────────────────────────────
 msgid "app.library.category.asset"
 msgstr "Asset"

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -3524,6 +3524,21 @@ msgstr ""
 msgid "app.layout.worktree.refreshFailed"
 msgstr ""
 
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.in"
+msgstr ""
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.out"
+msgstr ""
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.reset"
+msgstr ""
+
 #. ── Library ───────────────────────────────────────────────────────────────────
 msgid "app.library.category.asset"
 msgstr ""

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -3524,6 +3524,21 @@ msgstr "无法移至隔离工作区"
 msgid "app.layout.worktree.refreshFailed"
 msgstr "工作区状态刷新失败"
 
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.in"
+msgstr "放大"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.out"
+msgstr "缩小"
+
+#. Runtime Lingui descriptors for app shell, entry, commands, and pages.
+ *  Translate at use time via `useLocale().i18n._(descriptor)`.
+msgid "app.layout.zoom.reset"
+msgstr "重置缩放"
+
 #. ── Library ───────────────────────────────────────────────────────────────────
 msgid "app.library.category.asset"
 msgstr "资产"

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/app-shell"
 import { useProjectDirectoryPicker } from "@/components/dialog/project-directory-picker"
 import { WorkbenchPanelsProvider } from "@/context/workbench"
+import { zoomIn, zoomOut, zoomReset } from "@/context/zoom"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore] = createStore({
@@ -339,6 +340,27 @@ export default function Layout(props: ParentProps) {
         keybind: "mod+shift+t",
         slash: "theme",
         onSelect: () => cycleColorScheme(1),
+      },
+      {
+        id: "zoom.in",
+        title: i18n._(AP.layoutZoomIn.id),
+        category: "View",
+        keybind: "mod+=",
+        onSelect: () => zoomIn(),
+      },
+      {
+        id: "zoom.out",
+        title: i18n._(AP.layoutZoomOut.id),
+        category: "View",
+        keybind: "mod+-",
+        onSelect: () => zoomOut(),
+      },
+      {
+        id: "zoom.reset",
+        title: i18n._(AP.layoutZoomReset.id),
+        category: "View",
+        keybind: "mod+0",
+        onSelect: () => zoomReset(),
       },
       {
         id: "help.show",

--- a/packages/app/test/context/zoom-layout.test.ts
+++ b/packages/app/test/context/zoom-layout.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { layoutSizeForZoom } from "../../src/context/zoom-layout"
+
+describe("layoutSizeForZoom", () => {
+  test("converts viewport pixels into CSS zoom coordinates", () => {
+    expect(layoutSizeForZoom(720, 1.2)).toBe(600)
+    expect(layoutSizeForZoom(720, 0.5)).toBe(1440)
+  })
+
+  test("keeps the default scale unchanged", () => {
+    expect(layoutSizeForZoom(1280, 1)).toBe(1280)
+  })
+
+  test("falls back safely for invalid scales", () => {
+    expect(layoutSizeForZoom(720, 0)).toBe(720)
+    expect(layoutSizeForZoom(720, Number.NaN)).toBe(720)
+  })
+})

--- a/packages/synergy/test/tool/openai-image-gen.test.ts
+++ b/packages/synergy/test/tool/openai-image-gen.test.ts
@@ -229,7 +229,12 @@ describe("tool.openai_image_gen", () => {
     await using tmp = await tmpdir({ git: true })
     await connectCodex()
     let fetchCalls = 0
-    globalThis.fetch = asFetch(async () => {
+    globalThis.fetch = asFetch(async (input) => {
+      // Test shards share globalThis.fetch, so unrelated requests must not
+      // affect the assertion that invalid image arguments make no image call.
+      if (!String(input).includes("/images/")) {
+        return jsonResponse({ error: { message: "unrelated" } }, { status: 200 })
+      }
       fetchCalls++
       return jsonResponse({})
     })

--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -11,6 +11,8 @@ export interface ResizeHandleProps extends Omit<JSX.HTMLAttributes<HTMLDivElemen
   onResizeEnd?: () => void
   onCollapse?: () => void
   collapseThreshold?: number
+  /** Scale applied by an ancestor CSS zoom when converting pointer deltas. */
+  coordinateScale?: number
 }
 
 export function ResizeHandle(props: ResizeHandleProps) {
@@ -25,6 +27,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
     "onResizeEnd",
     "onCollapse",
     "collapseThreshold",
+    "coordinateScale",
     "class",
     "classList",
   ])
@@ -42,7 +45,10 @@ export function ResizeHandle(props: ResizeHandleProps) {
     const edge = local.edge ?? "end"
     const onMouseMove = (moveEvent: MouseEvent) => {
       const pos = local.direction === "horizontal" ? moveEvent.clientX : moveEvent.clientY
-      const delta = edge === "start" ? start - pos : pos - start
+      const rawDelta = edge === "start" ? start - pos : pos - start
+      const coordinateScale =
+        typeof local.coordinateScale === "number" && local.coordinateScale > 0 ? local.coordinateScale : 1
+      const delta = rawDelta / coordinateScale
       current = startSize + delta
       const clamped = Math.min(local.max, Math.max(local.min, current))
       local.onResize(clamped)


### PR DESCRIPTION
## Summary

- add persistent UI zoom controls from 50% to 200% through keyboard shortcuts, Ctrl/Cmd + mouse wheel, and the command palette
- keep the root layout, workbench size limits, and resize-handle pointer deltas correct under CSS zoom
- preserve the viewport-filling app surface at every supported scale

## Testing

- `bun test test/context/zoom-layout.test.ts test/context/layout/workspace.test.ts`
- `bunx oxlint -c oxlintrc.json --deny-warnings packages/app/src/context/zoom.ts`
- `bun run build` (in `packages/app`)