### PR TITLE
feat(settings): apply theme and color scheme instantly without Save Changes

### DIFF
--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -61,7 +61,6 @@ import {
   retainDraftAfterSave,
   saveExplicitSettingsChanges,
   snapshotSettingsDraft,
-  themeIdToApplyAfterSave,
 } from "./settings-explicit-save"
 import { prepareLocaleSettingsSave, rejectLocaleSettingsSave } from "./settings-locale-save"
 import { pluginSettingsResourceKey } from "./plugin-settings-resource"
@@ -209,6 +208,7 @@ const copy = {
     message: "Moved to {path}",
   },
   interfaceZoomRow: { id: "settings.catalog.general.row.zoom", message: "Interface Zoom" },
+  themeSaveFailed: { id: "settings.panel.theme.saveFailed", message: "Theme change could not be saved" },
 }
 
 export type SettingsPanelProps = DialogSettingsProps & {
@@ -501,7 +501,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
     pluginDraftVersion()
     return pluginDrafts.dirty()
   }
-  const colorSchemeDirty = () => settings.general.colorScheme !== theme.colorScheme()
   const desktopUpdateDirty = () => {
     const draft = desktopUpdateDraft()
     return draft !== undefined && draft !== (productUpdate.desktopStatus()?.mode ?? "auto")
@@ -520,7 +519,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
       hasPluginChanges() ||
       personalizeController.dirty() ||
       font.dirty() ||
-      colorSchemeDirty() ||
       desktopUpdateDirty() ||
       desktopZoomDirty(),
   )
