### PR TITLE
fix(session): gate coauthor reminder on an actual git working tree

### DIFF
--- a/docs/decisions/implemented/bug-fix/2026-09-02-coauthor-reminder-git-guard.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-02-coauthor-reminder-git-guard.md
@@ -1,0 +1,26 @@
+# Decision Record: Gate the git coauthor reminder on an actual git working tree
+
+Status: implemented
+
+## Problem
+
+The coauthor footer reminder (Layer 4.55 in `session/invoke.ts`) was injected unconditionally whenever `experimental.coauthor_reminder` was not disabled. Sessions running outside a git repository (home scope, plain directories) still received "When creating git commits, always include this footer…" every turn, directly contradicting the environment block ("Is directory a git repo: no") the model saw moments earlier. The reminder is only actionable inside a git working tree, so the unconditional injection was noise at best and a prompt-cache-breaking contradiction at worst.
+
+## Decision
+
+`projectChannelTaskParts`-adjacent Layer 4.55 in `session/invoke.ts` now pushes the `<coauthor-reminder>` block only when both hold:
+
+- `experimental.coauthor_reminder !== false` (unchanged opt-out), and
+- the live probe `SessionProjectHealth.isGitRepo(ScopeContext.current.directory)` returns true for a `project`-type scope.
+
+The probe is the same function the environment block uses (`system.ts`), so the reminder can never disagree with "Is directory a git repo" in the environment text. The `scope.type === "project"` short-circuit mirrors the env block exactly; home-scope sessions never pay for a git probe. When the config disables the reminder, no probe runs at all.
+
+## Alternatives considered
+
+- **Reuse the env block's boolean instead of probing again** — rejected: `SystemPrompt.environment` renders the result into text and does not return it to the invoke caller; threading a new return value across the parallel turn-preparation call site is a larger contract change than one extra cheap probe per turn.
+- **Filter in the prompt text renderer** — rejected: the reminder is assembled in `invoke.ts`, not rendered by `system.ts`; moving it would blur the layer's ownership.
+- **Keep the unconditional injection and rely on the model to ignore it** — rejected: it contradicts the env block, wastes prompt budget, and is exactly the reported symptom.
+
+## Consequences
+
+Non-git sessions no longer receive the coauthor footer instruction, removing the contradiction with the env block and cutting one dynamic system-prompt entry for home/plain-directory sessions. Git sessions are unaffected (probe cost is one `git rev-parse` per turn, same as the env block already pays). Tests now cover git-repo injection, explicit config opt-out, and non-git omission.

