### PR TITLE
fix(cortex): restore delivery notification reset when reusing a child session

### DIFF
--- a/packages/synergy/src/cortex/manager.ts
+++ b/packages/synergy/src/cortex/manager.ts
@@ -260,6 +260,7 @@ export namespace Cortex {
       draft.cortex.completedAt = undefined
       draft.cortex.error = undefined
       draft.cortex.launchFailure = undefined
+      draft.cortex.deliveryNotifiedAt = undefined
       draft.cortex.output = undefined
       draft.cortex.owner = input.owner
       draft.cortex.timeoutMs = input.timeoutMs

--- a/packages/synergy/test/cortex/manager.test.ts
+++ b/packages/synergy/test/cortex/manager.test.ts
@@ -244,6 +244,49 @@ describe.serial("Cortex", () => {
         },
       })
     })
+
+    test("resets the delivery notification timestamp when reusing a child session", async () => {
+      await using tmp = await tmpdir({ git: true })
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const parent = await Session.create({})
+          const parentMessageID = Identifier.ascending("message")
+          const child = await Session.create({
+            parentID: parent.id,
+            cortex: {
+              taskID: "ctx_previous_task",
+              parentSessionID: parent.id,
+              parentMessageID,
+              description: "Previous task",
+              agent: "developer",
+              status: "completed",
+              startedAt: Date.now(),
+              completedAt: Date.now(),
+              deliveryNotifiedAt: Date.now(),
+            },
+          })
+
+          const task = await Cortex.prepare({
+            description: "Reused reviewer recovery",
+            prompt: "Review again",
+            agent: "developer",
+            executionRole: "delegated_subagent",
+            parentSessionID: parent.id,
+            parentMessageID,
+            sessionID: child.id,
+            visibility: "hidden",
+          })
+
+          const persisted = await Session.get(child.id)
+          expect(persisted.cortex?.taskID).toBe(task.id)
+          expect(persisted.cortex?.status).toBe("queued")
+          expect(persisted.cortex?.deliveryNotifiedAt).toBeUndefined()
+
+          await Cortex.cancel(task.id)
+        },
+      })
+    })
   })
 
   test("explicit sessionID has priority over reusableSession from reuseInterrupted search", async () => {


### PR DESCRIPTION
## Summary

Review follow-up restoring an invariant that was accidentally dropped while adding the `launchFailure` reviewer-classification fix.

While adding `draft.cortex.launchFailure = undefined` to the `Cortex.prepare()` session-reuse reset block, the adjacent `draft.cortex.deliveryNotifiedAt = undefined` line was unintentionally deleted. That line was introduced intentionally by `8c9b118f7` ("fix(workflows): serialize session continuation delivery") and preserves the delivery-serialization invariant when a child session is reused: a reused reviewer session (review-tool recovery rounds reuse the same audit session via explicit `sessionID`) must not carry a stale delivery timestamp, or it would skip parent continuation notification on the new turn.

## Changes

- `packages/synergy/src/cortex/manager.ts`: restore `draft.cortex.deliveryNotifiedAt = undefined` in the `prepare()` reuse reset block (immediately after `draft.cortex.launchFailure = undefined`), matching the original ordering from `8c9b118f7`.
- `packages/synergy/test/cortex/manager.test.ts`: new regression test — `prepare` with an explicit `sessionID` reusing a child session whose cortex already has `deliveryNotifiedAt` set results in `deliveryNotifiedAt === undefined` after reuse, alongside the existing task-control reset assertions.

## Verification

- `bun test test/cortex/manager.test.ts test/session/blueprint-continuation.test.ts test/session/light-loop-continuation.test.ts`: 86 pass / 0 fail.
- `bun run quality:quick`: all 14 gates pass.
- `bun run decision:check`: passed.