### PR TITLE
refactor(channel): remove unconsumed channel surface

### DIFF
--- a/docs/decisions/implemented/simplification/2026-08-17-remove-unconsumed-channel-surface.md
+++ b/docs/decisions/implemented/simplification/2026-08-17-remove-unconsumed-channel-surface.md
@@ -1,0 +1,31 @@
+# Decision Record: Remove unconsumed channel surface
+
+Status: implemented
+
+## Problem
+
+The channel domain shipped three surfaces with no production consumer:
+
+- `ChannelHost` `status` seam (`packages/synergy/src/channel/host.ts`): providers could publish status through `host.status.update`, but no provider called it; the only caller was `test/channel/host.test.ts`. Channel core owns canonical status via the `statuses` map and `Channel.status()`.
+- `Channel.Event.MessageReceived` (`packages/synergy/src/channel/index.ts`): published on message receipt but had zero subscribers in `packages/synergy/src`, `packages/app/src`, `packages/desktop`, `packages/plugin`, or `packages/ui`; it only leaked into the generated SDK surface (`packages/sdk/openapi.json`, `packages/sdk/js/src/gen/types.gen.ts`).
+- `diagnostics.hasData` (`packages/synergy/src/channel/diagnostics.ts`): exported, zero callers anywhere. Its sibling `list`/`Channel.getDiagnostics` are retained.
+
+## Decision
+
+- Delete the `status` option from `ChannelHost.create()` and the `status` member from the host instance. `test/channel/host.test.ts` no longer exercises a status seam and asserts that creating a host leaves core status untouched; core status stays canonical via the `statuses` map and `Channel.status()`, covered by `test/channel/lifecycle.test.ts` and `test/channel/refresh.test.ts`.
+- Remove `Event.MessageReceived` and its publish site. The SDK was regenerated with `./script/generate.ts`, which removed the event from the generated OpenAPI and SDK types.
+- Delete `diagnostics.hasData`.
+
+`Channel.getDiagnostics` and `diagnostics.list` remain: production uses `streamDiagnostics` for the NDJSON route (`server/channel.ts`), but the list form pins the retained-diagnostics-window behavior across `test/channel/diagnostics.test.ts` and `refresh.test.ts` — that behavior is load-bearing, not test scaffolding.
+
+The `findProjectScope`/`ensureProjectScope`/`archiveProjectScope` wrappers remain: they are test-only today, but production host paths go through `ManagedProjectOwnership` directly; moving the wrappers to a test helper is a follow-up refactor, not part of this removal.
+
+## Alternatives considered
+
+- **Keep the status seam for future providers** — rejected: a seam every provider must be able to use but none uses is speculative generality; reintroducing it is a small diff when a provider needs it.
+- **Keep `MessageReceived` for future subscribers** — rejected: shipping an unobserved public event grows the SDK contract and generated types; the publish site remains available if a consumer appears.
+- **Keep `hasData` for symmetry with `list`** — rejected: symmetry with an unused function is not a consumer.
+
+## Consequences
+
+Removing `MessageReceived` shrinks the public event contract; out-of-repo SDK consumers subscribing to it (none observed) would break. The event was published but never consumed in-repo, so no internal behavior changes. Future provider work may re-add the status seam; the removed code is recoverable from history.

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -8609,16 +8609,6 @@ export type EventChannelDisconnected = {
   }
 }
 
-export type EventChannelMessageReceived = {
-  type: "channel.message.received"
-  properties: {
-    channelType: string
-    accountId: string
-    chatId: string
-    text: string
-  }
-}
-
 export type EventSynergyLinkTargetCreated = {
   type: "synergy_link.target.created"
   properties: {
@@ -8853,7 +8843,6 @@ export type Event =
   | EventChannelCommandExecuted
   | EventChannelConnected
   | EventChannelDisconnected
-  | EventChannelMessageReceived
   | EventSynergyLinkTargetCreated
   | EventSynergyLinkTargetUpdated
   | EventSynergyLinkTargetRemoved

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -47427,34 +47427,6 @@
         },
         "required": ["type", "properties"]
       },
