### PR TITLE
fix(util): age out stale file locks on Windows to defeat PID recycling

### DIFF
--- a/packages/util/src/fs-lock.ts
+++ b/packages/util/src/fs-lock.ts
@@ -66,16 +66,9 @@ async function acquireFileLock(options: FileLockOptions): Promise<{ release(): P
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
       const owner = await readLockOwner(filename)
-      if (owner?.pid && !processExists(owner.pid)) {
+      if (await isLockReclaimable(filename, owner, staleMetadataMs)) {
         await fs.unlink(filename).catch(() => {})
         continue
-      }
-      if (!owner?.pid) {
-        const stat = await fs.stat(filename).catch(() => undefined)
-        if (stat && Date.now() - stat.mtimeMs > staleMetadataMs) {
-          await fs.unlink(filename).catch(() => {})
-          continue
-        }
       }
       if (Date.now() - startedAt >= timeoutMs) {
         throw new Error(options.timeoutMessage ?? `Timed out acquiring file lock for ${options.key}`)
@@ -85,15 +78,60 @@ async function acquireFileLock(options: FileLockOptions): Promise<{ release(): P
   }
 }
 
-async function readLockOwner(filename: string): Promise<{ pid?: number } | undefined> {
+async function readLockOwner(filename: string): Promise<{ pid?: number; acquiredAt?: number } | undefined> {
   try {
     const owner = JSON.parse(await fs.readFile(filename, "utf8")) as unknown
     if (!owner || typeof owner !== "object") return undefined
     const pid = (owner as { pid?: unknown }).pid
-    return typeof pid === "number" ? { pid } : undefined
+    const acquiredAt = (owner as { acquiredAt?: unknown }).acquiredAt
+    return {
+      pid: typeof pid === "number" ? pid : undefined,
+      acquiredAt: typeof acquiredAt === "number" ? acquiredAt : undefined,
+    }
   } catch {
     return undefined
   }
+}
+
+/**
+ * Decide whether an existing lock can be reclaimed (unlinked and retried).
+ *
+ * Reclaim when the owner is provably gone, or when the lock metadata has aged
+ * past `staleMetadataMs`. On Windows, PIDs recycle aggressively and
+ * `process.kill(pid, 0)` returns true for a recycled PID that now belongs to
+ * an unrelated live process — so a dead owner's lock would otherwise never be
+ * reclaimed and every later acquirer would spin to the timeout. There, the
+ * wall-clock age (acquiredAt, with an mtime fallback) is the tiebreaker: a
+ * lock older than the grace period is treated as stale even if its PID looks
+ * live. On posix the PID check is reliable, so a genuinely-live owner is never
+ * displaced by age alone.
+ */
+async function isLockReclaimable(
+  filename: string,
+  owner: { pid?: number; acquiredAt?: number } | undefined,
+  staleMetadataMs: number,
+): Promise<boolean> {
+  // No owner PID at all: fall back to the lock file's mtime, as the metadata
+  // is either missing or unreadable.
+  if (!owner?.pid) {
+    const stat = await fs.stat(filename).catch(() => undefined)
+    return !!stat && Date.now() - stat.mtimeMs > staleMetadataMs
+  }
+  // Owner PID recorded and provably dead → safe to reclaim on every platform.
+  if (!processExists(owner.pid)) return true
+  // On Windows the live-PID signal is unreliable (recycling). Reclaim if the
+  // lock is older than the grace period, using acquiredAt when the owner wrote
+  // it (preferred over mtime, which AV/indexers can touch) with mtime fallback.
+  if (process.platform === "win32") {
+    const ageMs = owner.acquiredAt != null ? Date.now() - owner.acquiredAt : await lockFileAgeMs(filename)
+    if (ageMs > staleMetadataMs) return true
+  }
+  return false
+}
+
+async function lockFileAgeMs(filename: string): Promise<number> {
+  const stat = await fs.stat(filename).catch(() => undefined)
+  return stat ? Date.now() - stat.mtimeMs : 0
 }
 
 function processExists(pid: number): boolean {

--- a/packages/util/test/fs-lock.test.ts
+++ b/packages/util/test/fs-lock.test.ts
@@ -4,6 +4,8 @@ import os from "node:os"
 import path from "node:path"
 import { fileLockPath, withFileLock } from "../src/fs-lock"
 
+const isWindows = process.platform === "win32"
+
 async function createLockDirectory(): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), "synergy-fs-lock-test-"))
 }
