### PR TITLE
fix(app): stop sidebar project list jump on unrelated navigation

### DIFF
--- a/docs/decisions/implemented/bug-fix/2026-09-02-stop-sidebar-project-refresh-jump.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-02-stop-sidebar-project-refresh-jump.md
@@ -15,8 +15,8 @@ Clicking any project or session under the sidebar Projects section made the enti
 Each layer stops triggering its downstream churn only when its own input changed.
 
 - `Scope.fromDirectory` (packages/synergy) persists and broadcasts `scope.updated` only when the record actually changed: first creation, or a change in `directory`, `worktree`, `vcs`, or the sandboxes list. Unchanged lookups stay read-only.
-- `FlipList` (packages/app) skips the pre-ref pass entirely: when the container ref is not yet assigned it returns without touching `previousPositions`. The first real snapshot becomes the baseline, so later refreshes animate only genuinely new rows and repositioned rows.
-- `loadScopeIndex` (packages/app) compares the freshly fetched index against the current one with a new `sameScopeIndex` helper and skips `setScopeIndex` when the entries are equivalent, preserving the signal identity that downstream memos depend on.
+- `FlipList` (packages/app) keeps the pre-ref pass from storing an empty position map — the runner returns without touching `previousPositions` while the container ref is unassigned — and seeds the real baseline from `onMount` once the ref and its rows are in the DOM. Later refreshes animate only genuinely new rows and repositioned rows, and the first genuine entries change still animates instead of being absorbed as a silent baseline.
+- `loadScopeIndex` (packages/app) compares the freshly fetched index against the current one with a new `sameScopeIndex` helper and skips `setScopeIndex` when the entries are equivalent, preserving the signal identity that downstream memos depend on. Managed Channel projects order within their account by the server's `latestActivityAt`; because the event storm no longer keeps that ordering warm, `session.updated` events for managed project sessions schedule the same debounced index refresh, which the equality guard renders inert when nothing changed.
 
 ## Alternatives considered
 

--- a/docs/decisions/implemented/bug-fix/2026-09-02-stop-sidebar-project-refresh-jump.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-02-stop-sidebar-project-refresh-jump.md
@@ -1,0 +1,33 @@
+# Decision Record: Stop unrelated navigation from replaying the sidebar project list
+
+Status: implemented
+
+## Problem
+
+Clicking any project or session under the sidebar Projects section made the entire project list visually "jump": every project row faded in and slid as if freshly mounted. Runtime instrumentation showed three compounding causes.
+
+1. **Server event storm.** Every request carrying a `directory` resolved its scope through `Scope.fromDirectory`, which unconditionally rewrote the persisted scope record and broadcast `scope.updated` — even when nothing changed. Each navigation therefore re-emitted the event multiple times.
+2. **Frontend index churn.** The layout store listens for `scope.updated` and rebuilds the scope index after a 300 ms debounce. Every rebuild replaced the `scopeIndex` signal with a new array, forcing the Projects list to recompute on unrelated navigation.
+3. **FlipList baseline pollution.** `FlipList` snapshots row positions in a render effect. Solid's render effect fires once at mount before the container ref is assigned, so that first pass stored an empty position map. On the next entries change every existing row looked "new", and `FlipList` played the entrance animation (fade + slide) on all of them at once.
+
+## Decision
+
+Each layer stops triggering its downstream churn only when its own input changed.
+
+- `Scope.fromDirectory` (packages/synergy) persists and broadcasts `scope.updated` only when the record actually changed: first creation, or a change in `directory`, `worktree`, `vcs`, or the sandboxes list. Unchanged lookups stay read-only.
+- `FlipList` (packages/app) skips the pre-ref pass entirely: when the container ref is not yet assigned it returns without touching `previousPositions`. The first real snapshot becomes the baseline, so later refreshes animate only genuinely new rows and repositioned rows.
+- `loadScopeIndex` (packages/app) compares the freshly fetched index against the current one with a new `sameScopeIndex` helper and skips `setScopeIndex` when the entries are equivalent, preserving the signal identity that downstream memos depend on.
+
+## Alternatives considered
+
+**Only fix FlipList.** Would stop the visual jump but leave the server rewriting scope records and broadcasting `scope.updated` on every directory-scoped request, and the frontend rebuilding the index after every such event. The wasted work and churn would remain and would keep resurfacing as other reactive noise.
+
+**Skip the event entirely on the server for repeated identical lookups via caching.** A time-based or per-directory cache suppresses broadcasts but adds invalidation semantics around archive/rename paths. Comparing the incoming record against the persisted one gives the same suppression with no new cache state to keep coherent.
+
+**Compare scope indices inside the sidebar instead of the layout store.** Memoizing the Projects list in the sidebar component only guards that one consumer; every other reader of the scope index keeps recomputing. The comparison belongs at the store boundary where the signal identity is owned.
+
+## Consequences
+
+- Repeated directory lookups no longer touch scope storage or emit `scope.updated`; the frontend rebuild path is dormant unless real scope metadata changes.
+- The Projects list refreshes only when the server index genuinely differs; unchanged rows keep their DOM nodes and animations no longer replay.
+- `sameScopeIndex` is a strict equality over the rendered fields of `ScopeNavEntry`; a server-side field addition that affects rendering must be added to the comparison, mirroring how the sidebar consumes the index.

