### PR TITLE
fix(app): expect New Session Workspace row in settings catalog test

### DIFF
--- a/packages/app/test/components/settings/settings-section-copy.test.ts
+++ b/packages/app/test/components/settings/settings-section-copy.test.ts
@@ -49,6 +49,7 @@ describe("settings section localization", () => {
         "Color Scheme",
         "界面语言",
         "Activity display",
+        "New Session Workspace",
         "Snapshot",
         "Product Updates",
         "Notifications",


### PR DESCRIPTION
## What does this PR do?

Adds the missing `New Session Workspace` entry to the expected `rowLabels` in `packages/app/test/components/settings/settings-section-copy.test.ts`.

## Why?

PR #1262 added the `New Session Workspace` row to the General settings catalog (`catalog.ts`) but did not update the localization test expectation. Since fbfa02262 landed, every CI run on `dev` — including docs-only pushes — fails in the **Test** and **Coverage** jobs on `settings section localization > resolves built-in metadata through the active Lingui catalog` (received array has the extra untranslated row; the zh-CN catalog message itself was added correctly).

## External sources and provenance

None

## How was it tested?

- Reproduced the failure locally on 264437108 before the fix (1 fail in `settings-section-copy.test.ts`, matching CI).
- After the fix: `bun test test/components/settings/settings-section-copy.test.ts` → 3 pass / 0 fail.
- Full settings suite: `bun test test/components/settings/` in `packages/app` → 270 pass / 0 fail.
- `bun run quality:quick`: 14/15 gates pass; `secrets:check` cannot run locally (gitleaks not installed) and is covered by the CI Secret Scan job — no credential surface in this change.

## Checklist

- [x] `bun run quality:quick` passes *(secrets:check unavailable locally; CI covers it)*
- [x] Relevant narrow tests pass; commands are listed in "How was it tested?"
- [x] New or moved tests live under the owning package's `test/` directory (or the root `test/` directory for repository tests)
- [x] `bun run package:check` passes if package exports, build output, release logic, or publishable packages changed *(not touched)*
- [x] `bun run workflow:check` passes if `.github/workflows/**`, GitHub Actions config, or CI helper scripts changed *(not touched)*
- [x] Browser capability or App bootstrap changes pass the browser crypto contract and private HTTP browser smoke *(not touched)*
- [x] `bun run secrets:check` passes locally or CI Gitleaks covers the change if auth, provider, channel, config, or credential examples changed *(CI Gitleaks covers; no credential surface)*
- [x] SDK regenerated if server routes or schemas changed (`./script/generate.ts`) *(not touched)*
- [x] `bun run localization:check` passes if product copy, accessibility text, locale-sensitive formatting, or shared UI copy changed *(test-only change; product copy untouched)*
- [x] Documentation, AGENTS, and `.synergy` help updated if developer workflow, quality tooling, commands, or contributor rules changed *(not touched)*
- [x] Material external sources are marked near the authoritative implementation and listed above, or the section says `None`
- [x] No secrets, local auth files, unrelated cleanup, placeholder scripts, or redundant compatibility wrappers included