### PR TITLE
fix(server): reconnect evicted event subscribers

### DIFF
--- a/.synergy/skill/change-server-api/SKILL.md
+++ b/.synergy/skill/change-server-api/SKILL.md
@@ -33,6 +33,7 @@ description: Add or modify a Synergy HTTP route, request/response schema, OpenAP
 3. Run the affected frontend context/component test when response identity or event reconciliation changes.
 4. Inspect the generated diff; do not hand-edit generated SDK files. Use `bun run --cwd packages/sdk/js build --compile-only` to validate the existing client concurrently with source readers. Full generation cleans and rewrites `src/gen`, so reserve it for explicit generation work, not read-only package checks.
 5. Run `bun run quality:quick` after focused checks.
+6. For event transports, test dropped sends, send exceptions, and subscription removal through the client's observed close/reconnect path. Verify that successful heartbeats require an active event subscription and that one failed client does not interrupt healthy subscribers.
 
 Update [Frontend data sync](../../../docs/architecture/frontend-data-sync.md) when snapshot/event/replay semantics change, and update API/help/product docs when the route is a public or user-facing contract.
 

--- a/docs/architecture/frontend-data-sync.md
+++ b/docs/architecture/frontend-data-sync.md
@@ -37,6 +37,8 @@ The connection:
 - reconnects with jittered exponential delay from 1 to 30 seconds;
 - ignores server heartbeat frames as transport liveness only.
 
+The server owns event subscription and socket lifetime together. A dropped send, send exception, explicit subscription removal, or sustained streaming backpressure closes the affected socket so the client can reconnect and replay or resync. Connected acknowledgements, pongs, and server heartbeats use the same subscription registry as broadcasts; a ping on an unregistered socket closes it instead of reporting healthy transport. Transient control-frame backpressure does not advance the streaming eviction threshold. Failure diagnostics record the send outcome and transport mode without event contents.
+
 Incoming events are batched on an approximately 16 ms cadence while visible. Replaceable high-frequency state such as session status, inbox snapshots, LSP state, and full part updates is coalesced by identity before the Solid batch is applied. While the page is hidden the cadence relaxes to 1 second and streaming `message.part.delta` frames are merged per part into a single pending delta (the ≤1 s server checkpoint converges the authoritative part), keeping the background main-thread cost bounded without dropping sequenced state events. The event queue is capped; when the cap is reached it flushes early so watermarks keep advancing.
 
 ## Store Shape

--- a/docs/decisions/implemented/bug-fix/2026-09-12-event-subscription-liveness.md
+++ b/docs/decisions/implemented/bug-fix/2026-09-12-event-subscription-liveness.md
@@ -1,0 +1,25 @@
+# Decision Record: Couple event subscription removal to WebSocket closure
+
+Status: implemented
+
+## Problem
+
+A global event subscriber can lose its registry entry after a failed send while its WebSocket remains open. Direct pong replies can keep the frontend's connection check healthy despite permanently missing session status and message events. Reconnect and replay cannot repair a connection that never reports failure.
+
+## Decision
+
+The global event registry closes open sockets when removing their subscriptions. Dropped sends and send exceptions remove the registry entry before requesting a retryable close, so reentrant close callbacks cannot remove the same entry twice. Diagnostics include the failure outcome and transport mode without payload contents. Already closed sockets require only registry cleanup; clearing the registry also closes its remaining open subscriptions.
+
+Connected acknowledgements, pong replies, and periodic heartbeats use the registry's reply operation. Replies to unregistered sockets request closure without sending a success frame. Control frames retain the existing tolerance for transient backpressure and do not advance the streaming eviction threshold. WebSocket envelopes, Scope routing, event sequencing, replay, snapshots, and the frontend state model remain unchanged.
+
+## Alternatives considered
+
+**Poll every session status periodically.** Polling would mask lost status events at additional cost while leaving message, inbox, and other event consumers stale. Closing the failed subscription invokes the existing recovery path for every resource.
+
+**Only close after consecutive backpressure.** A zero send result or exception can remove the subscriber before that threshold is reached. Every removal of an open subscription must terminate the connection.
+
+**Reduce pruning bursts first.** Limiting historical part updates could reduce pressure but cannot eliminate transport failures. Subscription recovery must work independently of event volume.
+
+## Consequences
+
+A failed subscriber incurs a reconnect and replay or snapshot refresh instead of retaining indefinitely stale UI state. Healthy subscribers continue receiving events, and control-frame backpressure retains its existing behavior. Unit coverage checks removal, send failures, orphan pings, and reentrant callbacks; a real WebSocket fixture verifies a lost terminal event produces a close and allows idle state to be read after reconnect. The [postmortem](../../../postmortem/0010-event-subscription-liveness.md) records the diagnostic and coverage gap.

