### PR TITLE
refactor(session): remove SYNERGY_TEST_HOME fork from AgentTurn.stream

### DIFF
--- a/docs/decisions/implemented/simplification/2026-08-17-remove-agent-turn-test-fork.md
+++ b/docs/decisions/implemented/simplification/2026-08-17-remove-agent-turn-test-fork.md
@@ -1,0 +1,40 @@
+# Decision Record: Remove the SYNERGY_TEST_HOME fork from AgentTurn.stream
+
+Status: implemented
+
+## Problem
+
+`packages/synergy/src/session/agent-turn/index.ts` shipped a second stream implementation selected by the `SYNERGY_TEST_HOME` env var: it called `LLM.stream` in-process, projected text into synthetic `"test-text"` deltas, and bypassed the worker pool entirely. Consequences:
+
+- Tests (`test/preload.ts` sets `SYNERGY_TEST_HOME` for every test file) never exercised the production stream path (pool + `prepared.system` + `FrameStream`), while production never exercised the fork.
+- The fork embedded test-only semantics in production code (synthetic `"test-text"` ids, a noop `dispose` in one sub-case).
+- The same file also carried `AgentTurn.collectText` with zero callers in src or tests.
+
+`SYNERGY_TEST_HOME` itself must stay: `src/global/index.ts` (Path.root), `src/provider/models-macro.ts` (build-time), and `src/plugin/marketplace-registry.ts` depend on it.
+
+## Decision
+
+The env fork was removed from the production stream path and replaced with a narrow, explicit test-only hook:
+
+- `index.ts` deletes the `SYNERGY_TEST_HOME` branch; `stream()` performs the admission check, delegates to the registered in-process hook when present, and otherwise runs the pool path (existing code unchanged). `AgentTurn.setInProcessStream(hook | undefined)` registers the hook.
+- New module `agent-turn/in-process.ts` carries the old fork body verbatim (`LLM.stream` in-process, the three projection sub-cases, usage catch, dispose handling) exported as `runInProcessStream`. Production `index.ts` does not import it.
+- `startContextUsageDraft` moved into the shared module `agent-turn/context-usage-draft.ts`, used by both the pool path (with `prepared.system`) and the hook (with raw `input.system`); behavior is unchanged.
+- `test/preload.ts` registers the hook after setting the test home (`AgentTurn.setInProcessStream(runInProcessStream)`). Behavior of every existing fork-using test (`test/agent/call.test.ts` mocks `LLM.stream`/`LLM.takeTextStream`) is unchanged.
+- `test/session/agent-turn.test.ts` replaces its `delete process.env.SYNERGY_TEST_HOME` with `AgentTurn.setInProcessStream(undefined)` to reach the pool path, restoring the hook in `finally`.
+- `AgentTurn.collectText` was deleted (zero callers).
+
+Worker processes inherit `SYNERGY_TEST_HOME` but never consulted the fork (`runner.ts` runs the full product path); no worker-side change was needed.
+
+## Alternatives considered
+
+- **Run all tests against the real worker pool** — rejected: workers need a working provider inside the spawned process plus `ScopeContext` wiring for every call-style test; it would rewrite test infrastructure far beyond this cleanup.
+- **Keep the fork but select it by env inside a test-only module** — rejected: that still keeps an env-sensitive branch reachable from production; the explicit hook makes the seam visible and defaults to undefined in production.
+- **Delete the fork outright and re-mock at the `AgentTurn.stream` boundary in tests** — rejected: churns mocks across tests for no behavioral gain; the hook keeps the same seam the mocks already target (`LLM.stream`/`LLM.takeTextStream`).
+
+## Consequences
+
+- The `packages/synergy` suites stay green: `test/agent/call.test.ts`, `test/session/agent-turn.test.ts`, `agent-turn-protocol`, `llm-stream-lifecycle`, `agent-worker-pool`, `agent-worker-process`, `agent-worker-runtime-boundary`, `restart-while-queued`, `test/server/shutdown-admission.test.ts`.
+- No `SYNERGY_TEST_HOME` reference remains in `src/session/agent-turn/**`; `"test-text"` appears only inside the in-process module.
+- The production stream path contains no env check; the pool path is unchanged; the moved fork body keeps coverage via the preload-registered hook.
+- Cost: the hook is a test-only seam registered in preload; a future test that forgets to unregister it (as `agent-turn.test.ts` must) would silently keep the in-process path. Mitigated by the explicit `setInProcessStream(undefined)` pattern and the comment in `preload.ts`.
+- Cost: `startContextUsageDraft` now lives in a shared module; the pool path uses `prepared.system` and the hook uses raw `input.system`, verified by existing tests.