--- a/packages/synergy/src/session/invoke.ts
+++ b/packages/synergy/src/session/invoke.ts
@@ -799,8 +799,16 @@ export namespace SessionInvoke {
         if (gitHealthBlock) lateSystemParts.push(gitHealthBlock)
 
         // Layer 4.55: Configurable advisory context — git commit coauthor footer reminder
+        // Only meaningful in a git working tree; use the same live probe as the
+        // env block (SessionProjectHealth.isGitRepo) so the reminder never
+        // contradicts "Is directory a git repo" in the environment text.
         if ((await Config.current()).experimental?.coauthor_reminder !== false) {
-          lateSystemParts.push(`<coauthor-reminder>\n${COAUTHOR_REMINDER.trim()}\n</coauthor-reminder>`)
+          const inGitRepo =
+            ScopeContext.current.scope.type === "project" &&
+            (await SessionProjectHealth.isGitRepo(ScopeContext.current.directory))
+          if (inGitRepo) {
+            lateSystemParts.push(`<coauthor-reminder>\n${COAUTHOR_REMINDER.trim()}\n</coauthor-reminder>`)
+          }
         }
 
         // Layer 5: Dynamic advisory context — upcoming agenda wake-ups

--- a/packages/synergy/test/session/invoke.test.ts
+++ b/packages/synergy/test/session/invoke.test.ts
@@ -32,11 +32,13 @@ import { registerSkillDomain } from "../../src/skill/register"
 import { registerCommandDomain } from "../../src/command/register"
 import { registerCommandSessionRuntime } from "../../src/command/session-runtime"
 import { registerLibrarySessionRecall } from "../../src/library/session-recall"
+import { registerProjectSessionHealth } from "../../src/project/session-health"
 
 registerSkillDomain()
 registerCommandDomain()
 registerCommandSessionRuntime()
 registerLibrarySessionRecall()
+registerProjectSessionHealth()
 
 const sessionID = "ses_test"
 
@@ -1806,6 +1808,38 @@ describe("SessionInvoke coauthor reminder prompt", () => {
 
           expect(systemPrompt).not.toContain("<coauthor-reminder>")
           expect(systemPrompt).not.toContain("Co-authored-by: synergy-agent")
+          expect(lateSystemPrompt).not.toContain("<coauthor-reminder>")
+          expect(lateSystemPrompt).not.toContain("Co-authored-by: synergy-agent")
+        },
+      })
+    } finally {
+      restore()
+      if (activeSessionID) SessionManager.unregisterRuntime(activeSessionID)
+    }
+  })
+
+  test("omits the coauthor reminder when the working directory is not a git repo", async () => {
+    await using tmp = await tmpdir()
+    let activeSessionID = ""
+    let systemPrompt = ""
+    let lateSystemPrompt = ""
+    const restore = installBasicLoopMocks({
+      onProcess: async (input) => {
+        systemPrompt = input.system.join("\n")
+        lateSystemPrompt = input.lateSystem?.join("\n") ?? ""
+      },
+    })
+
+    try {
+      await ScopeContext.provide({
+        scope: await tmp.scope(),
+        fn: async () => {
+          const { session } = await createSessionWithUser()
+          activeSessionID = session.id
+
+          await SessionInvoke.loop.force(session.id)
+
+          expect(systemPrompt).not.toContain("<coauthor-reminder>")
           expect(lateSystemPrompt).not.toContain("<coauthor-reminder>")
           expect(lateSystemPrompt).not.toContain("Co-authored-by: synergy-agent")
         },


### PR DESCRIPTION
## What

`<coauthor-reminder>` (Layer 4.55 in `packages/synergy/src/session/invoke.ts`) was injected unconditionally whenever `experimental.coauthor_reminder` was not disabled (`!== false`), with no git detection. Sessions running outside a git repository — home scope, plain directories — received the commit-footer instruction every turn.

Now the block is pushed only when **both** hold:
1. `experimental.coauthor_reminder !== false` (unchanged opt-out), and
2. the live probe `SessionProjectHealth.isGitRepo(ScopeContext.current.directory)` returns true for a `project`-type scope.

The probe and the `scope.type === "project"` short-circuit are the **same ones the env block uses** (`system.ts` `Is directory a git repo` line), so the reminder can never contradict the environment text. When the config disables the reminder, no git probe runs at all.

## Why

Users in non-git sessions repeatedly saw the model quote "(非 git 环境,co-author 提示不适用。)" — the model noticing the contradiction: the env block said `Is directory a git repo: no`, yet the injected reminder said "When creating git commits, always include this footer…". The reminder is only actionable inside a git working tree, so the unconditional injection was noise and a prompt-cache-breaking contradiction.

## Verification

- New regression test: `omits the coauthor reminder when the working directory is not a git repo` (non-git tmpdir → reminder absent from late system prompt).
- Existing tests still pass: `includes the coauthor reminder by default` (git tmpdir → present) and `omits the coauthor reminder when explicitly disabled` (config off → absent).
- `bun test test/session/invoke.test.ts` — 43 pass / 0 fail.
- `bun run decision:check` ✅, `bun run format:check` ✅, `oxlint` 0 warnings ✅.
- `tsc --noEmit` (packages/synergy): no errors in changed files (2 pre-existing unrelated errors in `test/tool/arxiv-download.test.ts`).
- Live repro during development: the boss worker's own home-scope (non-git) session kept receiving `<coauthor-reminder>` on every turn before the fix; the new logic removes it for exactly that shape.

## Notes

- The env block's boolean is rendered to text and not returned to the invoke caller, so reusing it would require threading a new return value across the parallel turn-preparation call site — one extra `git rev-parse` per turn (already paid by the env block) is the smaller change. Documented in the decision record.
- Decision record: `docs/decisions/implemented/bug-fix/2026-09-02-coauthor-reminder-git-guard.md`.