### PR TITLE
docs(skill): seed isolated dev home with model catalog cache

### DIFF
--- a/.synergy/skill/develop-synergy/SKILL.md
+++ b/.synergy/skill/develop-synergy/SKILL.md
@@ -22,12 +22,12 @@ mkdir -p "$DEV_HOME/.synergy"
 cp -R ~/.synergy/config "$DEV_HOME/.synergy/config"
 ```
 
-3. Copying configuration preserves provider settings but does not copy the separate credential store. Do not copy sessions, daemon state, locks, logs, cache, or Library data. Seed only the fixture credentials a test requires inside the isolated home; never copy or overwrite the live credential store implicitly.
+3. Copying configuration preserves provider settings but does not copy the separate credential store. Do not copy sessions, daemon state, locks, logs, cache, or Library data — the two model catalog files in step 4 are the sole cache exception. Seed only the fixture credentials a test requires inside the isolated home; never copy or overwrite the live credential store implicitly.
 4. Copy model catalog data from the main home when the isolated environment cannot reach models.dev (offline or restricted-network debugging machines), so the isolated model list does not depend on a live models.dev fetch:
 
 ```bash
 mkdir -p "$DEV_HOME/.synergy/cache"
-cp ~/.synergy/cache/provider-model-catalogs.v1.json ~/.synergy/cache/models.json "$DEV_HOME/.synergy/cache/"
+for f in provider-model-catalogs.v1.json models.json; do cp ~/.synergy/cache/"$f" "$DEV_HOME/.synergy/cache/" 2>/dev/null || true; done
 ```
 
 Treat these two cache files as seed data only: they are refreshed in place by the isolated runtime and never copied back to the main home. If the files are absent from the main home, the isolated instance will fetch models.dev on first use as usual.

--- a/.synergy/skill/develop-synergy/SKILL.md
+++ b/.synergy/skill/develop-synergy/SKILL.md
@@ -23,7 +23,16 @@ cp -R ~/.synergy/config "$DEV_HOME/.synergy/config"
 ```
 
 3. Copying configuration preserves provider settings but does not copy the separate credential store. Do not copy sessions, daemon state, locks, logs, cache, or Library data. Seed only the fixture credentials a test requires inside the isolated home; never copy or overwrite the live credential store implicitly.
-4. Run `bun dev prepare` once when dependencies, generated SDK, Web dist, plugin SDK, or sandbox helper are missing.
+4. Copy model catalog data from the main home when the isolated environment cannot reach models.dev (offline or restricted-network debugging machines), so the isolated model list does not depend on a live models.dev fetch:
+
+```bash
+mkdir -p "$DEV_HOME/.synergy/cache"
+cp ~/.synergy/cache/provider-model-catalogs.v1.json ~/.synergy/cache/models.json "$DEV_HOME/.synergy/cache/"
+```
+
+Treat these two cache files as seed data only: they are refreshed in place by the isolated runtime and never copied back to the main home. If the files are absent from the main home, the isolated instance will fetch models.dev on first use as usual.
+
+5. Run `bun dev prepare` once when dependencies, generated SDK, Web dist, plugin SDK, or sandbox helper are missing.
 
 ## Choose the Smallest Mode
 


### PR DESCRIPTION
## Summary

扩展 `develop-synergy` skill 的隔离环境准备流程：当调试机无法访问 models.dev（离线/受限网络）时，从主 home 复制模型目录缓存作为种子数据，让隔离实例的模型列表不依赖在线拉取。

## Changes

- `.synergy/skill/develop-synergy/SKILL.md` "Prepare an Isolated Home" 新增步骤 4（原步骤 4 顺延为 5）：
- 复制 `~/.synergy/cache/provider-model-catalogs.v1.json` + `~/.synergy/cache/models.json`（models.dev 快照）到 `$DEV_HOME/.synergy/cache/`
- 边界约束：仅作种子数据，由隔离运行时原地刷新，永不回写主 home；主 home 缺文件时隔离实例照常首用自拉 models.dev

## Verification

- 提交钩子 `Validated 20 repository Skills` 通过（skill 格式校验）
- 步骤本身已在真实隔离环境验证过（复制两个 cache 文件 + 重启 server 后模型目录正常加载）