### PR TITLE
fix(session): tolerate malformed reasoning stream boundaries

### DIFF
--- a/packages/synergy/src/session/llm.ts
+++ b/packages/synergy/src/session/llm.ts
@@ -22,6 +22,7 @@ import { ObservabilitySpans } from "@/observability/spans"
 import type { LLMTurnMemory } from "./llm-memory"
 import { SessionRootVariant } from "./root-variant"
 import { SessionPluginHooks } from "./plugin-hooks"
+import { reasoningStreamGuardMiddleware } from "./reasoning-stream-guard"
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
@@ -522,6 +523,9 @@ export namespace LLM {
                 return args.params
               },
             },
+            // This must wrap extractReasoningMiddleware so malformed empty
+            // reasoning blocks are repaired before streamText consumes them.
+            reasoningStreamGuardMiddleware(),
             extractReasoningMiddleware({ tagName: "think", startWithReasoning: false }),
           ],
         }),

--- a/packages/synergy/src/session/reasoning-stream-guard.ts
+++ b/packages/synergy/src/session/reasoning-stream-guard.ts
@@ -1,0 +1,57 @@
+import type { LanguageModelV2Middleware } from "@ai-sdk/provider"
+
+/**
+ * Keep malformed reasoning event sequences from terminating streamText.
+ *
+ * Some OpenAI-compatible endpoints and AI SDK's reasoning extractor can emit
+ * an empty reasoning-end, or a delta, without a matching reasoning-start.
+ * streamText treats that sequence as fatal. Repair only the missing boundary;
+ * well-formed streams pass through unchanged.
+ */
+export function reasoningStreamGuardMiddleware(): LanguageModelV2Middleware {
+  return {
+    middlewareVersion: "v2",
+    async wrapStream({ doStream }) {
+      const result = await doStream()
+      const activeReasoning = new Set<string>()
+
+      return {
+        ...result,
+        stream: result.stream.pipeThrough(
+          new TransformStream({
+            transform(part, controller) {
+              if (part.type === "reasoning-start") {
+                activeReasoning.add(part.id)
+                controller.enqueue(part)
+                return
+              }
+
+              if (part.type === "reasoning-delta") {
+                if (!activeReasoning.has(part.id)) {
+                  controller.enqueue({
+                    type: "reasoning-start",
+                    id: part.id,
+                    ...(part.providerMetadata ? { providerMetadata: part.providerMetadata } : {}),
+                  })
+                  activeReasoning.add(part.id)
+                }
+                controller.enqueue(part)
+                return
+              }
+
+              if (part.type === "reasoning-end") {
+                // An end without any content is produced for an empty
+                // <think></think> block. There is no reasoning part to retain.
+                if (!activeReasoning.delete(part.id)) return
+                controller.enqueue(part)
+                return
+              }
+
+              controller.enqueue(part)
+            },
+          }),
+        ),
+      }
+    },
+  }
+}

