### PR TITLE
fix(app): avoid project list bounce while loading sessions

### DIFF
--- a/packages/app/src/components/sidebar/project-disclosure.ts
+++ b/packages/app/src/components/sidebar/project-disclosure.ts
@@ -1,0 +1,8 @@
+export function shouldOpenProjectDisclosure(input: {
+  expanded: boolean
+  isSupplemental: boolean
+  navLoaded: boolean
+}): boolean {
+  if (!input.expanded) return false
+  return input.isSupplemental || input.navLoaded
+}

--- a/packages/app/src/components/sidebar/sidebar.tsx
+++ b/packages/app/src/components/sidebar/sidebar.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, createSignal, For, on, onCleanup, Show, type JSX } from "solid-js"
 import { FlipList } from "./flip-list"
+import { shouldOpenProjectDisclosure } from "./project-disclosure"
 import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
 import { A, useLocation, useNavigate, useParams } from "@solidjs/router"
 import { useLayout } from "@/context/layout"
@@ -838,6 +839,14 @@ function SidebarProjectGroup(props: {
     const scope = props.scope()
     return scope ? props.navLoaded(scope) : false
   })
+  const disclosureOpen = createMemo(() =>
+    shouldOpenProjectDisclosure({
+      expanded: !!props.scope()?.expanded,
+      isSupplemental: isSupplemental(),
+      navLoaded: navLoaded(),
+    }),
+  )
+  const sessionsLoading = createMemo(() => !!props.scope()?.expanded && !isSupplemental() && !navLoaded())
   const entries = createMemo(() => {
     const scope = props.scope()
     return scope ? props.projectNavEntries(scope) : []
@@ -869,12 +878,18 @@ function SidebarProjectGroup(props: {
             class="sb-project-chevron-btn"
             aria-label={props.scope()?.expanded ? props._(sidebar.collapseProject) : props._(sidebar.expandProject)}
             aria-expanded={props.scope()?.expanded}
+            aria-busy={sessionsLoading() || undefined}
             onClick={(event) => {
               const scope = props.scope()
               if (scope) props.onProjectToggle(event, scope)
             }}
           >
-            <Icon name={props.scope()?.expanded ? "chevron-down" : "chevron-right"} size="small" />
+            <Show
+              when={sessionsLoading()}
+              fallback={<Icon name={props.scope()?.expanded ? "chevron-down" : "chevron-right"} size="small" />}
+            >
+              <Spinner class="size-3" />
+            </Show>
           </button>
           <button
             type="button"
@@ -964,7 +979,7 @@ function SidebarProjectGroup(props: {
           </div>
         </div>
 
-        <SidebarDisclosure open={!!props.scope()?.expanded}>
+        <SidebarDisclosure open={disclosureOpen()}>
           <Show
             when={!isSupplemental()}
             fallback={
@@ -1012,14 +1027,7 @@ function SidebarProjectGroup(props: {
               </Show>
             }
           >
-            <Show
-              when={navLoaded()}
-              fallback={
-                <div class="sb-sessions">
-                  <For each={Array(6)}>{() => <div class="sb-session-skeleton" />}</For>
-                </div>
-              }
-            >
+            <Show when={navLoaded()}>
               <GroupedSessionList
                 entries={entries()}
                 scope={props.scope()}

--- a/packages/app/test/components/sidebar/project-disclosure.test.ts
+++ b/packages/app/test/components/sidebar/project-disclosure.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { shouldOpenProjectDisclosure } from "../../../src/components/sidebar/project-disclosure"
+
+describe("shouldOpenProjectDisclosure", () => {
+  test("waits for a local project's real sessions before changing the sidebar layout", () => {
+    expect(
+      shouldOpenProjectDisclosure({
+        expanded: true,
+        isSupplemental: false,
+        navLoaded: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("opens a local project once its session list is available", () => {
+    expect(
+      shouldOpenProjectDisclosure({
+        expanded: true,
+        isSupplemental: false,
+        navLoaded: true,
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps supplemental projects open so their load-sessions action remains available", () => {
+    expect(
+      shouldOpenProjectDisclosure({
+        expanded: true,
+        isSupplemental: true,
+        navLoaded: false,
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps collapsed projects closed even after their sessions have loaded", () => {
+    expect(
+      shouldOpenProjectDisclosure({
+        expanded: false,
+        isSupplemental: false,
+        navLoaded: true,
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- defer opening a local project disclosure until its real session navigation data is available
- show an inline loading indicator in the project toggle instead of expanding six placeholder rows
- retain the existing supplemental-project disclosure so its explicit **Load sessions** action remains reachable

## Problem

Expanding an unloaded local project previously animated six skeleton rows into the sidebar. Once the actual session list arrived, projects with fewer than six sessions were pulled back upward. This made projects below the expanded one appear to overshoot and rebound.

## Testing

- `bun test test/components/sidebar/project-disclosure.test.ts`
- `bunx prettier --check packages/app/src/components/sidebar/sidebar.tsx packages/app/src/components/sidebar/project-disclosure.ts packages/app/test/components/sidebar/project-disclosure.test.ts`
- `bun run build` (in `packages/app`)

`bun run typecheck` was not runnable locally because this Windows checkout materializes the existing `src/custom-elements.d.ts` symlink as a plain path file. CI remains the full validation environment.