### PR TITLE
perf(observability): silence expected storage misses and add performance toggle

### DIFF
--- a/packages/app/src/components/performance/browser-metrics.ts
+++ b/packages/app/src/components/performance/browser-metrics.ts
@@ -64,8 +64,17 @@ export function mergeTokenReceipt(current: TokenReceipt | undefined, next: Token
   }
 }
 
-export function startBrowserPerformanceMetrics(input: { url: string; client: SynergyClient }) {
-  if (started || typeof window === "undefined") return
+// Mirror the backend ObservabilityConfig.effective() semantics: the master
+// observability.enabled flag wins when performance.enabled is unset. The
+// collector must not run when the effective value is false.
+export function browserPerformanceEnabled(config?: {
+  observability?: { enabled?: boolean; performance?: { enabled?: boolean } }
+}): boolean {
+  return config?.observability?.performance?.enabled ?? config?.observability?.enabled ?? true
+}
+
+export function startBrowserPerformanceMetrics(input: { url: string; client: SynergyClient }): boolean {
+  if (started || typeof window === "undefined") return started
   started = true
 
   const flush = () => void flushBrowserMetrics(input)
@@ -87,6 +96,7 @@ export function startBrowserPerformanceMetrics(input: { url: string; client: Syn
   cleanup.push(() => window.removeEventListener("pagehide", flushOnPageHide))
   cleanup.push(() => window.removeEventListener("popstate", onLocationChange))
   cleanup.push(() => window.removeEventListener("hashchange", onLocationChange))
+  return true
 }
 
 function enqueue(entry: QueueEntry) {

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -312,6 +312,15 @@ function buildRuntimePatch(cfg: Config, state: SettingsState, patch: Record<stri
 
   const logLevel = runtime.logLevel.trim()
   if (logLevel !== (cfg.logLevel ?? UI_DEFAULTS.logLevel)) patch.logLevel = logLevel || undefined
+
+  const performanceEnabled = runtime.performanceEnabled !== "false"
+  const currentPerformanceEnabled = cfg.observability?.performance?.enabled !== false
+  if (performanceEnabled !== currentPerformanceEnabled) {
+    patch.observability = {
+      ...(cfg.observability ?? {}),
+      performance: { ...(cfg.observability?.performance ?? {}), enabled: performanceEnabled },
+    }
+  }
 }
 
 function buildTimeoutPatch(cfg: Config, runtime: SettingsState["runtime"]) {

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -314,7 +314,10 @@ function buildRuntimePatch(cfg: Config, state: SettingsState, patch: Record<stri
   if (logLevel !== (cfg.logLevel ?? UI_DEFAULTS.logLevel)) patch.logLevel = logLevel || undefined
 
   const performanceEnabled = runtime.performanceEnabled !== "false"
-  const currentPerformanceEnabled = cfg.observability?.performance?.enabled !== false
+  // The effective backend value honors the master observability.enabled flag
+  // when performance.enabled is unset; mirror that so the switch shows the
+  // real runtime state and one save can re-enable a master-disabled setup.
+  const currentPerformanceEnabled = cfg.observability?.performance?.enabled ?? cfg.observability?.enabled ?? true
   if (performanceEnabled !== currentPerformanceEnabled) {
     patch.observability = {
       ...(cfg.observability ?? {}),

--- a/packages/app/src/components/settings/hooks/useSettingsForm.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.ts
@@ -144,6 +144,7 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
     toolOverrides: formatRecord(cfg.timeout?.tool?.overrides),
     watcherIgnore: formatList(cfg.watcher?.ignore),
     logLevel: cfg.logLevel ?? UI_DEFAULTS.logLevel,
+    performanceEnabled: cfg.observability?.performance?.enabled !== false ? "true" : "false",
     coauthorReminder: cfg.experimental?.coauthor_reminder !== false ? "true" : "false",
     bossMode: cfg.experimental?.boss_mode === true ? "true" : "false",
     bossIdentityText: cfg.experimental?.boss_identity_text ?? "",

--- a/packages/app/src/components/settings/hooks/useSettingsForm.ts
+++ b/packages/app/src/components/settings/hooks/useSettingsForm.ts
@@ -144,7 +144,8 @@ export function ensureInit(params: EnsureInitParams): string | undefined {
     toolOverrides: formatRecord(cfg.timeout?.tool?.overrides),
     watcherIgnore: formatList(cfg.watcher?.ignore),
     logLevel: cfg.logLevel ?? UI_DEFAULTS.logLevel,
-    performanceEnabled: cfg.observability?.performance?.enabled !== false ? "true" : "false",
+    performanceEnabled:
+      (cfg.observability?.performance?.enabled ?? cfg.observability?.enabled ?? true) === false ? "false" : "true",
     coauthorReminder: cfg.experimental?.coauthor_reminder !== false ? "true" : "false",
     bossMode: cfg.experimental?.boss_mode === true ? "true" : "false",
     bossIdentityText: cfg.experimental?.boss_identity_text ?? "",

--- a/packages/app/src/components/settings/panels/RuntimePanels.tsx
+++ b/packages/app/src/components/settings/panels/RuntimePanels.tsx
@@ -162,6 +162,15 @@ const watcherRowDesc = {
   id: "settings.runtime.observ.watcher.desc",
   message: "Patterns the file watcher should skip, one per line.",
 }
+const performanceEnabledRowTitle = {
+  id: "settings.runtime.observ.performanceEnabled.title",
+  message: "Performance Monitoring",
+}
+const performanceEnabledRowDesc = {
+  id: "settings.runtime.observ.performanceEnabled.desc",
+  message:
+    "Collect local performance metrics, traces, and diagnostics. Disable to stop all background sampling and writes.",
+}
 const shellSectionTitle = { id: "settings.runtime.observ.shell.title", message: "Desktop Shell Environment" }
 const shellSectionDesc = {
   id: "settings.runtime.observ.shell.desc",
@@ -474,6 +483,16 @@ export function ObservabilityPanel(props: {
   return (
     <SettingsPage title={_(observPageTitle)} description={_(observPageDesc)}>
       <SettingsSection title={_(loggingSectionTitle)}>
+        <SettingRow
+          title={_(performanceEnabledRowTitle)}
+          description={_(performanceEnabledRowDesc)}
+          trailing={
+            <Switch
+              checked={props.runtime.performanceEnabled !== "false"}
+              onChange={(value) => props.onRuntimeChange("performanceEnabled", value ? "true" : "false")}
+            />
+          }
+        />
         <SettingRow
           title={_(logLevelRowTitle)}
           description={_(logLevelRowDesc)}

--- a/packages/app/src/components/settings/types.ts
+++ b/packages/app/src/components/settings/types.ts
@@ -73,6 +73,7 @@ export const UI_DEFAULTS = {
   toolOverrides: "" as string,
   watcherIgnore: "" as string,
   logLevel: "" as string,
+  performanceEnabled: "true" as "true" | "false",
   coauthorReminder: "true" as string,
   bossMode: "false" as "true" | "false",
   bossIdentityText: "" as string,
@@ -363,6 +364,7 @@ export type RuntimeStore = {
   toolOverrides: string
   watcherIgnore: string
   logLevel: string
+  performanceEnabled: "true" | "false"
   coauthorReminder: string
   bossMode: "true" | "false"
   bossIdentityText: string
@@ -460,6 +462,7 @@ export function defaultSettingsState(sendShortcut: SendShortcut, colorScheme: Co
       toolOverrides: UI_DEFAULTS.toolOverrides,
       watcherIgnore: UI_DEFAULTS.watcherIgnore,
       logLevel: UI_DEFAULTS.logLevel,
+      performanceEnabled: UI_DEFAULTS.performanceEnabled,
       coauthorReminder: UI_DEFAULTS.coauthorReminder,
       bossMode: UI_DEFAULTS.bossMode,
       bossIdentityText: UI_DEFAULTS.bossIdentityText,

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -4,11 +4,7 @@ import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, createSignal, onCleanup } from "solid-js"
 import { createEventQueue } from "./event-queue"
 import { usePlatform } from "./platform"
-import {
-  recordTokenReceive,
-  startBrowserPerformanceMetrics,
-  stopBrowserPerformanceMetrics,
-} from "@/components/performance/browser-metrics"
+import { recordTokenReceive, stopBrowserPerformanceMetrics } from "@/components/performance/browser-metrics"
 import { useServer } from "./server"
 import { streamingTokenReceipt } from "./streaming-token-event"
 
@@ -172,8 +168,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       fetch: platform.fetch,
       throwOnError: true,
     })
-
-    startBrowserPerformanceMetrics({ url: server.url, client: sdk })
 
     return { url: server.url, client: sdk, event: emitter, connected, disconnectedAt }
   },

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -90,7 +90,12 @@ import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { getFilename } from "@ericsanchezok/synergy-util/path"
 import { HOME_SCOPE_KEY, isHomeScope } from "@/utils/scope"
-import { recordTokenApply } from "@/components/performance/browser-metrics"
+import {
+  browserPerformanceEnabled,
+  recordTokenApply,
+  startBrowserPerformanceMetrics,
+  stopBrowserPerformanceMetrics,
+} from "@/components/performance/browser-metrics"
 
 type GlobalPaths = {
   home: string
@@ -1801,6 +1806,19 @@ function createGlobalSync() {
     if (isConnected && globalStore.ready) {
       void resyncInstances(Object.keys(children))
       void loadGlobalAgenda()
+    }
+  })
+
+  // Drive the browser performance collector from the effective config. The
+  // server drops batches when observability is disabled, but the collector
+  // itself (observers, timers, network) must stop too — start/stop on every
+  // config change so a live toggle applies immediately.
+  createEffect(() => {
+    if (!globalStore.ready) return
+    if (browserPerformanceEnabled(globalStore.config)) {
+      startBrowserPerformanceMetrics({ url: globalSDK.url, client: globalSDK.client })
+    } else {
+      stopBrowserPerformanceMetrics()
     }
   })
 

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -17405,6 +17405,14 @@ msgid "settings.runtime.observ.page.title"
 msgstr "Observability"
 
 #. js-lingui-explicit-id
+msgid "settings.runtime.observ.performanceEnabled.desc"
+msgstr "Collect local performance metrics, traces, and diagnostics. Disable to stop all background sampling and writes."
+
+#. js-lingui-explicit-id
+msgid "settings.runtime.observ.performanceEnabled.title"
+msgstr "Performance Monitoring"
+
+#. js-lingui-explicit-id
 msgid "settings.runtime.observ.shell.command.found"
 msgstr "Resolved"
 

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -17405,6 +17405,14 @@ msgid "settings.runtime.observ.page.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+msgid "settings.runtime.observ.performanceEnabled.desc"
+msgstr ""
+
+#. js-lingui-explicit-id
+msgid "settings.runtime.observ.performanceEnabled.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 msgid "settings.runtime.observ.shell.command.found"
 msgstr ""
 

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -17405,6 +17405,14 @@ msgid "settings.runtime.observ.page.title"
 msgstr "可观测性"
 
 #. js-lingui-explicit-id
+msgid "settings.runtime.observ.performanceEnabled.desc"
+msgstr "收集本地性能指标、追踪与诊断信息。关闭后停止全部后台采样与写入。"
+
+#. js-lingui-explicit-id
+msgid "settings.runtime.observ.performanceEnabled.title"
+msgstr "性能监控"
+
+#. js-lingui-explicit-id
 msgid "settings.runtime.observ.shell.command.found"
 msgstr "已解析"
 

--- a/packages/app/test/components/performance/browser-metrics.test.ts
+++ b/packages/app/test/components/performance/browser-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  browserPerformanceEnabled,
   buildSessionSwitchMetrics,
   buildTokenTimingMetric,
   fitBrowserMetricBatch,
@@ -7,6 +8,27 @@ import {
   pageContextFromUrl,
   shouldRetryBrowserMetricBatch,
 } from "../../../src/components/performance/browser-metrics"
+
+describe("browser performance effective enablement", () => {
+  test("defaults to enabled when no observability config is present", () => {
+    expect(browserPerformanceEnabled()).toBe(true)
+    expect(browserPerformanceEnabled({})).toBe(true)
+  })
+
+  test("honors explicit performance.enabled", () => {
+    expect(browserPerformanceEnabled({ observability: { performance: { enabled: false } } })).toBe(false)
+    expect(browserPerformanceEnabled({ observability: { performance: { enabled: true } } })).toBe(true)
+  })
+
+  test("falls back to the master observability.enabled switch", () => {
+    expect(browserPerformanceEnabled({ observability: { enabled: false } })).toBe(false)
+    expect(browserPerformanceEnabled({ observability: { enabled: true } })).toBe(true)
+  })
+
+  test("performance.enabled wins over the master switch", () => {
+    expect(browserPerformanceEnabled({ observability: { enabled: false, performance: { enabled: true } } })).toBe(true)
+  })
+})
 
 describe("browser performance metrics", () => {
   test("builds safe route and session context", () => {

--- a/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
@@ -734,3 +734,39 @@ describe("settings config patch activity display", () => {
     )
   })
 })
+
+describe("settings config patch performance monitoring", () => {
+  test("does not emit a performance patch when the form matches the effective value", () => {
+    const state = defaultSettingsState("enter")
+    state.runtime.performanceEnabled = "false"
+    expect(
+      buildPatch({
+        cfg: { observability: { enabled: false } } as Config,
+        state,
+        originalMcps: {},
+      }),
+    ).not.toHaveProperty("observability")
+  })
+
+  test("emits performance.enabled true when the master switch disabled it and the form is on", () => {
+    const state = defaultSettingsState("enter")
+    state.runtime.performanceEnabled = "true"
+    const patch = buildPatch({
+      cfg: { observability: { enabled: false } } as Config,
+      state,
+      originalMcps: {},
+    })
+    expect((patch.observability as { performance?: { enabled?: boolean } })?.performance?.enabled).toBe(true)
+  })
+
+  test("emits performance.enabled false when only performance.enabled is set on the server", () => {
+    const state = defaultSettingsState("enter")
+    state.runtime.performanceEnabled = "false"
+    const patch = buildPatch({
+      cfg: { observability: { performance: { enabled: true } } } as Config,
+      state,
+      originalMcps: {},
+    })
+    expect((patch.observability as { performance?: { enabled?: boolean } })?.performance?.enabled).toBe(false)
+  })
+})

--- a/packages/app/test/components/settings/hooks/useSettingsForm.test.ts
+++ b/packages/app/test/components/settings/hooks/useSettingsForm.test.ts
@@ -107,6 +107,21 @@ describe("settings form boss mode", () => {
   })
 })
 
+describe("settings form performance monitoring", () => {
+  test("defaults performance monitoring on when observability config is absent", () => {
+    expect(initializedRuntime({}).performanceEnabled).toBe("true")
+  })
+
+  test("hydrates explicit performance.enabled false", () => {
+    expect(initializedRuntime({ observability: { performance: { enabled: false } } }).performanceEnabled).toBe("false")
+  })
+
+  test("honors the master observability.enabled switch when performance.enabled is unset", () => {
+    expect(initializedRuntime({ observability: { enabled: false } }).performanceEnabled).toBe("false")
+    expect(initializedRuntime({ observability: { enabled: true } }).performanceEnabled).toBe("true")
+  })
+})
+
 describe("settings form channel accounts", () => {
   test("hydrates Feishu model overrides and Clarus enablement", () => {
     expect(

--- a/packages/synergy/src/config/config.ts
+++ b/packages/synergy/src/config/config.ts
@@ -1318,8 +1318,11 @@ export namespace Config {
   }
 
   export async function globalRaw() {
-    await migrateLegacyGlobalConfig()
-    return loadDomainDirectory(Global.Path.config)
+    // global() lazily loads and caches the merged domain directory. Every
+    // write path (reload, domain update, import, setup, watcher auto-reload)
+    // resets that cache, so reads are cheap without serving stale config
+    // after a commit. Clone on the way out so callers cannot mutate the cache.
+    return structuredClone(await global())
   }
 
   export const DomainSummary = z

--- a/packages/synergy/src/note/store.ts
+++ b/packages/synergy/src/note/store.ts
@@ -164,7 +164,9 @@ export namespace NoteStore {
   async function loadIndex(scopeID: string): Promise<Metadata[]> {
     const sid = Identifier.asScopeID(scopeID)
     try {
-      const raw = await Storage.read<unknown>(indexPath(sid))
+      // A missing index is an expected first-run state, not a storage fault:
+      // fall through to a rebuild without raising a storage issue.
+      const raw = await Storage.read<unknown>(indexPath(sid), { silentNotFound: true })
       if (!Array.isArray(raw)) return rebuildIndex(scopeID)
       const entries = raw
         .map((entry) => normalizeMetadataEntry(entry, scopeID))
@@ -226,8 +228,14 @@ export namespace NoteStore {
     noteID: string,
   ): Promise<{ scopeID: string; note: z.infer<typeof NoteTypes.Info> }> {
     const sid = Identifier.asScopeID(scopeID)
+    // Cross-scope probing is expected control flow: a note legitimately
+    // missing from one scope is a miss, not a storage fault. Probe reads
+    // stay silent so ordinary lookups stop raising PERF_STORAGE_OPERATION_ERROR
+    // issues for every scope that does not own the note.
     try {
-      const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(sid, noteID))
+      const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(sid, noteID), {
+        silentNotFound: true,
+      })
       return { scopeID, note: normalize(note) }
     } catch {
       // fallthrough
@@ -235,7 +243,9 @@ export namespace NoteStore {
     if (scopeID !== HOME_SCOPE_ID) {
       const globalSid = Identifier.asScopeID(HOME_SCOPE_ID)
       try {
-        const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(globalSid, noteID))
+        const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(StoragePath.note(globalSid, noteID), {
+          silentNotFound: true,
+        })
         return { scopeID: HOME_SCOPE_ID, note: normalize(note) }
       } catch {
         // fallthrough
@@ -247,6 +257,7 @@ export namespace NoteStore {
       try {
         const note = await Storage.read<z.infer<typeof NoteTypes.Info>>(
           StoragePath.note(Identifier.asScopeID(candidate), noteID),
+          { silentNotFound: true },
         )
         return { scopeID: candidate, note: normalize(note) }
       } catch {

--- a/packages/synergy/src/observability/diagnostics.ts
+++ b/packages/synergy/src/observability/diagnostics.ts
@@ -380,9 +380,23 @@ export namespace Diagnostics {
     }
   }
 
+  let pendingSessionsCache: { at: number; root: string; value: Summary["sessions"]["pendingReply"] } | undefined
+  const PENDING_SESSIONS_CACHE_MS = 15_000
+
   async function pendingSessions() {
+    const now = Date.now()
     const root = path.join(Global.Path.data, "sessions")
+    if (
+      pendingSessionsCache &&
+      pendingSessionsCache.root === root &&
+      now - pendingSessionsCache.at < PENDING_SESSIONS_CACHE_MS
+    ) {
+      return pendingSessionsCache.value
+    }
     const result: Summary["sessions"]["pendingReply"] = []
+    // Only session-level info.json files carry pendingReply; message-level
+    // files under messages/ never do. Skipping them turns an O(all messages)
+    // scan into an O(sessions) scan for the dashboard's 5s polling.
     await walk(root, async (file) => {
       if (!file.endsWith("info.json")) return
       const data = await fs.readFile(file, "utf8").catch(() => "")
@@ -391,7 +405,9 @@ export namespace Diagnostics {
       if (!json.pendingReply || !json.id) return
       result.push({ sessionID: json.id, path: file, updated: json.time?.updated })
     })
-    return result.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0)).slice(0, 50)
+    const value = result.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0)).slice(0, 50)
+    pendingSessionsCache = { at: now, root, value }
+    return value
   }
 
   async function walk(dir: string, visit: (file: string) => Promise<void>) {
@@ -399,7 +415,12 @@ export namespace Diagnostics {
     await Promise.all(
       entries.map(async (entry) => {
         const full = path.join(dir, entry.name)
-        if (entry.isDirectory()) return walk(full, visit)
+        // Message payloads live under messages/ and never carry pendingReply;
+        // skipping them bounds the scan to session-level info.json files.
+        if (entry.isDirectory()) {
+          if (entry.name === "messages") return
+          return walk(full, visit)
+        }
         if (entry.isFile()) return visit(full)
       }),
     )

--- a/packages/synergy/src/observability/diagnostics.ts
+++ b/packages/synergy/src/observability/diagnostics.ts
@@ -24,7 +24,7 @@ export namespace Diagnostics {
     output?: string
   }
 
-  export async function summary(): Promise<Summary> {
+  export async function summary(input: { freshPendingSessions?: boolean } = {}): Promise<Summary> {
     const lock = await ServerProcessLock.read().catch(() => undefined)
     const inspection = lock ? await ServerProcessLock.inspect(lock).catch(() => undefined) : undefined
     const recentErrors = ObservabilityStore.queryEvents({ limit: 200 })
@@ -70,7 +70,7 @@ export namespace Diagnostics {
         finished: ProcessRegistry.listFinished().map(summarizeFinishedProcess),
       },
       sessions: {
-        pendingReply: await pendingSessions().catch(() => []),
+        pendingReply: await pendingSessions(input.freshPendingSessions).catch(() => []),
       },
     })
   }
@@ -84,7 +84,10 @@ export namespace Diagnostics {
     await fs.mkdir(path.join(root, "observability"), { recursive: true })
     await fs.mkdir(path.join(root, "runtime"), { recursive: true })
 
-    const info = await summary()
+    // Diagnostic packages are on-demand support snapshots: bypass the
+    // dashboard's pending-session cache so a stuck session that changed in
+    // the last 15s is still captured (or a finished one omitted).
+    const info = await summary({ freshPendingSessions: true })
     await fs.writeFile(path.join(root, "summary.json"), JSON.stringify(info, null, 2) + "\n")
 
     const logFiles = [info.logs.current, info.logs.dev, info.logs.daemon, ...info.logs.devArchives].filter(
@@ -383,10 +386,11 @@ export namespace Diagnostics {
   let pendingSessionsCache: { at: number; root: string; value: Summary["sessions"]["pendingReply"] } | undefined
   const PENDING_SESSIONS_CACHE_MS = 15_000
 
-  async function pendingSessions() {
+  async function pendingSessions(fresh = false) {
     const now = Date.now()
     const root = path.join(Global.Path.data, "sessions")
     if (
+      !fresh &&
       pendingSessionsCache &&
       pendingSessionsCache.root === root &&
       now - pendingSessionsCache.at < PENDING_SESSIONS_CACHE_MS

--- a/packages/synergy/src/observability/events.ts
+++ b/packages/synergy/src/observability/events.ts
@@ -4,6 +4,7 @@ import { ObservabilityRedaction } from "./redaction"
 import { ObservabilitySchema } from "./schema"
 import { ObservabilityStore } from "./store"
 import { parseJson } from "@/util/json-parse"
+import { ObservabilityConfig } from "./config"
 
 export namespace ObservabilityEvents {
   export async function emit(
@@ -12,6 +13,7 @@ export namespace ObservabilityEvents {
       data?: Record<string, unknown>
     } = {},
   ) {
+    if (!ObservabilityConfig.current().enabled) return undefined
     const context = ObservabilityContext.merge({
       correlationId: input.correlationId,
       traceId: input.traceId,

--- a/packages/synergy/src/observability/index.ts
+++ b/packages/synergy/src/observability/index.ts
@@ -47,6 +47,7 @@ export namespace Observability {
     } = {},
   ) {
     const event = await ObservabilityEvents.emit(type, input)
+    if (!event) return undefined
     ObservabilityWriter.append(fileForDate(new Date(event.time)), JSON.stringify(event) + "\n")
     return event
   }

--- a/packages/synergy/src/observability/issues.ts
+++ b/packages/synergy/src/observability/issues.ts
@@ -5,6 +5,7 @@ import { ObservabilityRedaction } from "./redaction"
 import { ObservabilitySchema } from "./schema"
 import { parseJson } from "@/util/json-parse"
 import { ObservabilityStore } from "./store"
+import { ObservabilityConfig } from "./config"
 
 export namespace ObservabilityIssues {
   const publishedFingerprints = new Map<string, number>()
@@ -29,6 +30,11 @@ export namespace ObservabilityIssues {
     evidence?: Record<string, unknown>
     fingerprint?: string
   }) {
+    // When observability is disabled, skip construction, persistence, and
+    // live-event publishing entirely so the write path and the dashboard
+    // data version stay quiet (a growing data version would defeat the
+    // summary cache even when nothing is stored).
+    if (!ObservabilityConfig.current().enabled) return undefined
     const context = ObservabilityContext.merge({
       correlationId: input.correlationId,
       traceId: input.traceId,

--- a/packages/synergy/src/observability/store.ts
+++ b/packages/synergy/src/observability/store.ts
@@ -253,6 +253,10 @@ export namespace ObservabilityStore {
   }
 
   export function insertMetric(metric: ObservabilitySchema.Metric) {
+    // Data version must stay frozen while disabled: the dashboard summary
+    // cache keys on it, so an increment that never persists would still
+    // defeat the cache.
+    if (!ObservabilityConfig.current().enabled) return
     dataVersionCounter++
     if (!inlineMode()) {
       workerEnqueue({ kind: "metric", row: metric })
@@ -265,6 +269,7 @@ export namespace ObservabilityStore {
   }
 
   export function insertSpan(span: ObservabilitySchema.Span) {
+    if (!ObservabilityConfig.current().enabled) return
     dataVersionCounter++
     if (!inlineMode()) {
       workerEnqueue({ kind: "span", row: span })
@@ -281,6 +286,7 @@ export namespace ObservabilityStore {
   }
 
   export function insertEvent(event: ObservabilitySchema.Event) {
+    if (!ObservabilityConfig.current().enabled) return
     dataVersionCounter++
     if (!inlineMode()) {
       workerEnqueue({ kind: "event", row: event })
@@ -293,6 +299,7 @@ export namespace ObservabilityStore {
   }
 
   export function insertResource(sample: ObservabilitySchema.ResourceSample) {
+    if (!ObservabilityConfig.current().enabled) return
     dataVersionCounter++
     if (!inlineMode()) {
       workerEnqueue({ kind: "resource", row: sample })
@@ -305,6 +312,7 @@ export namespace ObservabilityStore {
   }
 
   export function insertIssue(issue: ObservabilitySchema.Issue) {
+    if (!ObservabilityConfig.current().enabled) return
     dataVersionCounter++
     if (!inlineMode()) {
       workerEnqueue({ kind: "issue", row: issue })
@@ -324,6 +332,7 @@ export namespace ObservabilityStore {
     rejected: number
     page: Record<string, unknown>
   }) {
+    if (!ObservabilityConfig.current().enabled) return
     dataVersionCounter++
     if (!inlineMode()) {
       workerEnqueue({ kind: "browser-batch", row: input })

--- a/packages/synergy/src/runtime/reload.ts
+++ b/packages/synergy/src/runtime/reload.ts
@@ -361,10 +361,26 @@ export namespace RuntimeReload {
           const { ObservabilityConfig } = await import("../observability/config")
           const { ObservabilityStore } = await import("../observability/store")
           const { ObservabilityResources } = await import("../observability/resources")
+          // storage.sqliteEnabled is restart-required: performance-route.ts
+          // rejects it on PATCH (PERF_CONFIG_RESTART_REQUIRED). A config
+          // import or file edit must not reopen/close the telemetry store
+          // live, so only refresh the effective config (and resource
+          // sampling, which is store-independent) and flag the restart.
+          const oldSqlite =
+            oldConfig.observability?.performance?.storage?.sqliteEnabled ??
+            ObservabilityConfig.defaults.storage.sqliteEnabled
+          const newSqlite =
+            result.config.observability?.performance?.storage?.sqliteEnabled ??
+            ObservabilityConfig.defaults.storage.sqliteEnabled
           ObservabilityConfig.refresh(result.config)
-          ObservabilityStore.reconfigure()
           ObservabilityResources.reconfigure()
-          ctx.liveApplied.add("observability")
+          if (oldSqlite === newSqlite) {
+            ObservabilityStore.reconfigure()
+            ctx.liveApplied.add("observability")
+          } else {
+            ctx.restartRequired.add("observability.performance.storage.sqliteEnabled")
+            ctx.liveApplied.delete("observability")
+          }
         }
         // P11: Handle library → autonomy/anima sync (migrated from Config.reload)
         if (changedFields.includes("library")) {

--- a/packages/synergy/src/runtime/reload.ts
+++ b/packages/synergy/src/runtime/reload.ts
@@ -54,6 +54,7 @@ export namespace RuntimeReload {
     "library",
     "external_agent",
     "email",
+    "observability",
   ])
   export const CONFIG_CLIENT_SIDE = new Set(["theme", "keybinds", "layout", "toast", "locale"])
 
@@ -355,6 +356,15 @@ export namespace RuntimeReload {
         if (resolvedScope === "global" && changedFields.includes("embedding")) {
           const { Embedding } = await import("../vector/embedding")
           await Embedding.dispose()
+        }
+        if (resolvedScope === "global" && changedFields.includes("observability")) {
+          const { ObservabilityConfig } = await import("../observability/config")
+          const { ObservabilityStore } = await import("../observability/store")
+          const { ObservabilityResources } = await import("../observability/resources")
+          ObservabilityConfig.refresh(result.config)
+          ObservabilityStore.reconfigure()
+          ObservabilityResources.reconfigure()
+          ctx.liveApplied.add("observability")
         }
         // P11: Handle library → autonomy/anima sync (migrated from Config.reload)
         if (changedFields.includes("library")) {

--- a/packages/synergy/src/storage/storage.ts
+++ b/packages/synergy/src/storage/storage.ts
@@ -34,18 +34,22 @@ export namespace Storage {
     })
   }
 
-  export async function read<T>(key: string[]) {
+  export async function read<T>(key: string[], options: { silentNotFound?: boolean } = {}) {
     const dir = resolveDir()
     const target = path.join(dir, ...key) + ".json"
-    return measureStorage("read", key, async () =>
-      withErrorHandling(async () => {
-        using _ = await Lock.read(target)
-        const file = Bun.file(target)
-        const result = await file.json()
-        const size = file.size
-        ObservabilityResources.addRead(size)
-        return result as T
-      }),
+    return measureStorage(
+      "read",
+      key,
+      async () =>
+        withErrorHandling(async () => {
+          using _ = await Lock.read(target)
+          const file = Bun.file(target)
+          const result = await file.json()
+          const size = file.size
+          ObservabilityResources.addRead(size)
+          return result as T
+        }),
+      options,
     )
   }
 
@@ -149,25 +153,38 @@ export namespace Storage {
     }
   }
 
-  async function measureStorage<T>(operation: string, key: string[], body: () => Promise<T>) {
+  async function measureStorage<T>(
+    operation: string,
+    key: string[],
+    body: () => Promise<T>,
+    options: { silentNotFound?: boolean } = {},
+  ) {
     const start = performance.now()
     let status = "ok"
     try {
       return await body()
     } catch (error) {
       status = "error"
-      ObservabilityIssues.raise({
-        code: "PERF_STORAGE_OPERATION_ERROR",
-        severity: "warning",
-        module: "storage",
-        title: "Storage operation failed",
-        message: `${operation} failed for ${key[0] ?? "root"}`,
-        evidence: {
-          operation,
-          keyPrefix: key[0] ?? "root",
-          errorName: error instanceof Error ? error.name : "unknown",
-        },
-      })
+      // Expected "file does not exist" paths (note scope probing, index
+      // rebuilds) used try/catch as control flow; every miss raised a
+      // PERF_STORAGE_OPERATION_ERROR issue and amplified telemetry writes.
+      // Keep the error metric (observability still counts it) but skip the
+      // issue when the caller declared the miss expected.
+      const isNotFound = error instanceof NotFoundError
+      if (!(options.silentNotFound && isNotFound)) {
+        ObservabilityIssues.raise({
+          code: "PERF_STORAGE_OPERATION_ERROR",
+          severity: "warning",
+          module: "storage",
+          title: "Storage operation failed",
+          message: `${operation} failed for ${key[0] ?? "root"}`,
+          evidence: {
+            operation,
+            keyPrefix: key[0] ?? "root",
+            errorName: error instanceof Error ? error.name : "unknown",
+          },
+        })
+      }
       throw error
     } finally {
       const durationMs = performance.now() - start

--- a/packages/synergy/test/observability/diagnostics.test.ts
+++ b/packages/synergy/test/observability/diagnostics.test.ts
@@ -53,6 +53,29 @@ describe("Diagnostics", () => {
     expect(summary.resources.pressure.observabilityDroppedWrites).toBeGreaterThanOrEqual(0)
   })
 
+  test("createPackage bypasses the pending-session cache for a fresh snapshot", async () => {
+    const home = process.env.SYNERGY_TEST_HOME!
+    const sessionsDir = path.join(home, ".synergy", "data", "sessions", "scope:home", "ses_cached")
+    await fs.mkdir(sessionsDir, { recursive: true })
+    const infoPath = path.join(sessionsDir, "info.json")
+    await fs.writeFile(infoPath, JSON.stringify({ id: "ses_cached", pendingReply: true, time: { updated: 1 } }))
+
+    // First summary populates the cache.
+    const first = await Diagnostics.summary()
+    expect(first.sessions.pendingReply.some((item) => item.sessionID === "ses_cached")).toBe(true)
+
+    // A subsequent summary within the TTL reuses the cached list.
+    const cached = await Diagnostics.summary()
+    expect(cached.sessions.pendingReply.some((item) => item.sessionID === "ses_cached")).toBe(true)
+
+    // The session finishes; createPackage must see the fresh state even though
+    // the 15s cache would still hold the stale pending entry.
+    await fs.writeFile(infoPath, JSON.stringify({ id: "ses_cached", pendingReply: false, time: { updated: 2 } }))
+    const output = path.join(home, "fresh-diagnostics.tar.gz")
+    const result = await Diagnostics.createPackage({ output })
+    expect(result.summary.sessions.pendingReply.some((item) => item.sessionID === "ses_cached")).toBe(false)
+  })
+
   test("package contains redacted indexed telemetry without JSONL-only events", async () => {
     await ObservabilityEvents.emit("tool.error", {
       traceId: "trace_pkg",

--- a/packages/synergy/test/observability/disabled.test.ts
+++ b/packages/synergy/test/observability/disabled.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { ObservabilityConfig } from "../../src/observability/config"
+import { ObservabilityEvents } from "../../src/observability/events"
+import { ObservabilityIssues } from "../../src/observability/issues"
+import { ObservabilityMetrics } from "../../src/observability/metrics"
+import { ObservabilityStore } from "../../src/observability/store"
+import { cleanupObservabilityHomes, resetObservabilityHome } from "./fixture"
+
+describe("observability disabled", () => {
+  beforeEach(() => resetObservabilityHome())
+  afterEach(() => cleanupObservabilityHomes())
+
+  test("enabled=false drops metrics, issues, and events and freezes dataVersion", async () => {
+    ObservabilityConfig.refresh({ observability: { performance: { enabled: false } } })
+    const before = ObservabilityStore.dataVersion()
+
+    ObservabilityMetrics.record({ name: "disabled.metric", value: 1, unit: "count", module: "observability" })
+    ObservabilityIssues.raise({
+      code: "PERF_DISABLED",
+      severity: "warning",
+      module: "observability",
+      title: "Disabled issue",
+      message: "Disabled issue",
+    })
+    await ObservabilityEvents.emit("disabled.event", {})
+    ObservabilityStore.flush()
+
+    expect(ObservabilityStore.dataVersion()).toBe(before)
+    expect(ObservabilityStore.queryMetrics({ since: 0, names: ["disabled.metric"] })).toHaveLength(0)
+    expect(ObservabilityIssues.list({ module: "observability" })).toHaveLength(0)
+    expect(ObservabilityStore.queryEvents({ type: "disabled.event" })).toHaveLength(0)
+  })
+
+  test("re-enabling restores recording", () => {
+    ObservabilityConfig.refresh({ observability: { performance: { enabled: false } } })
+    ObservabilityMetrics.record({ name: "disabled.metric", value: 1, unit: "count", module: "observability" })
+    ObservabilityStore.flush()
+    expect(ObservabilityStore.queryMetrics({ since: 0, names: ["disabled.metric"] })).toHaveLength(0)
+
+    ObservabilityConfig.refresh({ observability: { performance: { enabled: true } } })
+    ObservabilityMetrics.record({ name: "reenabled.metric", value: 1, unit: "count", module: "observability" })
+    ObservabilityStore.flush()
+    expect(ObservabilityStore.queryMetrics({ since: 0, names: ["reenabled.metric"] })).toHaveLength(1)
+  })
+})

--- a/packages/synergy/test/runtime/reload.test.ts
+++ b/packages/synergy/test/runtime/reload.test.ts
@@ -635,4 +635,42 @@ describe("runtime.reload", () => {
       },
     })
   })
+
+  test("observability sqliteEnabled changes stay restart-required instead of live-applying", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        Config.reload = mock(async () => ({
+          config: { observability: { performance: { storage: { sqliteEnabled: false } } } },
+          changedFields: ["observability"],
+          oldConfig: { observability: { performance: { storage: { sqliteEnabled: true } } } },
+        })) as typeof Config.reload
+
+        const result = await RuntimeReload.reload({ targets: ["config"], scope: "global", reason: "test" })
+
+        expect(result.restartRequired).toContain("observability.performance.storage.sqliteEnabled")
+        expect(result.liveApplied).not.toContain("observability")
+      },
+    })
+  })
+
+  test("observability changes without sqliteEnabled changes live-apply", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await ScopeContext.provide({
+      scope: await tmp.scope(),
+      fn: async () => {
+        Config.reload = mock(async () => ({
+          config: { observability: { performance: { enabled: false } } },
+          changedFields: ["observability"],
+          oldConfig: { observability: { performance: { enabled: true } } },
+        })) as typeof Config.reload
+
+        const result = await RuntimeReload.reload({ targets: ["config"], scope: "global", reason: "test" })
+
+        expect(result.restartRequired).not.toContain("observability.performance.storage.sqliteEnabled")
+        expect(result.liveApplied).toContain("observability")
+      },
+    })
+  })
 })

--- a/packages/synergy/test/storage/storage-silent-not-found.test.ts
+++ b/packages/synergy/test/storage/storage-silent-not-found.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { ObservabilityConfig } from "../../src/observability/config"
+import { ObservabilityIssues } from "../../src/observability/issues"
+import { ObservabilityStore } from "../../src/observability/store"
+import { Storage } from "../../src/storage/storage"
+import { cleanupObservabilityHomes, resetObservabilityHome } from "../observability/fixture"
+
+beforeEach(() => {
+  resetObservabilityHome("synergy-storage-silent-")
+  ObservabilityStore.open()
+})
+
+afterEach(() => {
+  cleanupObservabilityHomes()
+})
+
+describe("storage silent NotFound reads", () => {
+  test("expected missing reads raise no issue but still record the error metric", async () => {
+    const key = ["storage-silent", Math.random().toString(36).slice(2), "missing"]
+
+    await expect(Storage.read(key, { silentNotFound: true })).rejects.toThrow()
+    ObservabilityStore.flush()
+
+    const issues = ObservabilityIssues.list({ module: "storage" })
+    expect(issues.filter((issue) => issue.code === "PERF_STORAGE_OPERATION_ERROR")).toHaveLength(0)
+
+    const errorRows = ObservabilityStore.queryMetrics({
+      since: 0,
+      names: ["storage.operation.error"],
+    })
+    expect(errorRows.length).toBeGreaterThan(0)
+  })
+
+  test("unexpected missing reads still raise the storage issue", async () => {
+    const key = ["storage-silent", Math.random().toString(36).slice(2), "missing"]
+
+    await expect(Storage.read(key)).rejects.toThrow()
+    ObservabilityStore.flush()
+
+    const issues = ObservabilityIssues.list({ module: "storage" })
+    expect(issues.filter((issue) => issue.code === "PERF_STORAGE_OPERATION_ERROR").length).toBeGreaterThan(0)
+  })
+
+  test("silentNotFound is a no-op for successful reads", async () => {
+    const key = ["storage-silent", Math.random().toString(36).slice(2), "present"]
+    await Storage.write(key, { ok: true })
+
+    expect(await Storage.read<{ ok: boolean }>(key, { silentNotFound: true })).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
## Summary

- **Silence expected storage misses** — `Storage.read` gains a `silentNotFound` option; note scope probes and missing-index rebuilds stop raising `PERF_STORAGE_OPERATION_ERROR` issues (74k-issue storm) while the error metric is still recorded.
- **Cache `pendingSessions()`** — 15s TTL + skip `messages/` subdirectories turns an O(all messages) scan into an O(sessions) scan for the dashboard poll.
- **Cache `globalRaw()`** — reuse the cached `global()` (every write path already resets it) instead of re-reading all config domain files per request (observed 7.5s worst-case reads).
- **Performance toggle** — `observability.performance.enabled=false` now fully stops sampling and writes: issues, events, and all store inserts honor the flag and freeze the dashboard data version; the setting live-applies on global config reload.
- **Settings panel switch** — new "Performance Monitoring" toggle in the Observability panel patches `observability.performance.enabled`.

## Test Plan

- New tests: `test/observability/disabled.test.ts`, `test/storage/storage-silent-not-found.test.ts`
- Targeted suites all green: note (35), observability+config (243), reload+config-domain (32), app useConfigPatch (44), app settings (231)
- Repo gates: `typecheck` 11/11, `lint`, `format:check`, `localization:check`, `monorepo:check`, `package:check`, `skill:check`, `package-guide:check`, `test-layout:check` all pass
- Full synergy suite: 12 fail + 2 error, all confirmed pre-existing flakes (boss-runtime timeouts reproduce on clean HEAD baseline; embedding/synthesizer/migration pass in isolation)