### PR TITLE
chore(coverage): drop duplicate interface-zoom exemption

### DIFF
--- a/script/coverage-exempt.json
+++ b/script/coverage-exempt.json
@@ -961,10 +961,6 @@
           "reason": "settings panels render through the app shell; unit suite covers hooks/models"
         },
         {
-          "glob": "src/components/settings/panels/interface-zoom.tsx",
-          "reason": "settings panels render through the app shell; unit suite covers hooks/models"
-        },
-        {
           "glob": "src/components/settings/panels/library-embedding-section.tsx",
           "reason": "settings panels render through the app shell; unit suite covers hooks/models"
         },


### PR DESCRIPTION
## Summary

PR #1225 and PR #1224 both added a coverage exemption for `src/components/settings/panels/interface-zoom.tsx`. After #1225 merged, `script/coverage-exempt.json` contained two identical entries, and the coverage gate failed with:

```
- packages/app: 'src/components/settings/panels/interface-zoom.tsx' matches multiple exemptions
```

This removes the duplicate entry, keeping the one in its alphabetical position.

## Verification

- `bun script/coverage-check.ts --validate` → `Coverage gate passed.`
- `bun test --config /dev/null test/script/coverage-check.test.ts` → 19 pass, 0 fail (includes the existing "rejects overlapping exemptions" case)

## Note

The full coverage gate run locally hits pre-existing failures in `packages/synergy` Library embedding/vector tests (network-dependent model downloads time out in this sandbox); those are unrelated to this change.