### PR TITLE
chore(coverage): exempt dialog-fork-confirm from unit-suite coverage

### DIFF
--- a/script/coverage-exempt.json
+++ b/script/coverage-exempt.json
@@ -713,6 +713,10 @@
           "reason": "session views require a live session runtime; covered by E2E/browser suites"
         },
         {
+          "glob": "src/components/session/dialog-fork-confirm.tsx",
+          "reason": "UI component not rendered by the unit suite; covered by dom/browser suites"
+        },
+        {
           "glob": "src/components/session/dialog-rewind-confirm.tsx",
           "reason": "session views require a live session runtime; covered by E2E/browser suites"
         },


### PR DESCRIPTION
## Summary
- dev's Coverage gate is red: `packages/app` reports exactly one never-loaded file, `src/components/session/dialog-fork-confirm.tsx`, introduced by #1226.
- The component is covered by the Playwright-isolated DOM suite (`dialog-fork-confirm.dom.test.tsx`), which runs after the coverage batch, so the module is never loaded under bun instrumentation. Its pure logic already lives in `dialog-fork-confirm-model.ts` with unit tests.
- Every other file in the `playwrightIsolated` list carries a matching exemption; this adds the missing one, matching the `dialog-rewind-confirm.tsx` / `mobile-drawer-root.tsx` precedent.

## Test plan
- [x] `bun script/coverage-check.ts --validate` passes (no duplicate/stale exemption)
- [ ] CI Coverage job green on this PR

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>