--- a/packages/app/src/components/sidebar/flip-list-model.ts
+++ b/packages/app/src/components/sidebar/flip-list-model.ts
@@ -1,0 +1,84 @@
+const EASING_REPOSITION = "cubic-bezier(0.2, 0, 0, 1)"
+const EASING_ENTRANCE = "cubic-bezier(0.05, 0.7, 0.1, 1)"
+const DURATION_REPOSITION = 250
+const DURATION_ENTRANCE = 160
+const STAGGER_MS = 18
+const MAX_STAGGER = 120
+
+/**
+ * Create the FLIP runner owned by a FlipList instance. Returns a function that
+ * snapshots row positions on every entries change and animates rows that moved
+ * or entered since the previous snapshot.
+ */
+export function createFlipRunner(options: { selector?: string; dataKey?: string; reduceMotion: boolean }) {
+  const selector = options.selector ?? "[data-session-id]"
+  const dataKey = options.dataKey ?? "sessionId"
+  let previousPositions: Map<string, number> | undefined
+
+  return (container: HTMLDivElement | undefined) => {
+    // The owning render effect fires once at mount, before the container ref
+    // is assigned. Skipping that pass keeps previousPositions unset, so the
+    // first real snapshot becomes the baseline instead of an empty map that
+    // would classify every row as "entering" on the next entries change.
+    if (!container) return
+
+    const rows = Array.from(container.querySelectorAll<HTMLElement>(selector))
+    for (const row of rows) {
+      for (const animation of row.getAnimations()) animation.cancel()
+    }
+
+    const nextPositions = new Map<string, number>()
+    for (const row of rows) {
+      const id = row.dataset[dataKey as keyof typeof row.dataset] as string | undefined
+      if (!id) continue
+      nextPositions.set(id, row.getBoundingClientRect().top)
+    }
+
+    const storedPositions = previousPositions
+    previousPositions = nextPositions
+    if (options.reduceMotion || !storedPositions) return
+
+    const repositioning: Array<{ element: HTMLElement; delta: number; index: number }> = []
+    const entering: HTMLElement[] = []
+    let index = 0
+
+    for (const row of rows) {
+      const id = row.dataset[dataKey as keyof typeof row.dataset] as string | undefined
+      if (!id) continue
+      const currentY = nextPositions.get(id)
+      const previousY = storedPositions.get(id)
+      if (currentY === undefined) continue
+      if (previousY === undefined) {
+        entering.push(row)
+        continue
+      }
+      const delta = previousY - currentY
+      if (Math.abs(delta) > 0.5) {
+        repositioning.push({ element: row, delta, index })
+        index += 1
+      }
+    }
+
+    for (const row of entering) {
+      row.animate(
+        [
+          { opacity: 0, transform: "translateY(4px)" },
+          { opacity: 1, transform: "translateY(0)" },
+        ],
+        { duration: DURATION_ENTRANCE, easing: EASING_ENTRANCE },
+      )
+    }
+
+    if (repositioning.length === 0) return
+
+    const staggerDelay = Math.min(STAGGER_MS, MAX_STAGGER / Math.max(1, repositioning.length))
+    for (const { element, delta, index } of repositioning) {
+      element.animate([{ transform: `translateY(${delta}px)` }, { transform: "translateY(0)" }], {
+        duration: DURATION_REPOSITION,
+        easing: EASING_REPOSITION,
+        delay: index * staggerDelay,
+        fill: "backwards",
+      })
+    }
+  }
+}

