### PR TITLE
refactor(app): fold frontend freshness mechanisms onto a shared key-space primitive

### DIFF
--- a/docs/decisions/implemented/simplification/2026-08-17-fold-frontend-freshness-mechanisms.md
+++ b/docs/decisions/implemented/simplification/2026-08-17-fold-frontend-freshness-mechanisms.md
@@ -1,0 +1,35 @@
+# Decision Record: Fold frontend freshness mechanisms onto a shared key-space primitive
+
+Status: implemented
+
+## Problem
+
+Three modules in `packages/app/src/context` independently implement the same "keyed map + monotonic counter + prefix-scoped release" machinery, each re-deriving per-scope/per-session generation counters:
+
+- `SyncResourceFreshness` (`sync-resource-freshness.ts:44-193`): `generations Map<string,number>` + `nextGeneration` (:48-49), `revisions Map<string,number>` + `nextRevision` (:50-51), prefix-scoped `clearResources` (:184-192). Guards scope/resource sync responses/events/snapshots with epoch+seq versions.
+- `SessionPartSnapshotFreshness` (`session-part-snapshot-freshness.ts:16-87`): `generations` + `nextGeneration` (:17,20), `revisions` + `nextRevision` (:18,21), `snapshotRequiredRevisions` (:19), prefix-scoped `releaseScope`/`releaseSession` (:54-77). Guards message-page apply decisions for a session's message parts.
+- `createScopeReconnectRecovery` (`scope-reconnect-recovery.ts:1-33`): `versions Map<string,number>` (:2) and `lifecycles Map<string,object>` (:3) guarding async reconnect completion with lifecycle identity.
+
+The mechanical pipe (allocate a monotonic number, get-or-default, set, delete, delete-by-prefix) is duplicated verbatim in at least four places across the three modules. The semantic layers (epoch/seq comparisons, snapshot-required `>` semantics, async lifecycle identity) guard genuinely different facts and must not be merged.
+
+## Decision
+
+`packages/app/src/context/monotonic-key-space.ts` now ships a `MonotonicKeySpace` class: a `Map<string, number>` with a global monotonic `next` counter and `get` (0 default), `ensure` (lazy create), `allocate` (unconditional fresh number), `set`, `delete`, `deletePrefix`, and `entries` (yields the raw stored pairs).
+
+- `SyncResourceFreshness` (`sync-resource-freshness.ts`): `generations` and `revisions` are `MonotonicKeySpace` instances; `generation()` uses `ensure`, `advanceGeneration()`/`bumpRevision()` use `allocate`, and `clearResources()` calls `deletePrefix` on the revisions space while still clearing `resources` directly. `resources`/`scopes`/`retiredEpochs` and every public method signature and semantic are unchanged.
+- `SessionPartSnapshotFreshness` (`session-part-snapshot-freshness.ts`): `generations`, `revisions`, and `snapshotRequiredRevisions` are `MonotonicKeySpace` instances; `capture()` iterates `revisions.entries()`, `touch()` uses `allocate`, and `releaseScope()`/`releaseSession()` use `deletePrefix`. The `action` decision rules are unchanged (revision `===` captured → apply, snapshot-required `>` captured → retry, else preserve; generation mismatch → retry).
+- `createScopeReconnectRecovery` (`scope-reconnect-recovery.ts`): `versions` is a `MonotonicKeySpace`; `version()` reads with `get` (0 default), `run()` writes only externally supplied generations via `set` after the strict `generation > current` check, and `release()` uses `delete`. The `lifecycles` identity map and `run()` semantics are unchanged.
+
+No public API, signature, return value, or decision semantic of the three modules changed; no consumers were touched. The primitive imports nothing from outside `packages/app/src/context`.
+
+## Alternatives considered
+
+- **Merge the three modules into one freshness controller** — rejected: they guard different facts (versioned data freshness vs request validity vs async reconnect completion) across different request flows (`sync.tsx`, `global-sync.tsx`, layout prefetch, prompt-input mutations); one controller would force a single key schema and couple unrelated flows.
+- **Leave the duplication** — rejected: the counter/prefix plumbing is the drift-prone part (already four copies), and the shared primitive removes it without touching semantics.
+- **Fold `scope-reconnect-recovery` into `SyncResourceFreshness`'s generation counter** — rejected: recovery versions are externally supplied and guarded by lifecycle identity for async release-during-flight, which the freshness classes do not model.
+
+## Consequences
+
+- The 27 existing freshness/reconnect tests pass unmodified, plus the `global-sync`, `global-sync-recovery`, `session-volatile-resync`, and `sync-watermark` suites; a focused unit test for the primitive covers paths the class suites do not exercise (`deletePrefix` boundary cases, `ensure` reuse, `allocate` monotonicity, `set` without counter bump).
+- The drift-prone counter/prefix plumbing now lives in one place; freshness decisions are unchanged but any future change to the primitive is covered by both the class suites and the primitive's own tests.
+- `get` returns 0 for missing keys, `allocate` never reuses a number, and `deletePrefix` matches the raw string key prefix, so callers keep their `"\n"`-separated key contracts.

