### PR TITLE
fix: upgrade Oryn diagnostics and model request budgets

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -23,7 +23,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: ac0b788d1d8db8e304c13e9c7167f45778cf0cef
+        ref: 775ff40758ffb18ae67e9fdbbf0a335fb447aeaf
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/docs/decisions/implemented/process/2026-09-10-oryn-repository-maintenance.md
+++ b/docs/decisions/implemented/process/2026-09-10-oryn-repository-maintenance.md
@@ -16,6 +16,8 @@ A trusted validation entry captures the workspace graph from the workflow revisi
 
 Maintain canonical advisory labels alongside human-owned labels. Migrate matching legacy classifications without dropping assignments; retire stale in-progress stages to needs-triage on open items rather than claiming current execution. The [operations guide](../../../operations/oryn.md) owns setup, verification and command details.
 
+Use the remaining task budget as the default per-request wall limit while preserving first-byte/idle limits and cancellation. A separate short fixed wall cap can interrupt healthy max-reasoning streams before the task budget expires. Preserve bounded, redacted failure evidence from the pinned Core public APIs through worker, CLI and Actions artifacts so provider errors, report format failures and host cancellation remain diagnosable. Do not export raw model history or infer a cause from a bare abort status. The upstream implementation and real Core fault fixtures are recorded in Oryn Mini decision 0013 at the setup action's pinned revision.
+
 ## Alternatives considered
 
 **Run the sweeper from another repository.** Centralized execution reuses configuration but separates target secrets, Actions history and operational ownership from this repository.

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -6,7 +6,7 @@ Oryn runs in this repository's GitHub Actions with the pinned runtime in [setup-
 
 The GitHub App needs installation on `SII-Holos/synergy` and the private runtime repository `yzxoi/oryn-mini`. Repository secrets are `ORYN_APP_PRIVATE_KEY` and `ORYN_GLM_API_KEY`; `ORYN_APP_CLIENT_ID` is an Actions variable. The source token is Contents-read and scoped to Oryn Mini. Target model jobs receive a read-only GitHub token in the host, and the model subprocess receives no GitHub credentials. Publication runs in a separate job with a fresh installation token.
 
-The model defaults to `oryn/glm-5.3-flash`, the official Zhipu Coding Plan API, max reasoning and image input. Its configured context window is 1,000,000 tokens; this setting is not a capacity benchmark. Optional Actions variables are `ORYN_MODEL`, `ORYN_BASE_URL`, `ORYN_TASK_TIMEOUT_SECONDS` (default 1800) and `ORYN_REQUEST_TIMEOUT_SECONDS` (runtime default 300). Keys remain secrets rather than repository files or model prompts.
+The model defaults to `oryn/glm-5.3-flash`, the official Zhipu Coding Plan API, max reasoning and image input. Its configured context window is 1,000,000 tokens; this setting is not a capacity benchmark. Optional Actions variables are `ORYN_MODEL`, `ORYN_BASE_URL`, `ORYN_TASK_TIMEOUT_SECONDS` (default 1800) and `ORYN_REQUEST_TIMEOUT_SECONDS` (optional 1–3000 seconds; defaults to the remaining task budget). Keys remain secrets rather than repository files or model prompts.
 
 The App permissions are Contents, Issues and Pull requests read/write, plus Actions, Checks and Commit statuses read. It needs no Workflows, Administration or organization grant. Executable workflows and policy come from the trusted default branch for native events, or the selected workflow commit for manual runs. PR source is inspected in a separate checkout as untrusted evidence.
 
@@ -21,6 +21,8 @@ Maintainers can use `@oryn-mini review`, `ask …`, `fix`, `implement issue`, `r
 Source/title/body changes, command edits, revoked command authority and authorized stop commands invalidate a task. Ordinary comments, labels and CI/review progress remain evidence rather than cancellation authority. Publication rechecks current source and authority; merge separately checks live readiness. Protected labels exclude new admissions, while the stop command interrupts active work.
 
 PR context contains statistics and a complete paged file inventory. The model uses Core read tools to inspect per-file diffs and related repository files on demand. Evidence snapshots are outside the candidate checkout and validation home, disappear with the task, and cannot be modified by the model. Incomplete coverage is reported as needs_human; the task deadline and separate repair-publication output limits remain.
+
+Long model requests may use the remaining task budget; first-byte and idle limits remain at most 120 and 60 seconds. Remove a legacy `ORYN_REQUEST_TIMEOUT_SECONDS=300` override to adopt this default. Total task deadlines and authorized cancellation still apply. Failed runs retain a bounded, redacted `diagnostic` in `failure.json` and an `oryn_failure` log event, including Core status, available provider error details, budgets and progress counts. Report format failures include the correction attempt and output size. Raw prompts, reasoning, headers and provider bodies are excluded. An abort without a recorded cause remains explicitly uncertain.
 
 ## Repair Verification
 


### PR DESCRIPTION
## What does this PR do?
Upgrade the pinned Oryn runtime so long model requests use the remaining task budget and failures preserve redacted Core/Provider evidence through Actions artifacts. First-byte/idle bounds, cancellation and publication gates remain enforced.

## Why?
A fixed five-minute request cap can interrupt healthy max-reasoning streams, while generic cancelled/failed receipts hide the available failure details. The operations guide and existing decision record document the new budget and diagnostic behavior.

## External sources and provenance
Runtime implementation and real Core fault fixtures: https://github.com/yzxoi/oryn-mini/pull/12

## How was it tested?
All 17 local quality gates passed, including workflow, documentation, decision, secrets and typecheck checks. Normal pre-commit and pre-push hooks passed. Upstream tests cover HTTP errors, JSON correction exhaustion, stream timeouts, total budget, cancellation and diagnostic redaction. This deployment changes only the runtime pin and documentation.