--- a/docs/postmortem/0010-event-subscription-liveness.md
+++ b/docs/postmortem/0010-event-subscription-liveness.md
@@ -1,0 +1,33 @@
+# Global event subscription loss left the UI connected but stale
+
+## Executive summary
+
+Completed sessions remained running in the sidebar while another active session appeared to await execution. A failed WebSocket send removed the event subscriber without closing its socket, and direct pong replies concealed that loss. Tests covered registry size and sustained backpressure but missed whether every removal informed the client. Subscription ownership and connection liveness must be verified together.
+
+## Summary
+
+Canonical messages contained terminal replies, tools had settled, inboxes were empty, and the backend status endpoint reported no work for the affected project. The frontend retained older states across multiple sessions because all Scope events shared one global connection. Session execution and persistence continued while the UI stopped receiving updates.
+
+## Timeline
+
+- A burst of historical tool-part updates caused sustained backpressure; the server closed the connection and the client successfully reconnected.
+- A subsequent pruning burst produced another send failure and removed the only subscriber. There was no corresponding disconnect or reconnect record.
+- Sessions continued to produce terminal replies and release their execution runtimes, while the sidebar retained running states.
+- A read-only investigation compared runtime logs, canonical session records, HTTP status, and the visible UI. Isolated fault injection reproduced an empty registry with an open socket after both zero send results and send exceptions.
+
+## Root cause
+
+The registry treated closed sockets, dropped sends, and send exceptions identically by deleting the entry. Only sustained backpressure requested an explicit socket close. A dropped send or exception does not establish that the socket has closed. The ping handler bypassed registry membership and could continue sending pongs, so the client neither reconnected nor observed later event sequence gaps.
+
+The original tests verified stable socket identity, closed-socket cleanup, encoding reuse, and backpressure eviction. They did not assert that a client observes closure after a zero send or exception, and did not exercise pongs after subscription loss. The runtime log identified removal but omitted the exact send outcome; the incident cannot distinguish the zero-result and exception branches.
+
+## Guardrails added
+
+- [Registry regression tests](../../packages/server/test/server/global-event-clients.test.ts) cover failed broadcasts, heartbeats and replies, orphan pings, removal, cleanup, healthy subscribers, and reentrant close callbacks.
+- [Real WebSocket coverage](../../packages/server/test/server/global-event-recovery.test.ts) checks observable closure and idle recovery after reconnect.
+- [Transport verification guidance](../../.synergy/skill/change-server-api/SKILL.md) requires subscription and heartbeat behavior to be checked together.
+- [The decision record](../decisions/implemented/bug-fix/2026-09-12-event-subscription-liveness.md) defines the recovery choice and its tradeoffs; the [sync reference](../architecture/frontend-data-sync.md) defines the resulting behavior.
+
+## Lessons
+
+An open socket and successful ping/pong exchange establish transport responsiveness, not event delivery. Removing an event subscription must produce a client-visible recovery signal. Backend terminal state and frontend projection should be checked independently before attempting session repair.

