### PR TITLE
chore(coverage): drop duplicate interface-zoom exemption

### DIFF
--- a/script/coverage-exempt.json
+++ b/script/coverage-exempt.json
@@ -913,10 +913,6 @@
           "reason": "settings panels render through the app shell; unit suite covers hooks/models"
         },
         {
-          "glob": "src/components/settings/panels/interface-zoom.tsx",
-          "reason": "settings panels render through the app shell; unit suite covers hooks/models"
-        },
-        {
           "glob": "src/components/settings/panels/LibraryPanels.tsx",
           "reason": "settings panels render through the app shell; unit suite covers hooks/models"
         },


### PR DESCRIPTION
## Summary

`script/coverage-exempt.json` contained two identical `src/components/settings/panels/interface-zoom.tsx` exemptions (one merged via dev, one via PR #1225), so the app coverage gate failed with "matches multiple exemptions" and the Coverage CI job stayed red on dev.

Remove the duplicate entry, keeping a single exemption with the standard settings-panel reason.

## Verification

- `bun run coverage:check` no longer reports the duplicate-exemption error for `interface-zoom.tsx` (1 matching exemption remains).
- No source or contract changes; only the manifest is deduplicated.