### PR TITLE
fix(test): restore ToolScheduler admission after shutdown tests

### DIFF
--- a/packages/synergy/test/session/tool-scheduler.test.ts
+++ b/packages/synergy/test/session/tool-scheduler.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
 import type { Tool as AITool } from "ai"
 import { SessionProcessor } from "../../src/session/processor"
 import { ToolScheduler, ToolTaskScheduler } from "../../src/session/tool-scheduler"
+
+afterAll(async () => {
+  // The global ToolScheduler is module-level state shared with every test file
+  // in the same worker. stop() permanently closes admission until configure()
+  // is called again; restore the pristine accepting state so later files in the
+  // same worker (e.g. auto-expand's real dispatch path) can still run.
+  await ToolScheduler.stop()
+  ToolScheduler.configure()
+})
 
 function processor() {
   const slots = new Map<string, SessionProcessor.ToolExecutionSlot>()

--- a/script/coverage-exempt.json
+++ b/script/coverage-exempt.json
@@ -965,6 +965,10 @@
           "reason": "settings panels render through the app shell; unit suite covers hooks/models"
         },
         {
+          "glob": "src/components/settings/panels/interface-zoom.tsx",
+          "reason": "settings panels render through the app shell; unit suite covers hooks/models"
+        },
+        {
           "glob": "src/components/settings/settings-dialog-frame.tsx",
           "reason": "settings panels render through the app shell; unit suite covers hooks/models"
         },


### PR DESCRIPTION
## Summary

Fixes the dev-baseline CI regression that has been failing since #1219 landed (06:31 UTC): `SessionProcessor auto-expand interception` tests fail consistently in the `Test` job (and `packages/app` coverage gate fails in the `Coverage` job).

### Root cause

`test/session/tool-scheduler.test.ts` stops the **global** `ToolScheduler` to exercise shutdown semantics. `ToolScheduler.stop()` closes admission permanently until `configure()` is called again, and the suite's last tests left it closed. The module-level scheduler state is shared with every test file in the same worker.

#1219 added four agenda test files, which shifted the CI `--shard=4/4` boundary so `tool-scheduler.test.ts` and `auto-expand.test.ts` landed in the same shard process. The auto-expand suite drives the real `ToolScheduler.dispatch` path; every dispatch was rejected with "Tool scheduler is stopping", so tool parts were settled as `error` instead of `completed`.

Evidence:
- Pre-#1219 (`9da3a701`) same shard command: **2342 pass, 0 fail**
- Post-#1219 dev: the 3 auto-expand tests fail on every run (CI + local)
- A probe dispatch inside the failing test printed `PROBE_DISPATCH_ERR Tool scheduler is stopping`
- After the fix, the same shard passes (only local-network embedding timeouts remain, which pass in CI)

### Changes

1. `packages/synergy/test/session/tool-scheduler.test.ts` — add `afterAll` that restores the pristine global scheduler state (`stop()` then `configure()`) so later files in the same worker can dispatch again.
2. `script/coverage-exempt.json` — exempt `src/components/settings/panels/interface-zoom.tsx` from the unit coverage universe, matching the other settings panels covered by dom/browser suites (it was added by #1221 and never loaded by the unit suite, breaking the dev coverage gate).

## Verification

- `bun run test:ci` in `packages/synergy`: auto-expand failures gone (1711 pass; only 2 local embedding timeouts that pass in CI)
- `bun run script/coverage-check.ts --validate`: coverage gate passed
- `prettier --check` on both changed files: clean