### PR TITLE
perf: share 1Hz tick timers and replace handoff polling with events

### DIFF
--- a/packages/app/src/components/session/second-tick.ts
+++ b/packages/app/src/components/session/second-tick.ts
@@ -1,0 +1,84 @@
+import { createSignal } from "solid-js"
+
+export type SecondTickSource = {
+  /** Registers a consumer. The shared 1 Hz timer runs only while at least one
+   * consumer is subscribed and the document is visible. Returns unsubscribe. */
+  subscribe: () => () => void
+  /** Current tick counter; calling this inside a memo/effect subscribes to it. */
+  read: () => number
+}
+
+type SecondTickOptions = {
+  schedule?: (fn: () => void, ms: number) => unknown
+  cancel?: (handle: unknown) => void
+  isHidden?: () => boolean
+  listenVisibility?: (handler: () => void) => () => void
+}
+
+export function createSecondTickSource(options: SecondTickOptions = {}): SecondTickSource {
+  const schedule = options.schedule ?? ((fn: () => void, ms: number) => setInterval(fn, ms))
+  const cancel = options.cancel ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
+  const isHidden = options.isHidden ?? (() => typeof document !== "undefined" && document.visibilityState === "hidden")
+  const listenVisibility =
+    options.listenVisibility ??
+    ((handler: () => void) => {
+      if (typeof document === "undefined") return () => {}
+      document.addEventListener("visibilitychange", handler)
+      return () => document.removeEventListener("visibilitychange", handler)
+    })
+
+  const [tick, setTick] = createSignal(0)
+  let subscribers = 0
+  let timer: unknown
+  let unsubscribeVisibility: (() => void) | undefined
+
+  const stop = () => {
+    if (timer === undefined) return
+    cancel(timer)
+    timer = undefined
+  }
+
+  const start = () => {
+    if (timer !== undefined || isHidden()) return
+    timer = schedule(() => setTick((count) => count + 1), 1000)
+  }
+
+  const handleVisibility = () => {
+    if (isHidden()) {
+      stop()
+    } else if (subscribers > 0) {
+      start()
+    }
+  }
+
+  return {
+    subscribe() {
+      subscribers++
+      if (subscribers === 1) {
+        unsubscribeVisibility = listenVisibility(handleVisibility)
+        start()
+      }
+      let active = true
+      return () => {
+        if (!active) return
+        active = false
+        subscribers--
+        if (subscribers === 0) {
+          stop()
+          unsubscribeVisibility?.()
+          unsubscribeVisibility = undefined
+        }
+      }
+    },
+    read: () => tick(),
+  }
+}
+
+// Module-level singleton so every avatar/greeting shares one 1 Hz timer.
+// Created outside any component owner so its signal is never disposed with a
+// subscribing component; the timer only runs while subscribers exist.
+const shared: SecondTickSource = createSecondTickSource()
+
+export function sharedSecondTick(): SecondTickSource {
+  return shared
+}

--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -1,6 +1,7 @@
-import { onCleanup, createSignal } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { useLocale, type IntlFormatter } from "@/context/locale"
 import { BRAND_ASSETS, brandAssetPath } from "@/utils/brand-assets"