--- a/packages/synergy/test/session/reasoning-stream-guard.test.ts
+++ b/packages/synergy/test/session/reasoning-stream-guard.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import type { LanguageModelV2StreamPart } from "@ai-sdk/provider"
+import { extractReasoningMiddleware } from "ai"
+import { reasoningStreamGuardMiddleware } from "../../src/session/reasoning-stream-guard"
+
+function stream(parts: LanguageModelV2StreamPart[]) {
+  return new ReadableStream<LanguageModelV2StreamPart>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part)
+      controller.close()
+    },
+  })
+}
+
+async function collect(input: ReadableStream<LanguageModelV2StreamPart>) {
+  const result: LanguageModelV2StreamPart[] = []
+  const reader = input.getReader()
+  while (true) {
+    const item = await reader.read()
+    if (item.done) break
+    result.push(item.value)
+  }
+  return result
+}
+
+async function applyMiddleware(
+  middleware: ReturnType<typeof reasoningStreamGuardMiddleware> | ReturnType<typeof extractReasoningMiddleware>,
+  input: ReadableStream<LanguageModelV2StreamPart>,
+) {
+  const wrapped = await middleware.wrapStream!({
+    doStream: async () => ({ stream: input }),
+    doGenerate: async () => {
+      throw new Error("not used")
+    },
+    params: {} as never,
+    model: {} as never,
+  })
+  return wrapped.stream
+}
+
+describe("reasoningStreamGuardMiddleware", () => {
+  test("drops the orphan reasoning-end produced by an empty think block", async () => {
+    const extracted = await applyMiddleware(
+      extractReasoningMiddleware({ tagName: "think", startWithReasoning: false }),
+      stream([
+        { type: "text-start", id: "txt-0" },
+        { type: "text-delta", id: "txt-0", delta: "<think></think>summary" },
+        { type: "text-end", id: "txt-0" },
+      ]),
+    )
+    const guarded = await applyMiddleware(reasoningStreamGuardMiddleware(), extracted)
+    const parts = await collect(guarded)
+
+    expect(parts.some((part) => part.type === "reasoning-end")).toBe(false)
+    expect(parts.filter((part) => part.type === "text-delta")).toEqual([
+      { type: "text-delta", id: "txt-0", delta: "summary" },
+    ])
+  })
+
+  test("synthesizes a start before an orphan reasoning delta", async () => {
+    const guarded = await applyMiddleware(
+      reasoningStreamGuardMiddleware(),
+      stream([
+        { type: "reasoning-delta", id: "reasoning-0", delta: "analysis" },
+        { type: "reasoning-end", id: "reasoning-0" },
+      ]),
+    )
+
+    expect(await collect(guarded)).toEqual([
+      { type: "reasoning-start", id: "reasoning-0" },
+      { type: "reasoning-delta", id: "reasoning-0", delta: "analysis" },
+      { type: "reasoning-end", id: "reasoning-0" },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- prevent malformed reasoning event boundaries from terminating otherwise successful model streams
- drop orphan `reasoning-end` events produced by empty `<think></think>` blocks
- synthesize a matching `reasoning-start` when a provider emits a reasoning delta first

## Root cause
With `extractReasoningMiddleware({ tagName: "think", startWithReasoning: false })`, an empty think block can produce `reasoning-end` without a preceding `reasoning-start`. AI SDK `streamText` treats this as fatal and reports `reasoning part reasoning-0 not found`, even when the provider has already generated a valid compaction summary or final response.

This matches the upstream AI SDK failure described in [vercel/ai#12054](https://github.com/vercel/ai/issues/12054). Recent AI SDK 5.x packages still expose the malformed sequence, so Synergy needs a narrow boundary guard until the upstream stream processor accepts it consistently.

## Changes
| File | Change |
|------|--------|
| `packages/synergy/src/session/reasoning-stream-guard.ts` | Add a stream middleware that repairs only missing reasoning lifecycle boundaries. |
| `packages/synergy/src/session/llm.ts` | Place the guard around reasoning extraction before `streamText` consumes events. |
| `packages/synergy/test/session/reasoning-stream-guard.test.ts` | Reproduce the empty-think failure and cover orphan-delta recovery. |

Well-formed reasoning streams pass through unchanged. This does not alter prompts, model selection, compaction policy, retry behavior, or generated text.

## Verification
- `bun test test/session/reasoning-stream-guard.test.ts test/session/invoke-compaction.test.ts`: 19 passed, 0 failed
- `bun run typecheck` in `packages/synergy`: passed
- pre-push gates: Prettier, oxlint, all 11 workspace typechecks, sherif, doc validation, and decision validation passed
- production-shaped verification: a previously failing long-context compaction completed with `finish=stop`, committed its summary boundary, preserved a 9.8k-character summary, and emitted no new missing-reasoning-part error

No service restart is included in this PR.