### PR TITLE
fix(app): restore expanded workspace folders on file explorer mount

### DIFF
--- a/docs/decisions/implemented/bug-fix/2026-09-01-file-explorer-restores-expanded-directories.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-01-file-explorer-restores-expanded-directories.md
@@ -1,0 +1,23 @@
+# Decision Record: File explorer restores persisted expanded folders on mount
+
+Status: implemented
+
+## Problem
+
+The workspace Files panel's expanded-folder list (`file-explorer.expanded`) is persisted to workspace-level localStorage through `Persist.workspace`, while the tree's node and directory caches (`context/file.tsx` `store.nodes` / `store.directories`) live only inside the `FileProvider` context. Navigating between sessions that cross Scope boundaries unmounts the whole directory layout's `<Show keyed>` branch, recreating `FileProvider` with a clean tree store; the `FileExplorer` mount hook populated only the root directory that was previously shown to the user. The next panel painted the tree with `expanded(path) === true` for the persisted folders but an empty child list, so every re-opened folder looked collapsed. Toggling a row flipped the stale `expanded` flag first (true → false) and only the second click both flipped it back and triggered `loadChildren`, which made folders appear to need two clicks to expand.
+
+## Decision
+
+`FileExplorer` mounts also walk `file.explorer.expanded()` and call `loadChildren(path)` for each persisted folder, alongside the existing root `loadChildren("")`. The calls reuse the directory cache's existing fast paths (`complete && !stale` returns a no-op), so a folder whose children are already warm in the new provider does not make another request. The fix stays in `explorer.tsx`; `context/file.tsx` keeps expansion state as the persisted source of truth.
+
+## Alternatives considered
+
+**Persist the tree cache too** — writing `store.nodes` / `store.directories` into localStorage would have restored rendering without any new fetch, but cached entries become untrustworthy the moment an internal or external edit changes the tree, and rehydrating stale nodes through reconcile would re-introduce the same stale-tree bug we were just fixing.
+
+**Restore lazily on first paint of a persisted row** — waiting until the `rows` memo hit an expanded-but-uncached folder would avoid eager loads for folders the user no longer cares about, but it complicates the memo and keeps the broken first paint visible; the persisted list is already bounded (user-expanded folders only), so eager restore is cheap.
+
+**Skip the fix and rely on manual refresh** — the refresh button and window-focus handler already run `refresh()`, which reloads every expanded folder. Rejected because it makes a core panel interaction (switching away and back) require an extra corrective action and leaves the UI in a half-open state.
+
+## Consequences
+
+Switching sessions or Scopes no longer requires folders to be re-opened one by one; the tree paints its persisted expansion in the first render after `FileExplorer` mounts. The change adds at most one extra `loadChildren` request per persisted folder on mount, which hits the same pagination and abort-semantics as the existing expand flow. The `explorer-restore.dom.test.ts` Playwright fixture pins the regression by constructing a stub file model with persisted `expanded = ["docs"]` and an empty in-memory tree, then asserting the subtree renders.