@@ -548,6 +546,9 @@ export function SettingsPanel(props: SettingsPanelProps) {
     setDesktopZoomDraft(undefined)
     resetEditor()
     doEnsureInit()
+    // Restore instant-applied theme — ensureInit reads `theme` from the server config resource
+    // which may still hold the previous value if the background save hasn't landed yet.
+    setSettings("general", "theme", theme.themeId() === "synergy" ? "" : theme.themeId())
   }
 
   const save = useSettingsSave({
@@ -560,10 +561,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
     preparePatchSave: (patch) => prepareLocaleSettingsSave(patch, locale.controller),
     rejectPatchSave: async (patch) => {
       await rejectLocaleSettingsSave(patch, locale.controller, globalSync.data.config.locale)
-    },
-    onPatchSaved: (patch) => {
-      const themeId = themeIdToApplyAfterSave(patch)
-      if (themeId !== undefined) theme.setThemeId(themeId)
     },
     discardChanges,
     closeDialog: () => props.onClose?.() ?? dialog.close(),
@@ -613,10 +610,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
     return font.save()
   }
 
-  async function saveColorSchemeChanges() {
-    theme.setColorScheme(settings.general.colorScheme)
-    return true
-  }
 
   async function saveDesktopUpdateChanges() {
     const mode = desktopUpdateDraft()
@@ -643,7 +636,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
     { dirty: hasPluginChanges, save: savePluginChanges },
     { dirty: personalizeController.dirty, save: savePersonalizeChanges },
     { dirty: font.dirty, save: saveFontChanges },
-    { dirty: colorSchemeDirty, save: saveColorSchemeChanges },
     { dirty: desktopUpdateDirty, save: saveDesktopUpdateChanges },
     { dirty: desktopZoomDirty, save: saveDesktopZoomChanges },
   ]
@@ -793,7 +785,29 @@ export function SettingsPanel(props: SettingsPanelProps) {
     general: () => (
       <GeneralPanel
         general={settings.general}
-        onGeneralChange={(key, value) => setSettings("general", key, value)}
+        onGeneralChange={(key, value) => {
+          if (key === "colorScheme") {
+            theme.setColorScheme(value)
+            setSettings("general", "colorScheme", value)
+            return
+          }
+          if (key === "theme") {
+            theme.setThemeId(value || "synergy")
+            setSettings("general", "theme", value)
+            // Persist to server independently — fire-and-forget with error toast on failure.
+            void globalSDK.client.config.domain
+              .update({ domain: "general", configDomainUpdateInput: { config: { theme: value } } })
+              .catch((error) => {
+                showToast({
+                  type: "error",
+                  title: _(copy.themeSaveFailed),
+                  description: requestErrorMessage(error),
+                })
+              })
+            return
+          }
+          setSettings("general", key, value)
+        }}
         desktopUpdateMode={desktopUpdateDraft() ?? productUpdate.desktopStatus()?.mode}
         onDesktopUpdateModeChange={stageDesktopUpdateMode}
         desktopZoom={desktopZoomDraft() ?? desktopZoomSaved() ?? 1}

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -20,7 +20,7 @@ import { Spinner } from "@ericsanchezok/synergy-ui/spinner"
 import { useDialog } from "@ericsanchezok/synergy-ui/context/dialog"
 import { showToast } from "@ericsanchezok/synergy-ui/toast"
 import { getSemanticIcon } from "@ericsanchezok/synergy-ui/semantic-icon"
-import { useTheme } from "@ericsanchezok/synergy-ui/theme"
+import { useTheme, type ColorScheme } from "@ericsanchezok/synergy-ui/theme"
 import type {
   ChannelStatus,
   ConfigDomainSummary,
@@ -787,16 +787,18 @@ export function SettingsPanel(props: SettingsPanelProps) {
         general={settings.general}
         onGeneralChange={(key, value) => {
           if (key === "colorScheme") {
-            theme.setColorScheme(value)
-            setSettings("general", "colorScheme", value)
+            const scheme = value as ColorScheme
+            theme.setColorScheme(scheme)
+            setSettings("general", "colorScheme", scheme)
             return
           }
           if (key === "theme") {
-            theme.setThemeId(value || "synergy")
-            setSettings("general", "theme", value)
+            const themeValue = value as string
+            theme.setThemeId(themeValue || "synergy")
+            setSettings("general", "theme", themeValue)
             // Persist to server independently — fire-and-forget with error toast on failure.
             void globalSDK.client.config.domain
-              .update({ domain: "general", configDomainUpdateInput: { config: { theme: value } } })
+              .update({ domain: "general", configDomainUpdateInput: { config: { theme: themeValue } } })
               .catch((error) => {
                 showToast({
                   type: "error",

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -61,6 +61,7 @@ import {
   retainDraftAfterSave,
   saveExplicitSettingsChanges,
   snapshotSettingsDraft,
+  themeIdToSettingsValue,
 } from "./settings-explicit-save"
 import { prepareLocaleSettingsSave, rejectLocaleSettingsSave } from "./settings-locale-save"
 import { pluginSettingsResourceKey } from "./plugin-settings-resource"
@@ -485,6 +486,16 @@ export function SettingsPanel(props: SettingsPanelProps) {
     if (submittedDraft && currentDraft) {
       setSettings(reconcile(rebaseDraftAfterSave(snapshotSettingsDraft(settings), submittedDraft, currentDraft)))
     }
+    if (submittedDraft) restoreInstantTheme()
+  }
+
+  // Theme is applied instantly and persisted by a background update, so the
+  // server config resource may still hold the previous value when the panel
+  // re-initializes. Restore the live provider value on discard and after an
+  // explicit save so the picker stays in sync with the applied appearance.
+  // Config imports skip this: there the server value is the intended one.
+  function restoreInstantTheme() {
+    setSettings("general", "theme", themeIdToSettingsValue(theme.themeId()))
   }
 
   const serverPatch = createMemo<Record<string, unknown>>(() => {
@@ -528,7 +539,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
       plugin: pluginDraftVersion(),
       personalize: [personalizeController.content(), personalizeController.resetPending()],
       font: [font.selected("sans"), font.selected("mono")],
-      colorScheme: settings.general.colorScheme,
       desktopUpdate: desktopUpdateDraft(),
       desktopZoom: desktopZoomDraft(),
     }),
@@ -546,9 +556,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
     setDesktopZoomDraft(undefined)
     resetEditor()
     doEnsureInit()
-    // Restore instant-applied theme — ensureInit reads `theme` from the server config resource
-    // which may still hold the previous value if the background save hasn't landed yet.
-    setSettings("general", "theme", theme.themeId() === "synergy" ? "" : theme.themeId())
+    restoreInstantTheme()
   }
 
   const save = useSettingsSave({

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -610,7 +610,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
     return font.save()
   }
 
-
   async function saveDesktopUpdateChanges() {
     const mode = desktopUpdateDraft()
     if (mode === undefined) return true

--- a/packages/app/src/components/settings/hooks/useConfigPatch.ts
+++ b/packages/app/src/components/settings/hooks/useConfigPatch.ts
@@ -39,8 +39,8 @@ function buildGeneralPatch(cfg: Config, state: SettingsState, patch: Record<stri
   const username = general.username.trim()
   if (username !== (cfg.username ?? UI_DEFAULTS.username)) patch.username = username || undefined
 
-  const theme = general.theme.trim()
-  if (theme !== (cfg.theme ?? UI_DEFAULTS.theme)) patch.theme = theme
+  // Theme is applied instantly and persisted independently via a background
+  // domain update — it must not appear in the normal save-changes patch.
 
   const resolvedLocale = cfg.locale ?? UI_DEFAULTS.locale
   if (general.locale !== resolvedLocale) patch.locale = general.locale

--- a/packages/app/src/components/settings/settings-explicit-save.ts
+++ b/packages/app/src/components/settings/settings-explicit-save.ts
@@ -11,9 +11,14 @@ export function retainDraftAfterSave<T>(current: T | undefined, submitted: T): T
   return current === submitted ? undefined : current
 }
 
-// `themeIdToApplyAfterSave` was removed — theme is now applied instantly on
-// selection and persisted via a background domain update, so the normal
-// save-changes flow no longer needs to extract it from the patch.
+// Theme is applied instantly on selection and persisted via a background
+// domain update, so the explicit save flow no longer extracts it from the
+// patch. When the panel re-reads server config that has not yet received the
+// background update, callers restore the live provider value with
+// `themeIdToSettingsValue` so a stale server value never overrides it.
+export function themeIdToSettingsValue(themeId: string, defaultThemeId = "synergy"): string {
+  return themeId === defaultThemeId ? "" : themeId
+}
 
 export function snapshotSettingsDraft<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T

--- a/packages/app/src/components/settings/settings-explicit-save.ts
+++ b/packages/app/src/components/settings/settings-explicit-save.ts
@@ -11,10 +11,9 @@ export function retainDraftAfterSave<T>(current: T | undefined, submitted: T): T
   return current === submitted ? undefined : current
 }
 
-export function themeIdToApplyAfterSave(patch: Record<string, unknown>): string | undefined {
-  if (!("theme" in patch)) return undefined
-  return typeof patch.theme === "string" ? patch.theme : ""
-}
+// `themeIdToApplyAfterSave` was removed — theme is now applied instantly on
+// selection and persisted via a background domain update, so the normal
+// save-changes flow no longer needs to extract it from the patch.
 
 export function snapshotSettingsDraft<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T

--- a/packages/app/src/locales/en/messages.po
+++ b/packages/app/src/locales/en/messages.po
@@ -16629,6 +16629,10 @@ msgid "settings.panel.section.unavailable"
 msgstr "{label} is not available"
 
 #. js-lingui-explicit-id
+msgid "settings.panel.theme.saveFailed"
+msgstr "Theme change could not be saved"
+
+#. js-lingui-explicit-id
 msgid "settings.pathRow.copied"
 msgstr "Copied"
 

--- a/packages/app/src/locales/pseudo/messages.po
+++ b/packages/app/src/locales/pseudo/messages.po
@@ -16629,6 +16629,10 @@ msgid "settings.panel.section.unavailable"
 msgstr ""
 
 #. js-lingui-explicit-id
+msgid "settings.panel.theme.saveFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
 msgid "settings.pathRow.copied"
 msgstr ""
 

--- a/packages/app/src/locales/zh-CN/messages.po
+++ b/packages/app/src/locales/zh-CN/messages.po
@@ -16629,6 +16629,10 @@ msgid "settings.panel.section.unavailable"
 msgstr "{label} 不可用"
 
 #. js-lingui-explicit-id
+msgid "settings.panel.theme.saveFailed"
+msgstr "主题更改无法保存"
+
+#. js-lingui-explicit-id
 msgid "settings.pathRow.copied"
 msgstr "已复制"
 

--- a/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
+++ b/packages/app/test/components/settings/hooks/useConfigPatch.test.ts
@@ -39,25 +39,11 @@ describe("settings config patch", () => {
       variant: "high",
     })
   })
-  test("clears a stored theme when the Synergy default is selected", () => {
+  test("does not include theme in the general patch", () => {
+    // Theme is applied instantly via a fire-and-forget server call, not through
+    // the explicit-save patch. The patch must never carry a theme field.
     const state = defaultSettingsState("enter")
     state.general.theme = ""
-
-    const patch = buildPatch({
-      cfg: { theme: "ayu" } as Config,
-      state,
-      originalMcps: {},
-    })
-
-    // The cleared value must survive JSON serialization: an undefined value
-    // is dropped by the SDK request serializer, so the server would keep the
-    // previous theme and the picker would jump back after refresh.
-    expect(JSON.parse(JSON.stringify(patch))).toHaveProperty("theme", "")
-  })
-
-  test("does not re-send the theme when it matches the server config", () => {
-    const state = defaultSettingsState("enter")
-    state.general.theme = "ayu"
 
     const patch = buildPatch({
       cfg: { theme: "ayu" } as Config,

--- a/packages/app/test/components/settings/settings-explicit-save.test.ts
+++ b/packages/app/test/components/settings/settings-explicit-save.test.ts
@@ -4,6 +4,7 @@ import {
   rebaseDraftAfterSave,
   retainDraftAfterSave,
   saveExplicitSettingsChanges,
+  themeIdToSettingsValue,
   type ExplicitSettingsSaveSource,
 } from "../../../src/components/settings/settings-explicit-save"
 
@@ -58,7 +59,17 @@ describe("settings explicit save coordination", () => {
     expect(retainDraftAfterSave("auto", "auto")).toBeUndefined()
     expect(retainDraftAfterSave("manual", "auto")).toBe("manual")
   })
+  test("maps the live theme id to the stored settings value", () => {
+    expect(themeIdToSettingsValue("ayu")).toBe("ayu")
+    expect(themeIdToSettingsValue("catppuccin")).toBe("catppuccin")
+  })
 
+  test("stores the default theme as an empty string", () => {
+    expect(themeIdToSettingsValue("synergy")).toBe("")
+    expect(themeIdToSettingsValue("synergy", "synergy")).toBe("")
+    expect(themeIdToSettingsValue("catppuccin", "catppuccin")).toBe("")
+    expect(themeIdToSettingsValue("ayu", "catppuccin")).toBe("ayu")
+  })
   test("rebases only edits made while the submitted settings were saving", () => {
     const refreshed = {
       general: { username: "alice", locale: "en" },

--- a/packages/app/test/components/settings/settings-explicit-save.test.ts
+++ b/packages/app/test/components/settings/settings-explicit-save.test.ts
@@ -4,7 +4,6 @@ import {
   rebaseDraftAfterSave,
   retainDraftAfterSave,
   saveExplicitSettingsChanges,
-  themeIdToApplyAfterSave,
   type ExplicitSettingsSaveSource,
 } from "../../../src/components/settings/settings-explicit-save"
 
@@ -58,12 +57,6 @@ describe("settings explicit save coordination", () => {
   test("clears a saved draft only while it still matches the submitted value", () => {
     expect(retainDraftAfterSave("auto", "auto")).toBeUndefined()
     expect(retainDraftAfterSave("manual", "auto")).toBe("manual")
-  })
-
-  test("applies a saved theme change including a reset to the default theme", () => {
-    expect(themeIdToApplyAfterSave({ theme: "plugin-theme" })).toBe("plugin-theme")
-    expect(themeIdToApplyAfterSave({ theme: undefined })).toBe("")
-    expect(themeIdToApplyAfterSave({ locale: "en" })).toBeUndefined()
   })
 
   test("rebases only edits made while the submitted settings were saving", () => {


### PR DESCRIPTION
## Summary

- Theme and color scheme selections now apply **immediately on click** instead of requiring the user to press "Save Changes"
- Color scheme is purely client-side (localStorage) — no server call needed
- Theme ID is persisted to the server via an independent background domain update, with error toast on failure
- "Save Changes" button and dirty-state tracking no longer include theme/colorScheme
- Discarding other changes restores the instant-applied theme from the live theme provider to prevent stale server config from overwriting it

## Test plan

- [x] Open Settings → General, switch theme → applies instantly
- [x] Switch color scheme (light/dark) → applies instantly
- [x] Modify other settings then Discard → theme/colorScheme not reverted
- [x] Refresh page after theme change → theme persists (server-side)