-      "Event.channel.message.received": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "channel.message.received"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "channelType": {
-                "type": "string"
-              },
-              "accountId": {
-                "type": "string"
-              },
-              "chatId": {
-                "type": "string"
-              },
-              "text": {
-                "type": "string"
-              }
-            },
-            "required": ["channelType", "accountId", "chatId", "text"]
-          }
-        },
-        "required": ["type", "properties"]
-      },
       "Event.synergy_link.target.created": {
         "type": "object",
         "properties": {
@@ -48119,9 +48091,6 @@
           },
           {
             "$ref": "#/components/schemas/Event.channel.disconnected"
-          },
-          {
-            "$ref": "#/components/schemas/Event.channel.message.received"
           },
           {
             "$ref": "#/components/schemas/Event.synergy_link.target.created"

--- a/packages/synergy/src/channel/diagnostics.ts
+++ b/packages/synergy/src/channel/diagnostics.ts
@@ -253,9 +253,3 @@ export async function* iterate(channelType: string, accountId: string): AsyncGen
 export async function list(channelType: string, accountId: string): Promise<DiagnosticRecord[]> {
   return Array.fromAsync(iterate(channelType, accountId))
 }
-
-export async function hasData(channelType: string, accountId: string): Promise<boolean> {
-  const account = accountHash(channelType, accountId)
-  const cutoff = Date.now() - RETENTION_MS
-  return (await retainedRecordIDs(account, cutoff)).length > 0
-}

--- a/packages/synergy/src/channel/host.ts
+++ b/packages/synergy/src/channel/host.ts
@@ -11,7 +11,6 @@ import { SessionInbox } from "@/session/inbox"
 import { SessionDrive } from "@/session/drive"
 
 export namespace ChannelHost {
-  export type ProviderStatus = { kind: string }
   export type ConversationMessage = Omit<MessageContext, "channelType" | "accountId">
   /**
    * Conversation acceptance result: the provider lane awaits only durable
@@ -112,23 +111,16 @@ export namespace ChannelHost {
   export function create(options: {
     channelType: string
     accountId: string
-    onStatus?: (status: ProviderStatus) => void
     onDiagnostic?: (record: DiagnosticRecordInput) => void | Promise<void>
     onConversationMessage?: (message: MessageContext) => Promise<ReceiveResult>
     activateTasks?: boolean
   }) {
-    const { channelType, accountId, onStatus, onDiagnostic, onConversationMessage, activateTasks = false } = options
+    const { channelType, accountId, onDiagnostic, onConversationMessage, activateTasks = false } = options
     const hostIdentity = { channelType, accountId }
 
     return {
       channelType,
       accountId,
-
-      status: {
-        update(status: ProviderStatus) {
-          onStatus?.(status)
-        },
-      },
 
       diagnostics: {
         async record(record: DiagnosticRecordInput) {

--- a/packages/synergy/src/channel/index.ts
+++ b/packages/synergy/src/channel/index.ts
@@ -200,15 +200,6 @@ export namespace Channel {
         reason: z.string().optional(),
       }),
     ),
-    MessageReceived: BusEvent.define(
-      "channel.message.received",
-      z.object({
-        channelType: z.string(),
-        accountId: z.string(),
-        chatId: z.string(),
-        text: z.string(),
-      }),
-    ),
   }
 
   type Connection = {
@@ -657,13 +648,6 @@ export namespace Channel {
             accountHash: externalIdentityHash(ctx.accountId),
             chatHash: externalIdentityHash(ctx.chatId),
             senderHash: externalIdentityHash(ctx.senderId),
-          })
-
-          Bus.publish(Event.MessageReceived, {
-            channelType: ctx.channelType,
-            accountId: ctx.accountId,
-            chatId: ctx.chatId,
-            text: ctx.text,
           })
 
           const cmdResult = await ChannelCommand.execute(

--- a/packages/synergy/test/channel/host.test.ts
+++ b/packages/synergy/test/channel/host.test.ts
@@ -3,15 +3,19 @@ import { ChannelHost } from "../../src/channel/host"
 import { ManagedProjectOwnership } from "../../src/channel/managed-project-ownership"
 import { Session } from "../../src/session"
 import { SessionInbox } from "../../src/session/inbox"
+import { Channel } from "../../src/channel"
+import { Scope } from "../../src/scope"
+import { ScopeContext } from "../../src/scope/context"
 
+function inHome<T>(fn: () => T | Promise<T>) {
+  return ScopeContext.provide({ scope: Scope.home(), fn })
+}
 function createHost(label = crypto.randomUUID()) {
-  const statuses: ChannelHost.ProviderStatus[] = []
   const diagnostics: ChannelHost.DiagnosticRecordInput[] = []
   const messages: ChannelHost.ConversationMessage[] = []
   const host = ChannelHost.create({
     channelType: "test-channel",
     accountId: `account-${label}`,
-    onStatus: (status) => statuses.push(status),
     onDiagnostic: async (record) => {
       diagnostics.push(record)
     },
@@ -20,14 +24,13 @@ function createHost(label = crypto.randomUUID()) {
       return { accepted: true, execution: Promise.resolve() }
     },
   })
-  return { host, statuses, diagnostics, messages }
+  return { host, diagnostics, messages }
 }
 
 describe("ChannelHost", () => {
-  test("binds account identity and forwards conversations, status, and diagnostics", async () => {
-    const { host, statuses, diagnostics, messages } = createHost()
+  test("binds account identity and forwards conversations and diagnostics", async () => {
+    const { host, diagnostics, messages } = createHost()
 
-    host.status.update({ kind: "syncing" })
     await host.diagnostics.record({ level: "warn", message: "partial discovery", data: { page: 2 } })
     await host.conversations.receive({
       chatId: "chat",
@@ -40,8 +43,9 @@ describe("ChannelHost", () => {
 
     expect(host.channelType).toBe("test-channel")
     expect(host.accountId).toStartWith("account-")
-    expect(statuses).toEqual([{ kind: "syncing" }])
     expect(diagnostics).toEqual([{ level: "warn", message: "partial discovery", data: { page: 2 } }])
+    // Core status is the canonical status surface; creating a host records nothing there.
+    expect(await inHome(() => Channel.status())).toEqual({})
     expect(messages).toEqual([
       expect.objectContaining({
         channelType: host.channelType,


### PR DESCRIPTION
## Summary

Remove three channel surfaces with no production consumer, per the [implemented decision record](docs/decisions/implemented/simplification/2026-08-17-remove-unconsumed-channel-surface.md):

- **`ChannelHost` status seam** — drop the `status` option from `ChannelHost.create()` and the `status` member from the host instance. Core status stays canonical via the `statuses` map / `Channel.status()`. `host.test.ts` no longer exercises the removed seam and now asserts core status is untouched.
- **`Channel.Event.MessageReceived`** — remove the event definition and its publish site, then regenerate the SDK so the event leaves `packages/sdk/openapi.json` and `packages/sdk/js/src/gen/types.gen.ts`.
- **`diagnostics.hasData`** — delete the unused export; `getDiagnostics`/`list` remain.

Retained: `Channel.getDiagnostics`/`diagnostics.list` (load-bearing retained-window behavior pinned by `diagnostics.test.ts` and `refresh.test.ts`) and the `findProjectScope`/`ensureProjectScope`/`archiveProjectScope` wrappers (follow-up refactor, out of scope).

## Verification

```bash
bun install --frozen-lockfile
bun ./script/generate.ts
bun test test/channel/host.test.ts
bun test test/channel test/server/channel.test.ts
bun run decision:check
bun run doc:check
bun run format:check
git diff --check
```

All green: 466 pass / 0 fail across the channel + server channel suites (host.test.ts 8/8, including the new core-status assertion), `decision:check`, `doc:check`, `format:check`, and `git diff --check` pass, and the regenerated SDK is clean of `MessageReceived`.