--- a/packages/app/script/test.ts
+++ b/packages/app/script/test.ts
@@ -15,6 +15,7 @@ const playwrightIsolated = [
   "test/components/file-workbench/scrollbar-dark.test.ts",
   "test/components/file-workbench/selection.test.ts",
   "test/components/file-workbench/open-in-browser.dom.test.ts",
+  "test/components/file-workbench/explorer-restore.dom.test.ts",
   "test/components/attachment-workbench/pdf-preview.dom.test.ts",
   "test/components/library/filter-menu-surface.test.ts",
   "test/components/menu-field/menu-field.test.ts",

--- a/packages/app/src/components/file-workbench/explorer.tsx
+++ b/packages/app/src/components/file-workbench/explorer.tsx
@@ -64,6 +64,7 @@ export function FileExplorer(props: { onClose: () => void }) {
 
   onMount(() => {
     void file.explorer.loadChildren("")
+    for (const path of file.explorer.expanded()) void file.explorer.loadChildren(path)
   })
 
   createEffect(() => {

--- a/packages/app/test/components/file-workbench/explorer-restore.dom.test.ts
+++ b/packages/app/test/components/file-workbench/explorer-restore.dom.test.ts
@@ -1,0 +1,226 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import path from "node:path"
+import { chromium, type Browser, type Page } from "playwright"
+import { createServer, type ViteDevServer } from "vite"
+import solidPlugin from "vite-plugin-solid"
+
+let browser: Browser
+let page: Page
+let server: ViteDevServer
+let fixtureDirectory: string
+let baseUrl: string
+const pageErrors: Error[] = []
+
+const explorerPath = path.resolve(import.meta.dir, "../../../src/components/file-workbench/explorer.tsx")
+const appSrc = path.resolve(import.meta.dir, "../../../src")
+
+beforeAll(async () => {
+  fixtureDirectory = await mkdtemp(path.join(import.meta.dir, ".explorer-restore-fixture-"))
+  const fileStubPath = path.join(fixtureDirectory, "file-stub.ts")
+
+  await Promise.all([
+    Bun.write(
+      path.join(fixtureDirectory, "index.html"),
+      '<div id="root"></div><script type="module" src="/main.tsx"></script>',
+    ),
+    Bun.write(
+      fileStubPath,
+      `
+        import { createStore } from "solid-js/store"
+
+        // Deterministic in-memory tree shaped like the real Synergy
+        // file-explorer model: loadChildren("docs") populates the child
+        // rows; without that call the persisted expansion state stays
+        // true but the subtree renders nothing.
+        const [store, setStore] = createStore({
+          expanded: ["docs"],
+          directories: {},
+          nodes: {},
+        })
+
+        const tree = {
+          "": [{ path: "docs", name: "docs", type: "directory" }],
+          docs: [
+            { path: "docs/api.md", name: "api.md", type: "file" },
+            { path: "docs/guide.md", name: "guide.md", type: "file" },
+          ],
+        }
+
+        function directory(path) {
+          return store.directories[path]
+        }
+
+        function node(path) {
+          return store.nodes[path]
+        }
+
+        function isExpanded(path) {
+          return store.expanded.includes(path)
+        }
+
+        async function loadChildren(path) {
+          const items = tree[path] ?? []
+          setStore("directories", path, {
+            items: items.map((item) => item.path),
+            nextCursor: undefined,
+            complete: true,
+            loading: false,
+            stale: false,
+            error: undefined,
+            generation: 1,
+          })
+          for (const item of items) {
+            setStore("nodes", item.path, item)
+          }
+        }
+
+        export const useFile = () => ({
+          activePath: () => undefined,
+          get: () => undefined,
+          openWorkspaceFile: async () => {},
+          explorer: {
+            open: () => true,
+            setOpen: () => {},
+            width: () => 296,
+            setWidth: () => {},
+            showHidden: () => false,
+            setShowHidden: () => {},
+            expanded: () => store.expanded,
+            isExpanded,
+            setExpanded: (path, expanded) => {
+              setStore("expanded", (items) =>
+                expanded ? (items.includes(path) ? items : [...items, path]) : items.filter((item) => item !== path),
+              )
+              if (expanded) void loadChildren(path)
+            },
+            collapseAll: () => setStore("expanded", []),
+            node,
+            directory,
+            loadChildren,
+            reveal: async () => {},
+            refresh: async () => {},
+          },
+          searchFiles: async () => ({ items: [] }),
+        })
+      `,
+    ),
+    Bun.write(
+      path.join(fixtureDirectory, "lingui-stub.tsx"),
+      `
+        import type { JSX } from "solid-js"
+        // Minimal Lingui stand-in; see open-in-browser.dom.test.ts for why.
+        export function I18nProvider(props: { children?: JSX.Element }) {
+          return props.children
+        }
+        export function useLingui() {
+          return {
+            _: (descriptor: { id: string; message?: string }) => descriptor.message ?? descriptor.id,
+          }
+        }
+      `,
+    ),
+    Bun.write(
+      path.join(fixtureDirectory, "lingui-core-stub.ts"),
+      `
+        // Minimal @lingui/core stand-in; see lingui-stub.tsx for why.
+        export function setupI18n() {
+          return {}
+        }
+      `,
+    ),
+    Bun.write(
+      path.join(fixtureDirectory, "main.tsx"),
+      `
+        import { createComponent } from "solid-js"
+        import { render } from "solid-js/web"
+        import { setupI18n } from "@lingui/core"
+        import { I18nProvider } from "@lingui/solid"
+        import { FileExplorer } from ${JSON.stringify(`/@fs/${explorerPath}`)}
+
+        const i18n = setupI18n({ locale: "en" })
+        render(
+          () =>
+            createComponent(I18nProvider, {
+              i18n,
+              children: () =>
+                createComponent(FileExplorer, {
+                  onClose: () => {},
+                }),
+            }),
+          document.querySelector("#root"),
+        )
+      `,
+    ),
+  ])
+
+  server = await createServer({
+    configFile: false,
+    root: fixtureDirectory,
+    plugins: [solidPlugin()],
+    resolve: {
+      alias: [
+        { find: /^@\/context\/file$/, replacement: fileStubPath },
+        { find: "@lingui/solid", replacement: path.join(fixtureDirectory, "lingui-stub.tsx") },
+        { find: "@lingui/core", replacement: path.join(fixtureDirectory, "lingui-core-stub.ts") },
+        {
+          find: "@ericsanchezok/synergy-plugin/theme",
+          replacement: path.resolve(import.meta.dir, "../../../../..", "packages/plugin/src/theme/index.ts"),
+        },
+        { find: "@", replacement: appSrc },
+      ],
+    },
+    optimizeDeps: {
+      include: ["solid-js", "solid-js/web", "solid-js/store", "solid-js/jsx-runtime", "zod"],
+      noDiscovery: true,
+    },
+    cacheDir: path.join(fixtureDirectory, ".vite"),
+    server: {
+      host: "127.0.0.1",
+      port: 5217,
+      strictPort: true,
+      fs: { allow: [path.resolve(import.meta.dir, "../../../../..")] },
+    },
+  })
+  await server.listen()
+  await server.warmupRequest("/main.tsx")
+
+  const resolved = server.resolvedUrls?.local[0]
+  if (!resolved) throw new Error("Expected Vite test server URL")
+  baseUrl = resolved
+
+  browser = await chromium.launch({ headless: true })
+  page = await browser.newPage({ viewport: { width: 420, height: 600 } })
+  page.on("pageerror", (error) => pageErrors.push(error))
+  page.on("console", (message) => {
+    if (message.type() === "error") pageErrors.push(new Error(message.text()))
+  })
+  page.on("response", (response) => {
+    if (response.status() >= 400) pageErrors.push(new Error(`HTTP ${response.status()} for ${response.url()}`))
+  })
+})
+
+afterAll(async () => {
+  await page?.close()
+  await browser?.close()
+  await server?.close()
+  if (fixtureDirectory) await rm(fixtureDirectory, { recursive: true, force: true })
+})
+
+describe("file explorer expanded-state restore", () => {
+  test("restores expanded directory children on mount when expansion state is persisted", async () => {
+    await page.goto(baseUrl)
+
+    // The stub keeps `expanded` = ["docs"] but starts with an empty tree
+    // (mirroring a session switch where the in-memory node cache was dropped
+    // while localStorage kept the expansion list). The explorer must relist
+    // the persisted folders' children so the subtree renders collapsed-open.
+    await page.waitForSelector('[role="tree"]', { timeout: 30000 })
+
+    const rows = page.locator('[role="treeitem"]')
+    expect(await rows.count()).toBe(3)
+    expect(await page.locator('[data-path="docs"]').getAttribute("aria-expanded")).toBe("true")
+    expect(await page.locator('[data-path="docs/api.md"]').isVisible()).toBe(true)
+    expect(await page.locator('[data-path="docs/guide.md"]').isVisible()).toBe(true)
+  }, 60000)
+})


### PR DESCRIPTION
## Summary
- Fix: expanded folders in the workspace Files panel now restore their children when the file explorer mounts, instead of rendering collapsed after a session switch.
- Root cause: the expanded-folder list is persisted per workspace, but the tree node/directory caches live only in the `FileProvider` context. Switching sessions across Scopes recreates the provider with an empty tree, and the mount hook only loaded the root directory — so previously expanded folders painted with a stale `expanded=true` flag and no children (the first click just cleared the flag, hence the perceived "two clicks to expand").
- Fix: `FileExplorer` walks the persisted expanded list on mount and calls `loadChildren` for each folder; the directory cache's existing complete-and-fresh fast path skips folders whose children are already warm.
- Adds a Playwright DOM regression test (`explorer-restore.dom.test.ts`) with a stub file model holding persisted expansion state against an empty tree, and registers it in the isolated test runner.
- Adds a bug-fix decision record.

## Test plan
- `bun test test/components/file-workbench/explorer-restore.dom.test.ts` — red before the fix (1 row vs expected 3), green after. ✅
- `bun run script/test.ts` (full `packages/app` orchestrator, including all isolated Playwright suites and the production-build CSS contract) — passes. ✅
- `bun run --cwd packages/app typecheck` — passes. ✅
- `bun run quality:quick` — 15/16 gates pass locally; `secrets:check` requires gitleaks which is not installed on this machine (covered by CI). ✅
- `bun run decision:check` / `bun run doc:check` — pass. ✅

🤖 Generated with [Synergy](https://github.com/SII-Holos/synergy)
