### PR TITLE
fix: preserve sidebar viewport after web package migration

### DIFF
--- a/.synergy/skill/develop-frontend/SKILL.md
+++ b/.synergy/skill/develop-frontend/SKILL.md
@@ -79,6 +79,7 @@ Derive activity steps and counts from canonical tool parts. Display preferences 
 3. Do not evaluate JSX child getters to detect detail presence: use an explicit availability value or property presence, then instantiate children only inside the mounted disclosure. Test closed → open → closed imperative-renderer counts. Bound tool previews and retained expanded-render caches by capacity; use resource identity to open full content on demand. See [bounded tool rendering](../../../docs/decisions/implemented/bug-fix/2026-09-07-bound-tool-rendering-memory.md).
 4. Import only fonts used by the active product typography contract. A dormant family must not be emitted by the default App build.
 5. Preserve `apps/web/test/app-build-css-contract.test.ts` as the production build regression gate for initial module preloads, emitted product fonts, and core compiled CSS.
+6. Keep the Web HTML entry in Tailwind's explicit source inputs when moving package roots. Validate the built HTML and CSS together in a browser with overflowing sidebar content and composer focus: the root must stay within the viewport and the list must scroll without moving the document or navigation header.
 
 ## Change Themes and Color Tokens
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,4 +1,5 @@
 @import "@ericsanchezok/synergy-ui/styles/tailwind";
+@source "../index.html";
 
 html:not([data-color-scheme]),
 html:not([data-color-scheme]) body,

--- a/apps/web/test/app-build-css-contract.test.ts
+++ b/apps/web/test/app-build-css-contract.test.ts
@@ -729,6 +729,75 @@ async function expectPromptDockBandAndMobileFloatFlow(css: string) {
   }
 }
 