--- a/packages/app/src/context/monotonic-key-space.ts
+++ b/packages/app/src/context/monotonic-key-space.ts
@@ -1,0 +1,40 @@
+export class MonotonicKeySpace {
+  private readonly values = new Map<string, number>()
+  private next = 1
+
+  get(key: string): number {
+    return this.values.get(key) ?? 0
+  }
+
+  ensure(key: string): number {
+    const existing = this.values.get(key)
+    if (existing !== undefined) return existing
+    const created = this.next++
+    this.values.set(key, created)
+    return created
+  }
+
+  allocate(key: string): number {
+    const created = this.next++
+    this.values.set(key, created)
+    return created
+  }
+
+  set(key: string, value: number) {
+    this.values.set(key, value)
+  }
+
+  delete(key: string) {
+    this.values.delete(key)
+  }
+
+  deletePrefix(prefix: string) {
+    for (const key of this.values.keys()) {
+      if (key.startsWith(prefix)) this.values.delete(key)
+    }
+  }
+
+  *entries(): IterableIterator<[string, number]> {
+    yield* this.values.entries()
+  }
+}

--- a/packages/app/src/context/scope-reconnect-recovery.ts
+++ b/packages/app/src/context/scope-reconnect-recovery.ts
@@ -1,8 +1,10 @@
+import { MonotonicKeySpace } from "./monotonic-key-space"
+
 export function createScopeReconnectRecovery(publish: (scopeKey: string, generation: number) => void) {
-  const versions = new Map<string, number>()
+  const versions = new MonotonicKeySpace()
   const lifecycles = new Map<string, object>()
 
-  const version = (scopeKey: string) => versions.get(scopeKey) ?? 0
+  const version = (scopeKey: string) => versions.get(scopeKey)
 
   const lifecycle = (scopeKey: string) => {
     const active = lifecycles.get(scopeKey)
@@ -17,7 +19,7 @@ export function createScopeReconnectRecovery(publish: (scopeKey: string, generat
     const recovered = await recover()
     if (!recovered) return false
     if (lifecycles.get(scopeKey) !== activeLifecycle) return false
-    if (generation <= version(scopeKey)) return true
+    if (generation <= versions.get(scopeKey)) return true
     versions.set(scopeKey, generation)
     publish(scopeKey, generation)
     return true

--- a/packages/app/src/context/session-part-snapshot-freshness.ts
+++ b/packages/app/src/context/session-part-snapshot-freshness.ts
@@ -1,3 +1,5 @@
+import { MonotonicKeySpace } from "./monotonic-key-space"
+
 export type SessionPartSnapshotRequest = {
   generation: number
   revisions: ReadonlyMap<string, number>
@@ -14,17 +16,15 @@ function messageKey(scopeKey: string, sessionID: string, messageID: string) {
 }
 
 export class SessionPartSnapshotFreshness {
-  private readonly generations = new Map<string, number>()
-  private readonly revisions = new Map<string, number>()
-  private readonly snapshotRequiredRevisions = new Map<string, number>()
-  private nextGeneration = 1
-  private nextRevision = 1
+  private readonly generations = new MonotonicKeySpace()
+  private readonly revisions = new MonotonicKeySpace()
+  private readonly snapshotRequiredRevisions = new MonotonicKeySpace()
 
   capture(scopeKey: string, sessionID: string): SessionPartSnapshotRequest {
     const generation = this.generation(scopeKey, sessionID)
     const prefix = `${sessionKey(scopeKey, sessionID)}\n`
     const revisions = new Map<string, number>()
-    for (const [key, revision] of this.revisions) {
+    for (const [key, revision] of this.revisions.entries()) {
       if (key.startsWith(prefix)) revisions.set(key.slice(prefix.length), revision)
     }
     return { generation, revisions }
@@ -32,8 +32,7 @@ export class SessionPartSnapshotFreshness {
 
   touch(scopeKey: string, sessionID: string, messageID: string, options?: { requiresSnapshot?: boolean }) {
     const key = messageKey(scopeKey, sessionID, messageID)
-    const revision = this.nextRevision++
-    this.revisions.set(key, revision)
+    const revision = this.revisions.allocate(key)
     if (options?.requiresSnapshot) this.snapshotRequiredRevisions.set(key, revision)
   }
 
@@ -46,42 +45,27 @@ export class SessionPartSnapshotFreshness {
     if (this.generation(scopeKey, sessionID) !== request.generation) return "retry"
     const key = messageKey(scopeKey, sessionID, messageID)
     const capturedRevision = request.revisions.get(messageID) ?? 0
-    if ((this.revisions.get(key) ?? 0) === capturedRevision) return "apply"
-    if ((this.snapshotRequiredRevisions.get(key) ?? 0) > capturedRevision) return "retry"
+    if (this.revisions.get(key) === capturedRevision) return "apply"
+    if (this.snapshotRequiredRevisions.get(key) > capturedRevision) return "retry"
     return "preserve"
   }
 
   releaseScope(scopeKey: string) {
     const generationPrefix = `${scopeKey}\n`
-    for (const key of this.generations.keys()) {
-      if (key.startsWith(generationPrefix)) this.generations.delete(key)
-    }
+    this.generations.deletePrefix(generationPrefix)
     const revisionPrefix = `${scopeKey}\n`
-    for (const key of this.revisions.keys()) {
-      if (key.startsWith(revisionPrefix)) this.revisions.delete(key)
-    }
-    for (const key of this.snapshotRequiredRevisions.keys()) {
-      if (key.startsWith(revisionPrefix)) this.snapshotRequiredRevisions.delete(key)
-    }
+    this.revisions.deletePrefix(revisionPrefix)
+    this.snapshotRequiredRevisions.deletePrefix(revisionPrefix)
   }
 
   releaseSession(scopeKey: string, sessionID: string) {
     this.generations.delete(sessionKey(scopeKey, sessionID))
     const prefix = `${sessionKey(scopeKey, sessionID)}\n`
-    for (const key of this.revisions.keys()) {
-      if (key.startsWith(prefix)) this.revisions.delete(key)
-    }
-    for (const key of this.snapshotRequiredRevisions.keys()) {
-      if (key.startsWith(prefix)) this.snapshotRequiredRevisions.delete(key)
-    }
+    this.revisions.deletePrefix(prefix)
+    this.snapshotRequiredRevisions.deletePrefix(prefix)
   }
 
   private generation(scopeKey: string, sessionID: string) {
-    const key = sessionKey(scopeKey, sessionID)
-    const existing = this.generations.get(key)
-    if (existing !== undefined) return existing
-    const created = this.nextGeneration++
-    this.generations.set(key, created)
-    return created
+    return this.generations.ensure(sessionKey(scopeKey, sessionID))
   }
 }

--- a/packages/app/src/context/sync-resource-freshness.ts
+++ b/packages/app/src/context/sync-resource-freshness.ts
@@ -1,3 +1,5 @@
+import { MonotonicKeySpace } from "./monotonic-key-space"
+
 export type SyncResource = "dag" | "todo" | "inbox" | "message"
 
 export type SyncVersion = {
@@ -45,10 +47,8 @@ export class SyncResourceFreshness {
   private readonly resources = new Map<string, SyncVersion>()
   private readonly scopes = new Map<string, ScopeVersion>()
   private readonly retiredEpochs = new Map<string, Set<string>>()
-  private readonly generations = new Map<string, number>()
-  private nextGeneration = 1
-  private readonly revisions = new Map<string, number>()
-  private nextRevision = 1
+  private readonly generations = new MonotonicKeySpace()
+  private readonly revisions = new MonotonicKeySpace()
 
   current(input: SyncResourceKey): SyncVersion | undefined {
     return this.resources.get(resourceKey(input))
@@ -57,14 +57,14 @@ export class SyncResourceFreshness {
   capture(input: SyncResourceKey): SyncResourceRequest {
     return {
       generation: this.generation(input.scopeKey),
-      revision: this.revisions.get(resourceKey(input)) ?? 0,
+      revision: this.revisions.get(resourceKey(input)),
     }
   }
 
   unchanged(input: SyncResourceKey, request: SyncResourceRequest): boolean {
     return (
       this.generation(input.scopeKey) === request.generation &&
-      (this.revisions.get(resourceKey(input)) ?? 0) === request.revision
+      this.revisions.get(resourceKey(input)) === request.revision
     )
   }
   invalidate(input: SyncResourceKey) {
@@ -74,7 +74,7 @@ export class SyncResourceFreshness {
 
   acceptResponse(input: SyncResourceKey, request: SyncResourceRequest, version: SyncVersion | undefined): boolean {
     if (this.generation(input.scopeKey) !== request.generation) return false
-    if ((this.revisions.get(resourceKey(input)) ?? 0) !== request.revision) {
+    if (this.revisions.get(resourceKey(input)) !== request.revision) {
       if (!isValidVersion(version) || !this.current(input)) return false
     }
     return this.acceptSnapshot(input, version)
@@ -166,19 +166,15 @@ export class SyncResourceFreshness {
   }
 
   private generation(scopeKey: string) {
-    const existing = this.generations.get(scopeKey)
-    if (existing !== undefined) return existing
-    const created = this.nextGeneration++
-    this.generations.set(scopeKey, created)
-    return created
+    return this.generations.ensure(scopeKey)
   }
 
   private advanceGeneration(scopeKey: string) {
-    this.generations.set(scopeKey, this.nextGeneration++)
+    this.generations.allocate(scopeKey)
   }
 
   private bumpRevision(input: SyncResourceKey) {
-    this.revisions.set(resourceKey(input), this.nextRevision++)
+    this.revisions.allocate(resourceKey(input))
   }
 
   private clearResources(scopeKey: string) {
@@ -186,8 +182,6 @@ export class SyncResourceFreshness {
     for (const key of this.resources.keys()) {
       if (key.startsWith(prefix)) this.resources.delete(key)
     }
-    for (const key of this.revisions.keys()) {
-      if (key.startsWith(prefix)) this.revisions.delete(key)
-    }
+    this.revisions.deletePrefix(prefix)
   }
 }

--- a/packages/app/test/context/monotonic-key-space.test.ts
+++ b/packages/app/test/context/monotonic-key-space.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { MonotonicKeySpace } from "../../src/context/monotonic-key-space"
+
+describe("monotonic key space", () => {
+  test("get returns the default of 0 for missing keys", () => {
+    const space = new MonotonicKeySpace()
+
+    expect(space.get("missing")).toBe(0)
+  })
+
+  test("ensure lazily creates a key once and reuses it afterwards", () => {
+    const space = new MonotonicKeySpace()
+
+    const first = space.ensure("scope")
+    const second = space.ensure("scope")
+
+    expect(first).toBe(1)
+    expect(second).toBe(first)
+  })
+
+  test("allocate never reuses a number across keys", () => {
+    const space = new MonotonicKeySpace()
+
+    const a = space.allocate("a")
+    const b = space.allocate("b")
+    const c = space.allocate("c")
+
+    expect(a).toBe(1)
+    expect(b).toBe(2)
+    expect(c).toBe(3)
+  })
+
+  test("allocate bumps the counter even when a key is re-allocated", () => {
+    const space = new MonotonicKeySpace()
+
+    const first = space.allocate("key")
+    const second = space.allocate("key")
+
+    expect(first).toBe(1)
+    expect(second).toBe(2)
+    expect(space.get("key")).toBe(2)
+  })
+
+  test("set stores the supplied value without bumping the counter", () => {
+    const space = new MonotonicKeySpace()
+
+    space.set("scope", 7)
+    space.set("scope", 8)
+
+    expect(space.get("scope")).toBe(8)
+    expect(space.allocate("other")).toBe(1)
+  })
+
+  test("delete removes only the exact key", () => {
+    const space = new MonotonicKeySpace()
+    space.set("scope", 1)
+    space.set("scope\nsession", 2)
+
+    space.delete("scope")
+
+    expect(space.get("scope")).toBe(0)
+    expect(space.get("scope\nsession")).toBe(2)
+  })
+
+  test("deletePrefix removes keys under the raw prefix", () => {
+    const space = new MonotonicKeySpace()
+    space.set("scope", 1)
+    space.set("scope\nsession", 2)
+    space.set("scope\nsession\nmessage", 3)
+
+    space.deletePrefix("scope\n")
+
+    expect(space.get("scope")).toBe(1)
+    expect(space.get("scope\nsession")).toBe(0)
+    expect(space.get("scope\nsession\nmessage")).toBe(0)
+  })
+
+  test("deletePrefix does not remove keys that merely start with the same characters", () => {
+    const space = new MonotonicKeySpace()
+    space.set("scope", 1)
+    space.set("scope-other", 2)
+
+    space.deletePrefix("scope\n")
+
+    expect(space.get("scope")).toBe(1)
+    expect(space.get("scope-other")).toBe(2)
+  })
+
+  test("entries yields the stored key/value pairs", () => {
+    const space = new MonotonicKeySpace()
+    space.set("a", 1)
+    space.set("b", 2)
+
+    expect([...space.entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Behavior-preserving refactor: extract a small `MonotonicKeySpace` primitive (`packages/app/src/context/monotonic-key-space.ts`) — a `Map<string, number>` with a global monotonic counter and `get`/`ensure`/`allocate`/`set`/`delete`/`deletePrefix`/`entries` — and reuse it in the three frontend freshness modules that each hand-rolled the same counter/prefix machinery:

- `SyncResourceFreshness`: `generations` + `revisions` now `MonotonicKeySpace` (`ensure` for lazy generation, `allocate` for advances/bumps, `deletePrefix` in `clearResources`).
- `SessionPartSnapshotFreshness`: `generations` + `revisions` + `snapshotRequiredRevisions` now `MonotonicKeySpace`; `action` decision rules unchanged (`===` captured → apply, snapshot-required `>` captured → retry, else preserve).
- `createScopeReconnectRecovery`: `versions` now `MonotonicKeySpace`; externally supplied generations still written via `set` only after the strict newer-than check, `lifecycles` identity map untouched.

No public API, signature, return value, or decision semantic changed; no consumers touched. Decision record moved to `docs/decisions/implemented/simplification/` with a focused unit test for the primitive (`deletePrefix` boundaries, `ensure` reuse, `allocate` monotonicity, `set` without counter bump).

## Verification

All commands run locally and green:

- `bun install --frozen-lockfile` — ok
- `cd packages/app && bun test test/context/sync-resource-freshness.test.ts test/context/session-part-snapshot-freshness.test.ts test/context/scope-reconnect-recovery.test.ts test/context/global-sync.test.ts test/context/global-sync-recovery.test.ts test/context/session-volatile-resync.test.ts test/context/sync-watermark.test.ts test/context/monotonic-key-space.test.ts` — **58 pass, 0 fail** (49 baseline tests unmodified + 9 new primitive tests)
- `cd packages/app && bun run typecheck` — pass
- `bun run decision:check` — pass
- `bun run doc:check` — pass
- `bun run format:check` — pass
- `git diff --check` — clean