--- a/packages/synergy/src/session/agent-turn/context-usage-draft.ts
+++ b/packages/synergy/src/session/agent-turn/context-usage-draft.ts
@@ -1,0 +1,17 @@
+import { ContextUsage } from "../context-usage"
+import type { AgentTurnInput } from "./worker-pool"
+
+export function startContextUsageDraft(
+  input: AgentTurnInput,
+  system: string[],
+  provenance: ContextUsage.Provenance | undefined,
+): Promise<ContextUsage.Draft | undefined> | undefined {
+  if (!provenance) return undefined
+  return ContextUsage.measureDraft({
+    modelID: input.model.id,
+    providerID: input.model.providerID,
+    limits: input.model.limit,
+    instructions: [...system, ...(input.lateSystem ?? [])],
+    provenance,
+  }).catch(() => undefined)
+}

--- a/packages/synergy/src/session/agent-turn/in-process.ts
+++ b/packages/synergy/src/session/agent-turn/in-process.ts
@@ -1,0 +1,57 @@
+import { LLM } from "../llm"
+import { ToolCatalog } from "../tool-catalog"
+import { AgentTurnProtocol } from "./protocol"
+import { startContextUsageDraft } from "./context-usage-draft"
+import type { AgentTurnInput, AgentTurnStream, AgentTurnStreamPart } from "./worker-pool"
+
+/**
+ * Test-only in-process stream implementation, registered via
+ * `AgentTurn.setInProcessStream` (see `test/preload.ts`). It mirrors the old
+ * `SYNERGY_TEST_HOME` fork: runs `LLM.stream` in-process and projects text
+ * into synthetic `"test-text"` deltas. Production code never imports this
+ * module.
+ */
+export async function runInProcessStream(input: AgentTurnInput): Promise<AgentTurnStream> {
+  const { contextUsageProvenance, ...turnInput } = input
+  const result = await LLM.stream({
+    ...turnInput,
+    tools: ToolCatalog.modelTools(input.toolDefinitions ?? []),
+  })
+  const contextUsageDraft = startContextUsageDraft(input, input.system, contextUsageProvenance)
+  const usage = result.usage?.catch(() => undefined) ?? Promise.resolve(undefined)
+  if (!result.fullStream) {
+    if (!result.textStream && result.text) {
+      return {
+        fullStream: (async function* () {
+          const text = await result.text
+          if (text) yield { type: "text-delta", id: "test-text", text } as AgentTurnStreamPart
+        })(),
+        contextUsageDraft,
+        usage,
+        async dispose() {},
+      }
+    }
+    const owned = LLM.takeTextStream(result)
+    return {
+      fullStream: (async function* () {
+        for await (const text of owned.stream) {
+          yield { type: "text-delta", id: "test-text", text } as AgentTurnStreamPart
+        }
+      })(),
+      contextUsageDraft,
+      usage,
+      dispose: owned.dispose,
+    }
+  }
+  const owned = LLM.takeFullStream(result)
+  return {
+    fullStream: (async function* () {
+      for await (const value of owned.stream) {
+        yield* AgentTurnProtocol.projectEvents([value])
+      }
+    })(),
+    contextUsageDraft,
+    usage,
+    dispose: owned.dispose,
+  }
+}

--- a/packages/synergy/src/session/agent-turn/index.ts
+++ b/packages/synergy/src/session/agent-turn/index.ts
@@ -1,24 +1,24 @@
 import { LLM } from "../llm"
-import { ContextUsage } from "../context-usage"
 import { ToolCatalog } from "../tool-catalog"
 import {
   AgentWorkerPool,
   DEFAULT_AGENT_WORKER_POOL_OPTIONS,
   type AgentTurnInput,
   type AgentTurnStream,
-  type AgentTurnStreamPart,
   type AgentWorkerPoolOptions,
 } from "./worker-pool"