+async function expectSidebarScrollStaysInsideViewport(css: string, index: string) {
+  const root = index.match(/<div\b[^>]*\bid="root"[^>]*>/)?.[0]
+  const body = index.match(/<body\b[^>]*>/)?.[0]
+  if (!root || !body) throw new Error("Missing production app root")
+  const browserType = process.env.SYNERGY_APP_LAYOUT_BROWSER === "webkit" ? webkit : chromium
+  const browser = await browserType.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    for (const colorScheme of ["light", "dark"] as const) {
+      await page.emulateMedia({ colorScheme, reducedMotion: "reduce" })
+      for (const height of [720, 420]) {
+        await page.setViewportSize({ width: 1200, height })
+        await page.setContent(`
+          <html data-color-scheme="${colorScheme}"><head><style>${css}</style></head>${body}${root}
+            <div class="relative flex-1 min-h-0 flex flex-col">
+              <header style="flex: 0 0 18px">Window chrome</header>
+              <div data-skin-root="synergy" style="display: contents">
+                <div class="flex-1 min-h-0 min-w-0 flex overflow-hidden">
+                  <div data-plugin-ui="synergy">
+                    <nav class="sb-root sb-expanded">
+                      <div class="sb-header"><button>Navigation</button></div>
+                      <div class="sb-scroll">
+                        ${Array.from({ length: 80 }, (_, i) => `<div class="sb-project-row">Project ${i}</div>`).join("")}
+                      </div>
+                      <button style="flex-shrink: 0">Account</button>
+                    </nav>
+                  </div>
+                  <main class="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
+                    <div class="flex-1"></div><input aria-label="Composer" />
+                  </main>
+                </div>
+              </div>
+            </div>
+          </div></body></html>
+        `)
+        await page.getByRole("textbox", { name: "Composer" }).focus()
+        const measure = () =>
+          page.evaluate(() => {
+            const root = document.getElementById("root")!
+            const scroll = document.querySelector<HTMLElement>(".sb-scroll")!
+            const header = document.querySelector(".sb-header")!
+            return {
+              rootHeight: root.getBoundingClientRect().height,
+              headerTop: header.getBoundingClientRect().top,
+              documentTop: document.scrollingElement!.scrollTop,
+              listHeight: scroll.clientHeight,
+              contentHeight: scroll.scrollHeight,
+              listTop: scroll.scrollTop,
+            }
+          })
+        const before = await measure()
+        expect(before.rootHeight).toBe(height)
+        expect(before.headerTop).toBeGreaterThanOrEqual(18)
+        expect(before.documentTop).toBe(0)
+        expect(before.contentHeight).toBeGreaterThan(before.listHeight)
+        await page.locator(".sb-scroll").evaluate((element) => {
+          element.scrollTop = element.scrollHeight
+        })
+        const after = await measure()
+        expect(after.listTop).toBeGreaterThan(0)
+        expect(after.headerTop).toBe(before.headerTop)
+        expect(after.documentTop).toBe(0)
+      }
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
 async function runAppBuild(outDir: string) {
   const proc = Bun.spawn({
     cmd: [process.execPath, "run", "build", "--outDir", outDir, "--emptyOutDir", "--manifest"],
@@ -760,6 +829,7 @@ describe("app production build contract", () => {
         readBuiltManifest(outDir),
       ])
 
+      await expectSidebarScrollStaysInsideViewport(css, index)
       for (const contract of rootRuleContracts) {
         expectRootRule(css, contract)
       }

--- a/docs/decisions/implemented/bug-fix/2026-09-08-web-html-style-source.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-08-web-html-style-source.md
@@ -1,0 +1,21 @@
+# Decision Record: Include the Web HTML entry in style generation
+
+Status: implemented
+
+## Problem
+
+The Web HTML entry declares the viewport height of the application root. Omitting that entry from Tailwind source discovery drops its height utility from production CSS, allowing a long sidebar to expand the entire document. Composer focus can then scroll the document and move navigation outside the viewport.
+
+## Decision
+
+The Web stylesheet explicitly includes its HTML entry as a Tailwind source. The production build test mounts the emitted root markup with emitted CSS and overflowing sidebar content, then checks viewport height, composer focus, and independent list scrolling in both color schemes and at multiple window heights.
+
+## Alternatives considered
+
+**Patch sidebar height or scrolling.** The sidebar already has an independent scroll container. Local constraints would conceal the missing application-root style and leave other HTML-only utilities outside source discovery.
+
+**Expand shared UI scanning to the entire repository.** This includes unrelated sources and couples shared style generation to more repository content. The HTML entry belongs to the Web app and can be declared beside its stylesheet.
+
+## Consequences
+
+The root retains its viewport constraint after package moves without changing sidebar behavior or stored project data. A browser layout regression check adds a small amount of work to the existing production-build suite and uses the emitted entry markup so test literals cannot conceal a missing scan input.


### PR DESCRIPTION
## What does this PR do?

Restores the application root’s viewport height so long project lists scroll inside the sidebar and focusing the composer keeps navigation visible. Adds the Web HTML entry to Tailwind source discovery, a production browser layout regression test, and the corresponding decision record and development guidance.

## Why?

The package migration in #1353 added the Web source directory to Tailwind scanning but omitted its HTML entry. This dropped the root height utility from generated CSS. A long sidebar expanded the document, and composer focus scrolled the navigation above the viewport.

## External sources and provenance

None. Based on repository history, browser layout measurements, and a failing production-build regression test.

## How was it tested?

- `bun test --cwd apps/web test/app-build-css-contract.test.ts` — reproduced the failure before the fix; passes afterward, including long-list scrolling and composer focus in light/dark modes at two window heights.
- `bun test --cwd apps/web test/app-boot-shell.test.ts test/testing/browser-crypto-contract.test.ts` — 11 tests pass.
- `bun run --cwd apps/web typecheck` — passes.
- `bun run quality:quick` — all 16 gates pass.

## Checklist

- [x] Local static checks and relevant narrow tests pass.
- [x] Regression coverage lives under the owning package’s test directory.
- [x] Decision record and owning development Skill updated.
- [x] No material external sources, credentials, runtime data, or unrelated changes included.
- [x] No API, localization, browser capability, or JavaScript bootstrap changes.