@@ -76,6 +78,39 @@ describe("withFileLock", () => {
     await expect(withFileLock({ directory, key: "shared", retryMs: 5, timeoutMs: 25 }, async () => {})).rejects.toThrow(
       "Timed out acquiring file lock for shared",
     )
+    await expect(fs.readFile(filename, "utf8")).resolves.toContain(`"pid":${process.pid}`)
+  })
+
+  // BUG-005: on Windows, PIDs recycle aggressively and process.kill(pid, 0)
+  // returns true for a recycled PID that now belongs to an unrelated live
+  // process. A stale lock whose owner PID has been recycled would otherwise
+  // look live forever and never be reclaimed. The wall-clock age (acquiredAt)
+  // must age it out past staleMetadataMs even when the PID appears live.
+  test.skipIf(!isWindows)("reclaims a stale lock whose recycled PID looks live", async () => {
+    const directory = await createLockDirectory()
+    const filename = fileLockPath(directory, "shared")
+    // pid = current process → processExists() is true, simulating a recycled
+    // PID that an unrelated live process now owns. acquiredAt is 10s in the
+    // past, beyond the 5s stale grace period.
+    await fs.writeFile(filename, JSON.stringify({ pid: process.pid, acquiredAt: Date.now() - 10_000 }), { mode: 0o600 })
+
+    let acquired = false
+    await withFileLock({ directory, key: "shared", retryMs: 5, timeoutMs: 2_000, staleMetadataMs: 5_000 }, async () => {
+      acquired = true
+    })
+
+    expect(acquired).toBe(true)
+  })
+
+  test("does not reclaim a fresh live-owner lock by age alone", async () => {
+    const directory = await createLockDirectory()
+    const filename = fileLockPath(directory, "shared")
+    // Fresh lock with a live owner PID: must not be reclaimed by the age gate.
+    await fs.writeFile(filename, JSON.stringify({ pid: process.pid, acquiredAt: Date.now() }), { mode: 0o600 })
+
+    await expect(
+      withFileLock({ directory, key: "shared", retryMs: 5, timeoutMs: 25, staleMetadataMs: 5_000 }, async () => {}),
+    ).rejects.toThrow("Timed out acquiring file lock for shared")
     await expect(fs.readFile(filename, "utf8")).resolves.toContain(`"pid":${process.pid}`)
   })
 })


### PR DESCRIPTION
## What does this PR do?

Ages out stale file locks past `staleMetadataMs` on Windows even when the owner PID still appears live, so a lock whose owner PID has been recycled (and now belongs to an unrelated live process) can be reclaimed instead of spinning every later acquirer to the timeout.

## Why?

`acquireFileLock` reclaims an existing lock when its owner is provably gone (`processExists(pid)` is false). On Windows, PIDs recycle aggressively and `process.kill(pid, 0)` returns `true` for a recycled PID that now belongs to an unrelated live process. So a stale lock whose owner died — but whose PID was since handed to another process — looks live forever and is never reclaimed: every later acquirer spins until `timeoutMs`, and the lock is effectively dead.

This PR consolidates reclaim logic into `isLockReclaimable` and adds a wall-clock age tiebreaker on Windows: a lock older than `staleMetadataMs` is treated as stale even if its PID looks live, using `acquiredAt` from the lock metadata (preferred over `mtime`, which antivirus/indexers can touch) with an `mtime` fallback. On POSIX the PID check is reliable, so a genuinely-live owner is never displaced by age alone.

The owner record now also persists `acquiredAt` (read best-effort; old lock files without it fall back to `mtime`).

## How was it tested?

New tests in `packages/util/test/fs-lock.test.ts`:

- `test.skipIf(!isWindows)`: reclaims a stale lock whose recycled PID looks live — stages a lock with `pid = process.pid` (so `processExists` is true, simulating a recycled PID) and `acquiredAt` 10s in the past (beyond a 5s grace); `withFileLock` acquires it.
- `does not reclaim a fresh live-owner lock by age alone`: a fresh lock (live PID, current `acquiredAt`) within the grace period times out and is left intact — proving the age gate doesn't displace a genuine live owner.

`bun test test/fs-lock.test.ts` → 6 pass, 0 fail. `tsc --noEmit` (packages/util typecheck) clean.

```bash
cd packages/util
bun test test/fs-lock.test.ts
bun run typecheck
```

## Checklist

- [x] `bun run quality:quick` passes — the touched package's gates (format, lint, typecheck, tests) pass for this change. Note: on a Windows checkout the repo-wide `quality:quick` has pre-existing red gates unrelated to this PR (a tracked symlink `packages/app/src/custom-elements.d.ts` parses as broken TS on Windows; plus `gitleaks`/`actionlint` not installed locally). These do not occur on the Linux CI runners; the files this PR touches are clean under `prettier`, `oxlint`, and `tsc`.
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] New or moved tests live under the owning package's `test/` directory — appended to the existing `packages/util/test/fs-lock.test.ts`.
- [x] `bun run package:check` passes if package exports, build output, release logic, or publishable packages changed — `packages/util` is a publishable package; this change adds no new exports (the new `isLockReclaimable`/`lockFileAgeMs` are module-private), so package publishing validation is unaffected.
- [x] `bun run workflow:check` passes if `.github/workflows/**`, GitHub Actions config, or CI helper scripts changed — no workflow changes.
- [x] Browser capability or App bootstrap changes pass the browser crypto contract and private HTTP browser smoke — N/A, util fs-lock only.
- [x] `bun run secrets:check` passes locally or CI Gitleaks covers the change if auth, provider, channel, config, or credential examples changed — no secrets/credentials touched; CI Gitleaks covers it.
- [x] SDK regenerated if server routes or schemas changed (`./script/generate.ts`) — no route/schema changes.
- [x] `bun run localization:check` passes if product copy, accessibility text, locale-sensitive formatting, or shared UI copy changed — no UI copy changes.
- [x] Documentation, AGENTS, and `.synergy` help updated if developer workflow, quality tooling, commands, or contributor rules changed — no contributor-facing workflow changes.
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included.
