### PR TITLE
fix(provider): cap Anthropic max thinking budget to keep max_tokens > budget_tokens

### DIFF
--- a/packages/synergy/src/provider/transform.ts
+++ b/packages/synergy/src/provider/transform.ts
@@ -616,7 +616,15 @@ export namespace ProviderTransform {
           max: {
             thinking: {
               type: "enabled",
-              budgetTokens: Math.min(31_999, model.limit.output - 1),
+              // Cap the thinking budget to half the output limit (minus one) so the
+              // resulting max_tokens (= modelCap - budgetTokens) always strictly
+              // exceeds budgetTokens. The previous `model.limit.output - 1` collapsed
+              // max_tokens to 1 for any model whose output limit <= 31_999 (e.g. the
+              // common 8 192 / 16 384 default-output Claude models), violating the
+              // Anthropic constraint budget_tokens < max_tokens and yielding a 400.
+              // Mirrors the `high` variant's half-output discipline; on large-output
+              // models (> ~64k) the 31_999 floor still keeps `max` above `high`.
+              budgetTokens: Math.min(31_999, Math.floor(model.limit.output / 2 - 1)),
             },
           },
         }

--- a/packages/synergy/test/provider/transform.test.ts
+++ b/packages/synergy/test/provider/transform.test.ts
@@ -1863,13 +1863,63 @@ describe("ProviderTransform.variants", () => {
           budgetTokens: 4095,
         },
       })
+      // At output 8192 the `max` budget is capped to ⌊8192/2 − 1⌋ = 4095 (same as
+      // `high`); the previous `model.limit.output - 1` = 8191 collapsed
+      // max_tokens to 1 and tripped Anthropic's budget_tokens < max_tokens rule.
       expect(result.max).toEqual({
         thinking: {
           type: "enabled",
-          budgetTokens: 8191,
+          budgetTokens: 4095,
         },
       })
     })
+  })
+
+  describe("Anthropic thinking variants - budget_tokens < max_tokens invariant", () => {
+    // Regression guard for BUG-002: for every model whose output limit fits in
+    // the common 8k–64k band, both the `high` and `max` Anthropic thinking
+    // variants must satisfy the Anthropic API constraint
+    //   0 < budget_tokens < max_tokens
+    // where max_tokens is derived by maxOutputTokens() from the same budget.
+    // The old `max` variant used `model.limit.output - 1`, which for these
+    // limits produced budget_tokens >= max_tokens and yielded an HTTP 400.
+    test.each([8192, 16384, 32000, 64000])(
+      "keeps max_tokens > budget_tokens > 0 for high and max at output %i",
+      (output) => {
+        const model = createMockModel({
+          id: "anthropic/claude-4",
+          providerID: "anthropic",
+          api: {
+            id: "claude-4",
+            url: "https://api.anthropic.com",
+            npm: "@ai-sdk/anthropic",
+          },
+          limit: { context: 200000, output },
+        })
+
+        const variants = ProviderTransform.variants(model) as Record<
+          "high" | "max",
+          { thinking?: { type?: string; budgetTokens?: number } }
+        >
+        expect(Object.keys(variants)).toEqual(["high", "max"])
+
+        for (const key of ["high", "max"] as const) {
+          const budgetTokens = variants[key].thinking?.budgetTokens
+          expect(budgetTokens, `${key} budgetTokens must be set`).toBeGreaterThan(0)
+
+          const maxTokens = ProviderTransform.maxOutputTokens(
+            "@ai-sdk/anthropic",
+            variants[key],
+            output,
+            OUTPUT_TOKEN_MAX,
+          )
+          expect(
+            maxTokens,
+            `${key}: max_tokens (${maxTokens}) must strictly exceed budget_tokens (${budgetTokens})`,
+          ).toBeGreaterThan(budgetTokens!)
+        }
+      },
+    )
   })
 
   describe("@ai-sdk/amazon-bedrock", () => {


### PR DESCRIPTION
## What does this PR do?

Caps the Anthropic `max` thinking variant's `budgetTokens` to `⌊model.limit.output / 2 − 1⌋` (mirroring the existing `high` variant's half-output discipline), so the derived `max_tokens` always strictly exceeds `budget_tokens`.

## Why?

Anthropic's API requires `0 < budget_tokens < max_tokens`. The previous `max` variant used `budgetTokens: Math.min(31_999, model.limit.output - 1)`. For any model whose output limit is ≤ 31_999 — e.g. the common 8_192 / 16_384 default-output Claude models — that made `budget_tokens` equal `output - 1`, while `maxOutputTokens()` derives `max_tokens = modelCap - budgetTokens`, collapsing `max_tokens` to `1`. That violates `budget_tokens < max_tokens` and the request fails with an HTTP 400 before any work happens.

On large-output models (> ~64k output) the `31_999` floor still keeps the `max` budget above `high`, so high-throughput models are unaffected.

## How was it tested?

- New regression guard in `packages/synergy/test/provider/transform.test.ts`: a `test.each` over `[8192, 16384, 32000, 64000]` asserts both `high` and `max` satisfy `0 < budget_tokens < max_tokens` (where `max_tokens` is derived from the same budget via `ProviderTransform.maxOutputTokens`).
- Updated the existing output-8192 expectation: the `max` budget is now `4095` (was `8191`).
- `bun test test/provider/transform.test.ts` → 110 pass, 0 fail.
- `tsgo --noEmit` (packages/synergy typecheck) clean.

```bash
cd packages/synergy
bun test test/provider/transform.test.ts
bun run typecheck
```

## Checklist

- [x] `bun run quality:quick` passes — the touched package's gates (format, lint, typecheck, tests) pass for this change. Note: on a Windows checkout the repo-wide `quality:quick` has pre-existing red gates unrelated to this PR (a tracked symlink `packages/app/src/custom-elements.d.ts` parses as broken TS on Windows; plus `gitleaks`/`actionlint` not installed locally). These do not occur on the Linux CI runners; the files this PR touches are clean under `prettier`, `oxlint`, and `tsgo`.
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] New or moved tests live under the owning package's `test/` directory (or the root `test/` directory for repository tests) — the new `test.each` is appended to the existing `packages/synergy/test/provider/transform.test.ts`.
- [x] `bun run package:check` passes if package exports, build output, release logic, or publishable packages changed — no package exports/build/release changes.
- [x] `bun run workflow:check` passes if `.github/workflows/**`, GitHub Actions config, or CI helper scripts changed — no workflow changes.
- [x] Browser capability or App bootstrap changes pass the browser crypto contract and private HTTP browser smoke — N/A, provider transform only.
- [x] `bun run secrets:check` passes locally or CI Gitleaks covers the change if auth, provider, channel, config, or credential examples changed — no secrets/credentials touched; CI Gitleaks covers it.
- [x] SDK regenerated if server routes or schemas changed (`./script/generate.ts`) — no route/schema changes.
- [x] `bun run localization:check` passes if product copy, accessibility text, locale-sensitive formatting, or shared UI copy changed — no UI copy changes.
- [x] Documentation, AGENTS, and `.synergy` help updated if developer workflow, quality tooling, commands, or contributor rules changed — no contributor-facing workflow changes.
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included.