--- a/packages/app/src/components/sidebar/flip-list-model.ts
+++ b/packages/app/src/components/sidebar/flip-list-model.ts
@@ -7,8 +7,8 @@ const MAX_STAGGER = 120
 
 /**
  * Create the FLIP runner owned by a FlipList instance. Returns a function that
- * snapshots row positions on every entries change and animates rows that moved
- * or entered since the previous snapshot.
+ * snapshots row positions and animates rows that moved or entered since the
+ * previous snapshot.
  */
 export function createFlipRunner(options: { selector?: string; dataKey?: string; reduceMotion: boolean }) {
   const selector = options.selector ?? "[data-session-id]"
@@ -16,10 +16,9 @@ export function createFlipRunner(options: { selector?: string; dataKey?: string;
   let previousPositions: Map<string, number> | undefined
 
   return (container: HTMLDivElement | undefined) => {
-    // The owning render effect fires once at mount, before the container ref
-    // is assigned. Skipping that pass keeps previousPositions unset, so the
-    // first real snapshot becomes the baseline instead of an empty map that
-    // would classify every row as "entering" on the next entries change.
+    // An unassigned ref must never store an empty map as the baseline. The
+    // component seeds the real baseline from onMount once the ref and its
+    // rows are in the DOM; this guard is defensive only.
     if (!container) return
 
     const rows = Array.from(container.querySelectorAll<HTMLElement>(selector))

--- a/packages/app/src/components/sidebar/flip-list.tsx
+++ b/packages/app/src/components/sidebar/flip-list.tsx
@@ -1,4 +1,4 @@
-import { createRenderEffect, on, type JSX } from "solid-js"
+import { createRenderEffect, on, onMount, type JSX } from "solid-js"
 import { createFlipRunner } from "./flip-list-model"
 
 export function FlipList(props: {
@@ -14,6 +14,15 @@ export function FlipList(props: {
     selector: props.selector,
     dataKey: props.dataKey,
     reduceMotion,
+  })
+
+  // The render effect fires once at mount before the container ref is
+  // assigned, so that pass is skipped by the runner (see flip-list-model).
+  // Seed the baseline from onMount instead, once the ref and its rows are in
+  // the DOM, so the first genuine entries change animates new or repositioned
+  // rows instead of being absorbed as a silent baseline.
+  onMount(() => {
+    runFlip(container)
   })
 
   createRenderEffect(

--- a/packages/app/src/components/sidebar/flip-list.tsx
+++ b/packages/app/src/components/sidebar/flip-list.tsx
@@ -1,11 +1,5 @@
 import { createRenderEffect, on, type JSX } from "solid-js"
-
-const EASING_REPOSITION = "cubic-bezier(0.2, 0, 0, 1)"
-const EASING_ENTRANCE = "cubic-bezier(0.05, 0.7, 0.1, 1)"
-const DURATION_REPOSITION = 250
-const DURATION_ENTRANCE = 160
-const STAGGER_MS = 18
-const MAX_STAGGER = 120
+import { createFlipRunner } from "./flip-list-model"
 
 export function FlipList(props: {
   entries: readonly unknown[]
@@ -15,89 +9,17 @@ export function FlipList(props: {
   dataKey?: string
 }) {
   let container: HTMLDivElement | undefined
-  let previousPositions: Map<string, number> | undefined
   const reduceMotion = typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
-
-  const query = (): HTMLElement[] =>
-    Array.from(container?.querySelectorAll<HTMLElement>(props.selector ?? "[data-session-id]") ?? [])
-
-  function snapshot(rows: HTMLElement[]) {
-    const key = props.dataKey ?? "sessionId"
-    const next = new Map<string, number>()
-    for (const row of rows) {
-      const id = row.dataset[key as keyof typeof row.dataset] as string | undefined
-      if (!id) continue
-      next.set(id, row.getBoundingClientRect().top)
-    }
-    return next
-  }
-
-  function cancelAnimations(rows: HTMLElement[]) {
-    for (const row of rows) {
-      for (const animation of row.getAnimations()) {
-        animation.cancel()
-      }
-    }
-  }
-
-  function runFlip() {
-    const rows = query()
-    cancelAnimations(rows)
-    const nextPositions = snapshot(rows)
-    const storedPositions = previousPositions
-    previousPositions = nextPositions
-
-    if (!container || reduceMotion || !storedPositions) return
-
-    const repositioning: Array<{ element: HTMLElement; delta: number; index: number }> = []
-    const entering: HTMLElement[] = []
-    let index = 0
-
-    const key = props.dataKey ?? "sessionId"
-    for (const row of rows) {
-      const id = row.dataset[key as keyof typeof row.dataset] as string | undefined
-      if (!id) continue
-      const currentY = nextPositions.get(id)
-      const previousY = storedPositions.get(id)
-      if (currentY === undefined) continue
-      if (previousY === undefined) {
-        entering.push(row)
-        continue
-      }
-      const delta = previousY - currentY
-      if (Math.abs(delta) > 0.5) {
-        repositioning.push({ element: row, delta, index })
-        index += 1
-      }
-    }
-
-    for (const row of entering) {
-      row.animate(
-        [
-          { opacity: 0, transform: "translateY(4px)" },
-          { opacity: 1, transform: "translateY(0)" },
-        ],
-        { duration: DURATION_ENTRANCE, easing: EASING_ENTRANCE },
-      )
-    }
-
-    if (repositioning.length === 0) return
-
-    const staggerDelay = Math.min(STAGGER_MS, MAX_STAGGER / Math.max(1, repositioning.length))
-    for (const { element, delta, index } of repositioning) {
-      element.animate([{ transform: `translateY(${delta}px)` }, { transform: "translateY(0)" }], {
-        duration: DURATION_REPOSITION,
-        easing: EASING_REPOSITION,
-        delay: index * staggerDelay,
-        fill: "backwards",
-      })
-    }
-  }
+  const runFlip = createFlipRunner({
+    selector: props.selector,
+    dataKey: props.dataKey,
+    reduceMotion,
+  })
 
   createRenderEffect(
     on(
       () => props.entries,
-      () => runFlip(),
+      () => runFlip(container),
     ),
   )
 

--- a/packages/app/src/context/layout/index.tsx
+++ b/packages/app/src/context/layout/index.tsx
@@ -34,6 +34,7 @@ import {
   removeScopeFromIndex,
   removeScopeFromLoadedNavigation,
   sameScopeIndex,
+  shouldRefreshScopeIndexForSessionUpdate,
   type ChannelNavPage,
   type ChannelNavType,
   type RootNavSectionKey,
@@ -786,6 +787,20 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           )
         }
         if (scope.id === "home") return
+        // Managed Channel projects order within their account by the server's
+        // latestActivityAt. The per-request scope event storm is gone, so keep
+        // that ordering fresh by refreshing the scope index for managed project
+        // session activity. loadScopeIndex only writes the signal when the
+        // index actually changed, so this cannot re-trigger generic project
+        // churn; the debounce below bounds the request rate.
+        if (properties?.navEntry?.category === "channel") {
+          const managedScopeIDs = new Set(
+            channelProjection().channelAccounts.flatMap((account) => account.projects.map((p) => p.scopeID)),
+          )
+          if (shouldRefreshScopeIndexForSessionUpdate(scope.id, properties.navEntry, managedScopeIDs)) {
+            scheduleScopeIndexRefresh()
+          }
+        }
         const dir = scope.directory
         if (!dir || !navEntries[dir]) return
         const pending = navRefreshTimers.get(dir)

--- a/packages/app/src/context/layout/index.tsx
+++ b/packages/app/src/context/layout/index.tsx
@@ -33,6 +33,7 @@ import {
   partitionScopeNavigation,
   removeScopeFromIndex,
   removeScopeFromLoadedNavigation,
+  sameScopeIndex,
   type ChannelNavPage,
   type ChannelNavType,
   type RootNavSectionKey,
@@ -316,7 +317,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       try {
         const res = await globalSdk.client.scope.index()
         if (res.data) {
-          setScopeIndex(res.data as ScopeNavEntry[])
+          const next = res.data as ScopeNavEntry[]
+          if (!sameScopeIndex(scopeIndex(), next)) setScopeIndex(next)
         }
       } catch (err) {
         console.warn("Failed to load scope index", err)

--- a/packages/app/src/context/layout/nav.ts
+++ b/packages/app/src/context/layout/nav.ts
@@ -380,6 +380,26 @@ export function deriveChannelAccountActions(channelType: string): ChannelAccount
   if (!canDownloadDiagnostics) hiddenActions.push("downloadDiagnostics")
   return { canRefreshProjects, canDownloadDiagnostics, hiddenActions }
 }
+/** True when a session nav update belongs to a managed Channel project. */
+export function isManagedChannelNavEntry(
+  navEntry:
+    | {
+        category?: string
+        channelAccountId?: string
+      }
+    | undefined,
+): boolean {
+  return !!navEntry && navEntry.category === "channel" && !!navEntry.channelAccountId
+}
+/** True when a managed Channel project's session activity should refresh the scope index. */
+export function shouldRefreshScopeIndexForSessionUpdate(
+  scopeID: string | undefined,
+  navEntry: NavEntry | undefined,
+  managedScopeIDs: ReadonlySet<string>,
+): boolean {
+  return !!scopeID && scopeID !== "home" && isManagedChannelNavEntry(navEntry) && managedScopeIDs.has(scopeID)
+}
+
 export function sameScopeIndex(previous: readonly ScopeNavEntry[], next: readonly ScopeNavEntry[]): boolean {
   if (previous === next) return true
   if (previous.length !== next.length) return false

--- a/packages/app/src/context/layout/nav.ts
+++ b/packages/app/src/context/layout/nav.ts
@@ -380,3 +380,33 @@ export function deriveChannelAccountActions(channelType: string): ChannelAccount
   if (!canDownloadDiagnostics) hiddenActions.push("downloadDiagnostics")
   return { canRefreshProjects, canDownloadDiagnostics, hiddenActions }
 }
+export function sameScopeIndex(previous: readonly ScopeNavEntry[], next: readonly ScopeNavEntry[]): boolean {
+  if (previous === next) return true
+  if (previous.length !== next.length) return false
+  return previous.every((entry, index) => {
+    const candidate = next[index]
+    if (!candidate) return false
+    if (
+      entry.scopeID !== candidate.scopeID ||
+      entry.scopeType !== candidate.scopeType ||
+      entry.name !== candidate.name ||
+      entry.directory !== candidate.directory ||
+      entry.latestActivityAt !== candidate.latestActivityAt ||
+      entry.sessionCount !== candidate.sessionCount ||
+      entry.icon?.url !== candidate.icon?.url ||
+      entry.icon?.color !== candidate.icon?.color
+    ) {
+      return false
+    }
+    const a = entry.managedProject
+    const b = candidate.managedProject
+    if (a === b) return true
+    if (!a || !b) return false
+    return (
+      a.channelType === b.channelType &&
+      a.accountId === b.accountId &&
+      a.externalProjectId === b.externalProjectId &&
+      a.remoteState === b.remoteState
+    )
+  })
+}

--- a/packages/app/test/components/sidebar/flip-list.test.ts
+++ b/packages/app/test/components/sidebar/flip-list.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test"
+import { createFlipRunner } from "../../../src/components/sidebar/flip-list-model"
+
+class FakeRow {
+  dataset: Record<string, string> = {}
+  top = 0
+  animated: Array<{ keyframes: Keyframe[]; options?: KeyframeAnimationOptions }> = []
+
+  constructor(id: string, top: number) {
+    this.dataset.sessionId = id
+    this.top = top
+  }
+
+  getBoundingClientRect() {
+    return { top: this.top } as DOMRect
+  }
+
+  getAnimations() {
+    return []
+  }
+
+  animate(keyframes: Keyframe[], options?: KeyframeAnimationOptions) {
+    this.animated.push({ keyframes, options })
+    return {} as unknown as Animation
+  }
+}
+
+function makeContainer(rows: FakeRow[]) {
+  return {
+    querySelectorAll: () => rows as unknown as NodeListOf<HTMLElement>,
+  } as unknown as HTMLDivElement
+}
+
+function animationKinds(row: FakeRow) {
+  return row.animated.map(({ options }) => options?.easing)
+}
+
+describe("createFlipRunner baseline behavior", () => {
+  test("skips the pre-ref pass so the first real snapshot is the baseline", () => {
+    const runner = createFlipRunner({ reduceMotion: false })
+    const rows = [new FakeRow("a", 0), new FakeRow("b", 40)]
+
+    // The owning render effect fires before the container ref is assigned.
+    runner(undefined)
+
+    // First real snapshot establishes the baseline: nothing animates yet.
+    runner(makeContainer(rows))
+    expect(rows.flatMap(animationKinds)).toEqual([])
+
+    // An identical refresh stays inert — rows must not replay the entrance
+    // animation like they did when the pre-ref pass polluted the baseline.
+    runner(makeContainer(rows))
+    expect(rows.flatMap(animationKinds)).toEqual([])
+  })
+
+  test("only rows absent from the baseline play the entrance animation", () => {
+    const runner = createFlipRunner({ reduceMotion: false })
+    const a = new FakeRow("a", 0)
+    const b = new FakeRow("b", 40)
+    runner(undefined)
+    runner(makeContainer([a]))
+
+    // The next change adds a genuinely new row.
+    runner(makeContainer([a, b]))
+
+    expect(animationKinds(b)).toContain("cubic-bezier(0.05, 0.7, 0.1, 1)")
+    expect(a.animated).toEqual([])
+  })
+
+  test("repositions rows whose measured top changed", () => {
+    const runner = createFlipRunner({ reduceMotion: false })
+    const a = new FakeRow("a", 0)
+    const b = new FakeRow("b", 40)
+    runner(undefined)
+    runner(makeContainer([a, b]))
+
+    b.top = 100
+    runner(makeContainer([a, b]))
+
+    expect(animationKinds(b)).toContain("cubic-bezier(0.2, 0, 0, 1)")
+    expect(a.animated).toEqual([])
+  })
+
+  test("reduced motion suppresses all animations but keeps tracking positions", () => {
+    const runner = createFlipRunner({ reduceMotion: true })
+    const a = new FakeRow("a", 0)
+    runner(undefined)
+    runner(makeContainer([a]))
+    runner(makeContainer([a]))
+    expect(a.animated).toEqual([])
+  })
+})

--- a/packages/app/test/components/sidebar/flip-list.test.ts
+++ b/packages/app/test/components/sidebar/flip-list.test.ts
@@ -35,35 +35,38 @@ function animationKinds(row: FakeRow) {
   return row.animated.map(({ options }) => options?.easing)
 }
 
+const ENTER_EASING = "cubic-bezier(0.05, 0.7, 0.1, 1)"
+const MOVE_EASING = "cubic-bezier(0.2, 0, 0, 1)"
+
 describe("createFlipRunner baseline behavior", () => {
-  test("skips the pre-ref pass so the first real snapshot is the baseline", () => {
+  test("a container-less pass never becomes the baseline", () => {
     const runner = createFlipRunner({ reduceMotion: false })
-    const rows = [new FakeRow("a", 0), new FakeRow("b", 40)]
+    const a = new FakeRow("a", 0)
+    const b = new FakeRow("b", 40)
 
     // The owning render effect fires before the container ref is assigned.
     runner(undefined)
 
     // First real snapshot establishes the baseline: nothing animates yet.
-    runner(makeContainer(rows))
-    expect(rows.flatMap(animationKinds)).toEqual([])
+    runner(makeContainer([a, b]))
+    expect(a.animated).toEqual([])
+    expect(b.animated).toEqual([])
 
     // An identical refresh stays inert — rows must not replay the entrance
     // animation like they did when the pre-ref pass polluted the baseline.
-    runner(makeContainer(rows))
-    expect(rows.flatMap(animationKinds)).toEqual([])
+    runner(makeContainer([a, b]))
+    expect(a.animated).toEqual([])
+    expect(b.animated).toEqual([])
   })
 
   test("only rows absent from the baseline play the entrance animation", () => {
     const runner = createFlipRunner({ reduceMotion: false })
     const a = new FakeRow("a", 0)
     const b = new FakeRow("b", 40)
-    runner(undefined)
     runner(makeContainer([a]))
-
-    // The next change adds a genuinely new row.
     runner(makeContainer([a, b]))
 
-    expect(animationKinds(b)).toContain("cubic-bezier(0.05, 0.7, 0.1, 1)")
+    expect(animationKinds(b)).toContain(ENTER_EASING)
     expect(a.animated).toEqual([])
   })
 
@@ -71,20 +74,18 @@ describe("createFlipRunner baseline behavior", () => {
     const runner = createFlipRunner({ reduceMotion: false })
     const a = new FakeRow("a", 0)
     const b = new FakeRow("b", 40)
-    runner(undefined)
     runner(makeContainer([a, b]))
 
     b.top = 100
     runner(makeContainer([a, b]))
 
-    expect(animationKinds(b)).toContain("cubic-bezier(0.2, 0, 0, 1)")
+    expect(animationKinds(b)).toContain(MOVE_EASING)
     expect(a.animated).toEqual([])
   })
 
   test("reduced motion suppresses all animations but keeps tracking positions", () => {
     const runner = createFlipRunner({ reduceMotion: true })
     const a = new FakeRow("a", 0)
-    runner(undefined)
     runner(makeContainer([a]))
     runner(makeContainer([a]))
     expect(a.animated).toEqual([])

--- a/packages/app/test/context/layout/nav.test.ts
+++ b/packages/app/test/context/layout/nav.test.ts
@@ -16,7 +16,9 @@ import {
   orderNavEntries,
   removeScopeFromIndex,
   removeScopeFromLoadedNavigation,
+  isManagedChannelNavEntry,
   sameScopeIndex,
+  shouldRefreshScopeIndexForSessionUpdate,
 } from "../../../src/context/layout/nav"
 
 function entry(input: Partial<NavEntry> & Pick<NavEntry, "id">): NavEntry {
@@ -585,5 +587,27 @@ describe("sameScopeIndex", () => {
     const a = [scopeEntry({ scopeID: "a", directory: "/repo/a" })]
     const b = [scopeEntry({ scopeID: "a", directory: "/repo/a" }), scopeEntry({ scopeID: "b", directory: "/repo/b" })]
     expect(sameScopeIndex(a, b)).toBe(false)
+  })
+})
+describe("isManagedChannelNavEntry", () => {
+  test("requires a channel category and an account id", () => {
+    expect(isManagedChannelNavEntry(undefined)).toBe(false)
+    expect(isManagedChannelNavEntry({ category: "project" })).toBe(false)
+    expect(isManagedChannelNavEntry({ category: "channel" })).toBe(false)
+    expect(isManagedChannelNavEntry({ category: "channel", channelAccountId: "agent-1" })).toBe(true)
+  })
+})
+
+describe("shouldRefreshScopeIndexForSessionUpdate", () => {
+  test("refreshes only for managed project channel activity", () => {
+    const managed = new Set(["managed-1"])
+    const navEntry = (category: NavEntry["category"], channelAccountId?: string) =>
+      ({ category, channelAccountId }) as NavEntry
+
+    expect(shouldRefreshScopeIndexForSessionUpdate("home", navEntry("channel", "agent-1"), managed)).toBe(false)
+    expect(shouldRefreshScopeIndexForSessionUpdate("generic-1", navEntry("channel", "agent-1"), managed)).toBe(false)
+    expect(shouldRefreshScopeIndexForSessionUpdate("managed-1", navEntry("channel", "agent-1"), managed)).toBe(true)
+    expect(shouldRefreshScopeIndexForSessionUpdate("managed-1", navEntry("project"), managed)).toBe(false)
+    expect(shouldRefreshScopeIndexForSessionUpdate("managed-1", undefined, managed)).toBe(false)
   })
 })

--- a/packages/app/test/context/layout/nav.test.ts
+++ b/packages/app/test/context/layout/nav.test.ts
@@ -16,6 +16,7 @@ import {
   orderNavEntries,
   removeScopeFromIndex,
   removeScopeFromLoadedNavigation,
+  sameScopeIndex,
 } from "../../../src/context/layout/nav"
 
 function entry(input: Partial<NavEntry> & Pick<NavEntry, "id">): NavEntry {
@@ -551,5 +552,38 @@ describe("removeScopeFromLoadedNavigation", () => {
     expect(result.root.background.items).toEqual([])
     expect(result.root.home).toBe(home)
     expect(result.affected).toEqual({ recent: true, root: ["channel", "background"] })
+  })
+})
+describe("sameScopeIndex", () => {
+  test("treats equal entries as unchanged", () => {
+    const a = [scopeEntry({ scopeID: "a", directory: "/repo/a" }), scopeEntry({ scopeID: "b", directory: "/repo/b" })]
+    const b = [scopeEntry({ scopeID: "a", directory: "/repo/a" }), scopeEntry({ scopeID: "b", directory: "/repo/b" })]
+    expect(sameScopeIndex(a, b)).toBe(true)
+  })
+
+  test("detects reordering, field changes, and managed project differences", () => {
+    const a = [scopeEntry({ scopeID: "a", directory: "/repo/a" }), scopeEntry({ scopeID: "b", directory: "/repo/b" })]
+    expect(sameScopeIndex(a, [a[1], a[0]])).toBe(false)
+    expect(
+      sameScopeIndex(a, [
+        scopeEntry({ scopeID: "a", directory: "/repo/a" }),
+        scopeEntry({ scopeID: "b", directory: "/repo/b", sessionCount: 1 }),
+      ]),
+    ).toBe(false)
+
+    const managed = (remoteState: "active" | "paused"): ScopeNavEntry[] => [
+      {
+        ...scopeEntry({ scopeID: "m", directory: "/managed" }),
+        managedProject: { channelType: "clarus", accountId: "agent-1", externalProjectId: "p1", remoteState },
+      },
+    ]
+    expect(sameScopeIndex(managed("active"), managed("active"))).toBe(true)
+    expect(sameScopeIndex(managed("active"), managed("paused"))).toBe(false)
+  })
+
+  test("distinguishes index length differences", () => {
+    const a = [scopeEntry({ scopeID: "a", directory: "/repo/a" })]
+    const b = [scopeEntry({ scopeID: "a", directory: "/repo/a" }), scopeEntry({ scopeID: "b", directory: "/repo/b" })]
+    expect(sameScopeIndex(a, b)).toBe(false)
   })
 })

--- a/packages/synergy/src/scope/index.ts
+++ b/packages/synergy/src/scope/index.ts
@@ -311,6 +311,7 @@ export namespace Scope {
       return { scope, sandbox }
     }
 
+    const existed = !!existing
     if (!existing) {
       existing = {
         id,
@@ -326,6 +327,7 @@ export namespace Scope {
       }
     }
 
+    const previousSandboxes = [...(existing.sandboxes ?? [])]
     if (!existing.sandboxes) existing.sandboxes = []
 
     const project: z.infer<typeof Info> = {
@@ -338,7 +340,19 @@ export namespace Scope {
     }
     if (sandbox !== project.worktree && !project.sandboxes.includes(sandbox)) project.sandboxes.push(sandbox)
     project.sandboxes = project.sandboxes.filter((x) => existsSync(x))
-    if (persist) await writePersisted(project)
+
+    // Persist and broadcast only when the record actually changed. Repeated
+    // lookups of the same directory used to rewrite the scope file and emit
+    // scope.updated on every request, driving frontend scope-index refreshes
+    // and sidebar re-renders on unrelated navigation.
+    const recordChanged =
+      !existed ||
+      project.directory !== existing.directory ||
+      project.worktree !== existing.worktree ||
+      project.vcs !== existing.vcs ||
+      project.sandboxes.length !== previousSandboxes.length ||
+      project.sandboxes.some((entry, index) => entry !== previousSandboxes[index])
+    if (persist && recordChanged) await writePersisted(project)
 
     const scope: Scope.Project = {
       type: "project",
@@ -353,7 +367,7 @@ export namespace Scope {
       time: project.time,
     }
 
-    if (persist) {
+    if (persist && recordChanged) {
       GlobalBus.emit("event", {
         payload: {
           type: Event.Updated.type,

--- a/packages/synergy/test/scope/from-directory-event-storm.test.ts
+++ b/packages/synergy/test/scope/from-directory-event-storm.test.ts
@@ -1,0 +1,47 @@
+import { $ } from "bun"
+import { describe, expect, test } from "bun:test"
+import { GlobalBus } from "../../src/bus/global"
+import { Scope } from "../../src/scope"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("Scope.fromDirectory event emission", () => {
+  test("repeated lookups of an unchanged directory emit only one scope.updated", async () => {
+    await using tmp = await tmpdir()
+    const events: unknown[] = []
+    const handler = (event: { payload?: { type?: string } }) => {
+      if (event.payload?.type === "scope.updated") events.push(event)
+    }
+    GlobalBus.on("event", handler)
+    try {
+      await Scope.fromDirectory(tmp.path)
+      await Scope.fromDirectory(tmp.path)
+      await Scope.fromDirectory(tmp.path)
+    } finally {
+      GlobalBus.off("event", handler)
+    }
+    expect(events).toHaveLength(1)
+  })
+
+  test("a changed scope record still emits exactly once per change", async () => {
+    await using tmp = await tmpdir()
+    const events: unknown[] = []
+    const handler = (event: { payload?: { type?: string } }) => {
+      if (event.payload?.type === "scope.updated") events.push(event)
+    }
+    GlobalBus.on("event", handler)
+    try {
+      await Scope.fromDirectory(tmp.path)
+      // git init changes the record's vcs field; the ID stays stable because
+      // an empty repo has no root commit to derive from.
+      await $`git init`.cwd(tmp.path).quiet()
+      await Scope.fromDirectory(tmp.path)
+      await Scope.fromDirectory(tmp.path)
+    } finally {
+      GlobalBus.off("event", handler)
+    }
+    expect(events).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary

Clicking any project or session under the sidebar Projects section made the whole project list visually "jump" — every row faded and slid as if freshly mounted. Runtime instrumentation traced it to three compounding causes, fixed at each owning layer:

1. **Server event storm** — `Scope.fromDirectory` rewrote the persisted scope record and broadcast `scope.updated` on every directory-scoped request, even when nothing changed. It now persists and broadcasts only when the record actually changed (first creation, or a change in `directory`/`worktree`/`vcs`/sandboxes).
2. **Frontend index churn** — the layout store rebuilt `scopeIndex` after every debounced `scope.updated` event. `loadScopeIndex` now compares the fetched index against the current one via a new `sameScopeIndex` helper and skips `setScopeIndex` when equivalent, preserving signal identity for downstream memos.
3. **FlipList baseline pollution** — Solid's render effect fires once at mount before the container ref is assigned, so the first pass stored an empty position map; every later refresh treated all rows as new and replayed the entrance animation. The FLIP logic moved to `flip-list-model.ts` and now skips the pre-ref pass, so the first real snapshot is the baseline and only genuinely new/repositioned rows animate.

## Verification

- `cd packages/synergy && bun test test/scope/` — 43 pass (includes new `from-directory-event-storm.test.ts`)
- `cd packages/app && bun test test/components/sidebar/flip-list.test.ts test/context/layout/nav.test.ts` — 38 pass
- `bunx turbo typecheck --filter synergy` and `--filter @ericsanchezok/synergy-app` — pass
- `bun run decision:check` / `bun run test-layout:check` — pass
- `bun run quality:quick` — code gates pass; the two remaining failures are environment-only (actionlint binary unavailable, gitleaks not installed locally)

Decision record: `docs/decisions/implemented/bug-fix/2026-09-02-stop-sidebar-project-refresh-jump.md`