--- a/docs/postmortem/README.md
+++ b/docs/postmortem/README.md
@@ -46,6 +46,7 @@ Entries are added only when an incident qualifies; the table stays empty until t
 | 0008   | Transition cleanup retained disposed frontend pages                        | implemented | 2026-09-07 |
 
 | 0009 | Local benchmark cancellation lost export evidence | implemented | 2026-09-10 |
+| 0010 | Global event subscription loss left the UI connected but stale | implemented | 2026-09-12 |
 
 ## History rules
 

--- a/packages/server/src/server/global-event-clients.ts
+++ b/packages/server/src/server/global-event-clients.ts
@@ -31,6 +31,7 @@ export namespace GlobalEventClients {
     size(): number
     add(ws: WSContext, mode: Mode): void
     remove(ws: WSContext): boolean
+    reply(ws: WSContext, data: string): SendResult
     broadcast(encode: (mode: Mode) => string): {
       clients: number
       sent: number
@@ -79,8 +80,20 @@ export namespace GlobalEventClients {
       })
     }
 
+    function close(ws: WSContext, reason: string) {
+      try {
+        ws.close(1013, reason)
+      } catch {}
+    }
+
     function remove(ws: WSContext): boolean {
-      return clients.delete(connectionKey(ws))
+      const key = connectionKey(ws)
+      const client = clients.get(key)
+      if (!client) return false
+      clients.delete(key)
+      const readyState = rawReadyState(client)
+      if (readyState === undefined || readyState === 1) close(client.ws, "websocket subscription removed")
+      return true
     }
 
     function rawReadyState(client: ClientState): number | undefined {
@@ -147,15 +160,19 @@ export namespace GlobalEventClients {
     }
 
     function maybeEvict(key: unknown, client: ClientState, result: SendResult): boolean {
-      if (result === "closed" || result === "error" || result === "dropped") {
+      if (result === "closed") {
         clients.delete(key)
         return true
       }
-      if (result === "backpressured" && client.consecutiveBackpressure >= maxConsecutiveBackpressure) {
-        try {
-          client.ws.close(1013, "websocket backpressure")
-        } catch {}
+      if (result === "error" || result === "dropped") {
         clients.delete(key)
+        close(client.ws, `websocket send ${result}`)
+        log.warn("evicted websocket client after send failure", { result, mode: client.mode })
+        return true
+      }
+      if (result === "backpressured" && client.consecutiveBackpressure >= maxConsecutiveBackpressure) {
+        clients.delete(key)
+        close(client.ws, "websocket backpressure")
         log.warn("evicted websocket client under backpressure", {
           consecutiveBackpressure: client.consecutiveBackpressure,
           droppedFrames: client.droppedFrames,
@@ -191,20 +208,30 @@ export namespace GlobalEventClients {
       return { clients: clients.size + removed, sent, dropped, removed }
     }
 
+    function reply(ws: WSContext, data: string): SendResult {
+      const key = connectionKey(ws)
+      const client = clients.get(key)
+      if (!client) {
+        close(ws, "websocket subscription lost")
+        return "closed"
+      }
+      const result = send(client, data)
+      // Control frames must not advance the streaming backpressure eviction threshold.
+      if (result === "backpressured") {
+        client.consecutiveBackpressure = Math.max(0, client.consecutiveBackpressure - 1)
+      } else {
+        maybeEvict(key, client, result)
+      }
+      return result
+    }
+
     function heartbeat(data: string) {
       let sent = 0
       let removed = 0
-      for (const [key, client] of clients) {
-        const result = send(client, data)
+      for (const client of clients.values()) {
+        const result = reply(client.ws, data)
         if (result === "sent") sent++
-        if (maybeEvict(key, client, result === "backpressured" ? "sent" : result)) {
-          // Heartbeats should not count toward streaming backpressure eviction.
-          // Only hard failures remove clients here.
-          if (result !== "backpressured") removed++
-        } else if (result === "backpressured") {
-          // Reset consecutive counter growth from heartbeats alone.
-          client.consecutiveBackpressure = Math.max(0, client.consecutiveBackpressure - 1)
-        }
+        if (result === "closed" || result === "error" || result === "dropped") removed++
       }
       return { clients: clients.size + removed, sent, removed }
     }
@@ -213,9 +240,12 @@ export namespace GlobalEventClients {
       size: () => clients.size,
       add,
       remove,
+      reply,
       broadcast,
       heartbeat,
-      clear: () => clients.clear(),
+      clear: () => {
+        for (const client of clients.values()) remove(client.ws)
+      },
       clients: () => clients.values(),
     }
   }

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -817,7 +817,8 @@ export namespace Server {
               onOpen(_event, ws) {
                 log.info("global event ws connected", { mode })
                 globalEventClients.add(ws, mode)
-                ws.send(
+                globalEventClients.reply(
+                  ws,
                   JSON.stringify({
                     payload: {
                       type: "server.connected",
@@ -838,7 +839,8 @@ export namespace Server {
                   if (typeof _event.data !== "string") return
                   const data = JSON.parse(_event.data)
                   if (data?.payload?.type === "client.ping") {
-                    ws.send(
+                    globalEventClients.reply(
+                      ws,
                       JSON.stringify({
                         payload: {
                           type: "server.pong",

--- a/packages/server/test/server/global-event-clients.test.ts
+++ b/packages/server/test/server/global-event-clients.test.ts
@@ -87,6 +87,111 @@ describe("GlobalEventClients", () => {
     expect(registry.size()).toBe(0)
   })
 
+  for (const transport of ["broadcast", "heartbeat", "reply"] as const) {
+    for (const failure of ["dropped", "error"] as const) {
+      test(`${transport} closes an open socket after send result ${failure}`, () => {
+        const closed: number[] = []
+        const removedDuringClose: boolean[] = []
+        const registry = GlobalEventClients.createRegistry()
+        const raw = {
+          readyState: 1,
+          send: () => {
+            if (failure === "error") throw new Error("transport failure")
+            return 0
+          },
+        }
+        const ws = fakeWs({
+          raw,
+          close: (code) => {
+            closed.push(code!)
+            removedDuringClose.push(registry.remove(fakeWs({ raw })))
+          },
+        })
+        registry.add(ws, "delta")
+
+        if (transport === "reply") registry.reply(fakeWs({ raw }), "pong")
+        else if (transport === "heartbeat") registry.heartbeat("heartbeat")
+        else registry.broadcast(() => "idle")
+
+        expect(registry.size()).toBe(0)
+        expect(closed).toEqual([1013])
+        expect(removedDuringClose).toEqual([false])
+        const received: string[] = []
+        registry.add(fakeWs({ raw: { readyState: 1, send: (data) => received.push(data) } }), "delta")
+        registry.broadcast(() => "idle")
+        expect(received).toEqual(["idle"])
+      })
+    }
+  }
+
+  test("an unregistered socket cannot receive a pong that masks lost events", () => {
+    const registry = GlobalEventClients.createRegistry()
+    const received: string[] = []
+    const closed: number[] = []
+    const ws = fakeWs({
+      raw: { readyState: 1, send: (data) => received.push(data) },
+      close: (code) => closed.push(code!),
+    })
+
+    expect(registry.reply(ws, "pong")).toBe("closed")
+    expect(received).toEqual([])
+    expect(closed).toEqual([1013])
+  })
+
+  test("control frames do not evict a subscribed client under transient backpressure", () => {
+    const closed: number[] = []
+    const registry = GlobalEventClients.createRegistry({ maxConsecutiveBackpressure: 1 })
+    const raw = { readyState: 1, send: () => -1 }
+    const ws = fakeWs({ raw, close: (code) => closed.push(code!) })
+    registry.add(ws, "delta")
+
+    registry.heartbeat("heartbeat")
+    expect(registry.reply(fakeWs({ raw }), "pong")).toBe("backpressured")
+    expect(registry.size()).toBe(1)
+    expect(closed).toEqual([])
+    expect([...registry.clients()][0].consecutiveBackpressure).toBe(0)
+  })
+
+  test("explicit removal closes the registered socket across fresh wrappers", () => {
+    const closed: number[] = []
+    const registry = GlobalEventClients.createRegistry()
+    const raw = { readyState: 1, send: () => 1 }
+    registry.add(fakeWs({ raw, close: (code) => closed.push(code!) }), "delta")
+
+    expect(registry.remove(fakeWs({ raw }))).toBe(true)
+    expect(registry.remove(fakeWs({ raw }))).toBe(false)
+    expect(closed).toEqual([1013])
+  })
+
+  test("a failing close does not retain a dead subscription or block healthy clients", () => {
+    const registry = GlobalEventClients.createRegistry()
+    registry.add(
+      fakeWs({
+        raw: { readyState: 1, send: () => 0 },
+        close: () => {
+          throw new Error("close failed")
+        },
+      }),
+      "delta",
+    )
+    const received: string[] = []
+    registry.add(fakeWs({ raw: { readyState: 1, send: (data) => received.push(data) } }), "delta")
+
+    expect(registry.broadcast(() => "idle")).toEqual({ clients: 2, sent: 1, dropped: 1, removed: 1 })
+    expect(received).toEqual(["idle"])
+    expect(registry.size()).toBe(1)
+  })
+
+  test("clearing the registry closes remaining subscriptions", () => {
+    const registry = GlobalEventClients.createRegistry()
+    const closed: number[] = []
+    registry.add(fakeWs({ raw: { readyState: 1 }, close: (code) => closed.push(code!) }), "delta")
+
+    registry.clear()
+    expect(registry.size()).toBe(0)
+    expect(closed).toEqual([1013])
+  })
+
   test("encodes full and delta payloads once per broadcast", () => {
     const registry = GlobalEventClients.createRegistry()
     const rawA = { readyState: 1, send: () => 1 }

--- a/packages/server/test/server/global-event-recovery.test.ts
+++ b/packages/server/test/server/global-event-recovery.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test"
+import { WSContext } from "hono/ws"
+import { GlobalEventClients } from "../../src/server/global-event-clients"
+
+type Connection = { context?: WSContext; drop: boolean }
+
+test("a dropped terminal event closes the real socket and permits idle recovery on reconnect", async () => {
+  const registry = GlobalEventClients.createRegistry()
+  let status = "busy"
+  const frame = () => JSON.stringify({ type: "session.status", properties: { status: { type: status } } })
+  const connections = new Set<Bun.ServerWebSocket<Connection>>()
+  const server = Bun.serve<Connection>({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request, server) {
+      if (server.upgrade(request, { data: { drop: false } })) return
+      return new Response(null, { status: 400 })
+    },
+    websocket: {
+      open(socket) {
+        connections.add(socket)
+        const context = new WSContext({
+          raw: {
+            get readyState() {
+              return socket.readyState
+            },
+            send: (data: string) => (socket.data.drop ? 0 : socket.send(data)),
+          },
+          readyState: socket.readyState,
+          send: (data) => socket.send(data),
+          close: (code, reason) => socket.close(code, reason),
+        })
+        socket.data.context = context
+        registry.add(context, "delta")
+        registry.reply(context, frame())
+      },
+      message(socket, message) {
+        if (message === "complete") {
+          status = "idle"
+          socket.data.drop = true
+          registry.broadcast(frame)
+        } else if (message === "ping") {
+          registry.reply(socket.data.context!, "pong")
+        }
+      },
+      close(socket) {
+        connections.delete(socket)
+        const context = socket.data.context
+        socket.data.context = undefined
+        if (context) registry.remove(context)
+      },
+    },
+  })
+  const sockets: WebSocket[] = []
+  const connect = () => {
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}`)
+    sockets.push(socket)
+    return socket
+  }
+  const nextMessage = (socket: WebSocket) =>
+    new Promise<string>((resolve, reject) => {
+      socket.addEventListener("message", (event) => resolve(String(event.data)), { once: true })
+      socket.addEventListener("error", () => reject(new Error("WebSocket failed")), { once: true })
+    })
+
+  try {
+    const first = connect()
+    expect(JSON.parse(await nextMessage(first)).properties.status.type).toBe("busy")
+    const closed = new Promise<CloseEvent>((resolve) => first.addEventListener("close", resolve, { once: true }))
+    first.send("complete")
+    expect((await closed).code).toBe(1013)
+    expect(registry.size()).toBe(0)
+
+    const recovered = connect()
+    expect(JSON.parse(await nextMessage(recovered)).properties.status.type).toBe("idle")
+    const pong = nextMessage(recovered)
+    recovered.send("ping")
+    expect(await pong).toBe("pong")
+    expect(registry.size()).toBe(1)
+  } finally {
+    await Promise.all(
+      sockets.map((socket) => {
+        if (socket.readyState === WebSocket.CLOSED) return
+        return new Promise<void>((resolve) => {
+          socket.addEventListener("close", () => resolve(), { once: true })
+          socket.close()
+        })
+      }),
+    )
+    registry.clear()
+    for (const connection of connections) connection.terminate()
+    server.stop(true)
+  }
+})


### PR DESCRIPTION
## What does this PR do?

Close global event WebSockets when failed sends remove their subscriptions, so clients reconnect and recover session state. Connected acknowledgements, pongs, and heartbeats now use the same registry as broadcasts; an unregistered connection cannot keep receiving successful pongs.

Remove registry entries before closing sockets to tolerate reentrant callbacks, preserve transient control-frame backpressure behavior, and log failure outcomes without event contents. Add regression coverage, a real WebSocket recovery fixture, an implemented decision, and a postmortem.

## Why?

A dropped send or send exception previously removed a subscriber while leaving its socket open. Direct pong replies concealed the lost subscription, leaving completed sessions marked running and active sessions apparently stalled. Closing the connection activates existing reconnect, replay, and snapshot recovery without changing event envelopes or persisted state.

## External sources and provenance

None. The change follows repository source tracing and isolated fault-injection experiments.

## How was it tested?

- Regression tests failed before the fix and passed afterward.
- In `packages/server`: `bun test test/server/global-event-clients.test.ts test/server/global-event-recovery.test.ts test/server/event-wire.test.ts test/server/sync-batch-routes.test.ts` — 31 passed. The real socket fixture observes close code 1013 after an injected lost terminal event, then reconnects and reads idle state.
- In `apps/web`: `bun test test/context/event-queue.test.ts test/context/sync-watermark.test.ts test/context/global-sync-recovery.test.ts` — 25 passed.
- In `packages/server`: `bun run typecheck` — passed.
- `./script/generate.ts` — passed; no generated API or SDK differences.
- `bun run quality:quick` — 16 of 17 gates passed initially; the workflow scanner download failed due to a PyPI connection reset. `UV_OFFLINE=1 bun run workflow:check` then passed using the cached pinned tool, completing the remaining gate.

## Checklist

- [x] All local static gate checks passed, with the workflow scan completed separately as described above.
- [x] Relevant narrow tests pass and new tests live under the owning package's `test/` directory.
- [x] SDK generation verified; public API contracts are unchanged.
- [x] Architecture documentation, decision record, postmortem, and the owning development skill updated.
- [x] Material external sources listed above.
- [x] No secrets, local runtime identifiers, unrelated cleanup, or compatibility wrappers included.