-import { AgentTurnProtocol } from "./protocol"
+import { startContextUsageDraft } from "./context-usage-draft"
 
 export namespace AgentTurn {
   export type Input = AgentTurnInput
   export type Stream = AgentTurnStream
+  export type InProcessStream = (input: Input) => Promise<Stream>
 
   let pool: AgentWorkerPool | undefined
   let options = DEFAULT_AGENT_WORKER_POOL_OPTIONS
   let accepting = true
   let stopPromise: Promise<void> | undefined
+  let inProcessStream: InProcessStream | undefined
 
   export function configure(input: Partial<AgentWorkerPoolOptions> = {}): void {
     if (pool) throw new Error("Agent worker pool cannot be reconfigured after it has started")
@@ -27,6 +27,9 @@ export namespace AgentTurn {
       ...DEFAULT_AGENT_WORKER_POOL_OPTIONS,
       ...Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined)),
     }
+  }
+  export function setInProcessStream(hook: InProcessStream | undefined): void {
+    inProcessStream = hook
   }
 
   export function closeAdmission(): void {
@@ -43,50 +46,8 @@ export namespace AgentTurn {
 
   export async function stream(input: Input): Promise<Stream> {
     if (!accepting || stopPromise) throw new Error("Agent worker pool is stopping")
+    if (inProcessStream) return inProcessStream(input)
     const { contextUsageProvenance, ...turnInput } = input
-    if (process.env.SYNERGY_TEST_HOME) {
-      const result = await LLM.stream({
-        ...turnInput,
-        tools: ToolCatalog.modelTools(input.toolDefinitions ?? []),
-      })
-      const contextUsageDraft = startContextUsageDraft(input, input.system, contextUsageProvenance)
-      const usage = result.usage?.catch(() => undefined) ?? Promise.resolve(undefined)
-      if (!result.fullStream) {
-        if (!result.textStream && result.text) {
-          return {
-            fullStream: (async function* () {
-              const text = await result.text
-              if (text) yield { type: "text-delta", id: "test-text", text } as AgentTurnStreamPart
-            })(),
-            contextUsageDraft,
-            usage,
-            async dispose() {},
-          }
-        }
-        const owned = LLM.takeTextStream(result)
-        return {
-          fullStream: (async function* () {
-            for await (const text of owned.stream) {
-              yield { type: "text-delta", id: "test-text", text } as AgentTurnStreamPart
-            }
-          })(),
-          contextUsageDraft,
-          usage,
-          dispose: owned.dispose,
-        }
-      }
-      const owned = LLM.takeFullStream(result)
-      return {
-        fullStream: (async function* () {
-          for await (const value of owned.stream) {
-            yield* AgentTurnProtocol.projectEvents([value])
-          }
-        })(),
-        contextUsageDraft,
-        usage,
-        dispose: owned.dispose,
-      }
-    }
     pool ??= new AgentWorkerPool(options)
     const prepared = await LLM.prepare({
       ...turnInput,
@@ -95,33 +56,6 @@ export namespace AgentTurn {
     const result = await pool.run({ ...turnInput, prepared })
     const contextUsageDraft = startContextUsageDraft(input, prepared.system, contextUsageProvenance)
     return { ...result, contextUsageDraft }
-  }
-
-  function startContextUsageDraft(
-    input: Input,
-    system: string[],
-    provenance: ContextUsage.Provenance | undefined,
-  ): Promise<ContextUsage.Draft | undefined> | undefined {
-    if (!provenance) return undefined
-    return ContextUsage.measureDraft({
-      modelID: input.model.id,
-      providerID: input.model.providerID,
-      limits: input.model.limit,
-      instructions: [...system, ...(input.lateSystem ?? [])],
-      provenance,
-    }).catch(() => undefined)
-  }
-
-  export async function collectText(stream: Stream): Promise<string> {
-    let result = ""
-    try {
-      for await (const part of stream.fullStream) {
-        if (part.type === "text-delta") result += part.text
-      }
-      return result
-    } finally {
-      await stream.dispose()
-    }
   }
 
   export function stats() {

--- a/packages/synergy/test/preload.ts
+++ b/packages/synergy/test/preload.ts
@@ -87,9 +87,17 @@ delete process.env["SAMBANOVA_API_KEY"]
 
 // Now safe to import from src/
 const { Log } = await import("../src/util/log")
+const { AgentTurn } = await import("../src/session/agent-turn")
+const { runInProcessStream } = await import("../src/session/agent-turn/in-process")
 
 Log.init({
   print: false,
   dev: true,
   level: "DEBUG",
 })
+
+// Register the in-process stream hook so call-style tests keep exercising the
+// same LLM.stream seam they always mocked (see test/agent/call.test.ts).
+// Pool-path tests must explicitly unregister it with
+// AgentTurn.setInProcessStream(undefined) and restore it afterwards.
+AgentTurn.setInProcessStream(runInProcessStream)

--- a/packages/synergy/test/session/agent-turn.test.ts
+++ b/packages/synergy/test/session/agent-turn.test.ts
@@ -1,11 +1,11 @@
 import { expect, mock, test } from "bun:test"
 import { AgentTurn } from "../../src/session/agent-turn"
+import { runInProcessStream } from "../../src/session/agent-turn/in-process"
 import { AgentWorkerPool } from "../../src/session/agent-turn/worker-pool"
 import { ContextUsage } from "../../src/session/context-usage"
 import { LLM } from "../../src/session/llm"
 
 test("starts Context Usage estimation only after the Agent worker starts", async () => {
-  const originalTestHome = process.env.SYNERGY_TEST_HOME
   const originalPrepare = LLM.prepare
   const originalRun = AgentWorkerPool.prototype.run
   const originalMeasureDraft = ContextUsage.measureDraft
@@ -15,7 +15,7 @@ test("starts Context Usage estimation only after the Agent worker starts", async
   try {
     await AgentTurn.stop()
     AgentTurn.configure({ minIdle: 0 })
-    delete process.env.SYNERGY_TEST_HOME
+    AgentTurn.setInProcessStream(undefined)
     ;(LLM.prepare as any) = mock(async () => ({
       system: ["prepared system"],
       baseSystemLength: 1,
@@ -68,8 +68,7 @@ test("starts Context Usage estimation only after the Agent worker starts", async
     ;(LLM.prepare as any) = originalPrepare
     ;(AgentWorkerPool.prototype.run as any) = originalRun
     ;(ContextUsage.measureDraft as any) = originalMeasureDraft
-    if (originalTestHome === undefined) delete process.env.SYNERGY_TEST_HOME
-    else process.env.SYNERGY_TEST_HOME = originalTestHome
+    AgentTurn.setInProcessStream(runInProcessStream)
     await AgentTurn.stop()
     AgentTurn.configure()
   }


### PR DESCRIPTION
## Summary

Replaces the `SYNERGY_TEST_HOME`-selected in-process stream fork in `AgentTurn.stream` with an explicit test-only hook, and moves the fork out of production code:

- `packages/synergy/src/session/agent-turn/index.ts`: deletes the env fork; `stream()` is now admission check → registered in-process hook → pool path (unchanged). Adds `AgentTurn.setInProcessStream(hook | undefined)`.
- `packages/synergy/src/session/agent-turn/in-process.ts` (new): the old fork body verbatim (`LLM.stream` in-process, three projection sub-cases, usage catch, dispose), exported as `runInProcessStream`. Production `index.ts` does not import it.
- `packages/synergy/src/session/agent-turn/context-usage-draft.ts` (new): `startContextUsageDraft` shared by the pool path (`prepared.system`) and the hook (`input.system`); behavior unchanged.
- `packages/synergy/test/preload.ts`: registers the hook after setting the test home; `test/agent/call.test.ts` mocks (`LLM.stream`/`LLM.takeTextStream`) are unaffected.
- `packages/synergy/test/session/agent-turn.test.ts`: reaches the pool path via `setInProcessStream(undefined)` instead of deleting `SYNERGY_TEST_HOME`, restoring the hook in `finally`.
- Deletes `AgentTurn.collectText` (zero callers).
- Decision record migrated `docs/decisions/proposed/` → `docs/decisions/implemented/simplification/2026-08-17-remove-agent-turn-test-fork.md`.

`SYNERGY_TEST_HOME` itself stays: `src/global/index.ts`, `src/provider/models-macro.ts`, `src/plugin/marketplace-registry.ts` still use it.

## Verification

Narrow suite (from `packages/synergy`):

```bash
bun test test/agent/call.test.ts test/session/agent-turn.test.ts test/session/agent-turn-protocol.test.ts test/session/llm-stream-lifecycle.test.ts test/session/agent-worker-pool.test.ts test/session/agent-worker-process.test.ts test/session/agent-worker-runtime-boundary.test.ts test/session/restart-while-queued.test.ts test/server/shutdown-admission.test.ts
```

Result: **82 pass, 0 fail** across 9 files (baseline 42 + 38 remained green).

Gates:

- `bun run decision:check` — passed
- `bun run doc:check` — passed
- `bun run format:check` — passed
- `git diff --check` — clean
- Pre-push hooks: prettier, oxlint (0 warnings/errors), turbo typecheck (11/11 packages), sherif, doc/decision checks — all passed