### PR TITLE
fix(storage): retry transient EPERM/EACCES in atomic JSON persistence

### DIFF
--- a/.synergy/skill/change-persistence/SKILL.md
+++ b/.synergy/skill/change-persistence/SKILL.md
@@ -18,6 +18,7 @@ description: Add or modify Synergy durable state, JSON storage keys, SQLite tabl
 1. Build logical keys through `StoragePath`; use `Storage` for locks, atomic writes, reads, scans, and removal.
 2. Keep independently updated or streamed records independently addressable. Do not rewrite a whole session or collection for one leaf update.
 3. Update derived indexes and events in the same owner transaction/lifecycle as the canonical write.
+4. Preserve the atomic-write transient-retry contract: `Storage` write+rename retries `EPERM`/`EACCES`/`EBUSY` (classified by `isRetryableIOError`) so Windows sharing violations do not fail persistence, permanent errors fail fast, and temp files are removed (with the same transient retry) on the failure path. Do not bypass `Storage` with a bare rename; extend `test/storage/storage-retry.test.ts` when changing write-path failure behavior.
 
 ### SQLite and other domain stores
 

--- a/docs/decisions/implemented/bug-fix/2026-08-22-storage-atomic-write-transient-retry.md
+++ b/docs/decisions/implemented/bug-fix/2026-08-22-storage-atomic-write-transient-retry.md
@@ -1,0 +1,34 @@
+# Decision Record: Retry transient EPERM/EACCES in atomic JSON persistence
+
+Status: implemented
+
+## Problem
+
+On Windows, session-state persistence intermittently failed with `EPERM: operation not permitted, rename '.tmp-<pid>-<rand>' -> 'info.json'`, terminating background subagents and agenda runs through `SessionTerminalError` and leaving DAG/taskboard nodes failed until manually re-dispatched (#1247).
+
+Every persisted session object (info, messages, parts, dag, todo, inbox, agenda) funnels through `Storage.write`/`Storage.update` → `writeJsonAtomic` in `packages/synergy/src/storage/storage.ts`, which performed a single unguarded `Bun.write` + `fs.rename`. Node's `rename` maps to `MoveFileEx` on Windows: when another process holds a handle on the source or target without `FILE_SHARE_DELETE` — antivirus scans, OneDrive sync, or Synergy's own cross-process readers — the call fails with `EPERM`/`EACCES`. Such sharing violations typically clear within milliseconds, but one occurrence escalated fatally: the write error propagated up the invoke loop, was persisted as a terminal assistant-message error, and `selectResultMessage` rethrew it as `SessionTerminalError`.
+
+The repository already classified these codes as transient in `packages/synergy/src/util/io-retry.ts` (`EPERM`/`EACCES`/`EBUSY`, "Windows sharing violations, antivirus scans, OneDrive sync"), but only the read side used it; the write path had no retry.
+
+## Decision
+
+`writeJsonAtomic` retries the whole write+rename sequence on transient I/O errors:
+
+- Up to 4 attempts with exponential backoff (50 ms base, 200 ms cap), reusing the same temp-file name so a retry overwrites the previous partial temp write.
+- Retry classification reuses `isRetryableIOError` from `@/util/io-retry` — only `EPERM`/`EACCES`/`EBUSY` retry; permanent errors (`ENOENT`, `ENOSPC`, genuine permission failures) propagate on the first occurrence.
+- On exhaustion or non-retryable failure the original error propagates unchanged after the temp file is unlinked, so no `.tmp-*` residue is left behind on the failure path.
+
+The diagnostics pending-session scan (`packages/synergy/src/observability/diagnostics.ts`), a cross-process reader of the same `info.json` files, now reads through `readFileWithRetry` so its own reads survive a concurrent atomic rename on Windows instead of silently dropping sessions from the dashboard.
+
+Behavioral coverage lives in `packages/synergy/test/storage/storage-retry.test.ts`: transient rename failure recovers, transient temp-write failure recovers, exhausted retries propagate the original `code`, non-transient errors fail on the first attempt, and no temp files remain on any failure path.
+
+## Alternatives considered
+
+- **Catch `EPERM` in the session invoke loop** — rejected: it scatters storage-layer concerns into the session state machine, cannot distinguish transient from permanent failures at that altitude, and leaves the persistence gap unfixed for every other `Storage` consumer (notes, agenda, channels, lattice).
+- **Cross-process file locking (properLockfile-style)** — rejected for this fix: it adds a locking subsystem across processes, cannot control third-party handle holders (antivirus, OneDrive) that cause the violation, and addresses the separate lost-update problem rather than the observed crash. The in-process `Lock` keeps serializing same-process writers as before.
+- **Windows-native `ReplaceFile`/`FILE_SHARE_DELETE` handling** — rejected: requires platform-specific native bindings and divergent write paths per OS for a failure mode that bounded retry demonstrably clears.
+- **Downgrade `SessionTerminalError` to a retryable error only** — rejected: it stops killing subagents but still fails the write; the issue's core request is that persistence succeed under transient contention.
+
+## Consequences
+
+Transient Windows sharing violations during state persistence now absorb within roughly 50–350 ms instead of terminating sessions; permanent I/O failures keep failing fast with their original error codes. A permanently held handle costs up to ~350 ms of additional latency before the failure surfaces. The exhausted-retry error still propagates as before, so upstream terminal-error handling is unchanged. macOS and Linux behavior is untouched in practice (their renames do not produce these sharing violations) but gains the same bounded resilience. The fix does not address cross-process read-modify-write races on the same key — the process-local `Lock` was and remains same-process only; that lost-update concern is separate and unowned by this change. Windows sharing violations cannot be reproduced natively on the development platform, so verification relies on injected errno errors; real-machine confirmation depends on reporter feedback on #1247.

--- a/docs/decisions/implemented/bug-fix/2026-08-22-storage-atomic-write-transient-retry.md
+++ b/docs/decisions/implemented/bug-fix/2026-08-22-storage-atomic-write-transient-retry.md
@@ -16,7 +16,7 @@ The repository already classified these codes as transient in `packages/synergy/
 
 - Up to 4 attempts with exponential backoff (50 ms base, 200 ms cap), reusing the same temp-file name so a retry overwrites the previous partial temp write.
 - Retry classification reuses `isRetryableIOError` from `@/util/io-retry` — only `EPERM`/`EACCES`/`EBUSY` retry; permanent errors (`ENOENT`, `ENOSPC`, genuine permission failures) propagate on the first occurrence.
-- On exhaustion or non-retryable failure the original error propagates unchanged after the temp file is unlinked, so no `.tmp-*` residue is left behind on the failure path.
+- On exhaustion or non-retryable failure the original error propagates unchanged after the temp file is removed; the cleanup itself retries transient unlink errors with the same backoff (the same handle that failed the rename can block the unlink), so no `.tmp-*` residue is left behind on the failure path.
 
 The diagnostics pending-session scan (`packages/synergy/src/observability/diagnostics.ts`), a cross-process reader of the same `info.json` files, now reads through `readFileWithRetry` so its own reads survive a concurrent atomic rename on Windows instead of silently dropping sessions from the dashboard.
 

--- a/docs/reference/storage-and-paths.md
+++ b/docs/reference/storage-and-paths.md
@@ -24,7 +24,7 @@ Cache version changes can clear `cache/` on startup. Treat cache as reproducible
 
 ## JSON Storage
 
-Most durable product objects use file-based JSON storage rooted at `data/`. A logical storage key maps to nested directories plus a `.json` suffix. Writes take per-file locks and use a temporary file followed by atomic rename. Streaming message/part writes can use compact JSON; lower-frequency records remain indented.
+Most durable product objects use file-based JSON storage rooted at `data/`. A logical storage key maps to nested directories plus a `.json` suffix. Writes take per-file locks and use a temporary file followed by atomic rename. The write+rename sequence retries transient sharing-violation errors (`EPERM`/`EACCES`/`EBUSY`, classified via `isRetryableIOError`) up to 4 attempts with 50–200 ms backoff, because Windows renames fail when antivirus, sync clients, or cross-process readers briefly hold a handle; permanent errors fail on the first attempt and the temp file is removed (with the same transient retry) before the original error propagates. Cross-process readers of these files read through `readFileWithRetry` for the same reason. Streaming message/part writes can use compact JSON; lower-frequency records remain indented.
 
 Major collections include:
 

--- a/packages/synergy/src/observability/diagnostics.ts
+++ b/packages/synergy/src/observability/diagnostics.ts
@@ -14,6 +14,7 @@ import { ObservabilityRedaction } from "./redaction"
 import { ObservabilitySchema } from "./schema"
 import { ObservabilityStore } from "./store"
 import { parseJson } from "@/util/json-parse"
+import { readFileWithRetry } from "@/util/io-retry"
 
 export namespace Diagnostics {
   export type Summary = ObservabilitySchema.DiagnosticsSummary
@@ -403,7 +404,9 @@ export namespace Diagnostics {
     // scan into an O(sessions) scan for the dashboard's 5s polling.
     await walk(root, async (file) => {
       if (!file.endsWith("info.json")) return
-      const data = await fs.readFile(file, "utf8").catch(() => "")
+      // Cross-process read: on Windows a concurrent atomic rename can fail
+      // this read transiently; retry keeps the dashboard scan accurate (#1247).
+      const data = await readFileWithRetry(file).catch(() => "")
       if (!data.includes('"pendingReply"')) return
       const json = JSON.parse(data) as { id?: string; pendingReply?: boolean; time?: { updated?: number } }
       if (!json.pendingReply || !json.id) return

--- a/packages/synergy/src/storage/storage.ts
+++ b/packages/synergy/src/storage/storage.ts
@@ -273,13 +273,31 @@ export namespace Storage {
         return
       } catch (error) {
         if (!isRetryableIOError(error) || attempt >= ATOMIC_WRITE_ATTEMPTS) {
-          await fs.unlink(tmp).catch(() => {})
+          await removeTempFile(tmp)
           throw error
         }
-        const delay = Math.min(ATOMIC_WRITE_RETRY_MAX_MS, ATOMIC_WRITE_RETRY_BASE_MS * 2 ** (attempt - 1))
-        await new Promise((resolve) => setTimeout(resolve, delay))
+        await new Promise((resolve) => setTimeout(resolve, atomicRetryDelayMs(attempt)))
       }
     }
+  }
+
+  // The terminal-failure cleanup can hit the same Windows sharing violation
+  // that failed the rename (antivirus holding the temp handle), so transient
+  // unlink errors retry with the same backoff before being suppressed (#1247).
+  async function removeTempFile(tmp: string) {
+    for (let attempt = 1; attempt <= ATOMIC_WRITE_ATTEMPTS; attempt++) {
+      try {
+        await fs.unlink(tmp)
+        return
+      } catch (error) {
+        if (!isRetryableIOError(error) || attempt >= ATOMIC_WRITE_ATTEMPTS) return
+        await new Promise((resolve) => setTimeout(resolve, atomicRetryDelayMs(attempt)))
+      }
+    }
+  }
+
+  function atomicRetryDelayMs(attempt: number) {
+    return Math.min(ATOMIC_WRITE_RETRY_MAX_MS, ATOMIC_WRITE_RETRY_BASE_MS * 2 ** (attempt - 1))
   }
 
   function isTempFile(name: string) {

--- a/packages/synergy/src/storage/storage.ts
+++ b/packages/synergy/src/storage/storage.ts
@@ -2,6 +2,7 @@ import path from "path"
 import fs from "fs/promises"
 import { Global } from "../global"
 import { Lock } from "../util/lock"
+import { isRetryableIOError } from "@/util/io-retry"
 import { NamedError } from "@ericsanchezok/synergy-util/error"
 import z from "zod"
 import { ObservabilityIssues } from "@/observability/issues"
@@ -249,14 +250,36 @@ export namespace Storage {
     })
   }
 
+  // Windows maps rename onto MoveFileEx: when another process (antivirus,
+  // OneDrive, a cross-process reader of these JSON files) briefly holds a
+  // handle on the source or target without FILE_SHARE_DELETE, the rename
+  // fails with EPERM/EACCES. Sharing violations clear within milliseconds,
+  // so retry the whole write+rename sequence with short backoff instead of
+  // failing session persistence and terminating the owning session (#1247).
+  const ATOMIC_WRITE_ATTEMPTS = 4
+  const ATOMIC_WRITE_RETRY_BASE_MS = 50
+  const ATOMIC_WRITE_RETRY_MAX_MS = 200
+
   async function writeJsonAtomic(target: string, serialized: string) {
     await fs.mkdir(path.dirname(target), { recursive: true })
     const tmp = path.join(
       path.dirname(target),
       `.tmp-${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
     )
-    await Bun.write(tmp, serialized)
-    await fs.rename(tmp, target)
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await Bun.write(tmp, serialized)
+        await fs.rename(tmp, target)
+        return
+      } catch (error) {
+        if (!isRetryableIOError(error) || attempt >= ATOMIC_WRITE_ATTEMPTS) {
+          await fs.unlink(tmp).catch(() => {})
+          throw error
+        }
+        const delay = Math.min(ATOMIC_WRITE_RETRY_MAX_MS, ATOMIC_WRITE_RETRY_BASE_MS * 2 ** (attempt - 1))
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
   }
 
   function isTempFile(name: string) {

--- a/packages/synergy/test/observability/diagnostics.test.ts
+++ b/packages/synergy/test/observability/diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { ObservabilityEvents } from "../../src/observability/events"
@@ -74,6 +74,31 @@ describe("Diagnostics", () => {
     const output = path.join(home, "fresh-diagnostics.tar.gz")
     const result = await Diagnostics.createPackage({ output })
     expect(result.summary.sessions.pendingReply.some((item) => item.sessionID === "ses_cached")).toBe(false)
+  })
+
+  test("pending-session scan survives a transient EPERM on info.json reads", async () => {
+    const home = process.env.SYNERGY_TEST_HOME!
+    const sessionsDir = path.join(home, ".synergy", "data", "sessions", "scope:home", "ses_transient")
+    await fs.mkdir(sessionsDir, { recursive: true })
+    await fs.writeFile(
+      path.join(sessionsDir, "info.json"),
+      JSON.stringify({ id: "ses_transient", pendingReply: true, time: { updated: 1 } }),
+    )
+
+    const realReadFile: typeof fs.readFile = fs.readFile.bind(fs)
+    let calls = 0
+    const impl = (async (target: unknown, ...rest: unknown[]) => {
+      if (typeof target === "string" && target.endsWith("info.json")) {
+        calls += 1
+        if (calls === 1) throw Object.assign(new Error("injected EPERM"), { code: "EPERM" })
+      }
+      return realReadFile(target as Parameters<typeof realReadFile>[0], ...(rest as []))
+    }) as unknown as typeof fs.readFile
+    using _read = spyOn(fs, "readFile").mockImplementation(impl)
+
+    const summary = await Diagnostics.summary({ freshPendingSessions: true })
+    expect(summary.sessions.pendingReply.some((item) => item.sessionID === "ses_transient")).toBe(true)
+    expect(calls).toBeGreaterThanOrEqual(2)
   })
 
   test("package contains redacted indexed telemetry without JSONL-only events", async () => {

--- a/packages/synergy/test/storage/storage-retry.test.ts
+++ b/packages/synergy/test/storage/storage-retry.test.ts
@@ -82,4 +82,27 @@ describe("Storage atomic write transient-failure retry", () => {
     expect(calls).toBe(1)
     expect(await tempFiles(root)).toEqual([])
   })
+
+  test("retries transient EPERM on terminal cleanup and still removes the temp file", async () => {
+    const root = keyRoot()
+    const realUnlink: typeof fs.unlink = fs.unlink.bind(fs)
+    let renameCalls = 0
+    let unlinkCalls = 0
+    const renameImpl = (async () => {
+      renameCalls += 1
+      throw errnoError("EPERM")
+    }) as unknown as typeof fs.rename
+    using _rename = spyOn(fs, "rename").mockImplementation(renameImpl)
+    const unlinkImpl = (async (p: unknown) => {
+      unlinkCalls += 1
+      if (unlinkCalls === 1) throw errnoError("EPERM")
+      return realUnlink(p as Parameters<typeof realUnlink>[0])
+    }) as unknown as typeof fs.unlink
+    using _unlink = spyOn(fs, "unlink").mockImplementation(unlinkImpl)
+
+    await expect(Storage.write([...root, "item"], { value: 5 })).rejects.toMatchObject({ code: "EPERM" })
+    expect(renameCalls).toBe(4)
+    expect(unlinkCalls).toBe(2)
+    expect(await tempFiles(root)).toEqual([])
+  })
 })

--- a/packages/synergy/test/storage/storage-retry.test.ts
+++ b/packages/synergy/test/storage/storage-retry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Global } from "../../src/global"
+import { Storage } from "../../src/storage/storage"
+
+function keyRoot() {
+  return ["storage-retry-test", Math.random().toString(36).slice(2)]
+}
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`injected ${code}`), { code })
+}
+
+async function tempFiles(root: string[]): Promise<string[]> {
+  const dir = path.join(Global.Path.data, ...root)
+  const entries = await fs.readdir(dir).catch(() => [] as string[])
+  return entries.filter((name) => name.includes(".tmp-") || name.endsWith(".tmp"))
+}
+
+describe("Storage atomic write transient-failure retry", () => {
+  test("retries a transient EPERM on rename and persists the payload", async () => {
+    const root = keyRoot()
+    const realRename: typeof fs.rename = fs.rename.bind(fs)
+    let calls = 0
+    const impl = (async (from: unknown, to: unknown) => {
+      calls += 1
+      if (calls <= 2) throw errnoError("EPERM")
+      return realRename(from as Parameters<typeof realRename>[0], to as Parameters<typeof realRename>[1])
+    }) as unknown as typeof fs.rename
+    using _rename = spyOn(fs, "rename").mockImplementation(impl)
+
+    await Storage.write([...root, "item"], { value: 1 })
+
+    expect(calls).toBe(3)
+    expect(await Storage.read<{ value: number }>([...root, "item"])).toEqual({ value: 1 })
+    expect(await tempFiles(root)).toEqual([])
+  })
+
+  test("retries a transient EPERM on the temp-file write", async () => {
+    const root = keyRoot()
+    const realWrite: typeof Bun.write = Bun.write.bind(Bun)
+    let calls = 0
+    const impl = (async (destination: unknown, data: unknown) => {
+      calls += 1
+      if (calls === 1) throw errnoError("EPERM")
+      return realWrite(destination as never, data as never)
+    }) as unknown as typeof Bun.write
+    using _write = spyOn(Bun, "write").mockImplementation(impl)
+
+    await Storage.write([...root, "item"], { value: 2 })
+
+    expect(calls).toBe(2)
+    expect(await Storage.read<{ value: number }>([...root, "item"])).toEqual({ value: 2 })
+    expect(await tempFiles(root)).toEqual([])
+  })
+
+  test("propagates the original error after retries are exhausted without leaving temp files", async () => {
+    const root = keyRoot()
+    let calls = 0
+    const impl = (async () => {
+      calls += 1
+      throw errnoError("EPERM")
+    }) as unknown as typeof fs.rename
+    using _rename = spyOn(fs, "rename").mockImplementation(impl)
+
+    await expect(Storage.write([...root, "item"], { value: 3 })).rejects.toMatchObject({ code: "EPERM" })
+    expect(calls).toBe(4)
+    expect(await tempFiles(root)).toEqual([])
+  })
+
+  test("does not retry non-transient errors", async () => {
+    const root = keyRoot()
+    let calls = 0
+    const impl = (async () => {
+      calls += 1
+      throw errnoError("ENOSPC")
+    }) as unknown as typeof fs.rename
+    using _rename = spyOn(fs, "rename").mockImplementation(impl)
+
+    await expect(Storage.write([...root, "item"], { value: 4 })).rejects.toMatchObject({ code: "ENOSPC" })
+    expect(calls).toBe(1)
+    expect(await tempFiles(root)).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #1247.

## Summary

- **Root cause**: every persisted session object (info, messages, parts, dag, todo, inbox, agenda) funnels through `writeJsonAtomic` (`packages/synergy/src/storage/storage.ts`), which performed a single unguarded `Bun.write` + `fs.rename`. On Windows, `rename` maps to `MoveFileEx`; when another process (antivirus, OneDrive, or a cross-process reader) briefly holds a handle without `FILE_SHARE_DELETE`, the call fails with `EPERM`. One transient failure escalated through the invoke loop into a persisted terminal assistant error, killing the subagent via `SessionTerminalError` and leaving DAG nodes failed until manual re-dispatch.
- **Fix**: `writeJsonAtomic` retries the whole write+rename sequence — up to 4 attempts, 50–200 ms exponential backoff, reusing `isRetryableIOError` from `util/io-retry` so only `EPERM`/`EACCES`/`EBUSY` retry while permanent errors (`ENOSPC`, real permission failures) fail on the first attempt. The temp file is unlinked on terminal failure, so no `.tmp-*` residue remains.
- **Read-side hardening**: the diagnostics pending-session scan (`observability/diagnostics.ts`) reads the same `info.json` files cross-process; it now reads through `readFileWithRetry` so a concurrent atomic rename no longer silently drops sessions from the dashboard on Windows.
- Decision record: `docs/decisions/implemented/bug-fix/2026-08-22-storage-atomic-write-transient-retry.md`.

## Test plan

- [x] `cd packages/synergy && bun test test/storage/` — 10 pass (4 new retry tests: transient rename recovery, temp-write recovery, exhaustion propagates the original error code, non-transient fails on first attempt, no temp-file residue on any failure path)
- [x] `cd packages/synergy && bun test test/observability/diagnostics.test.ts test/util/io-retry.test.ts` — 10 pass
- [x] `bun run typecheck` — 11/11 tasks pass
- [x] `bun run decision:check`, `bun run test-layout:check` — pass
- [x] `bun run quality:quick` — 14/15 pass (`secrets:check` requires local gitleaks; CI runs the secret-scan job)
- [x] Full `bun run test:changed` — 5247 pass; 7 failures are pre-existing 5s-timeout flakes (BossRuntime, daemon entry, plugin host-service, embedding API, session migration) — re-verified in isolation and against the unmodified baseline, where they fail identically
- [ ] Windows real-machine confirmation by the reporter (sharing violations cannot be reproduced natively on macOS)