### PR TITLE
test(app): make open-in-browser DOM fixture hermetic for the Coverage gate

### DIFF
--- a/.synergy/skill/testing-guide/SKILL.md
+++ b/.synergy/skill/testing-guide/SKILL.md
@@ -39,6 +39,8 @@ Tests that exercise the cold-cache path — where no disk or memory cache exists
 
 Use a fake or local boundary only where the external system is not the subject of the test. Do not add Jest/Vitest mocks to the Bun suite without an established package-specific reason.
 
+Playwright DOM-test fixtures that boot a Vite dev server must be hermetic against a no-build checkout (the `ci-coverage` gate runs no build step): alias workspace-package entries whose `import` condition points at gitignored `dist/` output to their source entry; resolve runtime packages that break under dependency pre-bundling (Lingui's `@messageformat/parser` chain) to minimal fixture-local stubs when the suite asserts behavior unrelated to i18n rendering, or add them to `optimizeDeps.include` when the real runtime is the subject; set `optimizeDeps.include` for the Solid runtime/JSX runtime/zod with `noDiscovery: true` so the optimizer never re-runs mid-load and reloads the page; scope `cacheDir` to the fixture temp directory so sibling Playwright servers sharing `node_modules/.vite` cannot invalidate each other; `warmupRequest` the fixture entry before launching the browser and surface page/console/HTTP errors in the failure message instead of a bare 30s selector timeout; and register the suite in the package's `playwrightIsolated` list so bun's worker reaping cannot kill its Chromium process mid-suite. See the [hermetic Vite fixtures decision](../../../docs/decisions/implemented/testing/2026-08-31-hermetic-vite-fixtures-for-playwright-dom-tests.md).
+
 ## Run Core Suites Through the Orchestrators
 
 Run `packages/synergy` tests through the package scripts, never a raw `bun test --coverage --parallel`:

--- a/docs/decisions/implemented/testing/2026-08-31-hermetic-vite-fixtures-for-playwright-dom-tests.md
+++ b/docs/decisions/implemented/testing/2026-08-31-hermetic-vite-fixtures-for-playwright-dom-tests.md
@@ -1,0 +1,30 @@
+# Decision Record: Hermetic Vite fixtures for Playwright DOM tests
+
+Status: implemented
+
+## Problem
+
+The Coverage CI job (`bun script/gates.ts ci-coverage`) runs `packages/app` tests with no build step, so workspace packages that publish their `import` condition from a gitignored `dist/` are unresolvable inside Playwright DOM-test fixtures. `packages/plugin`'s exports map serves `@ericsanchezok/synergy-plugin/theme` from `dist/theme/index.js`, which a fresh checkout lacks; the real Lingui runtime additionally pulls `@messageformat/parser` (CJS) through `@lingui/message-utils`, whose named `parse` import breaks under Vite's on-demand dependency optimization. The `open-in-browser.dom.test.ts` suite from #1290 failed in Coverage CI (page 500 → 30s selector timeouts, reported as `ECONNREFUSED` in the gate's failure signals) because its fixture lacked the mitigations that `ThemePicker.behavior.test.tsx` had already accumulated over three earlier fixes (`e7fbc3974`, `43c4905ad`, `cd63660e5`). The same failure class had already surfaced there and was fixed per-file, but no shared rule captured it, so the next Playwright fixture re-introduced it.
+
+## Decision
+
+Playwright DOM-test fixtures that boot a Vite dev server must be hermetic against a no-build checkout:
+
+- Alias workspace-package entries whose `import` condition points at gitignored `dist/` output to their source entry (`packages/plugin/src/theme/index.ts` for the theme contract).
+- Resolve runtime packages that break under dependency pre-bundling (Lingui's `@messageformat/parser` chain) to minimal fixture-local stubs when the suite asserts behavior unrelated to i18n rendering, or add them to `optimizeDeps.include` when the real runtime is the subject.
+- Set `optimizeDeps.include` for the Solid runtime/JSX runtime/zod with `noDiscovery: true` so the optimizer never re-runs mid-load and reloads the page.
+- Scope `cacheDir` to the fixture temp directory so sibling Playwright servers sharing `packages/app/node_modules/.vite` cannot invalidate each other's optimizer cache.
+- `warmupRequest` the fixture entry before launching the browser, and surface page/console/HTTP errors in the failure message instead of a bare 30s selector timeout.
+- Register the suite in the package's `playwrightIsolated` list so bun's worker reaping cannot kill its Chromium process mid-suite.
+
+## Alternatives considered
+
+**Rely on `bun dev prepare`/turbo `^build` to materialize `dist/` before the Coverage job.** Rejected: `ci-coverage` deliberately runs no build step to keep the gate cheap; depending on a build artifact makes the gate's validity a function of CI pipeline ordering instead of the checkout itself.
+
+**Fix `@messageformat/parser` pre-bundling once globally.** Rejected: it would require either an app-wide `optimizeDeps` include (which the production build does not use) or a Vite plugin shim, both broader than the fixture's needs and untested outside DOM fixtures.
+
+**Stub only `@lingui/core`/`@lingui/solid` via alias and keep the real locale context.** Rejected: the fixture asserts toolbar chrome and click behavior, not translation rendering; the repo's own guidance already prefers minimal stubs at the boundary that is not the subject of the test.
+
+## Consequences
+
+`open-in-browser.dom.test.ts` passes in the Coverage job and locally without a plugin build, and the fixture reports real module-graph errors in `beforeAll` instead of timing out. The `testing-guide` skill now carries the hermetic-Vite-fixture checklist so future Playwright DOM tests get the mitigations up front instead of rediscovering them per file. The cost is a small per-fixture configuration block (alias + optimizeDeps + cacheDir + warmup) that each new DOM suite must include or consciously waive.

--- a/packages/app/script/test.ts
+++ b/packages/app/script/test.ts
@@ -13,6 +13,7 @@ const playwrightIsolated = [
   "test/components/app-shell/mobile-drawer-root.test.tsx",
   "test/components/dialog/model-selector-layout.test.ts",
   "test/components/file-workbench/selection.test.ts",
+  "test/components/file-workbench/open-in-browser.dom.test.ts",
   "test/components/attachment-workbench/pdf-preview.dom.test.ts",
   "test/components/library/filter-menu-surface.test.ts",
   "test/components/menu-field/menu-field.test.ts",

--- a/packages/app/test/components/file-workbench/open-in-browser.dom.test.ts
+++ b/packages/app/test/components/file-workbench/open-in-browser.dom.test.ts
@@ -10,6 +10,7 @@ let page: Page
 let server: ViteDevServer
 let fixtureDirectory: string
 let baseUrl: string
+const pageErrors: Error[] = []
 
 const componentPath = path.resolve(import.meta.dir, "../../../src/components/file-workbench/content.tsx")
 const appSrc = path.resolve(import.meta.dir, "../../../src")
@@ -68,9 +69,35 @@ beforeAll(async () => {
     Bun.write(
       localeStubPath,
       `
-        import { setupI18n } from "@lingui/core"
-        const i18n = setupI18n({ locale: "en" })
-        export const useLocale = () => ({ i18n, fmt: { number: (value) => String(value) } })
+        export const useLocale = () => ({ i18n: {}, fmt: { number: (value) => String(value) } })
+      `,
+    ),
+    Bun.write(
+      path.join(fixtureDirectory, "lingui-stub.tsx"),
+      `
+        import type { JSX } from "solid-js"
+        // Minimal Lingui stand-in: this fixture asserts workbench chrome and
+        // click behavior, not i18n rendering. The real @lingui/solid runtime
+        // pulls @messageformat/parser (CJS) through @lingui/message-utils,
+        // whose named import breaks under Vite's dependency pre-bundling in
+        // the Coverage job (no build step, shared .vite cache).
+        export function I18nProvider(props: { children?: JSX.Element }) {
+          return props.children
+        }
+        export function useLingui() {
+          return {
+            _: (descriptor: { id: string; message?: string }) => descriptor.message ?? descriptor.id,
+          }
+        }
+      `,
+    ),
+    Bun.write(
+      path.join(fixtureDirectory, "lingui-core-stub.ts"),
+      `
+        // Minimal @lingui/core stand-in; see lingui-stub.tsx for why.
+        export function setupI18n() {
+          return {}
+        }
       `,
     ),
     Bun.write(
@@ -111,9 +138,34 @@ beforeAll(async () => {
         { find: /^@\/context\/platform$/, replacement: platformStubPath },
         { find: /^@\/context\/sdk$/, replacement: sdkStubPath },
         { find: /^@\/context\/locale$/, replacement: localeStubPath },
+        // The real Lingui runtime pulls @messageformat/parser (CJS) through
+        // @lingui/message-utils; its named `parse` import breaks under Vite's
+        // on-demand dependency optimization in the no-build Coverage job.
+        // The fixture asserts workbench chrome and click behavior, not i18n
+        // rendering, so both Lingui entries resolve to hermetic stubs.
+        { find: "@lingui/solid", replacement: path.join(fixtureDirectory, "lingui-stub.tsx") },
+        { find: "@lingui/core", replacement: path.join(fixtureDirectory, "lingui-core-stub.ts") },
+        // The plugin package's exports map serves "import" from its
+        // gitignored dist/theme/index.js, which a fresh checkout lacks (the
+        // Coverage job runs no build step). Resolve the theme entry to source
+        // so the fixture is hermetic on any checkout.
+        {
+          find: "@ericsanchezok/synergy-plugin/theme",
+          replacement: path.resolve(import.meta.dir, "../../../../..", "packages/plugin/src/theme/index.ts"),
+        },
         { find: "@", replacement: appSrc },
       ],
     },
+    // Pre-bundle the Solid runtime, JSX runtime, and zod at server startup so
+    // the optimizer never re-runs mid-load (which reloads the page and 500s
+    // on slow cold Coverage CI starts). The cache is scoped to this fixture
+    // because sibling Playwright servers share packages/app/node_modules/.vite
+    // and invalidate each other's cache.
+    optimizeDeps: {
+      include: ["solid-js", "solid-js/web", "solid-js/store", "solid-js/jsx-runtime", "zod"],
+      noDiscovery: true,
+    },
+    cacheDir: path.join(fixtureDirectory, ".vite"),
     server: {
       host: "127.0.0.1",
       port: 5216,
@@ -122,6 +174,9 @@ beforeAll(async () => {
     },
   })
   await server.listen()
+  // Transform the whole fixture module graph server-side before the browser
+  // connects so transform errors surface here instead of a browser 500.
+  await server.warmupRequest("/main.tsx")
 
   const resolved = server.resolvedUrls?.local[0]
   if (!resolved) throw new Error("Expected Vite test server URL")
@@ -129,6 +184,23 @@ beforeAll(async () => {
 
   browser = await chromium.launch({ headless: true })
   page = await browser.newPage({ viewport: { width: 800, height: 600 } })
+  page.on("pageerror", (error) => pageErrors.push(error))
+  page.on("console", (message) => {
+    if (message.type() === "error") pageErrors.push(new Error(message.text()))
+  })
+  page.on("response", (response) => {
+    if (response.status() >= 400) pageErrors.push(new Error(`HTTP ${response.status()} for ${response.url()}`))
+  })
+  // Smoke the fixture once before the cases run so a broken module graph
+  // fails here with page errors attached instead of three 30s timeouts.
+  try {
+    await page.goto(`${baseUrl}?path=README.md`)
+    await page.waitForSelector(".file-workbench-toolbar", { timeout: 30000 })
+  } catch (error) {
+    const pageError = pageErrors[0]
+    if (pageError) throw new Error(`file workbench fixture page failed to render: ${pageError.stack}`, { cause: error })
+    throw error
+  }
 })
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary

Fixes the red `Coverage` gate on `dev` (and the failing `All checks passed` summary job). The `file-workbench open-in-browser` DOM suite added in #1290 fails in the `ci-coverage` job: its Vite fixture can't resolve `@ericsanchezok/synergy-plugin/theme` (the plugin exports map serves `import` from gitignored `dist/theme/index.js`, and the Coverage job runs no build step), and the real Lingui runtime pulls `@messageformat/parser` (CJS) whose named `parse` import breaks under Vite's dependency pre-bundling. The page 500s and every case times out after 30s (`ECONNREFUSED` in the gate's failure signals), which also zeroes `packages/app` coverage.

Ports the mitigations `ThemePicker.behavior.test.tsx` already accumulated (`e7fbc3974`, `43c4905ad`, `cd63660e5`) to this fixture:

- Alias `@ericsanchezok/synergy-plugin/theme` to its source entry
- Stub the Lingui runtime (`@lingui/solid`, `@lingui/core`) since the suite asserts chrome/click behavior, not i18n rendering
- Pre-bundle the Solid runtime + zod with `optimizeDeps.include` + `noDiscovery: true`
- Scope `cacheDir` to the fixture temp dir so sibling Playwright servers don't invalidate each other's optimizer cache
- `warmupRequest` the fixture before the browser connects; surface page/console/HTTP errors instead of bare selector timeouts
- Register the suite in `playwrightIsolated` in `packages/app/script/test.ts`

Adds a decision record (`docs/decisions/implemented/testing/2026-08-31-hermetic-vite-fixtures-for-playwright-dom-tests.md`) and codifies the hermetic-Vite-fixture checklist in the `testing-guide` skill so future Playwright DOM fixtures get the mitigations up front.

## Verification

- `bun test --timeout 120000 test/components/file-workbench/open-in-browser.dom.test.ts` — 3/3 pass (~7s total)
- Regression: ThemePicker, pdf-preview, selection suites — 8/8 pass
- `bun run decision:check`, `bun run skill:check`, staged lint — pass
- Verified with plugin `dist/` absent (same condition as the Coverage job)