### PR TITLE
test: cover generic-branch late-message tolerance for agent workers

### DIFF
--- a/packages/synergy/src/session/agent-turn/worker-pool.ts
+++ b/packages/synergy/src/session/agent-turn/worker-pool.ts
@@ -562,7 +562,10 @@ export class AgentWorkerPool {
           this.dropLateMessage(worker, message.type, message.requestId)
           return
         }
-        this.terminateForProtocol(worker, "heartbeat referenced an unowned turn")
+        this.terminateForProtocol(worker, "heartbeat referenced an unowned turn", {
+          messageType: message.type,
+          requestId: message.requestId,
+        })
         return
       }
       this.recordWorkerMemory(
@@ -608,7 +611,10 @@ export class AgentWorkerPool {
         this.dropLateMessage(worker, message.type, lateRequestId)
         return
       }
-      this.terminateForProtocol(worker, "message referenced an unowned turn")
+      this.terminateForProtocol(worker, "message referenced an unowned turn", {
+        messageType: message.type,
+        ...(lateRequestId !== undefined ? { requestId: lateRequestId } : {}),
+      })
       return
     }
     if (message.type === "run-ready") {
@@ -1166,7 +1172,11 @@ export class AgentWorkerPool {
     }
   }
 
-  private terminateForProtocol(worker: PoolWorker, reason: string): void {
+  private terminateForProtocol(
+    worker: PoolWorker,
+    reason: string,
+    context?: { messageType?: string; requestId?: string },
+  ): void {
     if (worker.stopping || this.stopping) return
     worker.startupFailureEligible = false
     worker.stopping = true
@@ -1174,6 +1184,8 @@ export class AgentWorkerPool {
       workerID: worker.id,
       pid: worker.pid,
       reason,
+      ...(context?.messageType !== undefined ? { messageType: context.messageType } : {}),
+      ...(context?.requestId !== undefined ? { requestId: context.requestId } : {}),
     })
     ObservabilityMetrics.record({
       name: "agent.worker.recycle",

--- a/packages/synergy/test/session/agent-worker-pool.test.ts
+++ b/packages/synergy/test/session/agent-worker-pool.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import { Scope } from "../../src/scope"
 import { ScopeContext } from "../../src/scope/context"
 import { AgentTurnProtocol } from "../../src/session/agent-turn/protocol"
@@ -8,6 +8,7 @@ import {
   type AgentWorkerPoolOptions,
 } from "../../src/session/agent-turn/worker-pool"
 import type { AgentWorkerProcess, SpawnAgentWorkerProcessOptions } from "../../src/session/agent-turn/process-host"
+import { ObservabilityMetrics } from "../../src/observability/metrics"
 
 interface FakeWorker {
   options: SpawnAgentWorkerProcessOptions
@@ -842,6 +843,98 @@ describe("AgentWorkerPool", () => {
     releaseTurn(fake.workers[0], secondRun.requestId)
     expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
     expect(fake.workers).toHaveLength(1)
+    await pool.stop()
+  })
+  test("drops late non-heartbeat messages that reference a recently released turn and records the drop", async () => {
+    const fake = fakeWorkers()
+    const pool = new AgentWorkerPool(options, fake.spawn)
+    using _metrics = spyOn(ObservabilityMetrics, "record")
+
+    const firstPromise = inScope(() => pool.run(input(new AbortController().signal)))
+    fake.workers[0].ready()
+    const firstRun = startTurn(fake.workers[0])
+    fake.workers[0].receive({ type: "started", requestId: firstRun.requestId })
+    const first = await firstPromise
+    fake.workers[0].receive({
+      type: "complete",
+      requestId: firstRun.requestId,
+      turns: 1,
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
+    })
+    releaseTurn(fake.workers[0], firstRun.requestId)
+    expect((await first.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
+
+    // The worker is already running its next turn when the late message arrives.
+    const secondPromise = inScope(() => pool.run(input(new AbortController().signal)))
+    const secondRun = startTurn(fake.workers[0])
+    fake.workers[0].receive({ type: "started", requestId: secondRun.requestId })
+    const second = await secondPromise
+
+    // A late duplicate terminal referencing the released turn hits the generic ownership
+    // branch and must be dropped without killing the worker.
+    fake.workers[0].receive({
+      type: "complete",
+      requestId: firstRun.requestId,
+      turns: 1,
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
+    })
+    expect(fake.workers).toHaveLength(1)
+
+    const calls = (
+      _metrics as unknown as {
+        mock: { calls: Array<Array<{ name?: string; labels?: Record<string, unknown> }>> }
+      }
+    ).mock.calls
+    const lateCalls = calls.filter((call) => call[0]?.name === "agent.worker.late_message")
+    expect(lateCalls).toHaveLength(1)
+    expect(lateCalls[0][0].labels).toEqual({ messageType: "complete" })
+    expect(calls.some((call) => call[0]?.name === "agent.worker.recycle")).toBe(false)
+
+    fake.workers[0].receive({
+      type: "complete",
+      requestId: secondRun.requestId,
+      turns: 2,
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
+    })
+    releaseTurn(fake.workers[0], secondRun.requestId)
+    expect((await second.fullStream[Symbol.asyncIterator]().next()).done).toBe(true)
+    expect(fake.workers).toHaveLength(1)
+    await pool.stop()
+  })
+
+  test("still kills the worker for a non-heartbeat message referencing a never-owned request", async () => {
+    const fake = fakeWorkers()
+    const pool = new AgentWorkerPool(options, fake.spawn)
+    using _metrics = spyOn(ObservabilityMetrics, "record")
+    const streamPromise = inScope(() => pool.run(input(new AbortController().signal)))
+    fake.workers[0].ready()
+    const run = startTurn(fake.workers[0])
+    fake.workers[0].receive({ type: "started", requestId: run.requestId })
+    const stream = await streamPromise
+
+    fake.workers[0].receive({
+      type: "complete",
+      requestId: "never-owned-request",
+      turns: 1,
+      memoryBeforeDispose: workerMemory(2, 2),
+      memory: workerMemory(),
+    })
+
+    await expect(stream.fullStream[Symbol.asyncIterator]().next()).rejects.toThrow("Agent worker exited")
+    expect(fake.workers).toHaveLength(1)
+    const calls = (
+      _metrics as unknown as {
+        mock: { calls: Array<Array<{ name?: string; labels?: Record<string, unknown> }>> }
+      }
+    ).mock.calls
+    expect(
+      calls.some(
+        (call) => call[0]?.name === "agent.worker.recycle" && call[0]?.labels?.reason === "protocol_violation",
+      ),
+    ).toBe(true)
     await pool.stop()
   })
 


### PR DESCRIPTION
## Summary

Follow-up to #1198 addressing review feedback on the late-message tolerance fix. The production SIGTERM incident hit the **generic ownership branch** in `AgentWorkerPool` (`message referenced an unowned turn`), but the original change only had drop-path regression coverage for `heartbeat`-type messages. This PR closes that gap and adds the observability assertions the review requested.

## Changes

- `packages/synergy/test/session/agent-worker-pool.test.ts`
- New test: a non-heartbeat late message (duplicate `complete` for a released turn) arriving while the worker runs its next turn is dropped without killing the worker, records `agent.worker.late_message` with the message type, and does not record a recycle — then the next turn still completes normally.
- New test: a non-heartbeat message referencing a never-owned request still kills the worker and records `agent.worker.recycle` with `reason: protocol_violation`.
- `packages/synergy/src/session/agent-turn/worker-pool.ts`
- `terminateForProtocol` accepts optional message context and includes `messageType`/`requestId` in the protocol-violation warn log, per the planned observability enhancement.

## Verification

- Focused suites (worker-pool, blueprint-continuation, light-loop-continuation, note-write, exposure, blueprint-route): 114 pass / 0 fail.
- `bun run quality:quick`: all 14 gates pass.
- `bun run test:changed`: 4191 pass / 7 fail — all seven are 5s timeout flakes (session migrations and one hook); `test/session/migration.test.ts` passes 20/20 in isolation and the touched surface is limited to the worker pool and its test file.