### PR TITLE
fix(push): sign VAPID JWT with a resolvable subject

### DIFF
--- a/docs/decisions/implemented/bug-fix/2026-09-06-push-vapid-subject.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-06-push-vapid-subject.md
@@ -1,0 +1,21 @@
+# Decision Record: Push VAPID subject must be a publicly resolvable URI
+
+Status: implemented
+
+## Problem
+
+Every push delivery to Apple failed with `403 {"reason":"BadJwtToken"}` from `web.push.apple.com` — no iOS device received a notification through the Web Push path introduced in #1315, while the stored subscriptions, the VAPID key pair, and the Bun runtime were all healthy. Holding the key and subscription constant isolated the failing variable: the VAPID JWT `sub` claim was `mailto:synergy@localhost`, and Apple resolves the subject host before accepting the token. RFC 8292 requires a contactable `mailto:` or `https:` URI; a `localhost` host is not resolvable, so Apple rejects the whole JWT. Desktop push services (FCM, Mozilla) accept such subjects, which is why the defect only surfaced on iOS home-screen web apps.
+
+## Decision
+
+`PushService` now signs every VAPID JWT with `subject: "https://github.com/SII-Holos/synergy"` — the project's public repository URL, ownership-equivalent to a contact address and verified to deliver (`201`) with the existing VAPID key and subscriptions. Delivery-failure warnings now include the push endpoint's HTTP status code, so endpoint rejections are diagnosable from logs alone. No key rotation and no device re-subscription: a subscription binds to the application server key, not to the subject claim.
+
+## Alternatives considered
+
+- **Rotating the VAPID key pair** — rejected: a fresh key pair with the same `localhost` subject still returned `403 BadJwtToken`, while the existing key with a resolvable subject delivered `201`; the key was never the failing variable, and rotation would have forced every device to re-subscribe.
+- **Asking devices to re-subscribe** — rejected for the same reason: re-subscription refreshes the endpoint and encryption keys but cannot change the server-side subject; the two stored subscriptions were proven deliverable as-is.
+- **A real-domain `mailto:` address** — viable in principle (RFC 8292 accepts mailto URIs), but the repository has no canonical contact mailbox whose resolvability is guaranteed; the public project URL is already owned, stable, and verified.
+
+## Consequences
+
+iOS Web Push deliveries work again with the existing VAPID key pair and subscriptions; running instances pick the fix up on restart. Delivery failures now surface their HTTP status in logs. The subject is a constant in `packages/synergy/src/push/service.ts`: if the project URL moves, that constant must move with it, and any future value must remain a publicly resolvable URI — the failure mode is silent except for endpoint warnings. The strictness is Apple-specific; other push services tolerate looser subjects, so a regression here would again only affect Apple endpoints.

--- a/packages/synergy/src/push/service.ts
+++ b/packages/synergy/src/push/service.ts
@@ -77,7 +77,10 @@ export namespace PushService {
         TTL: TTL_BY_CATEGORY[category],
         urgency: URGENCY_BY_CATEGORY[category],
         vapidDetails: {
-          subject: "mailto:synergy@localhost",
+          // RFC 8292 requires the subject to be a contactable mailto or
+          // https URI. Apple rejects JWTs whose host cannot be resolved
+          // (403 BadJwtToken), so this must stay a public, project-owned URL.
+          subject: "https://github.com/SII-Holos/synergy",
           publicKey: vapid.publicKey,
           privateKey: vapid.privateKey,
         },
@@ -88,7 +91,7 @@ export namespace PushService {
         await PushStore.removeById(sub.id).catch(() => undefined)
         log.info("pruned expired push subscription", { subscriptionID: sub.id })
       } else {
-        log.warn("push delivery failed", { subscriptionID: sub.id, error })
+        log.warn("push delivery failed", { subscriptionID: sub.id, statusCode, error })
       }
       if (options?.propagate) throw error
     }

--- a/packages/synergy/test/push/service.test.ts
+++ b/packages/synergy/test/push/service.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "../fixture/fixture"
 type SentCall = {
   subscription: { endpoint: string; keys: { p256dh: string; auth: string } }
   payload: string
-  options: { TTL?: number; urgency?: string; vapidDetails?: { publicKey: string; privateKey: string } }
+  options: { TTL?: number; urgency?: string; vapidDetails?: { publicKey: string; privateKey: string; subject: string } }
 }
 
 const APPLE = "https://web.push.apple.com/push/v1/device-a"
@@ -88,6 +88,7 @@ describe("PushService.send", () => {
         expect(payload.title).toBe("Session needs your input")
         expect(call.options.vapidDetails!.publicKey).toBeTruthy()
         expect(call.options.vapidDetails!.privateKey).toBeTruthy()
+        expect(call.options.vapidDetails!.subject).toBe("https://github.com/SII-Holos/synergy")
       }
 
       await PushService.send({


### PR DESCRIPTION
## Summary

iOS home-screen web app Web Push (#1315) never delivered on Apple endpoints: every send to `web.push.apple.com` failed with `403 {"reason":"BadJwtToken"}` while subscriptions, the VAPID key pair, and the runtime were all healthy. The failing variable was the VAPID JWT `sub` claim — `mailto:synergy@localhost`. RFC 8292 requires a contactable `mailto:`/`https:` URI, and Apple resolves the subject host before accepting the token; an unresolvable `localhost` host rejects the whole JWT. Desktop push services tolerate such subjects, which is why the defect only surfaced on iOS.

Changes:

- Sign VAPID JWTs with the public project URL (`https://github.com/SII-Holos/synergy`), verified end-to-end with a real delivery (`201`) using the existing VAPID key pair and subscriptions — no key rotation and no device re-subscription are needed.
- Include the endpoint HTTP status code in delivery-failure warnings; previously the status was swallowed by error serialization, hiding the actual `403` behind a generic message.
- Lock the subject contract with a test assertion (red first against the old value) and add a decision record.

## Test

- `cd packages/synergy && bun test test/push/` — 19 pass, including the new subject assertion (confirmed red before the fix).
- Real-endpoint verification with the production subscription: same key, old subject → `403 BadJwtToken`; same key, new subject → `201` delivered. A fresh key with the old subject still fails `403`, confirming the key was never the variable.
- `bun run decision:check` passes. `bun run quality:quick` passes 15/16 gates; the only failure is `workflow:check`, which fails on a network fetch of zizmor from pypi and is unrelated to this change.