+import { sharedSecondTick } from "./second-tick"
 
 const GREETINGS_MORNING = [
   "Rise and ship",
@@ -54,15 +55,23 @@ function getSubtitle(): string {
 
 export function NewSessionGreeting() {
   const { fmt } = useLocale()
-  const [clock, setClock] = createSignal(formatTime(new Date(), fmt))
+  const secondTick = sharedSecondTick()
+  // The live clock subscribes to the shared 1 Hz source, which pauses while
+  // the document is hidden, so the greeting stops ticking in the background.
+  createEffect(() => {
+    const unsubscribe = secondTick.subscribe()
+    onCleanup(unsubscribe)
+  })
+  const clock = createMemo(() => {
+    secondTick.read()
+    return formatTime(new Date(), fmt)
+  })
   const [greeting] = createSignal(getTimeGreeting())
   const [subtitle, setSubtitle] = createSignal(getSubtitle())
   const [transitioning, setTransitioning] = createSignal(false)
 
-  const clockInterval = setInterval(() => setClock(formatTime(new Date(), fmt)), 1000)
-  onCleanup(() => clearInterval(clockInterval))
-
   const subtitleInterval = setInterval(() => {
+    if (document.visibilityState === "hidden") return
     setTransitioning(true)
     setTimeout(() => {
       setSubtitle(getSubtitle())

--- a/packages/app/src/components/session/session-transition-handoff.ts
+++ b/packages/app/src/components/session/session-transition-handoff.ts
@@ -106,3 +106,38 @@ export function recoverSessionTransitionHandoff(input: {
       : { workspaceSelection: item.message.metadata.sessionTransition.workspaceSelection }),
   }
 }
+
+/**
+ * Schedules a one-shot stall check for a handoff attempt, anchored to the
+ * attempt identity (messageID + acceptedAt). A retry rewrites acceptedAt and
+ * therefore re-schedules a fresh window; the check is skipped when the
+ * attempt is no longer the live loading entry. Returns a cancel function.
+ */
+export function scheduleSessionTransitionHandoffDeadline(
+  attempt: { messageID: string; acceptedAt: number },
+  isCurrentAttempt: (attempt: { messageID: string; acceptedAt: number }) => boolean,
+  onDeadline: () => void,
+  options: {
+    schedule?: (fn: () => void, delay: number) => unknown
+    cancel?: (handle: unknown) => void
+    now?: () => number
+  } = {},
+): () => void {
+  const schedule = options.schedule ?? ((fn: () => void, delay: number) => setTimeout(fn, delay))
+  const cancel = options.cancel ?? ((handle: unknown) => clearTimeout(handle as ReturnType<typeof setTimeout>))
+  const now = options.now ?? Date.now
+  // A missing acceptedAt means the attempt was not anchored; count the window
+  // from the scheduling moment.
+  const acceptedAt = attempt.acceptedAt ?? now()
+  const delay = Math.max(0, acceptedAt + SESSION_TRANSITION_HANDOFF_TIMEOUT_MS - now())
+  let active = true
+  const handle = schedule(() => {
+    if (!active) return
+    if (isCurrentAttempt(attempt)) onDeadline()
+  }, delay)
+  return () => {
+    if (!active) return
+    active = false
+    cancel(handle)
+  }
+}

--- a/packages/app/src/components/session/subagent-dock.tsx
+++ b/packages/app/src/components/session/subagent-dock.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, createSignal, onCleanup, type JSX } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js"
 import { useSync } from "@/context/sync"
 import { useSDK } from "@/context/sdk"
 import { useNavigateToSession } from "@/composables/use-navigate-to-session"
@@ -11,6 +11,7 @@ import { useLocale } from "@/context/locale"
 import { translateDescriptor } from "@/locales/translate"
 import { S } from "./session-i18n"
 import "./subagent-dock.css"
+import { sharedSecondTick } from "./second-tick"
 
 type RetrySessionStatus = Extract<SessionStatus, { type: "retry" }>
 
@@ -20,8 +21,9 @@ function isRetryStatus(status: SessionStatus | undefined): status is RetrySessio
 
 const HOLD_TO_CANCEL_MS = 2000
 const HOLD_RING_CIRCUMFERENCE = 2 * Math.PI * 19
-function formatElapsed(startedAt: number): string {
-  const seconds = Math.floor((Date.now() - startedAt) / 1000)
+function formatElapsed(startedAt: number, completedAt?: number): string {
+  const end = completedAt ?? Date.now()
+  const seconds = Math.max(0, Math.floor((end - startedAt) / 1000))
   if (seconds < 60) return `${seconds}s`
   const minutes = Math.floor(seconds / 60)
   const remaining = seconds % 60
@@ -44,7 +46,6 @@ function SubagentAvatar(props: SubagentAvatarProps) {
   const sessionStatus = createMemo<SessionStatus | undefined>(() => sync.data.session_status[props.task.sessionID])
   const runtimeState = createMemo(() => resolveRuntimeIconState(sessionStatus(), false, i18n))
   const isRetrying = () => sessionStatus()?.type === "retry"
-  const [elapsed, setElapsed] = createSignal(formatElapsed(props.task.startedAt))
   const [holdProgress, setHoldProgress] = createSignal(0)
   const [isHolding, setIsHolding] = createSignal(false)
 
@@ -53,7 +54,23 @@ function SubagentAvatar(props: SubagentAvatarProps) {
   let cancelledByHold = false
   let suppressClick = false
 
-  const timer = setInterval(() => setElapsed(formatElapsed(props.task.startedAt)), 1000)
+  const secondTick = sharedSecondTick()
+  // Elapsed clock runs only while the task is pending or active: the shared
+  // 1 Hz source stays alive while at least one running/queued avatar
+  // subscribes and the document is visible, so completed/error/cancelled
+  // tasks stop ticking entirely (their duration is frozen at completedAt).
+  createEffect(() => {
+    if (props.task.status !== "running" && props.task.status !== "queued") return
+    const unsubscribe = secondTick.subscribe()
+    onCleanup(unsubscribe)
+  })
+  const elapsed = createMemo(() => {
+    if (props.task.status !== "running" && props.task.status !== "queued") {
+      return formatElapsed(props.task.startedAt, props.task.completedAt)
+    }
+    secondTick.read()
+    return formatElapsed(props.task.startedAt)
+  })
 
   const stopHold = () => {
     if (holdFrame) cancelAnimationFrame(holdFrame)
@@ -64,7 +81,6 @@ function SubagentAvatar(props: SubagentAvatarProps) {
   }
 
   onCleanup(() => {
-    clearInterval(timer)
     if (holdFrame) cancelAnimationFrame(holdFrame)
   })
 

--- a/packages/app/src/components/session/subagent-session-footer.tsx
+++ b/packages/app/src/components/session/subagent-session-footer.tsx
@@ -1,4 +1,4 @@
-import { Show, createMemo, createEffect, createSignal, onCleanup, untrack } from "solid-js"
+import { Show, createMemo, createEffect, onCleanup, untrack } from "solid-js"
 import { useSync } from "@/context/sync"
 import { Icon } from "@ericsanchezok/synergy-ui/icon"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
@@ -9,6 +9,7 @@ import { SUBAGENT_FOOTER_MODEL_LABEL_CLASS, subagentFooterSessionStatus } from "
 import { useLocale } from "@/context/locale"
 import { translateDescriptor } from "@/locales/translate"
 import { S } from "./session-i18n"
+import { sharedSecondTick } from "./second-tick"
 
 const HIDE_MODEL_LABEL_AGENTS = new Set(["codex", "claude-code"])
 
@@ -65,18 +66,20 @@ export function SubagentSessionFooter(props: {
 
   const visual = createMemo(() => getAgentVisual(props.cortex.agent))
   const preview = createMemo(() => cleanPreview(props.cortex.error ?? outputPreview(props.cortex.output)))
-  const [tick, setTick] = createSignal(0)
   const sessionStatus = createMemo<SessionStatus | undefined>(() =>
     subagentFooterSessionStatus(sync.data.session_status, props.sessionID),
   )
+  const secondTick = sharedSecondTick()
+  // The running clock subscribes to the shared 1 Hz source, which pauses
+  // while the document is hidden; non-running footers freeze at completedAt.
   createEffect(() => {
     if (props.cortex.status !== "running") return
-    const id = setInterval(() => setTick((t) => t + 1), 1000)
-    onCleanup(() => clearInterval(id))
+    const unsubscribe = secondTick.subscribe()
+    onCleanup(unsubscribe)
   })
 
   const duration = createMemo(() => {
-    tick()
+    secondTick.read()
     return formatDuration(props.cortex.startedAt, props.cortex.completedAt)
   })
   const modelLabel = createMemo(() => {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -71,6 +71,7 @@ import {
 import {
   decideSessionTransitionHandoff,
   recoverSessionTransitionHandoff,
+  scheduleSessionTransitionHandoffDeadline,
   type SessionTransitionHandoff,
 } from "@/components/session/session-transition-handoff"
 import { selectPendingTimelineItems } from "@/components/session/conversation-pending"
@@ -541,7 +542,6 @@ function SessionPageContent() {
   const dismissSessionTransitionHandoff = (sessionID: string, messageID: string) => {
     sessionTransition.dismissHandoff(sessionID, messageID)
   }
-  const [handoffNow, setHandoffNow] = createSignal(Date.now())
   const acceptedProgressForHandoff = (handoff: Pick<SessionTransitionHandoff, "workspaceSelection">) => {
     const selection = handoff.workspaceSelection
     return selection && isWorktreeWorkspaceSelection(selection)
@@ -623,23 +623,53 @@ function SessionPageContent() {
       success: successProgressForHandoff(recovered),
     })
   })
-  createEffect(() => {
-    const entry = visibleSessionTransitionEntry()
-    if (entry?.progress.phase !== "loading" || !entry.handoff) return
-    setHandoffNow(Date.now())
-    const timer = setInterval(() => setHandoffNow(Date.now()), 250)
-    onCleanup(() => clearInterval(timer))
-  })
+  // One-shot stall detection anchored to the attempt identity. A retry
+  // rewrites acceptedAt, which changes the entry and re-schedules a fresh
+  // window; the deadline skips itself when the attempt is no longer loading.
   createEffect(() => {
     const sessionID = params.id
     const entry = visibleSessionTransitionEntry()
     if (!sessionID || entry?.progress.phase !== "loading" || !entry.handoff) return
-    const acceptedAt = entry.handoff.acceptedAt ?? handoffNow()
+    const handoff = entry.handoff
+    const attempt = {
+      messageID: handoff.messageID,
+      acceptedAt: handoff.acceptedAt ?? Date.now(),
+    }
+    const cancel = scheduleSessionTransitionHandoffDeadline(
+      attempt,
+      (current) => {
+        const live = visibleSessionTransitionEntry()
+        return (
+          live?.progress.phase === "loading" &&
+          live.handoff?.messageID === current.messageID &&
+          // An unanchored attempt stays current by falling back to the
+          // scheduled identity; a retry writes a fresh acceptedAt, which
+          // changes identity and lets the old deadline expire silently.
+          (live.handoff.acceptedAt ?? current.acceptedAt) === current.acceptedAt
+        )
+      },
+      () => {
+        const live = visibleSessionTransitionEntry()
+        if (live?.handoff && live.progress.phase === "loading") {
+          showStalledHandoff(sessionID, live.handoff)
+        }
+      },
+    )
+    onCleanup(cancel)
+  })
+  // Event-driven handoff resolution: re-evaluates only when the message
+  // window, inbox, or transition entry changes. A message arriving in the
+  // window resolves the transition immediately — no polling required.
+  createEffect(() => {
+    const sessionID = params.id
+    const entry = visibleSessionTransitionEntry()
+    if (!sessionID || entry?.progress.phase !== "loading" || !entry.handoff) return
+    const acceptedAt = entry.handoff.acceptedAt ?? Date.now()
     const decision = decideSessionTransitionHandoff({
       messageID: entry.handoff.messageID,
       messages: messages(),
       inbox: sync.data.inbox[sessionID],
-      elapsedMs: Math.max(0, handoffNow() - acceptedAt),
+      elapsedMs: Math.max(0, Date.now() - acceptedAt),
       refreshAttempted: entry.handoff.refreshAttempted ?? false,
     })
     if (decision === "ready") {

--- a/packages/app/test/components/session/second-tick.test.ts
+++ b/packages/app/test/components/session/second-tick.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import { createSecondTickSource } from "../../../src/components/session/second-tick"
+
+function createHarness() {
+  let hidden = false
+  const visibilityListeners = new Set<() => void>()
+  const state = {
+    activeTimers: 0,
+    fired: 0,
+    /** Last scheduled callback, so tests can advance the fake clock. */
+    fire: () => {},
+  }
+  const schedule = (fn: () => void) => {
+    state.activeTimers++
+    state.fire = fn
+    return state.activeTimers
+  }
+  const cancel = () => {
+    state.activeTimers--
+  }
+  const source = createSecondTickSource({
+    schedule: (fn) => schedule(fn),
+    cancel,
+    isHidden: () => hidden,
+    listenVisibility: (handler) => {
+      visibilityListeners.add(handler)
+      return () => visibilityListeners.delete(handler)
+    },
+  })
+  return {
+    source,
+    state,
+    setHidden(next: boolean) {
+      hidden = next
+      for (const handler of visibilityListeners) handler()
+    },
+  }
+}
+
+describe("second-tick shared source", () => {
+  test("does not start a timer while nobody is subscribed", () => {
+    const { state } = createHarness()
+    expect(state.activeTimers).toBe(0)
+  })
+
+  test("starts the timer on first subscribe and increments the tick", () => {
+    const { source, state } = createHarness()
+    const unsubscribe = source.subscribe()
+    expect(state.activeTimers).toBe(1)
+    expect(source.read()).toBe(0)
+    state.fire()
+    expect(source.read()).toBe(1)
+    unsubscribe()
+    expect(state.activeTimers).toBe(0)
+  })
+
+  test("shares one timer across multiple subscribers", () => {
+    const { source, state } = createHarness()
+    const unsubA = source.subscribe()
+    const unsubB = source.subscribe()
+    expect(state.activeTimers).toBe(1)
+    state.fire()
+    expect(source.read()).toBe(1)
+    unsubA()
+    // Still one subscriber, timer keeps running.
+    expect(state.activeTimers).toBe(1)
+    unsubB()
+    expect(state.activeTimers).toBe(0)
+  })
+
+  test("unsubscribe is idempotent", () => {
+    const { source, state } = createHarness()
+    const unsubscribe = source.subscribe()
+    unsubscribe()
+    unsubscribe()
+    expect(state.activeTimers).toBe(0)
+  })
+
+  test("pauses the timer while hidden and resumes on visibility restore", () => {
+    const { source, state, setHidden } = createHarness()
+    const unsubscribe = source.subscribe()
+    expect(state.activeTimers).toBe(1)
+
+    setHidden(true)
+    expect(state.activeTimers).toBe(0)
+
+    setHidden(false)
+    expect(state.activeTimers).toBe(1)
+    state.fire()
+    expect(source.read()).toBe(1)
+    unsubscribe()
+  })
+
+  test("defers starting until visible when subscribed while hidden", () => {
+    const { source, state, setHidden } = createHarness()
+    setHidden(true)
+    const unsubscribe = source.subscribe()
+    expect(state.activeTimers).toBe(0)
+    setHidden(false)
+    expect(state.activeTimers).toBe(1)
+    unsubscribe()
+    expect(state.activeTimers).toBe(0)
+  })
+})

--- a/packages/app/test/components/session/session-transition-handoff.test.ts
+++ b/packages/app/test/components/session/session-transition-handoff.test.ts
@@ -4,6 +4,7 @@ import {
   decideSessionTransitionHandoff,
   isSessionTransitionHandoffReady,
   recoverSessionTransitionHandoff,
+  scheduleSessionTransitionHandoffDeadline,
 } from "../../../src/components/session/session-transition-handoff"
 
 const messageID = "msg_first"
@@ -89,5 +90,118 @@ describe("new session transition handoff", () => {
     expect(
       recoverSessionTransitionHandoff({ messages: [], inbox: [pending, { ...pending, id: "inb_second" }] }),
     ).toBeUndefined()
+  })
+})
+
+describe("session transition handoff deadline", () => {
+  // Deadline window = acceptedAt + TIMEOUT; clock starts at 0 so the deadline
+  // lands exactly at SESSION_TRANSITION_HANDOFF_TIMEOUT_MS.
+  const attempt = { messageID: "msg_first", acceptedAt: 0 }
+
+  function createClock() {
+    let current = 0
+    const timers = new Map<number, { fn: () => void; at: number }>()
+    let nextHandle = 1
+    return {
+      now: () => current,
+      advance(ms: number) {
+        current += ms
+        for (const [handle, timer] of [...timers]) {
+          if (timer.at <= current) {
+            timers.delete(handle)
+            timer.fn()
+          }
+        }
+      },
+      schedule(fn: () => void, delay: number) {
+        const handle = nextHandle++
+        timers.set(handle, { fn, at: current + delay })
+        return handle
+      },
+      cancel(handle: unknown) {
+        timers.delete(handle as number)
+      },
+      pendingCount: () => timers.size,
+    }
+  }
+
+  test("fires onDeadline once when the attempt is still current and the window elapses", () => {
+    const clock = createClock()
+    let fired = 0
+    scheduleSessionTransitionHandoffDeadline(
+      attempt,
+      () => true,
+      () => fired++,
+      {
+        schedule: clock.schedule,
+        cancel: clock.cancel,
+        now: clock.now,
+      },
+    )
+    clock.advance(SESSION_TRANSITION_HANDOFF_TIMEOUT_MS - 1)
+    expect(fired).toBe(0)
+    clock.advance(1)
+    expect(fired).toBe(1)
+    // The deadline is one-shot; nothing fires on a later tick.
+    clock.advance(SESSION_TRANSITION_HANDOFF_TIMEOUT_MS)
+    expect(fired).toBe(1)
+  })
+
+  test("skips the deadline when the attempt is no longer current", () => {
+    const clock = createClock()
+    let fired = 0
+    scheduleSessionTransitionHandoffDeadline(
+      attempt,
+      () => false,
+      () => fired++,
+      {
+        schedule: clock.schedule,
+        cancel: clock.cancel,
+        now: clock.now,
+      },
+    )
+    clock.advance(SESSION_TRANSITION_HANDOFF_TIMEOUT_MS)
+    expect(fired).toBe(0)
+  })
+
+  test("cancel stops the pending deadline", () => {
+    const clock = createClock()
+    let fired = 0
+    const cancel = scheduleSessionTransitionHandoffDeadline(
+      attempt,
+      () => true,
+      () => fired++,
+      {
+        schedule: clock.schedule,
+        cancel: clock.cancel,
+        now: clock.now,
+      },
+    )
+    cancel()
+    cancel()
+    clock.advance(SESSION_TRANSITION_HANDOFF_TIMEOUT_MS)
+    expect(fired).toBe(0)
+    expect(clock.pendingCount()).toBe(0)
+  })
+
+  test("schedules with the remaining delay when acceptedAt is in the past", () => {
+    const clock = createClock()
+    let fired = 0
+    // 10s of the 30s window have already elapsed; only 20s remain.
+    clock.advance(10_000)
+    scheduleSessionTransitionHandoffDeadline(
+      attempt,
+      () => true,
+      () => fired++,
+      {
+        schedule: clock.schedule,
+        cancel: clock.cancel,
+        now: clock.now,
+      },
+    )
+    clock.advance(20_000 - 1)
+    expect(fired).toBe(0)
+    clock.advance(1)
+    expect(fired).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

Fixes two sources of sustained renderer CPU usage in the Web/Desktop app:

- **1 Hz tick timers**: every subagent avatar, subagent footer, and the new-session greeting previously owned an unconditional `setInterval` that kept running after the task completed and while the document was hidden. Replaced with a module-level shared 1 Hz tick source (reference-counted, paused on `document.visibilityState === "hidden"`). Avatars/footers subscribe only while the task is running/queued and freeze elapsed durations at `completedAt`.
- **250 ms handoff polling**: the session transition handoff polled at 4 Hz while a transition was loading, re-scanning the message window indefinitely to detect a 30 s stall. Replaced with a one-shot deadline anchored to the attempt identity (`messageID` + `acceptedAt`); the resolution effect now re-evaluates only when messages/inbox/transition state change, retries schedule a fresh window, and stale deadlines skip themselves.

## Changes

- `packages/app/src/components/session/second-tick.ts` (new): shared 1 Hz tick source with refcount + visibility pause + injectable schedule/cancel/now for tests
- `packages/app/src/components/session/subagent-dock.tsx`: avatar elapsed clock subscribes to the shared tick only while running/queued; durations freeze at `completedAt`
- `packages/app/src/components/session/subagent-session-footer.tsx`: running clock reads the shared tick
- `packages/app/src/components/session/session-new-view.tsx`: greeting clock reads the shared tick; subtitle rotation gated on visibility
- `packages/app/src/components/session/session-transition-handoff.ts`: new `scheduleSessionTransitionHandoffDeadline` one-shot scheduler
- `packages/app/src/pages/session.tsx`: removed `handoffNow` signal + 250 ms interval; stall detection via one-shot deadline, resolution effect is event-driven
- Tests: `test/components/session/second-tick.test.ts` (refcount, hidden pause/resume, idempotent unsubscribe), `test/components/session/session-transition-handoff.test.ts` (one-shot fire, identity skip, cancel, remaining-delay scheduling)

## Verification

- `bun test test/components/session/ test/pages/` — 214 pass (1 pre-existing parallel-worker flake in `error-presentation.test.ts`, passes in isolation)
- `bunx tsc --noEmit -p packages/app/tsconfig.json` — clean
- `bunx oxlint -c oxlintrc.json --deny-warnings` on changed files — 0 warnings
- `bunx prettier --check` on changed files — clean
- `bun run quality:quick` — exit 0