### PR TITLE
chore(coverage): exempt session-draft-badge from unit-suite coverage

### DIFF
--- a/script/coverage-exempt.json
+++ b/script/coverage-exempt.json
@@ -985,6 +985,10 @@
           "reason": "UI component not rendered by the unit suite; covered by dom/browser suites"
         },
         {
+          "glob": "src/components/sidebar/session-draft-badge.tsx",
+          "reason": "UI component not rendered by the unit suite; covered by dom/browser suites"
+        },
+        {
           "glob": "src/components/sidebar/sidebar-attention-notice.tsx",
           "reason": "UI component not rendered by the unit suite; covered by dom/browser suites"
         },


### PR DESCRIPTION
## Summary

- Fixes the Coverage gate failure introduced by #1268: `packages/app` FAILed with `missing 1` because `src/components/sidebar/session-draft-badge.tsx` is never loaded by the unit suite.
- The badge component is verified by the Playwright behavioral suite (`test/components/sidebar/session-draft-badge.dom.test.tsx`), which runs in an isolated browser batch that produces no Bun coverage data — so the gate counted the file as never-loaded.
- Adds the exemption entry following the established pattern for sibling sidebar components (`sidebar.tsx`, `sidebar-attention-notice.tsx`, `mobile-drawer-root.tsx` — all "UI component not rendered by the unit suite; covered by dom/browser suites").

## Note on the other CI failure signal

The same CI run also showed a `packages/synergy` Cortex test failure (`manager.test.ts` — "publishes the terminal task before an idle parent processes its completion notice"). That is unrelated to #1268: the PR touched no `packages/synergy` files, local reruns pass 54/54, and the prior merge on dev was green. It looks like a timing flake; a re-run should confirm.

## Verification

- `bun script/coverage-check.ts --validate` — manifest self-consistency passed
- CI numbers for app were already above thresholds (lines 62.9%/60%, functions 79.6%/50%); the only FAIL signal was `missing 1`, which this exemption clears